### PR TITLE
Undo last drawn point on current polygon

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -219,6 +219,9 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         copy = action('&Duplicate\nPolygon', self.copySelectedShape, 'Ctrl+D',
                       'copy', 'Create a duplicate of the selected polygon',
                       enabled=False)
+        undoLastPoint = action('Undo last point', self.undoLastPoint,
+                               'Backspace', 'undoLastPoint',
+                               'Undo last drawn point', enabled=False)
 
         advancedMode = action('&Advanced Mode', self.toggleAdvancedMode,
                               'Ctrl+Shift+A', 'expert',
@@ -297,6 +300,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             save=save, saveAs=saveAs, open=open, close=close,
             lineColor=color1, fillColor=color2,
             create=create, delete=delete, edit=edit, copy=copy,
+            undoLastPoint=undoLastPoint,
             createMode=createMode, editMode=editMode,
             advancedMode=advancedMode,
             shapeLineColor=shapeLineColor, shapeFillColor=shapeFillColor,
@@ -305,11 +309,12 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             zoomActions=zoomActions,
             fileMenuActions=(open, opendir, save, saveAs, close, quit),
             beginner=(), advanced=(),
-            editMenu=(edit, copy, delete, None, color1, color2),
-            beginnerContext=(create, edit, copy, delete),
+            editMenu=(edit, copy, delete, None, undoLastPoint, None, color1, color2),
+            beginnerContext=(create, edit, copy, delete, undoLastPoint),
             advancedContext=(
                 createMode, editMode, edit, copy,
                 delete, shapeLineColor, shapeFillColor,
+                undoLastPoint,
             ),
             onLoadActive=(close, create, createMode, editMode),
             onShapesPresent=(saveAs, hideAll, showAll),
@@ -524,6 +529,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         In the middle of drawing, toggling between modes should be disabled.
         """
         self.actions.editMode.setEnabled(not drawing)
+        self.actions.undoLastPoint.setEnabled(drawing)
         if not drawing and self.beginner():
             # Cancel creation.
             self.canvas.setEditing(True)
@@ -1051,6 +1057,9 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             if self.noShapes():
                 for action in self.actions.onShapesPresent:
                     action.setEnabled(False)
+    
+    def undoLastPoint(self):
+        self.canvas.undoLastPoint()
 
     def chshapeLineColor(self):
         color = self.colorDialog.getColor(

--- a/labelme/canvas.py
+++ b/labelme/canvas.py
@@ -125,6 +125,7 @@ class Canvas(QtWidgets.QWidget):
                     color = self.current.line_color
                     self.overrideCursor(CURSOR_POINT)
                     self.current.highlightVertex(0, Shape.NEAR_VERTEX)
+                self.line[0] = self.current[-1]
                 self.line[1] = pos
                 self.line.line_color = color
                 self.repaint()
@@ -537,6 +538,16 @@ class Canvas(QtWidgets.QWidget):
         self.current.setOpen()
         self.line.points = [self.current[-1], self.current[0]]
         self.drawingPolygon.emit(True)
+        
+    def undoLastPoint(self):
+        if self.current and not self.current.isClosed():
+            self.current.popPoint()
+            if len(self.current) > 0:
+                self.line[0] = self.current[-1]
+            else:
+                self.current = None
+                self.drawingPolygon.emit(False)
+            self.repaint()                
 
     def loadPixmap(self, pixmap):
         self.pixmap = pixmap


### PR DESCRIPTION
Solves #83.

The reason I choose backspace as the hotkey instead of Ctrl-Z is mainly laziness: it's easier to press 1 key than a 2 key combination. Since there's no text entry in the main window I figured this would not be a problem.