### PR TITLE
[fix] fix a bug when opening a label file

### DIFF
--- a/labelme/widgets/file_dialog_preview.py
+++ b/labelme/widgets/file_dialog_preview.py
@@ -3,6 +3,7 @@ from qtpy import QtGui
 from qtpy import QtWidgets
 
 import json
+from labelme.label_file import open
 
 
 class ScrollAreaPreview(QtWidgets.QScrollArea):


### PR DESCRIPTION
Opening a label file using the same encoding when it was saved. 

By doing this, labelme can open a label file when it contains Unicode characters.