### PR TITLE
support CJK in labels file

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1231,8 +1231,8 @@ def main():
             sys.exit(1)
     else:
         if os.path.isfile(args.labels):
-            args.labels = [l.strip() for l in open(args.labels, 'r', encoding='utf-8')
-                           if l.strip()]
+            args.labels = [l.strip() for l in 
+                    open(args.labels, 'r', encoding='utf-8') if l.strip()]
         else:
             args.labels = [l for l in args.labels.split(',') if l]
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1231,7 +1231,7 @@ def main():
             sys.exit(1)
     else:
         if os.path.isfile(args.labels):
-            args.labels = [l.strip() for l in open(args.labels, 'r')
+            args.labels = [l.strip() for l in open(args.labels, 'r', encoding='utf-8')
                            if l.strip()]
         else:
             args.labels = [l for l in args.labels.split(',') if l]


### PR DESCRIPTION
If label list file contains Asian characters,  --labels will cause error when staring application. Use utf-8 encoding to improve this.