### PR TITLE
Add an option to specify whether to apply a smooth to the picture.

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -548,6 +548,14 @@ class MainWindow(QtWidgets.QMainWindow):
             checked=self._config["keep_prev_scale"],
             enabled=True,
         )
+        smoothPixmap = action(
+            self.tr("&Smooth Pixmap"),
+            self.enableSmoothPixmap,
+            tip=self.tr("Whether smooth pixmap"),
+            checkable=True,
+            checked=self._config["canvas"]["smooth_pixmap"],
+            enabled=True,
+        )
         fitWindow = action(
             self.tr("&Fit Window"),
             self.setFitWindow,
@@ -652,6 +660,7 @@ class MainWindow(QtWidgets.QMainWindow):
             zoomOut=zoomOut,
             zoomOrg=zoomOrg,
             keepPrevScale=keepPrevScale,
+            smoothPixmap=smoothPixmap,
             fitWindow=fitWindow,
             fitWidth=fitWidth,
             brightnessContrast=brightnessContrast,
@@ -760,6 +769,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 zoomOut,
                 zoomOrg,
                 keepPrevScale,
+                smoothPixmap,
                 None,
                 fitWindow,
                 fitWidth,
@@ -1549,6 +1559,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self._config["keep_prev_scale"] = enabled
         self.actions.keepPrevScale.setChecked(enabled)
 
+    def enableSmoothPixmap(self, enabled):
+        self._config["canvas"]["smooth_pixmap"] = enabled
+        self.actions.smoothPixmap.setChecked(enabled)
+        self.paintCanvas()
+
     def onNewBrightnessContrast(self, qimage):
         self.canvas.loadPixmap(QtGui.QPixmap.fromImage(qimage), clear_shapes=False)
 
@@ -1718,6 +1733,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def paintCanvas(self):
         assert not self.image.isNull(), "cannot paint null image"
+        self.canvas.smooth_pixmap = self._config["canvas"]["smooth_pixmap"]
         self.canvas.scale = 0.01 * self.zoomWidget.value()
         self.canvas.adjustSize()
         self.canvas.update()

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -81,6 +81,7 @@ canvas:
     linestrip: false
     ai_polygon: false
     ai_mask: false
+  smooth_pixmap: true
 
 shortcuts:
   close: Ctrl+W

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -102,6 +102,7 @@ class Canvas(QtWidgets.QWidget):
         self.setFocusPolicy(QtCore.Qt.WheelFocus)
 
         self._ai_model = None
+        self.smooth_pixmap = True
 
     def fillDrawing(self):
         return self._fill_drawing
@@ -686,9 +687,10 @@ class Canvas(QtWidgets.QWidget):
 
         p = self._painter
         p.begin(self)
-        p.setRenderHint(QtGui.QPainter.Antialiasing)
-        p.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
-        p.setRenderHint(QtGui.QPainter.SmoothPixmapTransform)
+        if self.smooth_pixmap:
+            p.setRenderHint(QtGui.QPainter.Antialiasing)
+            p.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
+            p.setRenderHint(QtGui.QPainter.SmoothPixmapTransform)
 
         p.scale(self.scale, self.scale)
         p.translate(self.offsetToCenter())


### PR DESCRIPTION
Add an option to specify whether to apply a smooth to the picture. It's useful when the picture is too small while there is a need of pixel-level precision annotation.