### PR TITLE
Exponential zooming and relative stickiness.

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -346,10 +346,10 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.zoomWidget.setEnabled(False)
 
-        zoomIn = action('Zoom &In', functools.partial(self.addZoom, 10),
+        zoomIn = action('Zoom &In', functools.partial(self.addZoom, 1.1),
                         shortcuts['zoom_in'], 'zoom-in',
                         'Increase zoom level', enabled=False)
-        zoomOut = action('&Zoom Out', functools.partial(self.addZoom, -10),
+        zoomOut = action('&Zoom Out', functools.partial(self.addZoom, 0.9),
                          shortcuts['zoom_out'], 'zoom-out',
                          'Decrease zoom level', enabled=False)
         zoomOrg = action('&Original size',
@@ -1069,13 +1069,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.zoomMode = self.MANUAL_ZOOM
         self.zoomWidget.setValue(value)
 
-    def addZoom(self, increment=10):
-        self.setZoom(self.zoomWidget.value() + increment)
+    def addZoom(self, increment=1.1):
+        self.setZoom(self.zoomWidget.value() * increment)
 
     def zoomRequest(self, delta, pos):
         canvas_width_old = self.canvas.width()
-
-        units = delta * 0.1
+        units = 1.1
+        if delta < 0:
+            units = 0.9
         self.addZoom(units)
 
         canvas_width_new = self.canvas.width()

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -40,7 +40,7 @@ fit_to_content:
   column: true
   row: false
 
-epsilon: 11.0
+epsilon: 10.0
 
 shortcuts:
   close: Ctrl+W

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -36,7 +36,7 @@ class Canvas(QtWidgets.QWidget):
     _fill_drawing = False
 
     def __init__(self, *args, **kwargs):
-        self.epsilon = kwargs.pop('epsilon', 11.0)
+        self.epsilon = kwargs.pop('epsilon', 10.0)
         super(Canvas, self).__init__(*args, **kwargs)
         # Initialise local state.
         self.mode = self.EDIT
@@ -542,7 +542,8 @@ class Canvas(QtWidgets.QWidget):
         # d = distance(p1 - p2)
         # m = (p1-p2).manhattanLength()
         # print "d %.2f, m %d, %.2f" % (d, m, d - m)
-        return labelme.utils.distance(p1 - p2) < self.epsilon
+        # divide by scale to allow more precision when zoomed in
+        return labelme.utils.distance(p1 - p2) < (self.epsilon / self.scale)
 
     def intersectionPoint(self, p1, p2):
         # Cycle through each image edge in clockwise fashion,

--- a/labelme/widgets/zoom_widget.py
+++ b/labelme/widgets/zoom_widget.py
@@ -8,7 +8,7 @@ class ZoomWidget(QtWidgets.QSpinBox):
     def __init__(self, value=100):
         super(ZoomWidget, self).__init__()
         self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
-        self.setRange(1, 500)
+        self.setRange(10, 1000)
         self.setSuffix(' %')
         self.setValue(value)
         self.setToolTip('Zoom Level')


### PR DESCRIPTION
## Exponential zooming

Exponential zooming gives better control than linear zooming.
- Change `zoomWidget.value() + increment` to `zoomWidget.value() * increment`
- Change increment from -10 or 10 to 0.9 or 1.1
- Change minZoom from 1 to 10, because you can never zoom back in after reaching 1
- Change maxZoom from 500 to 1000, because zooming at this level goes faster now

## Scaling stickiness

Currently the 'snap-to-point' sensitivity or 'stickiness' is too high when zoomed in, but too low when zoomed out. The sensitivity should be relative to the size of the screen, not relative to the size of the image. When zooming in this would allow more control, while still remaining the 'snap-to-point' ability when zooming out.

- Dividing the sensitivity epsilon by the scale of the canvas to allow more 'snap-to-point' sensitivity when zoomed out and less sensitivity when zoomed in: `distance < (epsilon / scale)`
- The default epsilon is changed from 11.0 to 10.0 as this value exactly allows pixel perfect sensitivity at the new maxZoom level of 1000, while maintaining a good sensitivity when zoomed out