### PR TITLE
Introduce shape_type field to enhance rectangle annotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ env:
     - MPLBACKEND=TkAgg  # for osx
 matrix:
   include:
+    - os: osx
+      env:
+        - PYTEST_QT_API=pyqt5
+        - PYQT_PACKAGE='pyqt=5'
+        - PYTHON_VERSION=3.6
+        - RUN_PYINSTALLER=true
     - os: linux
       dist: trusty
       env:
@@ -41,12 +47,6 @@ matrix:
         - PYTHON_VERSION=2.7
     - os: linux
       dist: trusty
-      env:
-        - PYTEST_QT_API=pyqt5
-        - PYQT_PACKAGE='pyqt=5'
-        - PYTHON_VERSION=3.6
-        - RUN_PYINSTALLER=true
-    - os: osx
       env:
         - PYTEST_QT_API=pyqt5
         - PYQT_PACKAGE='pyqt=5'

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -776,8 +776,8 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
 
     def loadLabels(self, shapes):
         s = []
-        for label, points, line_color, fill_color in shapes:
-            shape = Shape(label=label)
+        for label, points, line_color, fill_color, shape_type in shapes:
+            shape = Shape(label=label, shape_type=shape_type)
             for x, y in points:
                 shape.addPoint(QtCore.QPoint(x, y))
             shape.close()
@@ -805,7 +805,8 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
                         if s.line_color != self.lineColor else None,
                         fill_color=s.fill_color.getRgb()
                         if s.fill_color != self.fillColor else None,
-                        points=[(p.x(), p.y()) for p in s.points])
+                        points=[(p.x(), p.y()) for p in s.points],
+                        shape_type=s.shape_type)
 
         shapes = [format_shape(shape) for shape in self.labelList.shapes]
         flags = {}

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -48,7 +48,13 @@ class LabelFile(object):
             lineColor = data['lineColor']
             fillColor = data['fillColor']
             shapes = (
-                (s['label'], s['points'], s['line_color'], s['fill_color'])
+                (
+                    s['label'],
+                    s['points'],
+                    s['line_color'],
+                    s['fill_color'],
+                    s.get('shape_type'),
+                )
                 for s in data['shapes']
             )
         except Exception as e:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -155,6 +155,8 @@ class Canvas(QtWidgets.QWidget):
 
         # Polygon drawing.
         if self.drawing():
+            self.line.shape_type = self.createMode
+
             self.overrideCursor(CURSOR_DRAW)
             if not self.current:
                 return
@@ -176,9 +178,7 @@ class Canvas(QtWidgets.QWidget):
                 self.line[0] = self.current[-1]
                 self.line[1] = pos
             elif self.createMode == 'rectangle':
-                self.line.points = list(self.getRectangleFromLine(
-                    (self.current[0], pos)
-                ))
+                self.line.points = [self.current[0], pos]
                 self.line.close()
             elif self.createMode == 'line':
                 self.line.points = [self.current[0], pos]
@@ -271,13 +271,6 @@ class Canvas(QtWidgets.QWidget):
         self.hVertex = index
         self.hEdge = None
 
-    def getRectangleFromLine(self, line):
-        pt1 = line[0]
-        pt3 = line[1]
-        pt2 = QtCore.QPoint(pt3.x(), pt1.y())
-        pt4 = QtCore.QPoint(pt1.x(), pt3.y())
-        return pt1, pt2, pt3, pt4
-
     def mousePressEvent(self, ev):
         if QT5:
             pos = self.transformPos(ev.pos())
@@ -298,7 +291,7 @@ class Canvas(QtWidgets.QWidget):
                         self.finalise()
                 elif not self.outOfPixmap(pos):
                     # Create new shape.
-                    self.current = Shape()
+                    self.current = Shape(shape_type=self.createMode)
                     self.current.addPoint(pos)
                     if self.createMode == 'point':
                         self.finalise()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,7 +53,7 @@ def test_MainWindow_annotate_jpg(qtbot):
         (986, 742),
         (1184, 102),
     ]
-    shape = label, points, None, None
+    shape = label, points, None, None, 'polygon'
     shapes = [shape]
     win.loadLabels(shapes)
     win.saveFile()


### PR DESCRIPTION
Refer to `shape_type` introduced for `circle` in https://github.com/wkentaro/labelme/pull/236

cc @latticetower 

This may cause some conflicts with your commits, so please fix them if you don't mind.
Or I will do that soon.

This allows rectangle modification after annotating it.

![kapture 2018-11-02 at 9 20 02](https://user-images.githubusercontent.com/4310419/47907116-85667800-de82-11e8-83d0-b9f4eb33268f.gif)
