### PR TITLE
Show labels in main window

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -182,7 +182,7 @@ class Shape(object):
         self._highlightIndex = None
 
     def copy(self):
-        shape = Shape("Copy of %s" % self.label )
+        shape = Shape(self.label)
         shape.points= [p for p in self.points]
         shape.fill = self.fill
         shape.selected = self.selected


### PR DESCRIPTION
Close https://github.com/wkentaro/labelme/issues/90

# What is this?

## Show (unique) label list into the main window

## Select label first (from unique label list) then annotate polygon

![screenshot from 2018-03-30 20 13 25](https://user-images.githubusercontent.com/4310419/38136057-d4d46ee6-3456-11e8-8f7f-caa10f5af4c2.png)

I think this is better UI implementation of https://github.com/wkentaro/labelme/issues/44.
Do you have an idea? @ad-si

# How to try this?

```bash
cd examples/semantic_segmentation
labelme data_annotated --labels="$(tr '\n' , < labels.txt)" --nodata
```