### PR TITLE
Faster undo, and undo with autosave, and configurable undo stacksize. 

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -168,6 +168,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.canvas = self.labelList.canvas = Canvas(
             epsilon=self._config["epsilon"],
             double_click=self._config["canvas"]["double_click"],
+            num_backups=self._config["canvas"]["num_backups"],
         )
         self.canvas.zoomRequest.connect(self.zoomRequest)
 
@@ -830,6 +831,9 @@ class MainWindow(QtWidgets.QMainWindow):
         utils.addActions(self.menus.edit, actions + self.actions.editMenu)
 
     def setDirty(self):
+        # Even if we autosave the file, we keep the ability to undo
+        self.actions.undo.setEnabled(self.canvas.isShapeRestorable)
+
         if self._config["auto_save"] or self.actions.saveAuto.isChecked():
             label_file = osp.splitext(self.imagePath)[0] + ".json"
             if self.output_dir:
@@ -839,7 +843,6 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self.dirty = True
         self.actions.save.setEnabled(True)
-        self.actions.undo.setEnabled(self.canvas.isShapeRestorable)
         title = __appname__
         if self.filename is not None:
             title = "{} - {}*".format(title, self.filename)

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -64,6 +64,8 @@ canvas:
   # None: do nothing
   # close: close polygon
   double_click: close
+  # The max number of edits we can undo
+  num_backups: 10
 
 shortcuts:
   close: Ctrl+W

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -21,9 +21,17 @@ DEFAULT_HVERTEX_FILL_COLOR = QtGui.QColor(255, 255, 255, 255)  # hovering
 
 class Shape(object):
 
-    P_SQUARE, P_ROUND = 0, 1
+    # Render handles as squares
+    P_SQUARE = 0
 
-    MOVE_VERTEX, NEAR_VERTEX = 0, 1
+    # Render handles as circles
+    P_ROUND = 1
+
+    # Flag for the handles we would move if dragging
+    MOVE_VERTEX = 0
+
+    # Flag for all other handles on the curent shape
+    NEAR_VERTEX = 1
 
     # The following class variables influence the drawing of all shape objects.
     line_color = DEFAULT_LINE_COLOR
@@ -258,10 +266,18 @@ class Shape(object):
         self.points[i] = self.points[i] + offset
 
     def highlightVertex(self, i, action):
+        """Highlight a vertex appropriately based on the current action
+
+        Args:
+            i (int): The vertex index
+            action (int): The action
+            (see Shape.NEAR_VERTEX and Shape.MOVE_VERTEX)
+        """
         self._highlightIndex = i
         self._highlightMode = action
 
     def highlightClear(self):
+        """Clear the highlighted point"""
         self._highlightIndex = None
 
     def copy(self):


### PR DESCRIPTION
This addresses issue #620, and #854, and feature request  #855. 

- A configuration varibale num-backups is created
- An options --num-backups is added
- Several calls to 'repaint' are replaced with calls to 'update' in order to improve performance of undo
- This will update whether the undo action is enabled even when autosave is used. 