### PR TITLE
docs: fix simple typo, constrast -> contrast

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1508,7 +1508,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.setScroll(
                     orientation, self.scroll_values[orientation][self.filename]
                 )
-        # set brightness constrast values
+        # set brightness contrast values
         dialog = BrightnessContrastDialog(
             utils.img_data_to_pil(self.imageData),
             self.onNewBrightnessContrast,


### PR DESCRIPTION
There is a small typo in labelme/app.py.

Should read `contrast` rather than `constrast`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md