### PR TITLE
Add fix for PyQt4+python 2.7 to avoid window freeze.

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1,8 +1,11 @@
 import functools
+import io
 import os.path
 import re
 import warnings
 import webbrowser
+
+import PIL.Image
 
 from qtpy import QtCore
 from qtpy.QtCore import Qt
@@ -936,6 +939,16 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
         for item, shape in self.labelList.itemsToShapes:
             item.setCheckState(Qt.Checked if value else Qt.Unchecked)
 
+    def convertImageDataToPng(self, imageData):
+        if imageData is None:
+            return
+        img = PIL.Image.open(io.BytesIO(imageData))
+        with io.BytesIO() as imgBytesIO:
+            img.save(imgBytesIO, "PNG")
+            imgBytesIO.seek(0)
+            data = imgBytesIO.read()
+        return data
+
     def loadFile(self, filename=None):
         """Load the specified file, or the last opened file if None."""
         # changing fileListWidget loads file
@@ -966,6 +979,10 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
                 # and JSON encoded images.
                 # https://github.com/ContinuumIO/anaconda-issues/issues/131
                 if QtGui.QImage.fromData(self.labelFile.imageData).isNull():
+                    # tries to read image with PIL and convert it to PNG
+                    self.labelFile.imageData = self.convertImageDataToPng(
+                        self.labelFile.imageData)
+                if QtGui.QImage.fromData(self.labelFile.imageData).isNull():
                     raise LabelFileError(
                         'Failed loading image data from label file.\n'
                         'Maybe this is a known issue of PyQt4 built on'
@@ -991,6 +1008,8 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             if self.imageData is not None:
                 # the filename is image not JSON
                 self.imagePath = filename
+                if QtGui.QImage.fromData(self.imageData).isNull():
+                    self.imageData = self.convertImageDataToPng(self.imageData)
             self.labelFile = None
         image = QtGui.QImage.fromData(self.imageData)
         if image.isNull():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,8 +2,6 @@ import os.path as osp
 import shutil
 import tempfile
 
-import qtpy
-
 import labelme.app
 import labelme.config
 import labelme.testing
@@ -21,10 +19,6 @@ def test_MainWindow_open(qtbot):
 
 
 def test_MainWindow_open_json(qtbot):
-    if qtpy.PYQT4:
-        # Fails to load image from JSON on Anaconda + Python2.7 + PyQt4
-        return
-
     filename = osp.join(data_dir, 'apc2016_obj3.json')
     labelme.testing.assert_labelfile_sanity(filename)
     win = labelme.app.MainWindow(filename=filename)
@@ -34,10 +28,6 @@ def test_MainWindow_open_json(qtbot):
 
 
 def test_MainWindow_annotate_jpg(qtbot):
-    if qtpy.PYQT4:
-        # Fails to load image from JSON on Anaconda + Python2.7 + PyQt4
-        return
-
     tmp_dir = tempfile.mkdtemp()
     filename = osp.join(tmp_dir, 'apc2016_obj3.jpg')
     shutil.copy(osp.join(data_dir, 'apc2016_obj3.jpg'),


### PR DESCRIPTION
Cherry-picked from #236.
cc @latticetower

> When imageData cannot be read with PyQt4, the alert window is shown.
To avoid this, I do conversion from jpg to png (or from other
unsupported format to png).