### PR TITLE
avoid error -- cannot write mode P as JPEG

### DIFF
--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -34,7 +34,7 @@ class LabelFile(object):
     @staticmethod
     def load_image_file(filename):
         try:
-            image_pil = PIL.Image.open(filename)
+            image_pil = PIL.Image.open(filename).convert('RGB')
         except IOError:
             logger.error('Failed opening image file: {}'.format(filename))
             return


### PR DESCRIPTION
an error "cannot write mode P as JPEG" would occasionally occur when reading .jpg image into GUI
it's a simple fix to avoid that.