### PR TITLE
add support to read label files in the name of image filename (helps …

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1439,7 +1439,7 @@ class MainWindow(QtWidgets.QMainWindow):
             label_file
         ):
             try:
-                self.labelFile = LabelFile(label_file)
+                self.labelFile = LabelFile(label_file, image_path=filename)
             except LabelFileError as e:
                 self.errorMessage(
                     self.tr("Error opening file"),

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -36,17 +36,18 @@ class LabelFile(object):
 
     suffix = ".json"
 
-    def __init__(self, filename=None):
+    def __init__(self, filename=None, image_path=None):
         self.shapes = []
         self.imagePath = None
         self.imageData = None
         if filename is not None:
-            self.load(filename)
+            self.load(filename, image_path=image_path)
         self.filename = filename
 
     @staticmethod
     def load_image_file(filename):
         try:
+            logger.info('opening image file: ', filename)
             image_pil = PIL.Image.open(filename)
         except IOError:
             logger.error("Failed opening image file: {}".format(filename))
@@ -67,7 +68,7 @@ class LabelFile(object):
             f.seek(0)
             return f.read()
 
-    def load(self, filename):
+    def load(self, filename, image_path=None):
         keys = [
             "version",
             "imageData",
@@ -110,7 +111,11 @@ class LabelFile(object):
             else:
                 # relative path from label file to relative path from cwd
                 imagePath = osp.join(osp.dirname(filename), data["imagePath"])
-                imageData = self.load_image_file(imagePath)
+                if osp.isfile(imagePath):
+                    imageData = self.load_image_file(imagePath)
+                else:
+                    imageData = self.load_image_file(image_path)
+                    imagePath = image_path
             flags = data.get("flags") or {}
             imagePath = data["imagePath"]
             self._check_image_height_and_width(


### PR DESCRIPTION
If the filename of image and label files has changed and there is a label file, then the tool tries to load the image using the imagePath inside JSON file, which is not valid anymore. In this case, we can use the image filename provided before creating an instance of LabelFile class by passing the filename argument as an option to this class.