### PR TITLE
Application shutdowns when sliding canvas out of bixmap

### DIFF
--- a/labelme/utils/_io.py
+++ b/labelme/utils/_io.py
@@ -21,3 +21,4 @@ def lblsave(filename, lbl):
             "[%s] Cannot save the pixel-wise class label as PNG. "
             "Please consider using the .npy format." % filename
         )
+

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -556,12 +556,12 @@ class Canvas(QtWidgets.QWidget):
             return False  # No need to move
         o1 = pos + self.offsets[0]
         if self.outOfPixmap(o1):
-            pos -= QtCore.QPoint(min(0, o1.x()), min(0, o1.y()))
+            pos -= QtCore.QPoint(min(0, int(o1.x())), min(0, int(o1.y())))
         o2 = pos + self.offsets[1]
         if self.outOfPixmap(o2):
             pos += QtCore.QPoint(
-                min(0, self.pixmap.width() - o2.x()),
-                min(0, self.pixmap.height() - o2.y()),
+                min(0, int(self.pixmap.width() - o2.x())),
+                min(0, int(self.pixmap.height() - o2.y())),
             )
         # XXX: The next line tracks the new position of the cursor
         # relative to the shape, but also results in making it


### PR DESCRIPTION
When sliding the shape out of bixmap the application stops and complains that the parameters `QtCore.QPoint` needs to be `int` insread of `float`.


`pos += QtCore.QPoint(
TypeError: arguments did not match any overloaded call:
  QPoint(): too many arguments
  QPoint(int, int): argument 1 has unexpected type 'float'
  QPoint(QPoint): argument 1 has unexpected type 'float'`