### PR TITLE
Add directory config options

### DIFF
--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -77,3 +77,32 @@ def get_config(config_from_args=None, config_file=None):
                     validate_item=validate_config_item)
 
     return config
+
+
+def get_default_directory_config(config):
+    return config['default_directory_config']
+
+
+def get_directory_config(config, config_file=None):
+    # Configuration load order:
+    #
+    #   1. default config
+    #   2. config file from input directory
+
+    # 1. default config
+    directory_config = get_default_directory_config(config)
+
+    # 2. config from yaml file
+    if config_file is not None:
+        if osp.exists(config_file):
+            with open(config_file) as f:
+                user_config = yaml.load(f) or {}
+            update_dict(
+                directory_config, user_config,
+                validate_item=validate_config_item
+            )
+        else:
+            with open(config_file, 'w') as f:
+                yaml.safe_dump(config, f, default_flow_style=False)
+
+    return directory_config

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -33,6 +33,18 @@ file_dock:
   movable: true
   floatable: true
 
+#directory config
+directory_config: false
+#default config
+default_directory_config:
+  relative_paths: false
+  label_directory: null
+  label_file_prefix: null
+  label_file_postfix: null
+  image_directory: null
+  output_directory: null
+  
+
 # label_dialog
 show_label_text_field: true
 label_completion: startswith


### PR DESCRIPTION
Add optional directory config file with directory options
  relative_paths: false #use relative path from image directory in load/saving label files
  label_directory: null #optional - relative directory from open directory to labels
  label_file_prefix: null #optional - prefix for label files
  label_file_postfix: null #optional - postfix for label files
  image_directory: null #optional - relative directory from open directory to labels
  output_directory: null #optional - output directory for labels, defaults to current directory

Altered save to use output_dir if available.