### PR TITLE
When loading the image file, try both original and basename paths

### DIFF
--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -111,6 +111,14 @@ class LabelFile(object):
                 # relative path from label file to relative path from cwd
                 imagePath = osp.join(osp.dirname(filename), data["imagePath"])
                 imageData = self.load_image_file(imagePath)
+                if imageData is None:
+                    originalPath = imagePath
+                    # use relative path of label file and basename of imagePath
+                    imagePath = osp.join(osp.dirname(filename), osp.basename(data["imagePath"]))
+                    imageData = self.load_image_file(imagePath)
+                    if imageData is None:
+                        raise FileNotFoundError(f"Unable to load image from {originalPath} or {imagePath}")
+
             flags = data.get("flags") or {}
             imagePath = data["imagePath"]
             self._check_image_height_and_width(


### PR DESCRIPTION
- if the label file contains an imagePath is an absolute path, then os.path.join will return the original absolute path which may no longer reflect the imagePath of the file on a different computer
- if loading the imagePath fails, try using the dirname of the label file and the basename of the imagePath 