### PR TITLE
store image size

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1066,8 +1066,6 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
                 self.imagePath = filename
                 if QtGui.QImage.fromData(self.imageData).isNull():
                     self.imageData = self.convertImageDataToPng(self.imageData)
-
-
             self.labelFile = None
         image = QtGui.QImage.fromData(self.imageData)
         if image.isNull():

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -877,6 +877,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
                 shapes=shapes,
                 imagePath=imagePath,
                 imageData=imageData,
+                imageSize=self.imageSize,
                 lineColor=self.lineColor.getRgb(),
                 fillColor=self.fillColor.getRgb(),
                 otherData=self.otherData,
@@ -1059,11 +1060,14 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
             # Load image:
             # read data first and store for saving into label file.
             self.imageData = read(filename, None)
+            self.imageSize = None
             if self.imageData is not None:
                 # the filename is image not JSON
                 self.imagePath = filename
                 if QtGui.QImage.fromData(self.imageData).isNull():
                     self.imageData = self.convertImageDataToPng(self.imageData)
+
+
             self.labelFile = None
         image = QtGui.QImage.fromData(self.imageData)
         if image.isNull():
@@ -1076,6 +1080,7 @@ class MainWindow(QtWidgets.QMainWindow, WindowMixin):
                 .format(filename, ','.join(formats)))
             self.status("Error reading %s" % filename)
             return False
+        self.imageSize = [image.width(), image.height()]
         self.image = image
         self.filename = filename
         if self._config['keep_prev']:

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -33,6 +33,7 @@ class LabelFile(object):
             'fillColor',
             'shapes',  # polygonal annotations
             'flags',   # image level flags
+            'imageSize',  # image size: [width, height]
         ]
         try:
             with open(filename, 'rb' if PY2 else 'r') as f:
@@ -47,6 +48,10 @@ class LabelFile(object):
                     imageData = f.read()
             flags = data.get('flags')
             imagePath = data['imagePath']
+            if 'imageSize' in data:
+                imageSize = data['imageSize']
+            else:
+                imageSize = None
             lineColor = data['lineColor']
             fillColor = data['fillColor']
             shapes = (
@@ -72,12 +77,13 @@ class LabelFile(object):
         self.shapes = shapes
         self.imagePath = imagePath
         self.imageData = imageData
+        self.imageSize = imageSize
         self.lineColor = lineColor
         self.fillColor = fillColor
         self.filename = filename
         self.otherData = otherData
 
-    def save(self, filename, shapes, imagePath, imageData=None,
+    def save(self, filename, shapes, imagePath, imageSize, imageData=None,
              lineColor=None, fillColor=None, otherData=None,
              flags=None):
         if imageData is not None:
@@ -94,6 +100,7 @@ class LabelFile(object):
             fillColor=fillColor,
             imagePath=imagePath,
             imageData=imageData,
+            imageSize=imageSize,
         )
         for key, value in otherData.items():
             data[key] = value


### PR DESCRIPTION
Store image size in the output json file.
That should make json self contain and avoid loading/decoding original
image to get size annotation is made for. 
Quite noticeable for big datasets.