### PR TITLE
Fix outOfPixmap to solve crashing when outside of the pixmap

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -532,7 +532,7 @@ class Canvas(QtWidgets.QWidget):
 
     def outOfPixmap(self, p):
         w, h = self.pixmap.width(), self.pixmap.height()
-        return not (0 <= p.x() < w and 0 <= p.y() < h)
+        return not (0 <= p.x() <= w - 1 and 0 <= p.y() <= h - 1)
 
     def finalise(self):
         assert self.current


### PR DESCRIPTION
For https://github.com/wkentaro/labelme/issues/464
For https://github.com/wkentaro/labelme/issues/398