### PR TITLE
UI adjustments (select label by arrow key, save/discard/cancel dialog, arrow labels.txt)

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -796,7 +796,6 @@ class MainWindow(QMainWindow, WindowMixin):
             self.addRecentFile(self.filename)
             self.toggleActions(True)
             self.status("Loaded %s" % os.path.basename(str(filename)))
-            self.setWindowTitle('{} - {}'.format(__appname__, os.path.basename(str(filename))))
             if filename in self.imageList:
                 self.fileListWidget.setCurrentRow(self.imageList.index(filename))
             return True
@@ -1137,7 +1136,7 @@ def main():
     args = parser.parse_args()
 
     if args.labels is not None:
-        args.labels = args.labels.split(',')
+        args.labels = [l for l in args.labels.split(',') if len(l) > 0]
 
     app = QApplication(sys.argv)
     app.setApplicationName(__appname__)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1130,18 +1130,19 @@ def main():
     parser.add_argument('--output', '-O', '-o', help='output label name')
     parser.add_argument('--nodata', dest='store_data', action='store_false',
                         help='stop storing image data to JSON file')
-    parser.add_argument('--labels', help='comma separated list of labels OR file containing one label per line')
+    parser.add_argument('--labels',
+                        help='comma separated list of labels OR file '
+                        'containing one label per line')
     parser.add_argument('--nosortlabels', dest='sort_labels',
                         action='store_false', help='stop sorting labels')
     args = parser.parse_args()
 
     if args.labels is not None:
         if os.path.isfile(args.labels):
-            args.labels = [l.strip()
-                           for l in open(args.labels, 'r').readlines()
-                           if len(l.strip()) > 0]
+            args.labels = [l.strip() for l in open(args.labels, 'r')
+                           if l.strip()]
         else:
-            args.labels = [l for l in args.labels.split(',') if len(l) > 0]
+            args.labels = [l for l in args.labels.split(',') if l]
 
     app = QApplication(sys.argv)
     app.setApplicationName(__appname__)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -965,12 +965,22 @@ class MainWindow(QMainWindow, WindowMixin):
         return True
 
     def mayContinue(self):
-        return not (self.dirty and not self.discardChangesDialog())
-
-    def discardChangesDialog(self):
-        yes, no = QMessageBox.Yes, QMessageBox.No
-        msg = 'You have unsaved changes, proceed anyway?'
-        return yes == QMessageBox.warning(self, 'Attention', msg, yes|no)
+        if not self.dirty:
+            return True
+        mb = QMessageBox
+        msg = 'Save annotations to "{}" before closing?'.format(self.filename)
+        answer = mb.question(self,
+                             'Save annotations?',
+                             msg,
+                             mb.Save | mb.Discard | mb.Cancel,
+                             mb.Save)
+        if answer == mb.Discard:
+            return True
+        elif answer == mb.Save:
+            self.saveFile()
+            return True
+        else: # answer == mb.Cancel
+            return False
 
     def errorMessage(self, title, message):
         return QMessageBox.critical(self, title,

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -446,11 +446,13 @@ class MainWindow(QMainWindow, WindowMixin):
     def setDirty(self):
         self.dirty = True
         self.actions.save.setEnabled(True)
+        self.setWindowTitle('{} - {}*'.format(__appname__, os.path.basename(self.filename)))
 
     def setClean(self):
         self.dirty = False
         self.actions.save.setEnabled(False)
         self.actions.create.setEnabled(True)
+        self.setWindowTitle('{} - {}'.format(__appname__, os.path.basename(self.filename)))
 
     def toggleActions(self, value=True):
         """Enable/Disable widgets which depend on an opened image."""

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -681,8 +681,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
         position MUST be in global coordinates.
         """
-        text = ''
         items = self.uniqLabelList.selectedItems()
+        text = None
         if items:
             text = items[0].text()
         text = self.labelDialog.popUp(text)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1130,13 +1130,18 @@ def main():
     parser.add_argument('--output', '-O', '-o', help='output label name')
     parser.add_argument('--nodata', dest='store_data', action='store_false',
                         help='stop storing image data to JSON file')
-    parser.add_argument('--labels', help='comma separated list of labels')
+    parser.add_argument('--labels', help='comma separated list of labels OR file containing one label per line')
     parser.add_argument('--nosortlabels', dest='sort_labels',
                         action='store_false', help='stop sorting labels')
     args = parser.parse_args()
 
     if args.labels is not None:
-        args.labels = [l for l in args.labels.split(',') if len(l) > 0]
+        if os.path.isfile(args.labels):
+            args.labels = [l.strip()
+                           for l in open(args.labels, 'r').readlines()
+                           if len(l.strip()) > 0]
+        else:
+            args.labels = [l for l in args.labels.split(',') if len(l) > 0]
 
     app = QApplication(sys.argv)
     app.setApplicationName(__appname__)

--- a/labelme/labelDialog.py
+++ b/labelme/labelDialog.py
@@ -34,12 +34,25 @@ from .lib import newIcon, labelValidator
 
 BB = QDialogButtonBox
 
+
+class LabelQLineEdit(QLineEdit):
+
+    def setListWidget(self, list_widget):
+        self.list_widget = list_widget
+
+    def keyPressEvent(self, e):
+        if e.key() in [Qt.Key_Up, Qt.Key_Down]:
+            self.list_widget.keyPressEvent(e)
+        else:
+            super(LabelQLineEdit, self).keyPressEvent(e)
+
+
 class LabelDialog(QDialog):
 
     def __init__(self, text="Enter object label", parent=None, labels=None,
                  sort_labels=True):
         super(LabelDialog, self).__init__(parent)
-        self.edit = QLineEdit()
+        self.edit = LabelQLineEdit()
         self.edit.setPlaceholderText(text)
         self.edit.setValidator(labelValidator())
         self.edit.editingFinished.connect(self.postProcess)
@@ -62,6 +75,7 @@ class LabelDialog(QDialog):
         else:
             self.labelList.setDragDropMode(QAbstractItemView.InternalMove)
         self.labelList.currentItemChanged.connect(self.labelSelected)
+        self.edit.setListWidget(self.labelList)
         layout.addWidget(self.labelList)
         self.setLayout(layout)
 

--- a/labelme/labelDialog.py
+++ b/labelme/labelDialog.py
@@ -90,19 +90,15 @@ class LabelDialog(QDialog):
             self.edit.setText(self.edit.text().trimmed())
 
     def popUp(self, text=None, move=True):
-        if isinstance(text, str):
-            self.edit.setText(text)
-            self.edit.setSelection(0, len(text))
-            i = self.labelList.findItems(text, Qt.MatchFixedString)
-            if len(i) == 1:
-                self.labelList.setCurrentItem(i[0])
+        if text is None:
+            text = ''
+        self.edit.setText(text)
+        self.edit.setSelection(0, len(text))
+        items = self.labelList.findItems(text, Qt.MatchFixedString)
+        if items:
+            assert len(items) == 1
+            self.labelList.setCurrentItem(items[0])
         self.edit.setFocus(Qt.PopupFocusReason)
         if move:
             self.move(QCursor.pos())
         return self.edit.text() if self.exec_() else None
-
-    def keyPressEvent(self, e):
-        if e.key() in [Qt.Key_Up, Qt.Key_Down]:
-            self.labelList.keyPressEvent(e)
-        else:
-            super().keyPressEvent(e)

--- a/labelme/labelDialog.py
+++ b/labelme/labelDialog.py
@@ -104,14 +104,14 @@ class LabelDialog(QDialog):
             self.edit.setText(self.edit.text().trimmed())
 
     def popUp(self, text=None, move=True):
-        if text is None:
-            text = ''
-        self.edit.setText(text)
-        self.edit.setSelection(0, len(text))
-        items = self.labelList.findItems(text, Qt.MatchFixedString)
-        if items:
-            assert len(items) == 1
-            self.labelList.setCurrentItem(items[0])
+        # if text is None, the previous label in self.edit is kept
+        if text is not None:
+            self.edit.setText(text)
+            self.edit.setSelection(0, len(text))
+            items = self.labelList.findItems(text, Qt.MatchFixedString)
+            if items:
+                assert len(items) == 1
+                self.labelList.setCurrentItem(items[0])
         self.edit.setFocus(Qt.PopupFocusReason)
         if move:
             self.move(QCursor.pos())

--- a/labelme/labelDialog.py
+++ b/labelme/labelDialog.py
@@ -89,11 +89,20 @@ class LabelDialog(QDialog):
         else:
             self.edit.setText(self.edit.text().trimmed())
 
-    def popUp(self, text='', move=True):
-        self.edit.setText(text)
-        self.edit.setSelection(0, len(text))
+    def popUp(self, text=None, move=True):
+        if isinstance(text, str):
+            self.edit.setText(text)
+            self.edit.setSelection(0, len(text))
+            i = self.labelList.findItems(text, Qt.MatchFixedString)
+            if len(i) == 1:
+                self.labelList.setCurrentItem(i[0])
         self.edit.setFocus(Qt.PopupFocusReason)
         if move:
             self.move(QCursor.pos())
         return self.edit.text() if self.exec_() else None
 
+    def keyPressEvent(self, e):
+        if e.key() in [Qt.Key_Up, Qt.Key_Down]:
+            self.labelList.keyPressEvent(e)
+        else:
+            super().keyPressEvent(e)


### PR DESCRIPTION
Some small UI adjustments that I implemented over the past few days while using labelme.

1. When closing or switching to another file, the dialog now asks to `save changes` aside of `discard changes` and `cancel`, more similar to other applications.
2. The label dialog preselects the previously selected label or the label that is under edit because of clicking in the main window label list. Also it allows to change the selected label of the list by using the arrow keys.
3. Extended loading labels from file, filtering empty line labels or clarity.