### PR TITLE
fix issue with grayscale images in draw_json

### DIFF
--- a/labelme/cli/draw_json.py
+++ b/labelme/cli/draw_json.py
@@ -48,11 +48,9 @@ def main():
     label_names = [None] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():
         label_names[value] = name
-    if len(img.shape) < 3:
-        img = imgviz.gray2rgb(img)
     lbl_viz = imgviz.label2rgb(
         label=lbl,
-        img=imgviz.rgb2gray(img),
+        img=imgviz.asgray(img),
         label_names=label_names,
         font_size=30,
         loc='rb',

--- a/labelme/cli/draw_json.py
+++ b/labelme/cli/draw_json.py
@@ -48,6 +48,8 @@ def main():
     label_names = [None] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():
         label_names[value] = name
+    if len(img.shape) < 3:
+        img = imgviz.gray2rgb(img)
     lbl_viz = imgviz.label2rgb(
         label=lbl,
         img=imgviz.rgb2gray(img),


### PR DESCRIPTION
When the image data in the json represents a grayscale image you currently get an assertion error when calling imgviz.rgb2gray(img).
The added code snippet should fix this issue.