### PR TITLE
fix `description` not being defined if `display_label_popup=false`

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1349,6 +1349,7 @@ class MainWindow(QtWidgets.QMainWindow):
             text = items[0].data(Qt.UserRole)
         flags = {}
         group_id = None
+        description = None
         if self._config["display_label_popup"] or not text:
             previous_text = self.labelDialog.edit.text()
             text, flags, group_id, description = self.labelDialog.popUp(text)


### PR DESCRIPTION
As per the title. Fixes #370 which no longer works.