### PR TITLE
Fixed edit error

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -918,7 +918,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setDirty()
         if not self.uniqLabelList.findItemsByLabel(shape.label):
             item = QtWidgets.QListWidgetItem()
-            item.setData(role=Qt.UserRole, value=shape.label)
+            item.setData(Qt.UserRole, shape.label)
             self.uniqLabelList.addItem(item)
 
     def fileSearchChanged(self):


### PR DESCRIPTION
When editing a label with an group ID and u delete it, labelme crashed:

Fixed error "TypeError: setData() takes no keyword arguments"

Deleting the keywords fixed this error