### PR TITLE
Fix problem saving to output directory

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -660,7 +660,8 @@ class MainWindow(QtWidgets.QMainWindow):
         if self._config['auto_save'] or self.actions.saveAuto.isChecked():
             label_file = osp.splitext(self.imagePath)[0] + '.json'
             if self.output_dir:
-                label_file = osp.join(self.output_dir, label_file)
+                label_file_without_path = osp.basename(label_file)
+                label_file = osp.join(self.output_dir, label_file_without_path)
             self.saveLabels(label_file)
             return
         self.dirty = True
@@ -1120,7 +1121,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.status("Loading %s..." % osp.basename(str(filename)))
         label_file = osp.splitext(filename)[0] + '.json'
         if self.output_dir:
-            label_file = osp.join(self.output_dir, label_file)
+            label_file_without_path = osp.basename(label_file)
+            label_file = osp.join(self.output_dir, label_file_without_path)
         if QtCore.QFile.exists(label_file) and \
                 LabelFile.is_label_file(label_file):
             try:
@@ -1369,7 +1371,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dlg.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
         dlg.setOption(QtWidgets.QFileDialog.DontConfirmOverwrite, False)
         dlg.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, False)
-        basename = osp.splitext(self.filename)[0]
+        basename = osp.basename(osp.splitext(self.filename)[0])
         if self.output_dir:
             default_labelfile_name = osp.join(
                 self.output_dir, basename + LabelFile.suffix
@@ -1566,7 +1568,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 continue
             label_file = osp.splitext(filename)[0] + '.json'
             if self.output_dir:
-                label_file = osp.join(self.output_dir, label_file)
+                label_file_without_path = osp.basename(label_file)
+                label_file = osp.join(self.output_dir, label_file_without_path)
             item = QtWidgets.QListWidgetItem(filename)
             item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
             if QtCore.QFile.exists(label_file) and \


### PR DESCRIPTION
When images were open using a full filepath (either specified from the command line or from the dialogue that pops up in response to the "Open" or "Open Dir" QT buttons), they were not saved in the location that the user specified. Instead, they were being saved in the same directory as the image. This bug was caused by how Python's os.path.join() function handles full file paths given as the second argument. For example, os.path.join('first/path', '/second/full/path') will just return '/second/full/path'.

To recreate this problem, run "labelme --output path/to/output/directory --autosave /full/path/to/image.jpg" without the fix. Create a polygon on the image and click save. Notice that the save dialog opens up to "/full/path/to/". Even if you go to File->Change Output Dir and select a directory, the save dialog still opens up to "/full/path/to/". If you apply this fix and then repeat these steps, now the save dialog opens up to "--output path/to/output/directory". The same problem occurred when the "--autosave" flag was used. But this fix corrects this problem as well.

One issue that this change creates is when a directory that is being labeled contains subdirectory1/image.jpg and subdirectory2/image.jpg. This change would cause both of these images to use the label file "path/to/output/directory/image.json". However, I don't think this is a huge problem. This would already occur without the change if the directory being labeled contains image.jpg and image.gif. In addition, the program shows users existing annotations for a file. So this change should never cause someone to accidentally overwrite an existing annotation. People will see the annotations from subdirectory1/image.jpg when they go to annotate subdirectory2/image.jpg and realize that they either have to change the name of one of these files or not specify an output directory. 