### PR TITLE
Fix the order of loading configuration

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 
 import labelme.app
+import labelme.config
 import labelme.testing
 
 
@@ -33,7 +34,9 @@ def test_MainWindow_annotate_jpg(qtbot):
                 filename)
     output = osp.join(tmp_dir, 'apc2016_obj3.json')
 
-    win = labelme.app.MainWindow(filename=filename, output=output)
+    config = labelme.config.get_default_config()
+    win = labelme.app.MainWindow(
+        config=config, filename=filename, output=output)
     qtbot.addWidget(win)
     win.show()
 


### PR DESCRIPTION
Close https://github.com/wkentaro/labelme/issues/149

1. default config (lowest priority)
2. config file passed by command line argument or ~/.labelmerc
3. command line argument (highest priority)