### PR TITLE
Add support for double clicking labels

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -76,6 +76,7 @@ class LabelDialog(QtWidgets.QDialog):
             self.labelList.setDragDropMode(
                 QtWidgets.QAbstractItemView.InternalMove)
         self.labelList.currentItemChanged.connect(self.labelSelected)
+        self.labelList.itemDoubleClicked.connect(self.labelDoubleClicked)
         self.edit.setListWidget(self.labelList)
         layout.addWidget(self.labelList)
         # label_flags
@@ -125,6 +126,9 @@ class LabelDialog(QtWidgets.QDialog):
             text = text.trimmed()
         if text:
             self.accept()
+
+    def labelDoubleClicked(self, item):
+        self.validate()
 
     def postProcess(self):
         text = self.edit.text()


### PR DESCRIPTION
Here's a simple patch that accepts the label selection widget when a label is double clicked. I found it useful and I think that the behavior is quite intuitive. What are your thoughts?