### PR TITLE
Sort File-List in numerical order

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2076,5 +2076,5 @@ class MainWindow(QtWidgets.QMainWindow):
                 if file.lower().endswith(tuple(extensions)):
                     relativePath = osp.join(root, file)
                     images.append(relativePath)
-        images.sort(key=lambda x: x.lower())
+        images.sort(key=lambda x: utils.strnum_to_num(x.lower()))
         return images

--- a/labelme/utils/__init__.py
+++ b/labelme/utils/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from ._io import lblsave
+from ._io import strnum_to_num
 
 from .image import apply_exif_orientation
 from .image import img_arr_to_b64

--- a/labelme/utils/_io.py
+++ b/labelme/utils/_io.py
@@ -1,3 +1,5 @@
+import re
+
 import os.path as osp
 
 import numpy as np
@@ -21,3 +23,10 @@ def lblsave(filename, lbl):
             "[%s] Cannot save the pixel-wise class label as PNG. "
             "Please consider using the .npy format." % filename
         )
+
+
+def strnum_to_num(text):
+    out = []
+    for w in re.split(r"(\d+)", text):
+        out.append(int(w) if w.isdigit() else w)
+    return out


### PR DESCRIPTION
Currently, if the following files exist, they are displayed in string order.
```
$ ls
image1.png image2.png image10.png image3.png image200.png
```

In labelme.
```
image1.png
image10.png
image2.png
image200.png
image3.png
```

However, I think it is natural to use a list of string numbers converted to numbers for sorting. I added a utility function for this to `utils/_io.py` because file names are i/o identifiers.

