### PR TITLE
Fix missing fields

### DIFF
--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -135,13 +135,7 @@ def main():
             mask = np.asfortranarray(mask.astype(np.uint8))
             mask = pycocotools.mask.encode(mask)
             area = float(pycocotools.mask.area(mask))
-
-            bbox = []
-            for points in segmentations[label]:
-                bbox.extend(points)
-            bbox = np.asarray(bbox).reshape((-1, 2))
-            xmin, ymin = np.amin(bbox, axis=0).tolist();
-            xmax, ymax = np.amax(bbox, axis=0).tolist();
+            bbox = pycocotools.mask.toBbox(mask).flatten().tolist()
 
             data['annotations'].append(dict(
                 id=len(data['annotations']),
@@ -149,8 +143,8 @@ def main():
                 category_id=cls_id,
                 segmentation=segmentations[label],
                 area=area,
-                bbox=[xmin, ymin, xmax - xmin, ymax - ymin],
-                iscrowd=None,
+                bbox=bbox,
+                iscrowd=0,
             ))
 
     with open(out_ann_file, 'w') as f:

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -136,13 +136,21 @@ def main():
             mask = pycocotools.mask.encode(mask)
             area = float(pycocotools.mask.area(mask))
 
+            bbox = []
+            for points in segmentations[label]:
+                bbox.extend(points)
+            bbox = np.asarray(bbox).reshape((-1, 2))
+            xmin, ymin = np.amin(bbox, axis=0).tolist();
+            xmax, ymax = np.amax(bbox, axis=0).tolist();
+
             data['annotations'].append(dict(
                 id=len(data['annotations']),
-                segmentation=segmentations[label],
-                area=area,
-                iscrowd=None,
                 image_id=image_id,
                 category_id=cls_id,
+                segmentation=segmentations[label],
+                area=area,
+                bbox=[xmin, ymin, xmax - xmin, ymax - ymin],
+                iscrowd=None,
             ))
 
     with open(out_ann_file, 'w') as f:


### PR DESCRIPTION
Converting annotations into [COCO format](http://cocodataset.org/#format-data):
- Add missing 'bbox' field.
- 'iscrowd' is 0 when using polygons to represent segmentation.