### PR TITLE
Bump black

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 github2pypi==1.0.0
 hacking==4.1.0
 pytest


### PR DESCRIPTION
With version `22.1.0` I got:
```
▶ black --line-length 79 --check labelme/
Traceback (most recent call last):
  File "/Users/mwos/miniconda3/envs/labelme/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "src/black/__init__.py", line 1423, in patched_main
  File "src/black/__init__.py", line 1409, in patch_click
ImportError: cannot import name '_unicodefun' from 'click' (/Users/mwos/miniconda3/envs/labelme/lib/python3.9/site-packages/click/__init__.py)
```

As per: https://stackoverflow.com/a/71674345 version `22.3.0` contains the fix. I confirm that - checked locally:
```
▶ black --line-length 79 --check labelme/
All done! ✨ 🍰 ✨
29 files would be left unchanged.
```