### PR TITLE
Add available shape_type to labelme2voc.py in example of bbox_detection

### DIFF
--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -94,21 +94,31 @@ def main():
         bboxes = []
         labels = []
         for shape in label_file.shapes:
-            if shape["shape_type"] != "rectangle":
+            # cannot define bbox
+            if shape["shape_type"] == "point":
                 print(
                     "Skipping shape: label={label}, "
                     "shape_type={shape_type}".format(**shape)
                 )
                 continue
-
+            elif shape["shape_type"] == "circle":
+                center = shape["points"][0]
+                outside = shape["points"][1]
+                radius = ((center[0] - outside[0])**2.0 +
+                          (center[1] - outside[1])**2.0) ** 0.5
+                xmin, xmax = center[0] - radius, center[0] + radius
+                ymin, ymax = center[1] - radius, center[1] + radius
+            else:
+                xs, ys = [], []
+                for point in shape["points"]:
+                    xs.append(point[0])
+                    ys.append(point[1])
+                xmin, xmax = min(xs), max(xs)
+                ymin, ymax = min(ys), max(ys)
+            
             class_name = shape["label"]
-            class_id = class_names.index(class_name)
-
-            (xmin, ymin), (xmax, ymax) = shape["points"]
-            # swap if min is larger than max.
-            xmin, xmax = sorted([xmin, xmax])
-            ymin, ymax = sorted([ymin, ymax])
-
+            class_id = class_names.index(class_name)            
+            
             bboxes.append([ymin, xmin, ymax, xmax])
             labels.append(class_id)
 

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -120,7 +120,7 @@ def main():
             if class_name == "__ignore__":
                 continue
             if shape["shape_type"] != "rectangle":
-                print("Be careful, {shape_type} was conterted rectangle".format(**shape))
+                print("Be careful, {shape_type}(other than rectangle) was conterted to bounding box!".format(**shape))
             class_id = class_names.index(class_name)            
             
             bboxes.append([ymin, xmin, ymax, xmax])

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -117,6 +117,7 @@ def main():
                 ymin, ymax = min(ys), max(ys)
             
             class_name = shape["label"]
+            print(class_name)
             class_id = class_names.index(class_name)            
             
             bboxes.append([ymin, xmin, ymax, xmax])

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -18,7 +18,6 @@ except ImportError:
     print("Please install lxml:\n\n    pip install lxml\n")
     sys.exit(1)
 
-
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -53,6 +52,7 @@ def main():
         elif class_id == 0:
             assert class_name == "_background_"
         class_names.append(class_name)
+
     class_names = tuple(class_names)
     print("class_names:", class_names)
     out_class_names_file = osp.join(args.output_dir, "class_names.txt")
@@ -117,7 +117,10 @@ def main():
                 ymin, ymax = min(ys), max(ys)
             
             class_name = shape["label"]
-            print(class_name)
+            if class_name == "__ignore__":
+                continue
+            if shape["shape_type"] != "rectangle":
+                print("Be careful, {shape_type} was conterted rectangle".format(**shape))
             class_id = class_names.index(class_name)            
             
             bboxes.append([ymin, xmin, ymax, xmax])


### PR DESCRIPTION
Right now, labelme2voc.py in example of bbox_detection allows just **rectangle** for making bounding box.
So, I add the code to be able to make the bounding box from **All shape except a point**. (only a point can't be defined as bounding box)
Results are as below. 

![image](https://user-images.githubusercontent.com/70328564/93707955-98b18800-fb6d-11ea-844f-80c096cea24a.png)

 If shape is not rectangle, bounding box of a object might be separated,
So, I add the warning which appear when the shape other than rectangle is used to make bounding box as below.

![image](https://user-images.githubusercontent.com/70328564/93707116-ee366680-fb66-11ea-9e62-d2144eb7da87.png)

Thank you for reading!