### PR TITLE
images are sorted based on number in the image name

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -6,6 +6,7 @@ import os
 import os.path as osp
 import re
 import webbrowser
+import regex
 
 import imgviz
 from qtpy import QtCore
@@ -2075,5 +2076,5 @@ class MainWindow(QtWidgets.QMainWindow):
                 if file.lower().endswith(tuple(extensions)):
                     relativePath = osp.join(root, file)
                     images.append(relativePath)
-        images.sort(key=lambda x: x.lower())
+        images.sort(key=lambda f: int(regex.sub('\D', '', f.lower())))
         return images

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def get_install_requires():
         "PyYAML",
         "qtpy!=1.11.2",
         "termcolor",
+        "regex",
     ]
 
     # Find python binding for qt with priority:


### PR DESCRIPTION
I had problems where the order of the images is messed up when I labelled my images 0.png, 1.png, ...., 10.png, 11.png, etc...

This is a quick solution for sorting by number.