### PR TITLE
adaptively approximate the circle shape

### DIFF
--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -132,7 +132,9 @@ def main():
             if shape_type == "circle":
                 (x1, y1), (x2, y2) = points
                 r = np.linalg.norm([x2 - x1, y2 - y1])
-                n_points_circle = 12
+                # r(1-cos(a/2))<x, a=2*pi/N => N>pi/arccos(1-x/r)
+                # x: difference (pixels) between the arc and the line segment
+                n_points_circle = max(int(np.pi/np.arccos(1-1/r)), 12)
                 i = np.arange(n_points_circle)
                 x = x1 + r * np.sin(2 * np.pi / n_points_circle * i)
                 y = y1 + r * np.cos(2 * np.pi / n_points_circle * i)

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -133,8 +133,8 @@ def main():
                 (x1, y1), (x2, y2) = points
                 r = np.linalg.norm([x2 - x1, y2 - y1])
                 # r(1-cos(a/2))<x, a=2*pi/N => N>pi/arccos(1-x/r)
-                # x: difference (pixels) between the arc and the line segment
-                n_points_circle = max(int(np.pi/np.arccos(1-1/r)), 12)
+                # x: tolerance of the gap between the arc and the line segment
+                n_points_circle = max(int(np.pi / np.arccos(1 - 1 / r)), 12)
                 i = np.arange(n_points_circle)
                 x = x1 + r * np.sin(2 * np.pi / n_points_circle * i)
                 y = y1 + r * np.cos(2 * np.pi / n_points_circle * i)


### PR DESCRIPTION
As the radius of the circle increases, the difference between the circular arc and the approximate line segement increase. So, a fixed section number may result in terrible approaches for the big circles, which may lead to a bad instance segmetantion trained model when we actually want some circular segments.