### PR TITLE
Fix loading buggy images

### DIFF
--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -60,7 +60,10 @@ class LabelFile(object):
             if PY2 and QT4:
                 format = "PNG"
             elif ext in [".jpg", ".jpeg"]:
-                format = "JPEG"
+                if image_pil.mode == 'RGBA':  # for buggy images
+                    format = "PNG"
+                else:
+                    format = "JPEG"
             else:
                 format = "PNG"
             image_pil.save(f, format=format)

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -60,7 +60,7 @@ class LabelFile(object):
             if PY2 and QT4:
                 format = "PNG"
             elif ext in [".jpg", ".jpeg"]:
-                if image_pil.mode == 'RGBA':  # for buggy images
+                if image_pil.mode == 'RGBA':  # fix loading buggy images
                     format = "PNG"
                 else:
                     format = "JPEG"


### PR DESCRIPTION
Fix an error when loading an image that had the original extension "PNG" but was saved as "JPG".
I have attached a sample image.
![road pothole144](https://user-images.githubusercontent.com/67141457/194544017-d666f5c3-0eb6-4369-9700-22cf07c74779.jpg)
