### PR TITLE
Fix caption shown in label_viz

### DIFF
--- a/labelme/utils/draw.py
+++ b/labelme/utils/draw.py
@@ -71,7 +71,7 @@ def draw_label(label, img=None, label_names=None, colormap=None):
 
     plt_handlers = []
     plt_titles = []
-    for label_value, label_name in enumerate(label_names):
+    for label_value, label_name in enumerate(sorted(label_names)):
         if label_value not in label:
             continue
         if label_name.startswith('_'):


### PR DESCRIPTION
I fixed loading order of labels in `draw_label` function.

Below are `label_viz.png` images generated after `labelme_json_to_dataset JSON_FILE`.

## Before this PR
![before](https://user-images.githubusercontent.com/22876283/43647871-dcd1c87a-9773-11e8-84e1-a7e3f528b43a.png)

## After this PR
![after](https://user-images.githubusercontent.com/22876283/43647888-e7ac689a-9773-11e8-8344-803d015cbec7.png)
