### PR TITLE
opening a directory now discovers json files without images

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2050,6 +2050,8 @@ class MainWindow(QtWidgets.QMainWindow):
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
 
+        extensions += [".json"]
+
         images = []
         for root, dirs, files in os.walk(folderPath):
             for file in files:


### PR DESCRIPTION
Currently if you open a directory in labelme it won't show annotation JSONs without an image. 

Often we delete the images when working with 10GB+ of annotation files as it reduces the storage needed. But every time we want to go through a directory of annotations and check them we've got to extract the image from the "imageData" field so we can go through a folder of annotations. 

This will mean that it finds non-labelme json files in the directory; but that's already handled and you get a pop-up asking you to check if its a valid label file. 

