### PR TITLE
Add shortcut for remove selected point

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -724,7 +724,7 @@ class MainWindow(QtWidgets.QMainWindow):
             fitWidth,
         )
 
-        self.statusBar().showMessage(self.tr("%s started. Using local version.") % __appname__)
+        self.statusBar().showMessage(self.tr("%s started.") % __appname__)
         self.statusBar().show()
 
         if output_file is not None and self._config["auto_save"]:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -602,6 +602,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 None,
                 addPointToEdge,
                 removePoint,
+                None,
                 toggle_keep_prev_mode,
             ),
             # menu shown at right click

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -406,6 +406,7 @@ class MainWindow(QtWidgets.QMainWindow):
         removePoint = action(
             text="Remove Selected Point",
             slot=self.canvas.removeSelectedPoint,
+            shortcut=shortcuts["remove_selected_point"],
             icon="edit",
             tip="Remove selected point from polygon",
             enabled=False,
@@ -600,7 +601,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 undoLastPoint,
                 None,
                 addPointToEdge,
-                None,
+                removePoint,
                 toggle_keep_prev_mode,
             ),
             # menu shown at right click
@@ -723,7 +724,7 @@ class MainWindow(QtWidgets.QMainWindow):
             fitWidth,
         )
 
-        self.statusBar().showMessage(self.tr("%s started.") % __appname__)
+        self.statusBar().showMessage(self.tr("%s started. Using local version.") % __appname__)
         self.statusBar().show()
 
         if output_file is not None and self._config["auto_save"]:

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -98,3 +98,4 @@ shortcuts:
   add_point_to_edge: Ctrl+Shift+P
   edit_label: Ctrl+E
   toggle_keep_prev_mode: Ctrl+P
+  remove_selected_point: Ctrl+Shift+L


### PR DESCRIPTION

@wkentaro - thanks for all your work with this repo!

Some functionality that we use quite a lot is the 'remove selected point' menu option. This PR adds in the ability to use a shortcut, which is grouped with 'add point to edge' in the Edit menu.

![Screen Shot 2020-11-16 at 09 56 51](https://user-images.githubusercontent.com/33491122/99238827-1ef6ed00-27f2-11eb-84a5-a1739ac86360.png)
