### PR TITLE
add feature: instance label auto increment

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1034,7 +1034,15 @@ class MainWindow(QtWidgets.QMainWindow):
         if items:
             text = items[0].text()
         if self._config['display_label_popup'] or not text:
+            # instance label auto increment
+            if self._config['instance_label_auto_increment']:
+                previous_label = self.labelDialog.edit.text()
+                split = previous_label.split('-')
+                if len(split) > 1 and split[-1].isdigit():
+                    split[-1] = str(int(split[-1]) + 1)
+                    text = '-'.join(split)
             text = self.labelDialog.popUp(text)
+
         if text is not None and not self.validateLabel(text):
             self.errorMessage('Invalid label',
                               "Invalid label '{}' with validation type '{}'"

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -1,5 +1,6 @@
 auto_save: false
 display_label_popup: true
+instance_label_auto_increment: true
 store_data: true
 keep_prev: false
 logger_level: info


### PR DESCRIPTION
Add a convenient instance label auto increment feature:
- The ending number of a new instance label (`.*-[0-9]*$`) will be automatically incremented by one in the popup label dialog, e.g. person-1 => person-2.
- This feature is helpful when doing instance labeling continuously.