### PR TITLE
feature: copy and paste polygons

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -94,6 +94,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._noSelectionSlot = False
 
+        self.clipboard_shapes = None
+
         # Main widgets and related state.
         self.labelDialog = LabelDialog(
             parent=self,
@@ -387,6 +389,22 @@ class MainWindow(QtWidgets.QMainWindow):
             self.tr("Create a duplicate of the selected polygons"),
             enabled=False,
         )
+        copyClipboard = action(
+            self.tr("Copy Polygons"),
+            self.copyClipboardSelectedShape,
+            shortcuts["copy_polygon"],
+            "copy_clipboard",
+            self.tr("Copy selected polygons to clipboard"),
+            enabled=False,
+        )
+        paste = action(
+            self.tr("Paste Polygons"),
+            self.pasteSelectedShape,
+            shortcuts["paste_polygon"],
+            "paste",
+            self.tr("Paste copied polygons"),
+            enabled=False,
+        )
         undoLastPoint = action(
             self.tr("Undo last point"),
             self.canvas.undoLastPoint,
@@ -567,6 +585,8 @@ class MainWindow(QtWidgets.QMainWindow):
             delete=delete,
             edit=edit,
             copy=copy,
+            copyClipboard=copyClipboard,
+            paste=paste,
             undoLastPoint=undoLastPoint,
             undo=undo,
             addPointToEdge=addPointToEdge,
@@ -614,6 +634,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 editMode,
                 edit,
                 copy,
+                copyClipboard,
+                paste,
                 delete,
                 undo,
                 undoLastPoint,
@@ -715,6 +737,8 @@ class MainWindow(QtWidgets.QMainWindow):
             createMode,
             editMode,
             copy,
+            copyClipboard,
+            paste,
             delete,
             undo,
             brightnessContrast,
@@ -1097,6 +1121,7 @@ class MainWindow(QtWidgets.QMainWindow):
         n_selected = len(selected_shapes)
         self.actions.delete.setEnabled(n_selected)
         self.actions.copy.setEnabled(n_selected)
+        self.actions.copyClipboard.setEnabled(n_selected)
         self.actions.edit.setEnabled(n_selected == 1)
 
     def addLabel(self, shape):
@@ -1254,11 +1279,21 @@ class MainWindow(QtWidgets.QMainWindow):
             return False
 
     def copySelectedShape(self):
+        print("duplicate shapes")
         added_shapes = self.canvas.copySelectedShapes()
         self.labelList.clearSelection()
         for shape in added_shapes:
             self.addLabel(shape)
         self.setDirty()
+
+    def pasteSelectedShape(self):
+        self.loadShapes(self.clipboard_shapes, replace=False)
+        self.setDirty()
+
+    def copyClipboardSelectedShape(self):
+        self.clipboard_shapes = [s.copy() for s in self.canvas.selectedShapes]
+        n_clipboard_shapes = len(self.clipboard_shapes)
+        self.actions.paste.setEnabled(n_clipboard_shapes)
 
     def labelSelectionChanged(self):
         if self._noSelectionSlot:

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -93,6 +93,8 @@ shortcuts:
   edit_polygon: Ctrl+J
   delete_polygon: Delete
   duplicate_polygon: Ctrl+D
+  copy_polygon: Ctrl+C
+  paste_polygon: Ctrl+V
   undo: Ctrl+Z
   undo_last_point: [Ctrl+Z, Backspace]
   add_point_to_edge: Ctrl+Shift+P


### PR DESCRIPTION
When using this tool I found that I was missing the ability to copy polygons from one frame and paste them in another frame. This feature has also been requested in issue #786.

There is already a duplicate polygons function and this is confusingly called `copy` in `app.py`. I can do another pull-request to rename that `copy` to `duplicate`.

Let me know what you think.