### PR TITLE
Fix crash when opening pre/next image

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1287,38 +1287,43 @@ class MainWindow(QtWidgets.QMainWindow):
 
         position MUST be in global coordinates.
         """
-        items = self.uniqLabelList.selectedItems()
-        text = None
-        if items:
-            text = items[0].data(Qt.UserRole)
-        flags = {}
-        group_id = None
-        if self._config["display_label_popup"] or not text:
-            previous_text = self.labelDialog.edit.text()
-            text, flags, group_id = self.labelDialog.popUp(text)
-            if not text:
-                self.labelDialog.edit.setText(previous_text)
+        self.actions.openNextImg.setEnabled(False)
+        self.actions.openPrevImg.setEnabled(False)
+        try:
+            items = self.uniqLabelList.selectedItems()
+            text = None
+            if items:
+                text = items[0].data(Qt.UserRole)
+            flags = {}
+            group_id = None
+            if self._config["display_label_popup"] or not text:
+                previous_text = self.labelDialog.edit.text()
+                text, flags, group_id = self.labelDialog.popUp(text)
+                if not text:
+                    self.labelDialog.edit.setText(previous_text)
 
-        if text and not self.validateLabel(text):
-            self.errorMessage(
-                self.tr("Invalid label"),
-                self.tr("Invalid label '{}' with validation type '{}'").format(
-                    text, self._config["validate_label"]
-                ),
-            )
-            text = ""
-        if text:
-            self.labelList.clearSelection()
-            shape = self.canvas.setLastLabel(text, flags)
-            shape.group_id = group_id
-            self.addLabel(shape)
-            self.actions.editMode.setEnabled(True)
-            self.actions.undoLastPoint.setEnabled(False)
-            self.actions.undo.setEnabled(True)
-            self.setDirty()
-        else:
-            self.canvas.undoLastLine()
-            self.canvas.shapesBackups.pop()
+            if text and not self.validateLabel(text):
+                self.errorMessage(
+                    self.tr("Invalid label"),
+                    self.tr("Invalid label '{}' with validation type '{}'")
+                        .format(text, self._config["validate_label"]),
+                )
+                text = ""
+            if text:
+                self.labelList.clearSelection()
+                shape = self.canvas.setLastLabel(text, flags)
+                shape.group_id = group_id
+                self.addLabel(shape)
+                self.actions.editMode.setEnabled(True)
+                self.actions.undoLastPoint.setEnabled(False)
+                self.actions.undo.setEnabled(True)
+                self.setDirty()
+            else:
+                self.canvas.undoLastLine()
+                self.canvas.shapesBackups.pop()
+        finally:
+            self.actions.openNextImg.setEnabled(True)
+            self.actions.openPrevImg.setEnabled(True)
 
     def scrollRequest(self, delta, orientation):
         units = -delta * 0.1  # natural scroll


### PR DESCRIPTION
Labelme may crash when opening pre/next image by shortcuts and dismissing LabelDialog by clicking OK button at same time.

After opened new file, app will clear canvas.shapes before canvas.setLastLabel.