### PR TITLE
Fix "No module named 'numpy.random.common'" in pyinstaller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,11 @@ script:
 
       # Build the standalone executable
       pip install 'pyinstaller!=3.4'  # 3.4 raises error
+
+      # numpy 1.17 raises error
+      # See https://github.com/wkentaro/labelme/issues/465
+      pip install 'numpy<1.17'
+
       pyinstaller labelme.spec
       dist/labelme --version
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       env:
         - PYTEST_QT_API=pyside2
         - CONDA_CHANNELS='conda-forge'
-        - PYQT_PACKAGE='pyside2'
+        - PYQT_PACKAGE='pyside2!=5.12.4'
         - PYTHON_VERSION=2.7
     - os: linux
       dist: trusty


### PR DESCRIPTION
Close #465