### PR TITLE
Update readme for Windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,13 @@ brew cask install wkentaro/labelme/labelme
 
 ### Windows
 
-Firstly, follow instruction in [Anaconda](#anaconda).
+Install [Anaconda](https://www.continuum.io/downloads), then in an Anaconda Prompt run:
 
 ```bash
-# Pillow 5 causes dll load error on Windows.
-# https://github.com/wkentaro/labelme/pull/174
-conda install pillow=4.0.0
+# python3
+conda create --name=labelme python=3.6
+conda activate labelme
+pip install labelme
 ```
 
 


### PR DESCRIPTION
Since pillow version 7 works on Windows, there is no need to specifically install version 4 any more, so take this instruction out of the readme.

On Windows, the `source` command produces an error:

    'source' is not recognized as an internal or external command,
    operable program or batch file.

So update the setup instructions to invoke the `conda` binary instead.