### PR TITLE
Show currently loaded file

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -837,6 +837,7 @@ class MainWindow(QMainWindow, WindowMixin):
             filename = self.imageList[currIndex - 1]
             if filename:
                 self.loadFile(filename)
+                self.fileListWidget.setCurrentRow(self.imageList.index(self.filename))
 
     def openNextImg(self, _value=False):
         if not self.mayContinue():
@@ -855,6 +856,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
         if filename:
             self.loadFile(filename)
+            self.fileListWidget.setCurrentRow(self.imageList.index(self.filename))
 
     def openFile(self, _value=False):
         if not self.mayContinue():

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1039,8 +1039,7 @@ class MainWindow(QMainWindow, WindowMixin):
             for file in files:
                 if file.lower().endswith(tuple(extensions)):
                     relativePath = os.path.join(root, file)
-                    path = str(os.path.abspath(relativePath))
-                    images.append(path)
+                    images.append(relativePath)
         images.sort(key=lambda x: x.lower())
         return images
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -765,6 +765,8 @@ class MainWindow(QMainWindow, WindowMixin):
             self.toggleActions(True)
             self.status("Loaded %s" % os.path.basename(str(filename)))
             self.setWindowTitle('{} - {}'.format(__appname__, os.path.basename(str(filename))))
+            if filename in self.imageList:
+                self.fileListWidget.setCurrentRow(self.imageList.index(filename))
             return True
         return False
 
@@ -837,7 +839,6 @@ class MainWindow(QMainWindow, WindowMixin):
             filename = self.imageList[currIndex - 1]
             if filename:
                 self.loadFile(filename)
-                self.fileListWidget.setCurrentRow(self.imageList.index(self.filename))
 
     def openNextImg(self, _value=False):
         if not self.mayContinue():
@@ -856,7 +857,6 @@ class MainWindow(QMainWindow, WindowMixin):
 
         if filename:
             self.loadFile(filename)
-            self.fileListWidget.setCurrentRow(self.imageList.index(self.filename))
 
     def openFile(self, _value=False):
         if not self.mayContinue():

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -708,6 +708,7 @@ class MainWindow(QMainWindow, WindowMixin):
         filename = str(filename)
         if QFile.exists(filename):
             # assumes same name, but json extension
+            self.status("Loading %s..." % os.path.basename(str(filename)))
             label_file = os.path.splitext(filename)[0] + '.json'
             if QFile.exists(label_file) and LabelFile.isLabelFile(label_file):
                 try:
@@ -751,7 +752,6 @@ class MainWindow(QMainWindow, WindowMixin):
                     .format(filename, ','.join(formats)))
                 self.status("Error reading %s" % filename)
                 return False
-            self.status("Loaded %s" % os.path.basename(str(filename)))
             self.image = image
             self.filename = filename
             self.canvas.loadPixmap(QPixmap.fromImage(image))
@@ -763,6 +763,8 @@ class MainWindow(QMainWindow, WindowMixin):
             self.paintCanvas()
             self.addRecentFile(self.filename)
             self.toggleActions(True)
+            self.status("Loaded %s" % os.path.basename(str(filename)))
+            self.setWindowTitle('{} - {}'.format(__appname__, os.path.basename(str(filename))))
             return True
         return False
 


### PR DESCRIPTION
Some adjustments to visualize which file is currently loaded:
1. Show filename in the title
2. Select filename in file list widget

Also I modified the filenames in the file list widget to show the relative path. I mainly did this to save some space, maximizing the space for the image. Maybe there should be an option to either show absolute or relative paths?