### PR TITLE
Fix nearest vertex selection

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -147,10 +147,14 @@ class Shape(object):
             assert False, "unsupported vertex shape"
 
     def nearestVertex(self, point, epsilon):
+        min_distance = float('inf')
+        min_i = None
         for i, p in enumerate(self.points):
-            if distance(p - point) <= epsilon:
-                return i
-        return None
+            dist = distance(p - point)
+            if dist <= epsilon and dist < min_distance:
+                min_distance = dist
+                min_i = i
+        return min_i
 
     def containsPoint(self, point):
         return self.makePath().contains(point)


### PR DESCRIPTION
The original method just selected the first encountered vertex in an epsilon-neighborhood of the mouse cursor, which is very annoying when trying to pick a vertex on a densely annotated polygon. Now the closest one is picked. This is done in O(number_of_vertices) and could be someday improved by more efficient nearest neighbor using k-d tree.