### PR TITLE
Merge image flags from config and label file

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1317,12 +1317,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if self._config['keep_prev']:
             prev_shapes = self.canvas.shapes
         self.canvas.loadPixmap(QtGui.QPixmap.fromImage(image))
-        if self._config['flags']:
-            self.loadFlags({k: False for k in self._config['flags']})
+        flags = {k: False for k in self._config['flags'] or []}
         if self.labelFile:
             self.loadLabels(self.labelFile.shapes)
             if self.labelFile.flags is not None:
-                self.loadFlags(self.labelFile.flags)
+                flags.update(self.labelFile.flags)
+        self.loadFlags(flags)
         if self._config['keep_prev'] and not self.labelList.shapes:
             self.loadShapes(prev_shapes, replace=False)
             self.setDirty()


### PR DESCRIPTION
I've encountered the issue that flags from config don't show in the Flags widget in the interface if there is flags key in label file during loading the image. This small change fix this issue.