### PR TITLE
Add functionality to change point size using the config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,5 +139,6 @@ jobs:
         # Build the standalone executable
         pip install 'pyinstaller!=3.4'
         pip install 'setuptools<45.0.0'
+        pip install 'matplotlib'
         pyinstaller labelme.spec
         dist/labelme --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,5 @@ jobs:
         # Build the standalone executable
         pip install 'pyinstaller!=3.4'
         pip install 'setuptools<45.0.0'
-        pip install 'matplotlib'
         pyinstaller labelme.spec
         dist/labelme --version

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 .DS_Store
 .idea/
+
+/.anaconda3/*

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -86,6 +86,9 @@ class MainWindow(QtWidgets.QMainWindow):
             *self._config["shape"]["hvertex_fill_color"]
         )
 
+        # Set point size from config file
+        Shape.point_size = self._config["shape"]["point_size"]
+
         super(MainWindow, self).__init__()
         self.setWindowTitle(__appname__)
 

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -28,6 +28,7 @@ shape:
   select_line_color: [255, 255, 255, 255]
   select_fill_color: [0, 255, 0, 155]
   hvertex_fill_color: [255, 255, 255, 255]
+  point_size: 2
 
 # main
 flag_dock:

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -28,7 +28,7 @@ shape:
   select_line_color: [255, 255, 255, 255]
   select_fill_color: [0, 255, 0, 155]
   hvertex_fill_color: [255, 255, 255, 255]
-  point_size: 2
+  point_size: 8
 
 # main
 flag_dock:

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -33,7 +33,6 @@ class Shape(object):
     vertex_fill_color = DEFAULT_VERTEX_FILL_COLOR
     hvertex_fill_color = DEFAULT_HVERTEX_FILL_COLOR
     point_type = P_ROUND
-    point_size = 8
     scale = 1.0
 
     def __init__(


### PR DESCRIPTION
This allows a user to change the point size to be larger or smaller than the default size 8. This is done through the config file. Useful for annotating images with very small objects, which is why I made these changes to my own version of labelme in the first place. 