### PR TITLE
solves IOError: image file truncated in windows

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -32,6 +32,7 @@ from labelme.widgets import LabelListWidgetItem
 from labelme.widgets import ToolBar
 from labelme.widgets import UniqueLabelQListWidget
 from labelme.widgets import ZoomWidget
+from PIL import ImageFile
 
 from . import utils
 
@@ -43,7 +44,7 @@ from . import utils
 
 
 LABEL_COLORMAP = imgviz.label_colormap()
-
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 class MainWindow(QtWidgets.QMainWindow):
     FIT_WINDOW, FIT_WIDTH, MANUAL_ZOOM = 0, 1, 2


### PR DESCRIPTION
this issue appeared on the latset version of labelme on windows 11 