### PR TITLE
Zooming fix

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -787,9 +787,9 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             y_shift = round(pos.y() * canvas_scale_factor) - pos.y()
 
             self.scrollBars[Qt.Horizontal].setValue(
-                    self.scrollBars[Qt.Horizontal].value() + x_shift)
+                self.scrollBars[Qt.Horizontal].value() + x_shift)
             self.scrollBars[Qt.Vertical].setValue(
-                    self.scrollBars[Qt.Vertical].value() + y_shift)
+                self.scrollBars[Qt.Vertical].value() + y_shift)
 
     def setFitWindow(self, value=True):
         if value:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -290,7 +290,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.zoomWidget.setEnabled(False)
 
         zoomIn = action('Zoom &In', functools.partial(self.addZoom, 10),
-                        'Ctrl++', 'zoom-in', 'Increase zoom level',
+                        ['Ctrl++', 'Ctrl+='], 'zoom-in', 'Increase zoom level',
                         enabled=False)
         zoomOut = action('&Zoom Out', functools.partial(self.addZoom, -10),
                          'Ctrl+-', 'zoom-out', 'Decrease zoom level',

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -290,14 +290,14 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.zoomWidget.setEnabled(False)
 
         zoomIn = action('Zoom &In', functools.partial(self.addZoom, 10),
-                        'Ctrl++', 'zoom-in', 'Increase zoom level',
+                        'Ctrl+=', 'zoom-in', 'Increase zoom level',
                         enabled=False)
         zoomOut = action('&Zoom Out', functools.partial(self.addZoom, -10),
                          'Ctrl+-', 'zoom-out', 'Decrease zoom level',
                          enabled=False)
         zoomOrg = action('&Original size',
                          functools.partial(self.setZoom, 100),
-                         'Ctrl+=', 'zoom', 'Zoom to original size',
+                         'Ctrl+0', 'zoom', 'Zoom to original size',
                          enabled=False)
         fitWindow = action('&Fit Window', self.setFitWindow, 'Ctrl+F',
                            'fit-window', 'Zoom follows window size',

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -290,11 +290,11 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.zoomWidget.setEnabled(False)
 
         zoomIn = action('Zoom &In', functools.partial(self.addZoom, 10),
-                        ['Ctrl++', 'Ctrl+='], 'zoom-in', 'Increase zoom level',
-                        enabled=False)
+                        QtGui.QKeySequence.ZoomIn, 'zoom-in',
+                        'Increase zoom level', enabled=False)
         zoomOut = action('&Zoom Out', functools.partial(self.addZoom, -10),
-                         'Ctrl+-', 'zoom-out', 'Decrease zoom level',
-                         enabled=False)
+                         QtGui.QKeySequence.ZoomOut, 'zoom-out',
+                         'Decrease zoom level', enabled=False)
         zoomOrg = action('&Original size',
                          functools.partial(self.setZoom, 100),
                          'Ctrl+0', 'zoom', 'Zoom to original size',

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -202,12 +202,12 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.canvas = self.labelList.canvas = Canvas()
         self.canvas.zoomRequest.connect(self.zoomRequest)
 
-        scroll = QtWidgets.QScrollArea()
-        scroll.setWidget(self.canvas)
-        scroll.setWidgetResizable(True)
+        self.scrollArea = QtWidgets.QScrollArea()
+        self.scrollArea.setWidget(self.canvas)
+        self.scrollArea.setWidgetResizable(True)
         self.scrollBars = {
-            Qt.Vertical: scroll.verticalScrollBar(),
-            Qt.Horizontal: scroll.horizontalScrollBar(),
+            Qt.Vertical: self.scrollArea.verticalScrollBar(),
+            Qt.Horizontal: self.scrollArea.horizontalScrollBar(),
         }
         self.canvas.scrollRequest.connect(self.scrollRequest)
 
@@ -216,7 +216,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.canvas.selectionChanged.connect(self.shapeSelectionChanged)
         self.canvas.drawingPolygon.connect(self.toggleDrawingSensitive)
 
-        self.setCentralWidget(scroll)
+        self.setCentralWidget(self.scrollArea)
 
         self.addDockWidget(Qt.RightDockWidgetArea, self.labelsdock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.dock)
@@ -773,9 +773,12 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
     def addZoom(self, increment=10):
         self.setZoom(self.zoomWidget.value() + increment)
 
-    def zoomRequest(self, delta):
+    def zoomRequest(self, delta, pos):
         units = delta * 0.1
         self.addZoom(units)
+        x, y = pos.x(), pos.y()
+        w, h = self.scrollArea.width(), self.scrollArea.height()
+        self.scrollArea.ensureVisible(x, y, w // 2, h // 2)
 
     def setFitWindow(self, value=True):
         if value:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -290,7 +290,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.zoomWidget.setEnabled(False)
 
         zoomIn = action('Zoom &In', functools.partial(self.addZoom, 10),
-                        'Ctrl+=', 'zoom-in', 'Increase zoom level',
+                        'Ctrl++', 'zoom-in', 'Increase zoom level',
                         enabled=False)
         zoomOut = action('&Zoom Out', functools.partial(self.addZoom, -10),
                          'Ctrl+-', 'zoom-out', 'Decrease zoom level',

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -773,7 +773,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
     def addZoom(self, increment=10):
         self.setZoom(self.zoomWidget.value() + increment)
 
-    def zoomRequest(self, delta, pos, globalPos):
+    def zoomRequest(self, delta, pos):
         canvas_width_old = self.canvas.width()
 
         units = delta * 0.1

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -202,12 +202,12 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.canvas = self.labelList.canvas = Canvas()
         self.canvas.zoomRequest.connect(self.zoomRequest)
 
-        self.scrollArea = QtWidgets.QScrollArea()
-        self.scrollArea.setWidget(self.canvas)
-        self.scrollArea.setWidgetResizable(True)
+        scrollArea = QtWidgets.QScrollArea()
+        scrollArea.setWidget(self.canvas)
+        scrollArea.setWidgetResizable(True)
         self.scrollBars = {
-            Qt.Vertical: self.scrollArea.verticalScrollBar(),
-            Qt.Horizontal: self.scrollArea.horizontalScrollBar(),
+            Qt.Vertical: scrollArea.verticalScrollBar(),
+            Qt.Horizontal: scrollArea.horizontalScrollBar(),
         }
         self.canvas.scrollRequest.connect(self.scrollRequest)
 
@@ -216,7 +216,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         self.canvas.selectionChanged.connect(self.shapeSelectionChanged)
         self.canvas.drawingPolygon.connect(self.toggleDrawingSensitive)
 
-        self.setCentralWidget(self.scrollArea)
+        self.setCentralWidget(scrollArea)
 
         self.addDockWidget(Qt.RightDockWidgetArea, self.labelsdock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.dock)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -786,11 +786,10 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             x_shift = round(pos.x() * canvas_scale_factor) - pos.x()
             y_shift = round(pos.y() * canvas_scale_factor) - pos.y()
 
-            sb_h = self.scrollArea.horizontalScrollBar()
-            sb_v = self.scrollArea.verticalScrollBar()
-
-            sb_h.setValue(sb_h.value() + x_shift)
-            sb_v.setValue(sb_v.value() + y_shift)
+            self.scrollBars[Qt.Horizontal].setValue(
+                    self.scrollBars[Qt.Horizontal].value() + x_shift)
+            self.scrollBars[Qt.Vertical].setValue(
+                    self.scrollBars[Qt.Vertical].value() + y_shift)
 
     def setFitWindow(self, value=True):
         if value:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -773,12 +773,24 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
     def addZoom(self, increment=10):
         self.setZoom(self.zoomWidget.value() + increment)
 
-    def zoomRequest(self, delta, pos):
+    def zoomRequest(self, delta, pos, globalPos):
+        canvas_width_old = self.canvas.width()
+
         units = delta * 0.1
         self.addZoom(units)
-        x, y = pos.x(), pos.y()
-        w, h = self.scrollArea.width(), self.scrollArea.height()
-        self.scrollArea.ensureVisible(x, y, w // 2, h // 2)
+
+        canvas_width_new = self.canvas.width()
+        if canvas_width_old != canvas_width_new:
+            canvas_scale_factor = canvas_width_new / canvas_width_old
+
+            x_shift = round(pos.x() * canvas_scale_factor) - pos.x()
+            y_shift = round(pos.y() * canvas_scale_factor) - pos.y()
+
+            sb_h = self.scrollArea.horizontalScrollBar()
+            sb_v = self.scrollArea.verticalScrollBar()
+
+            sb_h.setValue(sb_h.value() + x_shift)
+            sb_v.setValue(sb_v.value() + y_shift)
 
     def setFitWindow(self, value=True):
         if value:

--- a/labelme/canvas.py
+++ b/labelme/canvas.py
@@ -29,7 +29,7 @@ CURSOR_GRAB = QtCore.Qt.OpenHandCursor
 
 
 class Canvas(QtWidgets.QWidget):
-    zoomRequest = QtCore.pyqtSignal(int)
+    zoomRequest = QtCore.pyqtSignal(int, QtCore.QPointF)
     scrollRequest = QtCore.pyqtSignal(int, int)
     newShape = QtCore.pyqtSignal()
     selectionChanged = QtCore.pyqtSignal(bool)
@@ -497,7 +497,7 @@ class Canvas(QtWidgets.QWidget):
             if QtCore.Qt.ControlModifier == int(mods):
                 # with Ctrl/Command key
                 # zoom
-                self.zoomRequest.emit(delta.y())
+                self.zoomRequest.emit(delta.y(), ev.pos())
             else:
                 # scroll
                 self.scrollRequest.emit(delta.x(), QtCore.Qt.Horizontal)
@@ -507,7 +507,7 @@ class Canvas(QtWidgets.QWidget):
                 mods = ev.modifiers()
                 if QtCore.Qt.ControlModifier == int(mods):
                     # with Ctrl/Command key
-                    self.zoomRequest.emit(ev.delta())
+                    self.zoomRequest.emit(ev.delta(), ev.pos())
                 else:
                     self.scrollRequest.emit(
                         ev.delta(),

--- a/labelme/canvas.py
+++ b/labelme/canvas.py
@@ -493,7 +493,7 @@ class Canvas(QtWidgets.QWidget):
     def wheelEvent(self, ev):
         if PYQT5:
             mods = ev.modifiers()
-            delta = ev.pixelDelta()
+            delta = ev.angleDelta()
             if QtCore.Qt.ControlModifier == int(mods):
                 # with Ctrl/Command key
                 # zoom

--- a/labelme/canvas.py
+++ b/labelme/canvas.py
@@ -29,7 +29,7 @@ CURSOR_GRAB = QtCore.Qt.OpenHandCursor
 
 
 class Canvas(QtWidgets.QWidget):
-    zoomRequest = QtCore.pyqtSignal(int, QtCore.QPointF)
+    zoomRequest = QtCore.pyqtSignal(int, QtCore.QPoint, QtCore.QPoint)
     scrollRequest = QtCore.pyqtSignal(int, int)
     newShape = QtCore.pyqtSignal()
     selectionChanged = QtCore.pyqtSignal(bool)
@@ -497,7 +497,7 @@ class Canvas(QtWidgets.QWidget):
             if QtCore.Qt.ControlModifier == int(mods):
                 # with Ctrl/Command key
                 # zoom
-                self.zoomRequest.emit(delta.y(), ev.pos())
+                self.zoomRequest.emit(delta.y(), ev.pos(), ev.globalPos())
             else:
                 # scroll
                 self.scrollRequest.emit(delta.x(), QtCore.Qt.Horizontal)
@@ -507,7 +507,7 @@ class Canvas(QtWidgets.QWidget):
                 mods = ev.modifiers()
                 if QtCore.Qt.ControlModifier == int(mods):
                     # with Ctrl/Command key
-                    self.zoomRequest.emit(ev.delta(), ev.pos())
+                    self.zoomRequest.emit(ev.delta(), ev.pos(), ev.globalPos())
                 else:
                     self.scrollRequest.emit(
                         ev.delta(),

--- a/labelme/canvas.py
+++ b/labelme/canvas.py
@@ -29,7 +29,7 @@ CURSOR_GRAB = QtCore.Qt.OpenHandCursor
 
 
 class Canvas(QtWidgets.QWidget):
-    zoomRequest = QtCore.pyqtSignal(int, QtCore.QPoint, QtCore.QPoint)
+    zoomRequest = QtCore.pyqtSignal(int, QtCore.QPoint)
     scrollRequest = QtCore.pyqtSignal(int, int)
     newShape = QtCore.pyqtSignal()
     selectionChanged = QtCore.pyqtSignal(bool)
@@ -497,7 +497,7 @@ class Canvas(QtWidgets.QWidget):
             if QtCore.Qt.ControlModifier == int(mods):
                 # with Ctrl/Command key
                 # zoom
-                self.zoomRequest.emit(delta.y(), ev.pos(), ev.globalPos())
+                self.zoomRequest.emit(delta.y(), ev.pos())
             else:
                 # scroll
                 self.scrollRequest.emit(delta.x(), QtCore.Qt.Horizontal)
@@ -507,7 +507,7 @@ class Canvas(QtWidgets.QWidget):
                 mods = ev.modifiers()
                 if QtCore.Qt.ControlModifier == int(mods):
                     # with Ctrl/Command key
-                    self.zoomRequest.emit(ev.delta(), ev.pos(), ev.globalPos())
+                    self.zoomRequest.emit(ev.delta(), ev.pos())
                 else:
                     self.scrollRequest.emit(
                         ev.delta(),


### PR DESCRIPTION
3 main changes:
1. Fixes scroll wheel zooming in my Ubuntu setup.
2. Zoom shortcut adjusted to be more similar to browsers: `Ctrl+0` to zoom to 100%, `Ctrl+=` to zoom in, `Ctrl+-` to zoom out.
3. Zoom into the cursor location instead of towards (0,0).

Regarding the Ubuntu setup: `pixelDelta()` is always 0 in my case, this is mentioned in the Qt documentation as a X11 specific issue: https://doc.qt.io/qt-5/qwheelevent.html#pixelDelta. I now changed it to `angleDelta()` instead, which based on the documentation I would expect to work on all platforms. However I don't have a Mac to test it.