### PR TITLE
Add community guides section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ If you're new to Labelme, you can get started with [Labelme Starter Pack](https:
 - **Step-by-step tutorials**: first annotation to editing, exporting, and integrating with other programs 📕
 - **A compilation of valuable resources** for further exploration 🔗.
 
+## Community Guides
 
+The community has also written guides on how to use Labelme, some of which are listed below.
+
+- [How to Use LabelMe](https://blog.roboflow.com/labelme/) by Roboflow
+- [Annotate images with labelme](https://jsk-docs.readthedocs.io/projects/jsk_recognition/en/latest/deep_learning_with_image_dataset/annotate_images_with_labelme.html) by jsk_recognition
 
 <!-- ## Requirements -->
 <!--  -->


### PR DESCRIPTION
This PR adds a new `Community Guides` section to the project README in which people can list guides for using the annotation tool. I spent a bit of time labeling data in Labelme this year to learn more about labeling tools I can run locally. I wrote a guide on Labelme which I added to the lsit. jsk_recognition also has a visual guide which I have added. 