### PR TITLE
changing output_dir BUG  and  anchor-based zoom feature enhancement 

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1488,7 +1488,10 @@ class MainWindow(QtWidgets.QMainWindow):
             label_file
         ):
             try:
-                self.labelFile = LabelFile(label_file)
+                if self.output_dir:
+                    self.labelFile = LabelFile(label_file, imgPath=filename)
+                else:
+                    self.labelFile = LabelFile(label_file)
             except LabelFileError as e:
                 self.errorMessage(
                     self.tr("Error opening file"),

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -177,6 +177,7 @@ class MainWindow(QtWidgets.QMainWindow):
         scrollArea = QtWidgets.QScrollArea()
         scrollArea.setWidget(self.canvas)
         scrollArea.setWidgetResizable(True)
+        self.scrollArea=scrollArea
         self.scrollBars = {
             Qt.Vertical: scrollArea.verticalScrollBar(),
             Qt.Horizontal: scrollArea.horizontalScrollBar(),
@@ -1394,6 +1395,22 @@ class MainWindow(QtWidgets.QMainWindow):
         if delta < 0:
             units = 0.9
         self.addZoom(units)
+
+        if self.canvas.culAnchorOnCanvas() is not None:
+
+            canvas_x,canvas_y=self.canvas.culAnchorOnCanvas()
+            canvas_x=max(canvas_x - self.scrollArea.width() // 2,0)
+            canvas_y = max(canvas_y - self.scrollArea.height() // 2, 0)
+
+            self.setScroll(
+                Qt.Horizontal,
+                canvas_x,
+            )
+            self.setScroll(
+                Qt.Vertical,
+                canvas_y,
+            )
+            return
 
         canvas_width_new = self.canvas.width()
         if canvas_width_old != canvas_width_new:

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -36,7 +36,8 @@ class LabelFile(object):
 
     suffix = ".json"
 
-    def __init__(self, filename=None):
+    def __init__(self, filename=None,**kwargs):
+        self._imgPath=kwargs.get("imgPath",None)
         self.shapes = []
         self.imagePath = None
         self.imageData = None
@@ -108,9 +109,12 @@ class LabelFile(object):
                 if PY2 and QT4:
                     imageData = utils.img_data_to_png_data(imageData)
             else:
-                # relative path from label file to relative path from cwd
-                imagePath = osp.join(osp.dirname(filename), data["imagePath"])
-                imageData = self.load_image_file(imagePath)
+                if self._imgPath is None:
+                    # relative path from label file to relative path from cwd
+                    imagePath = osp.join(osp.dirname(filename), data["imagePath"])
+                    imageData = self.load_image_file(imagePath)
+                else:
+                    imageData = self.load_image_file(self._imgPath)
             flags = data.get("flags") or {}
             imagePath = data["imagePath"]
             self._check_image_height_and_width(

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -479,6 +479,14 @@ class Canvas(QtWidgets.QWidget):
             self.current.popPoint()
             self.finalise()
 
+        if QtCore.Qt.ControlModifier == int( ev.modifiers()):
+            try:
+
+                self.anchor_point = self.transformPos(ev.localPos())
+
+            except AttributeError:
+                return
+
     def selectShapes(self, shapes):
         self.setHiding()
         self.selectionChanged.emit(shapes)
@@ -853,6 +861,7 @@ class Canvas(QtWidgets.QWidget):
 
     def loadPixmap(self, pixmap, clear_shapes=True):
         self.pixmap = pixmap
+        self.anchor_point = None
         if clear_shapes:
             self.shapes = []
         self.update()
@@ -886,3 +895,19 @@ class Canvas(QtWidgets.QWidget):
         self.pixmap = None
         self.shapesBackups = []
         self.update()
+
+    def culAnchorOnCanvas(self):
+        if  self.anchor_point is  None:
+            return None
+        else:
+            anchor_x = self.anchor_point.x()
+            anchor_y = self.anchor_point.y()
+            pixmap_w=self.pixmap.width()
+            pixmap_h=self.pixmap.height()
+            canvas_width=self.width()
+            canvas_height=self.height()
+
+            canvas_x=int((anchor_x/pixmap_w)*canvas_width)
+            canvas_y = int(anchor_y/ pixmap_h * canvas_height)
+
+            return  canvas_x,canvas_y


### PR DESCRIPTION
commit 1:
the original app fails to change to a new output_dir when the output_dir already has some JSON files. Because the JSON file class load image from the folder by default to check image data. 

commit2 :
I use LABELME to label industrial images for surface defect detection. These kinds of images usually have high resolution but small objects to label.  When I zoom in to observe small objects at the edge regions of the image, it always has view bias, which is very troublesome.   I add a feature that I use "ctrl+doubleclick" to remember the current pixel location, I call it to anchor, then it always keeps the anchor in the view center when zooming in or zooming out. I belives that this feature is very useful for some applications using high-resolution images, like surface defect detection, medical image detection.