### PR TITLE
Use natsort.os_sorted to sort files in the browser

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -8,6 +8,7 @@ import re
 import webbrowser
 
 import imgviz
+import natsort
 from qtpy import QtCore
 from qtpy.QtCore import Qt
 from qtpy import QtGui
@@ -2075,5 +2076,5 @@ class MainWindow(QtWidgets.QMainWindow):
                 if file.lower().endswith(tuple(extensions)):
                     relativePath = osp.join(root, file)
                     images.append(relativePath)
-        images.sort(key=lambda x: x.lower())
+        images = natsort.os_sorted(images)
         return images

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ def get_install_requires():
     install_requires = [
         "imgviz>=0.11",
         "matplotlib<3.3",  # for PyInstaller
+        "natsort>=7.1.0",
         "numpy",
         "Pillow>=2.8",
         "PyYAML",


### PR DESCRIPTION
Close https://github.com/wkentaro/labelme/pull/955
Close https://github.com/wkentaro/labelme/pull/989
Close https://github.com/wkentaro/labelme/issues/953

It seems there're many needs for sorting files *naturally* in the file browser.
With a bit of research, I have decided to use `natsort.os_sorted`, since it is at least to me the most "natural" if files are sorted as the same way as the file manager of an OS (I use Finder on macOS).

Below is an example of the result:

```python
import re
import natsort

filenames = [
    "img_1.jpg",
    "img_100.jpg",
    "img_10.jpg",
    "img_11.jpg",
    "img_1-1.jpg",
    "img_12-1.jpg",
]

print("original  :", filenames)
print(
    "re.sub(\D):",
    sorted(filenames, key=lambda x: int(re.sub("\D", "", x.lower()))),
)
print("natsorted :", natsort.natsorted(filenames))
print("os_sorted :", natsort.os_sorted(filenames))

print()

filenames = [
    "image1.png",
    "image10.png",
    "image2.png",
    "image200.png",
    "image3.png",
]
print("original  :", filenames)
print(
    "re.sub(\D):",
    sorted(filenames, key=lambda x: int(re.sub("\D", "", x.lower()))),
)
print("natsorted :", natsort.natsorted(filenames))
print("os_sorted :", natsort.os_sorted(filenames))
```

```
original  : ['img_1.jpg', 'img_100.jpg', 'img_10.jpg', 'img_11.jpg', 'img_1-1.jpg', 'img_12-1.jpg']
re.sub(\D): ['img_1.jpg', 'img_10.jpg', 'img_11.jpg', 'img_1-1.jpg', 'img_100.jpg', 'img_12-1.jpg']
natsorted : ['img_1-1.jpg', 'img_1.jpg', 'img_10.jpg', 'img_11.jpg', 'img_12-1.jpg', 'img_100.jpg']
os_sorted : ['img_1.jpg', 'img_1-1.jpg', 'img_10.jpg', 'img_11.jpg', 'img_12-1.jpg', 'img_100.jpg']

original  : ['image1.png', 'image10.png', 'image2.png', 'image200.png', 'image3.png']
re.sub(\D): ['image1.png', 'image2.png', 'image3.png', 'image10.png', 'image200.png']
natsorted : ['image1.png', 'image2.png', 'image3.png', 'image10.png', 'image200.png']
os_sorted : ['image1.png', 'image2.png', 'image3.png', 'image10.png', 'image200.png']
```