### PR TITLE
Fix for creating contours on the edges

### DIFF
--- a/labelme/ai/models/segment_anything.py
+++ b/labelme/ai/models/segment_anything.py
@@ -115,7 +115,11 @@ def _get_contour_length(contour):
     contour_end = np.r_[contour[1:], contour[0:1]]
     return np.linalg.norm(contour_end - contour_start, axis=1).sum()
 
-
+def _pad_with(vector, pad_width, iaxis, kwargs):
+    pad_value = kwargs.get('padder', 0)
+    vector[:pad_width[0]] = pad_value
+    vector[-pad_width[1]:] = pad_value
+    
 def compute_polygon_from_points(
     image_size, decoder_session, image, image_embedding, points, point_labels
 ):
@@ -153,6 +157,8 @@ def compute_polygon_from_points(
     masks, _, _ = decoder_session.run(None, decoder_inputs)
     mask = masks[0, 0]  # (1, 1, H, W) -> (H, W)
     mask = mask > 0.0
+    mask = np.pad(mask, 1, _pad_with, padder=0)
+    
     if 0:
         imgviz.io.imsave(
             "mask.jpg", imgviz.label2rgb(mask, imgviz.rgb2gray(image))


### PR DESCRIPTION
When the mask is on the edge of the image, skimage.measure.find_contours(mask) fails to create a contour. 1 pixel is padded on every edge of the mask in order to overcome the problem of the contours creation.