### PR TITLE
Fix always call setDirty after removing selected point

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1936,10 +1936,10 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self.canvas.hShape.points:
             self.canvas.deleteShape(self.canvas.hShape)
             self.remLabels([self.canvas.hShape])
-            self.setDirty()
             if self.noShapes():
                 for action in self.actions.onShapesPresent:
                     action.setEnabled(False)
+        self.setDirty()
 
     def deleteSelectedShape(self):
         yes, no = QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No


### PR DESCRIPTION
Fix always call setDirty after removing selected point.
Because without call it, removed point has been restored after moving next or previous image