### PR TITLE
Disable 'add point to edge' feature for circle, line, point and rectangle

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -481,7 +481,7 @@ class MainWindow(QtWidgets.QMainWindow):
             onShapesPresent=(saveAs, hideAll, showAll),
         )
 
-        self.canvas.possibleToAddPoint.connect(self.actions.addPointToEdge.setEnabled)
+        self.canvas.edgeSelected.connect(self.canvasShapeEdgeSelected)
 
         self.menus = utils.struct(
             file=self.menu('&File'),
@@ -717,6 +717,11 @@ class MainWindow(QtWidgets.QMainWindow):
             z.setEnabled(value)
         for action in self.actions.onLoadActive:
             action.setEnabled(value)
+
+    def canvasShapeEdgeSelected(self, selected, shape):
+        self.actions.addPointToEdge.setEnabled(
+            selected and shape and shape.canAddPoint()
+        )
 
     def queueEvent(self, function):
         QtCore.QTimer.singleShot(0, function)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -481,9 +481,7 @@ class MainWindow(QtWidgets.QMainWindow):
             onShapesPresent=(saveAs, hideAll, showAll),
         )
 
-        self.canvas.edgeSelected.connect(
-            self.actions.addPointToEdge.setEnabled
-        )
+        self.canvas.possibleToAddPoint.connect(self.actions.addPointToEdge.setEnabled)
 
         self.menus = utils.struct(
             file=self.menu('&File'),

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -84,6 +84,9 @@ class Shape(object):
         else:
             self.points.append(point)
 
+    def canAddPoint(self):
+        return self.shape_type in ['polygon', 'linestrip']
+
     def popPoint(self):
         if self.points:
             return self.points.pop()

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -26,7 +26,7 @@ class Canvas(QtWidgets.QWidget):
     selectionChanged = QtCore.Signal(list)
     shapeMoved = QtCore.Signal()
     drawingPolygon = QtCore.Signal(bool)
-    edgeSelected = QtCore.Signal(bool)
+    possibleToAddPoint = QtCore.Signal(bool)
 
     CREATE, EDIT = 0, 1
 
@@ -267,7 +267,7 @@ class Canvas(QtWidgets.QWidget):
                 self.hShape.highlightClear()
                 self.update()
             self.hVertex, self.hShape, self.hEdge = None, None, None
-        self.edgeSelected.emit(self.hEdge is not None)
+        self.possibleToAddPoint.emit(self.hEdge is not None and self.hShape is not None and self.hShape.canAddPoint())
 
     def addPointToEdge(self):
         if (self.hShape is None and

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -26,7 +26,7 @@ class Canvas(QtWidgets.QWidget):
     selectionChanged = QtCore.Signal(list)
     shapeMoved = QtCore.Signal()
     drawingPolygon = QtCore.Signal(bool)
-    possibleToAddPoint = QtCore.Signal(bool)
+    edgeSelected = QtCore.Signal(bool, object)
 
     CREATE, EDIT = 0, 1
 
@@ -267,7 +267,7 @@ class Canvas(QtWidgets.QWidget):
                 self.hShape.highlightClear()
                 self.update()
             self.hVertex, self.hShape, self.hEdge = None, None, None
-        self.possibleToAddPoint.emit(self.hEdge is not None and self.hShape is not None and self.hShape.canAddPoint())
+        self.edgeSelected.emit(self.hEdge is not None, self.hShape)
 
     def addPointToEdge(self):
         if (self.hShape is None and


### PR DESCRIPTION
Possible solution for #462.

Shape type is checked before the signal to allow adding points is emitted. The signal is emitted only if the shape type is polygon or linestrip (the only types where it is possible to add new points by right click on their edges).

The signal, originally called edgeSelected, was renamed to possibleToAddPoint because now it is not emitted every time an edge is selected.