### PR TITLE
streamline colorama dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def get_install_requires():
         "PyYAML",
         "qtpy",
         "termcolor",
+        "colorama ; platform_system=='Windows'",
     ]
 
     # Find python binding for qt with priority:
@@ -76,10 +77,6 @@ def get_install_requires():
             install_requires.append("PyQt5")
             QT_BINDING = "pyqt5"
     del QT_BINDING
-
-    if os.name == "nt":  # Windows
-        install_requires.append("colorama")
-
     return install_requires
 
 


### PR DESCRIPTION
Just a slight syntax change.

As a downstream packager, I find it quite confusing to have to decipher through if and else statements when hardcoding dependencies for the conda package.

I find this syntax cleaner.

Feel free to close if you don't agree.

Thanks for a cool package!

https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies