### PR TITLE
Add support for rotated ellipses defined via ellipse fitting method

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -344,6 +344,14 @@ class MainWindow(QtWidgets.QMainWindow):
             self.tr("Start drawing circles"),
             enabled=False,
         )
+        createEllipseMode = action(
+            self.tr("Create Ellipse"),
+            lambda: self.toggleDrawMode(False, createMode="ellipse"),
+            shortcuts["create_ellipse"],
+            "objects",
+            self.tr("Start drawing ellipses"),
+            enabled=False,
+        )
         createLineMode = action(
             self.tr("Create Line"),
             lambda: self.toggleDrawMode(False, createMode="line"),
@@ -599,6 +607,7 @@ class MainWindow(QtWidgets.QMainWindow):
             editMode=editMode,
             createRectangleMode=createRectangleMode,
             createCircleMode=createCircleMode,
+            createEllipseMode=createEllipseMode,
             createLineMode=createLineMode,
             createPointMode=createPointMode,
             createLineStripMode=createLineStripMode,
@@ -633,6 +642,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 createMode,
                 createRectangleMode,
                 createCircleMode,
+                createEllipseMode,
                 createLineMode,
                 createPointMode,
                 createLineStripMode,
@@ -651,6 +661,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 createMode,
                 createRectangleMode,
                 createCircleMode,
+                createEllipseMode,
                 createLineMode,
                 createPointMode,
                 createLineStripMode,
@@ -850,6 +861,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.actions.createMode,
             self.actions.createRectangleMode,
             self.actions.createCircleMode,
+            self.actions.createEllipseMode,
             self.actions.createLineMode,
             self.actions.createPointMode,
             self.actions.createLineStripMode,
@@ -881,6 +893,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actions.createMode.setEnabled(True)
         self.actions.createRectangleMode.setEnabled(True)
         self.actions.createCircleMode.setEnabled(True)
+        self.actions.createEllipseMode.setEnabled(True)
         self.actions.createLineMode.setEnabled(True)
         self.actions.createPointMode.setEnabled(True)
         self.actions.createLineStripMode.setEnabled(True)
@@ -958,6 +971,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.actions.createMode.setEnabled(True)
             self.actions.createRectangleMode.setEnabled(True)
             self.actions.createCircleMode.setEnabled(True)
+            self.actions.createEllipseMode.setEnabled(True)
             self.actions.createLineMode.setEnabled(True)
             self.actions.createPointMode.setEnabled(True)
             self.actions.createLineStripMode.setEnabled(True)
@@ -966,6 +980,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.actions.createMode.setEnabled(False)
                 self.actions.createRectangleMode.setEnabled(True)
                 self.actions.createCircleMode.setEnabled(True)
+                self.actions.createEllipseMode.setEnabled(True)
                 self.actions.createLineMode.setEnabled(True)
                 self.actions.createPointMode.setEnabled(True)
                 self.actions.createLineStripMode.setEnabled(True)
@@ -973,6 +988,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.actions.createMode.setEnabled(True)
                 self.actions.createRectangleMode.setEnabled(False)
                 self.actions.createCircleMode.setEnabled(True)
+                self.actions.createEllipseMode.setEnabled(True)
                 self.actions.createLineMode.setEnabled(True)
                 self.actions.createPointMode.setEnabled(True)
                 self.actions.createLineStripMode.setEnabled(True)
@@ -980,6 +996,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.actions.createMode.setEnabled(True)
                 self.actions.createRectangleMode.setEnabled(True)
                 self.actions.createCircleMode.setEnabled(True)
+                self.actions.createEllipseMode.setEnabled(True)
                 self.actions.createLineMode.setEnabled(False)
                 self.actions.createPointMode.setEnabled(True)
                 self.actions.createLineStripMode.setEnabled(True)
@@ -987,6 +1004,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.actions.createMode.setEnabled(True)
                 self.actions.createRectangleMode.setEnabled(True)
                 self.actions.createCircleMode.setEnabled(True)
+                self.actions.createEllipseMode.setEnabled(True)
                 self.actions.createLineMode.setEnabled(True)
                 self.actions.createPointMode.setEnabled(False)
                 self.actions.createLineStripMode.setEnabled(True)
@@ -994,6 +1012,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.actions.createMode.setEnabled(True)
                 self.actions.createRectangleMode.setEnabled(True)
                 self.actions.createCircleMode.setEnabled(False)
+                self.actions.createEllipseMode.setEnabled(True)
+                self.actions.createLineMode.setEnabled(True)
+                self.actions.createPointMode.setEnabled(True)
+                self.actions.createLineStripMode.setEnabled(True)
+            elif createMode == "ellipse":
+                self.actions.createMode.setEnabled(True)
+                self.actions.createRectangleMode.setEnabled(True)
+                self.actions.createCircleMode.setEnabled(True)
+                self.actions.createEllipseMode.setEnabled(False)
                 self.actions.createLineMode.setEnabled(True)
                 self.actions.createPointMode.setEnabled(True)
                 self.actions.createLineStripMode.setEnabled(True)
@@ -1001,6 +1028,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.actions.createMode.setEnabled(True)
                 self.actions.createRectangleMode.setEnabled(True)
                 self.actions.createCircleMode.setEnabled(True)
+                self.actions.createEllipseMode.setEnabled(True)
                 self.actions.createLineMode.setEnabled(True)
                 self.actions.createPointMode.setEnabled(True)
                 self.actions.createLineStripMode.setEnabled(False)

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -90,6 +90,7 @@ shortcuts:
   create_polygon: Ctrl+N
   create_rectangle: Ctrl+R
   create_circle: null
+  create_ellipse: null
   create_line: null
   create_point: null
   create_linestrip: null

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -4,12 +4,12 @@ import math
 from qtpy import QtCore
 from qtpy import QtGui
 
+from matplotlib import patches
 import numpy as np
 from skimage.measure import EllipseModel
-from matplotlib import patches
 
-import labelme.utils
 from labelme.logger import logger
+import labelme.utils
 
 
 # TODO(unknown):
@@ -167,8 +167,8 @@ class Shape(object):
             elif self.shape_type == "ellipse":
                 if len(self.points) >= 4:
                     a, b, theta, xc, yc = self.fitEllipse(self.points)
-                    if a != None:
-                        rectangle = QtCore.QRectF(-a, -b, 2*a, 2*b)
+                    if a is not None:
+                        rectangle = QtCore.QRectF(-a, -b, 2 * a, 2 * b)
                         line_path.addEllipse(rectangle)
                         painter.translate(xc, yc)
                         painter.rotate(theta)
@@ -205,10 +205,10 @@ class Shape(object):
             # For ellipses this step was performed in advance
             if self.shape_type != "ellipse":
                 painter.drawPath(line_path)
-            
+
             painter.drawPath(vrtx_path)
             painter.fillPath(vrtx_path, self._vertex_fill_color)
-            
+
             # For ellipses this step was performed in advance
             if self.shape_type != "ellipse":
                 if self.fill:
@@ -218,7 +218,6 @@ class Shape(object):
                         else self.fill_color
                     )
                     painter.fillPath(line_path, color)
-
 
     def drawVertex(self, path, i):
         d = self.point_size / self.scale
@@ -262,7 +261,12 @@ class Shape(object):
     def containsPoint(self, point):
         if self.shape_type == "ellipse":
             a, b, theta, xc, yc = self.fitEllipse(self.points)
-            ellipse = patches.Ellipse(xy=(xc, yc), width=2*a, height=2*b, angle=theta)
+            ellipse = patches.Ellipse(
+                xy=(xc, yc),
+                width=2 * a,
+                height=2 * b,
+                angle=theta
+            )
             return ellipse.contains_point([point.x(), point.y()])
         else:
             return self.makePath().contains(point)
@@ -287,10 +291,9 @@ class Shape(object):
 
         if ell.params:
             xc, yc, a, b, theta = ell.params
-            return a, b, theta*180/math.pi, xc, yc
+            return a, b, theta * 180 / math.pi, xc, yc
         else:
             return None, None, None, None, None
-
 
     def makePath(self):
         if self.shape_type == "rectangle":
@@ -310,7 +313,7 @@ class Shape(object):
         return path
 
     def boundingRect(self):
-        # TODO
+        # TODO(ellipse)
         logger.error(
             "The 'boundingRect' function is not supported for ellipses"
         )

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -262,10 +262,7 @@ class Shape(object):
         if self.shape_type == "ellipse":
             a, b, theta, xc, yc = self.fitEllipse(self.points)
             ellipse = patches.Ellipse(
-                xy=(xc, yc),
-                width=2 * a,
-                height=2 * b,
-                angle=theta
+                xy=(xc, yc), width=2 * a, height=2 * b, angle=theta
             )
             return ellipse.contains_point([point.x(), point.y()])
         else:

--- a/labelme/translate/empty.ts
+++ b/labelme/translate/empty.ts
@@ -221,6 +221,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app.py" line="271"/>
+        <source>Create Ellipse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app.py" line="271"/>
+        <source>Start drawing ellipses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app.py" line="279"/>
         <source>Create Line</source>
         <translation type="unfinished"></translation>

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -29,7 +29,7 @@ def shape_to_mask(
         d = math.sqrt((cx - px) ** 2 + (cy - py) ** 2)
         draw.ellipse([cx - d, cy - d, cx + d, cy + d], outline=1, fill=1)
     elif shape_type == "ellipse":
-        # TODO
+        # TODO(ellipse)
         logger.error(
             "The 'shape_to_mask' function is not supported for ellipses"
         )

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -28,6 +28,11 @@ def shape_to_mask(
         (cx, cy), (px, py) = xy
         d = math.sqrt((cx - px) ** 2 + (cy - py) ** 2)
         draw.ellipse([cx - d, cy - d, cx + d, cy + d], outline=1, fill=1)
+    elif shape_type == "ellipse":
+        # TODO
+        logger.error(
+            "The 'shape_to_mask' function is not supported for ellipses"
+        )
     elif shape_type == "rectangle":
         assert len(xy) == 2, "Shape of shape_type=rectangle must have 2 points"
         draw.rectangle(xy, outline=1, fill=1)

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -6,6 +6,7 @@ from labelme import QT5
 from labelme.shape import Shape
 import labelme.utils
 
+from labelme.logger import logger
 
 # TODO(unknown):
 # - [maybe] Find optimal epsilon value.
@@ -102,6 +103,7 @@ class Canvas(QtWidgets.QWidget):
             "polygon",
             "rectangle",
             "circle",
+            "ellipse",
             "line",
             "point",
             "linestrip",
@@ -228,6 +230,9 @@ class Canvas(QtWidgets.QWidget):
             elif self.createMode == "circle":
                 self.line.points = [self.current[0], pos]
                 self.line.shape_type = "circle"
+            elif self.createMode == "ellipse":
+                self.line.points = [self.current[0], pos]
+                self.line.shape_type = "ellipse"
             elif self.createMode == "line":
                 self.line.points = [self.current[0], pos]
                 self.line.close()
@@ -360,6 +365,8 @@ class Canvas(QtWidgets.QWidget):
                         assert len(self.current.points) == 1
                         self.current.points = self.line.points
                         self.finalise()
+                    elif self.createMode == "ellipse":
+                        self.current.addPoint(self.line[1])
                     elif self.createMode == "linestrip":
                         self.current.addPoint(self.line[1])
                         self.line[0] = self.current[-1]
@@ -374,6 +381,8 @@ class Canvas(QtWidgets.QWidget):
                     else:
                         if self.createMode == "circle":
                             self.current.shape_type = "circle"
+                        elif self.createMode == "ellipse":
+                            self.current.shape_type = "ellipse"
                         self.line.points = [pos, pos]
                         self.setHiding()
                         self.drawingPolygon.emit(True)
@@ -772,6 +781,11 @@ class Canvas(QtWidgets.QWidget):
             self.line.points = [self.current[-1], self.current[0]]
         elif self.createMode in ["rectangle", "line", "circle"]:
             self.current.points = self.current.points[0:1]
+        elif self.createMode == "ellipse":
+            # TODO
+            logger.error(
+                "The 'undoLastLine' function is not supported for ellipses"
+            )
         elif self.createMode == "point":
             self.current = None
         self.drawingPolygon.emit(True)

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -782,7 +782,7 @@ class Canvas(QtWidgets.QWidget):
         elif self.createMode in ["rectangle", "line", "circle"]:
             self.current.points = self.current.points[0:1]
         elif self.createMode == "ellipse":
-            # TODO
+            # TODO(ellipse)
             logger.error(
                 "The 'undoLastLine' function is not supported for ellipses"
             )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def get_install_requires():
         "PyYAML",
         "qtpy",
         "termcolor",
+        "scikit-image"
     ]
 
     # Find python binding for qt with priority:


### PR DESCRIPTION
**Description**

This pull request addresses issues #871, #391 and #298.

While rotated ellipses require at most 5 points to be defined, it is useful to define ellipses based on ellipse fitting techniques applied on a greater number of points to more easily and better approximate elliptical contours in images.

The implementation proposed here is based on the [EllipseModel](https://scikit-image.org/docs/dev/api/skimage.measure.html#skimage.measure.EllipseModel) class provided in the scikit-image library which returns exact ellipses when four or five points are provided, and approximating ellipses when more points are given. To finalize an elliptical shape, being the number of points required undefined, a double mouse click is required (as used also for polygonal shapes).

**Issues**

The biggest issue is in supporting **rotated** ellipses.

For example, the [makePath()](https://github.com/wkentaro/labelme/blob/4efcad25d91b4950364afacf1da88bd9e7abe367/labelme/shape.py#L242-L257) function is not easily extended as the QPainterPath object does not support rotated ellipses.

Similarly, it is unclear if and how the [boundingRect()](https://github.com/wkentaro/labelme/blob/4efcad25d91b4950364afacf1da88bd9e7abe367/labelme/shape.py#L259-L260) function should be extended, either depending on [makePath()](https://github.com/wkentaro/labelme/blob/4efcad25d91b4950364afacf1da88bd9e7abe367/labelme/shape.py#L242-L257) or customized.
For example, you could find the bounding box around the rotated ellipse, but this is non-trivial and is a worse approximation than a rotated bounding box. So it is probably easier to customize the [calculateOffsets()](https://github.com/wkentaro/labelme/blob/4efcad25d91b4950364afacf1da88bd9e7abe367/labelme/widgets/canvas.py#L481) function which invokes [boundingRect()](https://github.com/wkentaro/labelme/blob/4efcad25d91b4950364afacf1da88bd9e7abe367/labelme/shape.py#L259-L260) directly.

For the moment, I have marked these functions as unsupported by raising an error through the logger when they occur, e.g.:
https://github.com/bigcola317/labelme/blob/df8ceab1949ec3949e4609af4c4d6949acee7f37/labelme/shape.py#L312-L317
In my tests I wasn't able to excite these conditions, but I await feedback.