### PR TITLE
Stop using setLoggerClass

### DIFF
--- a/labelme/logger.py
+++ b/labelme/logger.py
@@ -67,5 +67,5 @@ class ColoredLogger(logging.Logger):
         return
 
 
-logging.setLoggerClass(ColoredLogger)
 logger = logging.getLogger(__appname__)
+logger.__class__ = ColoredLogger


### PR DESCRIPTION
`setLoggerClass` affects even when we use logger externally.