### PR TITLE
Group_id visualization by color 

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -18,6 +18,7 @@ default_shape_color: [0, 255, 0]
 shape_color: auto  # null, 'auto', 'manual'
 shift_auto_shape_color: 0
 label_colors: null
+group_id_line_color: null
 
 shape:
   # drawing

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -4,6 +4,8 @@
 import math
 import uuid
 
+import colorsys
+import random
 import numpy as np
 import PIL.Image
 import PIL.ImageDraw
@@ -107,3 +109,17 @@ def masks_to_bboxes(masks):
         bboxes.append((y1, x1, y2, x2))
     bboxes = np.asarray(bboxes, dtype=np.float32)
     return bboxes
+
+
+def generate_random_colors(shape_amount, bright=False):
+    """
+    Generate random colors.
+    To get visually distinct colors, generate them in HSV space then
+    convert to RGB.
+    """
+    brightness = 1.0 if bright else 0.7
+    hsv = [(i / shape_amount, 256, brightness) for i in range(shape_amount)]
+    colors = list(map(lambda c: tuple(abs(hue) for hue in colorsys.hsv_to_rgb(*c)), hsv))
+    random.shuffle(colors)
+    return colors
+

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -99,6 +99,7 @@ class Canvas(QtWidgets.QWidget):
         # Set widget options.
         self.setMouseTracking(True)
         self.setFocusPolicy(QtCore.Qt.WheelFocus)
+        self.groupIdColorObjSort = False
 
         self._ai_model = None
 


### PR DESCRIPTION
Add new feature into LabelMe to make it visualize group_id by color!
This feature is necessary for data validation when there is a need to show a user the relationship between parent and child shapes with the same group_id value.
![177431710-cdf26754-f38b-4f07-aed3-b4eb730b8ce4](https://user-images.githubusercontent.com/80475744/178370939-8a5a3271-6b59-4fea-a4a1-3b4247fe6d32.png)
![177431708-efd8bac2-f7ef-48b2-9721-dfe273dad447](https://user-images.githubusercontent.com/80475744/178370943-3a36e9b1-ed84-4d38-8e71-9149666233aa.png)
