### PR TITLE
Update ReadMe Testing on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ For more advanced usage, please refer to the examples:
 
 ## Testing
 
+On macOS use the following commands to install the **help2man** (1.48.5) and overwrite the `labelme.1` file in **$(pwd)/docs/man/labelme.1** before testing the labelme.
+
+```bash
+## macOS testing 
+# brew install help2man 
+# help2man labelme > $(pwd)/docs/man/labelme.1
+```
+
+Testing labelme.
 ```bash
 pip install hacking pytest pytest-qt
 flake8 .


### PR DESCRIPTION
I was following the ReadMe to test all the commands and find that on macOS users will need to install **help2man** and overwrite the **labelme.1** file before testing. 

```bash
## macOS testing 
brew install help2man 
help2man labelme > $(pwd)/docs/man/labelme.1
```
Then go with the following testing.

![code_review](https://user-images.githubusercontent.com/3784477/149234577-b32bf3f7-e8f8-407f-94f2-5f70a57108c9.png)
 