### PR TITLE
[Feature] shape rotation

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -185,6 +185,7 @@ class MainWindow(QtWidgets.QMainWindow):
             Qt.Horizontal: scrollArea.horizontalScrollBar(),
         }
         self.canvas.scrollRequest.connect(self.scrollRequest)
+        self.canvas.scrollToggleRequest.connect(self.toggleScrollBars)
 
         self.canvas.newShape.connect(self.newShape)
         self.canvas.shapeMoved.connect(self.setDirty)
@@ -1452,6 +1453,10 @@ class MainWindow(QtWidgets.QMainWindow):
         bar = self.scrollBars[orientation]
         value = bar.value() + bar.singleStep() * units
         self.setScroll(orientation, value)
+
+    def toggleScrollBars(self, enable: bool):
+        for bar in self.scrollBars.values():
+            bar.setEnabled(enable)
 
     def setScroll(self, orientation, value):
         self.scrollBars[orientation].setValue(int(value))

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -318,6 +318,33 @@ class Shape(object):
                 path.lineTo(p)
         return path
 
+    def rotateCenterBreak(self, rad: float):
+        """
+        Wrapper for `rotateCenter`.
+        But this will breaks the rectangle and turn the shape into
+        a polygon, therefore rotating it in "normal sense".
+
+        Notes:
+        - For points and circles, this is still useless.
+
+        Args:
+            rad (float): Angle to rotate in radian.
+        """
+        if self.shape_type == "rectangle":
+            tl = self.points[0]
+            br = self.points[1]
+            x0, y0 = tl.x(), tl.y()
+            x1, y1 = br.x(), br.y()
+            new_points = [
+                QtCore.QPointF(x0, y0),
+                QtCore.QPointF(x1, y0),
+                QtCore.QPointF(x1, y1),
+                QtCore.QPointF(x0, y1),
+            ]
+            self.points = new_points
+            self.shape_type = "polygon"
+        self.rotateCenter(rad)
+
     def rotateCenter(self, rad: float):
         """
         Rotate the shape around the center. This modifies the shape.

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -319,8 +319,8 @@ class Shape(object):
         return path
 
     def rotateCenterBreak(self, rad: float):
-        """
-        Wrapper for `rotateCenter`.
+        """Wrapper for `rotateCenter`.
+
         But this will breaks the rectangle and turn the shape into
         a polygon, therefore rotating it in "normal sense".
 
@@ -346,12 +346,12 @@ class Shape(object):
         self.rotateCenter(rad)
 
     def rotateCenter(self, rad: float):
-        """
-        Rotate the shape around the center. This modifies the shape.
+        """Rotate the shape around the center. This modifies the shape.
 
         Notes:
-        - For points and circles this is no-op since it's either useless or undesired behaviour
-        - For rectangle it will not rotate the rectangle in normal sense
+        - For points and circles this is no-op since
+          it's either useless or undesired behaviour.
+        - For rectangle it will not rotate the rectangle in normal sense.
 
         Args:
             rad (float): Angle to rotate in radian.

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -350,12 +350,15 @@ class Shape(object):
         Rotate the shape around the center. This modifies the shape.
 
         Notes:
-        - For points and circles, this is useless
+        - For points and circles this is no-op since it's either useless or undesired behaviour
         - For rectangle it will not rotate the rectangle in normal sense
 
         Args:
             rad (float): Angle to rotate in radian.
         """
+        if self.shape_type in ["point", "circle"]:
+            return
+
         def rotate(x, y, cx, cy):
             cos = math.cos(rad)
             sin = math.sin(rad)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -318,6 +318,47 @@ class Shape(object):
                 path.lineTo(p)
         return path
 
+    def rotateCenter(self, rad: float):
+        """
+        Rotate the shape around the center. This modifies the shape.
+
+        Notes:
+        - For points and circles, this is useless
+        - For rectangle it will not rotate the rectangle in normal sense
+
+        Args:
+            rad (float): Angle to rotate in radian.
+        """
+        def rotate(x, y, cx, cy):
+            cos = math.cos(rad)
+            sin = math.sin(rad)
+            # Translate
+            x = x - cx
+            y = y - cy
+
+            # Rotate
+            x_ = x * cos - y * sin
+            y_ = x * sin + y * cos
+
+            # Translate back
+            x_ = x_ + cx
+            y_ = y_ + cy
+            return x_, y_
+
+        # Calculate the center
+        cx, cy, n = 0, 0, 0
+        for pt in self.points:
+            cx = cx + pt.x()
+            cy = cy + pt.y()
+            n = n + 1
+        cx, cy = (cx / n, cy / n)
+
+        # Rotate
+        for pt in self.points:
+            x, y = rotate(pt.x(), pt.y(), cx, cy)
+            pt.setX(x)
+            pt.setY(y)
+
     def boundingRect(self):
         return self.makePath().boundingRect()
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1,7 +1,8 @@
+from datetime import datetime
+from datetime import timedelta
 import math
-import time
-from datetime import datetime, timedelta
 from threading import Thread
+import time
 
 import gdown
 from qtpy import QtCore
@@ -981,14 +982,13 @@ class Canvas(QtWidgets.QWidget):
         self._last_rotation = datetime.now()
         self.repaint()
 
-        # Enabled scroll again
-        # For whatever reason, enable the scroll right away does not block the scroll
+        # Enabled scroll again, for whatever reason
+        # enable the scroll right away does not block the scroll
         # A sleep of 0.1 is not very noticable
         def wait_and_enable_scroll():
             time.sleep(0.1)
             self.scrollToggleRequest.emit(True)
         Thread(target=wait_and_enable_scroll).start()
-
 
     def wheelEvent(self, ev):
         """Handles mouse wheel event.


### PR DESCRIPTION
## What has changed

- Add `rotateCenter` and `rotateCenterBreak` to `Shape`. `rotateCenter` rotate and keeps the shape, while `rotateCenterBreak` breaks the rectangle to create a quadrangle, then rotate it. The rotate action is a no-op on circles and points.
- Modify the canvas to rotate the shape when the mouse scroll and there are selected shapes. If the condition is not met, the scrolling falls back to the previous behavior.
- Add undo for scroll actions.
- Modify canvas and app to block the scrolling when rotating the shapes.

The shortcut:
- No modifier: rotate the shape 5deg.
- Shift modifier: rotate and break the shape.
- Ctrl modifier: rotate 30deg.

## Screencap example:

https://github.com/wkentaro/labelme/assets/33273948/f6d68cba-026d-4505-9e04-d6cc3a4cb546

