### PR TITLE
Add option for changing PIL.Image.MAX_IMAGE_PIXELS

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1254,7 +1254,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if QtCore.QFile.exists(label_file) and \
                 LabelFile.is_label_file(label_file):
             try:
-                self.labelFile = LabelFile(label_file)
+                self.labelFile = LabelFile(label_file, self._config["max_image_pixels"])
             except LabelFileError as e:
                 self.errorMessage(
                     self.tr('Error opening file'),
@@ -1276,7 +1276,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.fillColor = QtGui.QColor(*self.labelFile.fillColor)
             self.otherData = self.labelFile.otherData
         else:
-            self.imageData = LabelFile.load_image_file(filename)
+            self.imageData = LabelFile.load_image_file(filename, self._config["max_image_pixels"])
             if self.imageData:
                 self.imagePath = filename
             self.labelFile = None

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1254,7 +1254,8 @@ class MainWindow(QtWidgets.QMainWindow):
         if QtCore.QFile.exists(label_file) and \
                 LabelFile.is_label_file(label_file):
             try:
-                self.labelFile = LabelFile(label_file, self._config["max_image_pixels"])
+                self.labelFile = LabelFile(
+                    label_file, self._config["max_image_pixels"])
             except LabelFileError as e:
                 self.errorMessage(
                     self.tr('Error opening file'),
@@ -1276,7 +1277,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.fillColor = QtGui.QColor(*self.labelFile.fillColor)
             self.otherData = self.labelFile.otherData
         else:
-            self.imageData = LabelFile.load_image_file(filename, self._config["max_image_pixels"])
+            self.imageData = LabelFile.load_image_file(
+                filename, self._config["max_image_pixels"])
             if self.imageData:
                 self.imagePath = filename
             self.labelFile = None

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -11,6 +11,7 @@ labels: null
 file_search: null
 sort_labels: true
 validate_label: null
+max_image_pixels: null
 
 # main
 flag_dock:

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -20,17 +20,18 @@ class LabelFile(object):
 
     suffix = '.json'
 
-    def __init__(self, filename=None):
+    def __init__(self, filename=None, maxImagePixels=None):
         self.shapes = ()
         self.imagePath = None
         self.imageData = None
         if filename is not None:
             self.load(filename)
-        self.filename = filename
-
+        self.maxImagePixels = maxImagePixels
     @staticmethod
-    def load_image_file(filename):
+    def load_image_file(filename, max_image_pixels=None):
         try:
+            if max_image_pixels is not None:
+                PIL.Image.MAX_IMAGE_PIXELS = max_image_pixels
             image_pil = PIL.Image.open(filename)
         except IOError:
             logger.error('Failed opening image file: {}'.format(filename))
@@ -72,7 +73,7 @@ class LabelFile(object):
             else:
                 # relative path from label file to relative path from cwd
                 imagePath = osp.join(osp.dirname(filename), data['imagePath'])
-                imageData = self.load_image_file(imagePath)
+                imageData = self.load_image_file(imagePath, self.max_image_pixels)
             flags = data.get('flags') or {}
             imagePath = data['imagePath']
             self._check_image_height_and_width(

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -27,6 +27,7 @@ class LabelFile(object):
         if filename is not None:
             self.load(filename)
         self.maxImagePixels = maxImagePixels
+
     @staticmethod
     def load_image_file(filename, max_image_pixels=None):
         try:

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -73,7 +73,8 @@ class LabelFile(object):
             else:
                 # relative path from label file to relative path from cwd
                 imagePath = osp.join(osp.dirname(filename), data['imagePath'])
-                imageData = self.load_image_file(imagePath, self.max_image_pixels)
+                imageData = self.load_image_file(
+                    imagePath, self.max_image_pixels)
             flags = data.get('flags') or {}
             imagePath = data['imagePath']
             self._check_image_height_and_width(

--- a/labelme/main.py
+++ b/labelme/main.py
@@ -141,9 +141,6 @@ def main():
         else:
             args.label_flags = yaml.safe_load(args.label_flags)
 
-    if not hasattr(args, 'max_image_pixels'):
-        args.max_image_pixels = None
-
     config_from_args = args.__dict__
     config_from_args.pop('version')
     reset_config = config_from_args.pop('reset_config')

--- a/labelme/main.py
+++ b/labelme/main.py
@@ -108,7 +108,7 @@ def main():
     parser.add_argument(
         '--max-image-pixels',
         type=int,
-        help='for large images, raise PIL\'s default maximum pixel count using this option',
+        help='raise PIL\'s max pixels limit',
         dest='max_image_pixels',
         default=None
     )
@@ -141,7 +141,7 @@ def main():
         else:
             args.label_flags = yaml.safe_load(args.label_flags)
 
-    if not hasattr(args, 'max_image_pixels'): #add more
+    if not hasattr(args, 'max_image_pixels'):
         args.max_image_pixels = None
 
     config_from_args = args.__dict__

--- a/labelme/main.py
+++ b/labelme/main.py
@@ -130,9 +130,9 @@ def main():
     if hasattr(args, 'label_flags'):
         if os.path.isfile(args.label_flags):
             with codecs.open(args.label_flags, 'r', encoding='utf-8') as f:
-                args.label_flags = yaml.load(f)
+                args.label_flags = yaml.safe_load(f)
         else:
-            args.label_flags = yaml.load(args.label_flags)
+            args.label_flags = yaml.safe_load(args.label_flags)
 
     config_from_args = args.__dict__
     config_from_args.pop('version')

--- a/labelme/main.py
+++ b/labelme/main.py
@@ -105,6 +105,13 @@ def main():
         help='epsilon to find nearest vertex on canvas',
         default=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        '--max-image-pixels',
+        type=int,
+        help='for large images, raise PIL\'s default maximum pixel count using this option',
+        dest='max_image_pixels',
+        default=None
+    )
     args = parser.parse_args()
 
     if args.version:
@@ -133,6 +140,9 @@ def main():
                 args.label_flags = yaml.safe_load(f)
         else:
             args.label_flags = yaml.safe_load(args.label_flags)
+
+    if not hasattr(args, 'max_image_pixels'): #add more
+        args.max_image_pixels = None
 
     config_from_args = args.__dict__
     config_from_args.pop('version')


### PR DESCRIPTION
Fixes #519

New argument: "--max-image-pixels" (default = None)
New config setting: "max_image_pixels" (default = null)
New argument in LabelFile.load_image_file: "max_image_pixels" (default = None)

If the max_image_pixels argument is not None, then it will become the new MAX_IMAGE_PIXELS setting.

Note: when I ran labelme using a [large image](https://www.flickr.com/photos/88572252@N06/38400322472/in/pool-veryverylargephotos/), I only saw a warning, not an error. Still, this code should prevent the error as well.