### PR TITLE
Set transparent shape fill_color while drawing

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -22,7 +22,7 @@ label_colors: null
 shape:
   # drawing
   line_color: [0, 255, 0, 128]
-  fill_color: [0, 255, 0, 64]
+  fill_color: [0, 255, 0, 0]  # transparent
   vertex_fill_color: [0, 255, 0, 255]
   # selecting / hovering
   select_line_color: [255, 255, 255, 255]


### PR DESCRIPTION
I found this is not very useful especially when we're annotating
concave-shaped objects.

Related to https://github.com/wkentaro/labelme/issues/690