### PR TITLE
Fix for core dumped after creating any label

### DIFF
--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -45,7 +45,7 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
 
         textRect = style.subElementRect(
             QStyle.SE_ItemViewItemText, options, None
-            )
+        )
 
         if index.column() != 0:
             textRect.adjust(5, 0, 0, 0)

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -43,7 +43,7 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
                 option.palette.color(QPalette.Active, QPalette.Text),
             )
 
-        textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options)
+        textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options, NULL)
 
         if index.column() != 0:
             textRect.adjust(5, 0, 0, 0)

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -43,7 +43,7 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
                 option.palette.color(QPalette.Active, QPalette.Text),
             )
 
-        textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options, NULL)
+        textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options, None)
 
         if index.column() != 0:
             textRect.adjust(5, 0, 0, 0)

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -43,7 +43,9 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
                 option.palette.color(QPalette.Active, QPalette.Text),
             )
 
-        textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options, None)
+        textRect = style.subElementRect(
+            QStyle.SE_ItemViewItemText, options, None
+            )
 
         if index.column() != 0:
             textRect.adjust(5, 0, 0, 0)


### PR DESCRIPTION
Had to add a NULL parameter at line 46, probably due to version issue in Qt since there's a reimplementation of the subElementRect function.

See:
https://doc.qt.io/qt-5/qcommonstyle.html

Error log:
[me@my-pc folder]$ labelme
[INFO] Loading config file from: /home/myuser/.labelmerc (__init__.py:72)
qt5ct: using qt5ct plugin
qt5ct: D-Bus global menu: no
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/labelme/widgets/label_list_widget.py", line 46, in paint
    textRect = style.subElementRect(QStyle.SE_ItemViewItemText, options)
TypeError: subElementRect(self, QStyle.SubElement, QStyleOption, QWidget): not enough arguments
Aborted (core dumped)