### PR TITLE
Add flag --no-vis to semantic_segmentation/labelme2voc.py

### DIFF
--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -28,6 +28,9 @@ def main():
     parser.add_argument('input_dir', help='input annotated directory')
     parser.add_argument('output_dir', help='output dataset directory')
     parser.add_argument('--labels', help='labels file', required=True)
+    parser.add_argument(
+        '--noviz', help='no visualization', action='store_true'
+    )
     args = parser.parse_args()
 
     if osp.exists(args.output_dir):
@@ -36,7 +39,8 @@ def main():
     os.makedirs(args.output_dir)
     os.makedirs(osp.join(args.output_dir, 'JPEGImages'))
     os.makedirs(osp.join(args.output_dir, 'Annotations'))
-    os.makedirs(osp.join(args.output_dir, 'AnnotationsVisualization'))
+    if not args.noviz:
+        os.makedirs(osp.join(args.output_dir, 'AnnotationsVisualization'))
     print('Creating dataset:', args.output_dir)
 
     class_names = []
@@ -67,8 +71,9 @@ def main():
             args.output_dir, 'JPEGImages', base + '.jpg')
         out_xml_file = osp.join(
             args.output_dir, 'Annotations', base + '.xml')
-        out_viz_file = osp.join(
-            args.output_dir, 'AnnotationsVisualization', base + '.jpg')
+        if not args.noviz:
+            out_viz_file = osp.join(
+                args.output_dir, 'AnnotationsVisualization', base + '.jpg')
 
         img_file = osp.join(osp.dirname(label_file), data['imagePath'])
         img = np.asarray(PIL.Image.open(img_file))
@@ -123,11 +128,12 @@ def main():
                 )
             )
 
-        captions = [class_names[l] for l in labels]
-        viz = labelme.utils.draw_instances(
-            img, bboxes, labels, captions=captions
-        )
-        PIL.Image.fromarray(viz).save(out_viz_file)
+        if not args.noviz:
+            captions = [class_names[l] for l in labels]
+            viz = labelme.utils.draw_instances(
+                img, bboxes, labels, captions=captions
+            )
+            PIL.Image.fromarray(viz).save(out_viz_file)
 
         with open(out_xml_file, 'wb') as f:
             f.write(lxml.etree.tostring(xml, pretty_print=True))

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -22,6 +22,9 @@ def main():
     parser.add_argument('input_dir', help='input annotated directory')
     parser.add_argument('output_dir', help='output dataset directory')
     parser.add_argument('--labels', help='labels file', required=True)
+    parser.add_argument(
+        '--noviz', help='no visualization', action='store_true'
+    )
     args = parser.parse_args()
 
     if osp.exists(args.output_dir):
@@ -31,10 +34,16 @@ def main():
     os.makedirs(osp.join(args.output_dir, 'JPEGImages'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationClass'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationClassPNG'))
-    os.makedirs(osp.join(args.output_dir, 'SegmentationClassVisualization'))
+    if not args.noviz:
+        os.makedirs(
+            osp.join(args.output_dir, 'SegmentationClassVisualization')
+        )
     os.makedirs(osp.join(args.output_dir, 'SegmentationObject'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationObjectPNG'))
-    os.makedirs(osp.join(args.output_dir, 'SegmentationObjectVisualization'))
+    if not args.noviz:
+        os.makedirs(
+            osp.join(args.output_dir, 'SegmentationObjectVisualization')
+        )
     print('Creating dataset:', args.output_dir)
 
     class_names = []
@@ -68,20 +77,22 @@ def main():
                 args.output_dir, 'SegmentationClass', base + '.npy')
             out_clsp_file = osp.join(
                 args.output_dir, 'SegmentationClassPNG', base + '.png')
-            out_clsv_file = osp.join(
-                args.output_dir,
-                'SegmentationClassVisualization',
-                base + '.jpg',
-            )
+            if not args.noviz:
+                out_clsv_file = osp.join(
+                    args.output_dir,
+                    'SegmentationClassVisualization',
+                    base + '.jpg',
+                )
             out_ins_file = osp.join(
                 args.output_dir, 'SegmentationObject', base + '.npy')
             out_insp_file = osp.join(
                 args.output_dir, 'SegmentationObjectPNG', base + '.png')
-            out_insv_file = osp.join(
-                args.output_dir,
-                'SegmentationObjectVisualization',
-                base + '.jpg',
-            )
+            if not args.noviz:
+                out_insv_file = osp.join(
+                    args.output_dir,
+                    'SegmentationObjectVisualization',
+                    base + '.jpg',
+                )
 
             data = json.load(f)
 
@@ -100,17 +111,20 @@ def main():
             # class label
             labelme.utils.lblsave(out_clsp_file, cls)
             np.save(out_cls_file, cls)
-            clsv = labelme.utils.draw_label(
-                cls, img, class_names, colormap=colormap)
-            PIL.Image.fromarray(clsv).save(out_clsv_file)
+            if not args.noviz:
+                clsv = labelme.utils.draw_label(
+                    cls, img, class_names, colormap=colormap
+                )
+                PIL.Image.fromarray(clsv).save(out_clsv_file)
 
             # instance label
             labelme.utils.lblsave(out_insp_file, ins)
             np.save(out_ins_file, ins)
-            instance_ids = np.unique(ins)
-            instance_names = [str(i) for i in range(max(instance_ids) + 1)]
-            insv = labelme.utils.draw_label(ins, img, instance_names)
-            PIL.Image.fromarray(insv).save(out_insv_file)
+            if not args.noviz:
+                instance_ids = np.unique(ins)
+                instance_names = [str(i) for i in range(max(instance_ids) + 1)]
+                insv = labelme.utils.draw_label(ins, img, instance_names)
+                PIL.Image.fromarray(insv).save(out_insv_file)
 
 
 if __name__ == '__main__':

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -16,7 +16,9 @@ labelme data_annotated --labels labels.txt --nodata
 #   - data_dataset_voc/JPEGImages
 #   - data_dataset_voc/SegmentationClass
 #   - data_dataset_voc/SegmentationClassVisualization
-./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt
+# Supports flags:
+#   --no-vis  -  No visualization results produced (SegementationClassVisualization)
+python ./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt
 ```
 
 <img src="data_dataset_voc/JPEGImages/2011_000003.jpg" width="33%" /> <img src="data_dataset_voc/SegmentationClassPNG/2011_000003.png" width="33%" /> <img src="data_dataset_voc/SegmentationClassVisualization/2011_000003.jpg" width="33%" />

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -16,9 +16,7 @@ labelme data_annotated --labels labels.txt --nodata
 #   - data_dataset_voc/JPEGImages
 #   - data_dataset_voc/SegmentationClass
 #   - data_dataset_voc/SegmentationClassVisualization
-# Supports flags:
-#   --no-vis  -  No visualization results produced (SegementationClassVisualization)
-python ./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt
+./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt
 ```
 
 <img src="data_dataset_voc/JPEGImages/2011_000003.jpg" width="33%" /> <img src="data_dataset_voc/SegmentationClassPNG/2011_000003.png" width="33%" /> <img src="data_dataset_voc/SegmentationClassVisualization/2011_000003.jpg" width="33%" />

--- a/examples/semantic_segmentation/labelme2voc.py
+++ b/examples/semantic_segmentation/labelme2voc.py
@@ -22,6 +22,8 @@ def main():
     parser.add_argument('input_dir', help='input annotated directory')
     parser.add_argument('output_dir', help='output dataset directory')
     parser.add_argument('--labels', help='labels file', required=True)
+    parser.add_argument('--no-vis', help='no visualization results to be created', action='store_false')
+
     args = parser.parse_args()
 
     if osp.exists(args.output_dir):
@@ -31,7 +33,8 @@ def main():
     os.makedirs(osp.join(args.output_dir, 'JPEGImages'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationClass'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationClassPNG'))
-    os.makedirs(osp.join(args.output_dir, 'SegmentationClassVisualization'))
+    if not args.no_vis:
+        os.makedirs(osp.join(args.output_dir, 'SegmentationClassVisualization'))
     print('Creating dataset:', args.output_dir)
 
     class_names = []
@@ -65,11 +68,12 @@ def main():
                 args.output_dir, 'SegmentationClass', base + '.npy')
             out_png_file = osp.join(
                 args.output_dir, 'SegmentationClassPNG', base + '.png')
-            out_viz_file = osp.join(
-                args.output_dir,
-                'SegmentationClassVisualization',
-                base + '.jpg',
-            )
+            if not args.no_vis:
+                out_viz_file = osp.join(
+                    args.output_dir,
+                    'SegmentationClassVisualization',
+                    base + '.jpg',
+                )
 
             data = json.load(f)
 
@@ -86,9 +90,10 @@ def main():
 
             np.save(out_lbl_file, lbl)
 
-            viz = labelme.utils.draw_label(
-                lbl, img, class_names, colormap=colormap)
-            PIL.Image.fromarray(viz).save(out_viz_file)
+            if not args.no_vis:
+                viz = labelme.utils.draw_label(
+                    lbl, img, class_names, colormap=colormap)
+                PIL.Image.fromarray(viz).save(out_viz_file)
 
 
 if __name__ == '__main__':

--- a/examples/semantic_segmentation/labelme2voc.py
+++ b/examples/semantic_segmentation/labelme2voc.py
@@ -22,8 +22,9 @@ def main():
     parser.add_argument('input_dir', help='input annotated directory')
     parser.add_argument('output_dir', help='output dataset directory')
     parser.add_argument('--labels', help='labels file', required=True)
-    parser.add_argument('--no-vis', help='no visualization results to be created', action='store_false')
-
+    parser.add_argument(
+        '--noviz', help='no visualization', action='store_true'
+    )
     args = parser.parse_args()
 
     if osp.exists(args.output_dir):
@@ -33,8 +34,10 @@ def main():
     os.makedirs(osp.join(args.output_dir, 'JPEGImages'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationClass'))
     os.makedirs(osp.join(args.output_dir, 'SegmentationClassPNG'))
-    if not args.no_vis:
-        os.makedirs(osp.join(args.output_dir, 'SegmentationClassVisualization'))
+    if not args.noviz:
+        os.makedirs(
+            osp.join(args.output_dir, 'SegmentationClassVisualization')
+        )
     print('Creating dataset:', args.output_dir)
 
     class_names = []
@@ -68,7 +71,7 @@ def main():
                 args.output_dir, 'SegmentationClass', base + '.npy')
             out_png_file = osp.join(
                 args.output_dir, 'SegmentationClassPNG', base + '.png')
-            if not args.no_vis:
+            if not args.noviz:
                 out_viz_file = osp.join(
                     args.output_dir,
                     'SegmentationClassVisualization',
@@ -90,7 +93,7 @@ def main():
 
             np.save(out_lbl_file, lbl)
 
-            if not args.no_vis:
+            if not args.noviz:
                 viz = labelme.utils.draw_label(
                     lbl, img, class_names, colormap=colormap)
                 PIL.Image.fromarray(viz).save(out_viz_file)


### PR DESCRIPTION
The script `examples/semantic_segmentation/labelme2voc.py` coverts labelme annotation files to PASCAL VOC format for semantic segmentation. 

**Background**
Currently the script produces visualization images (found in  `SegmentationClassVisualization` directory). While highly useful for visual feedback on annotations, it is not needed for semantic segmentation training.

**Reasoning**
For large datasets, visualization images can take up significant storage as one is created for each individual annotation. Furthermore visualization images aren't needed for semantic segmentation.

**Pull request adds** :

- `--no-vis` flag to `labelme2voc.py` which prevents any visualization images being created 

 

