### PR TITLE
fix: QPoint arg must be int

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -656,7 +656,7 @@ class Canvas(QtWidgets.QWidget):
         aw, ah = area.width(), area.height()
         x = (aw - w) / (2 * s) if aw > w else 0
         y = (ah - h) / (2 * s) if ah > h else 0
-        return QtCore.QPoint(x, y)
+        return QtCore.QPoint(int(x), int(y))
 
     def outOfPixmap(self, p):
         w, h = self.pixmap.width(), self.pixmap.height()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/hong/PycharmProjects/labelme/labelme/widgets/canvas.py", line 618, in paintEvent
    p.translate(self.offsetToCenter())
  File "/home/hong/PycharmProjects/labelme/labelme/widgets/canvas.py", line 659, in offsetToCenter
    return QtCore.QPoint(x, y)
TypeError: arguments did not match any overloaded call:
  QPoint(): too many arguments
  QPoint(int, int): argument 1 has unexpected type 'float'
  QPoint(QPoint): argument 1 has unexpected type 'float'
```

fix bug