### PR TITLE
Apply Ruff upgrade and f-string fixes

### DIFF
--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import argparse
 import glob

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -64,11 +64,11 @@ def main():
         label_file = labelme.LabelFile(filename=filename)
 
         base = osp.splitext(osp.basename(filename))[0]
-        out_img_file = osp.join(args.output_dir, "JPEGImages", base + ".jpg")
-        out_xml_file = osp.join(args.output_dir, "Annotations", base + ".xml")
+        out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
+        out_xml_file = osp.join(args.output_dir, "Annotations", f"{base}.xml")
         if not args.noviz:
             out_viz_file = osp.join(
-                args.output_dir, "AnnotationsVisualization", base + ".jpg"
+                args.output_dir, "AnnotationsVisualization", f"{base}.jpg"
             )
 
         img = labelme.utils.img_data_to_arr(label_file.imageData)
@@ -77,7 +77,7 @@ def main():
         maker = lxml.builder.ElementMaker()
         xml = maker.annotation(
             maker.folder(),
-            maker.filename(base + ".jpg"),
+            maker.filename(f"{base}.jpg"),
             maker.database(),  # e.g., The VOC2007 Database
             maker.annotation(),  # e.g., Pascal VOC2007
             maker.image(),  # e.g., flickr

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -95,7 +95,7 @@ def main():
         label_file = labelme.LabelFile(filename=filename)
 
         base = osp.splitext(osp.basename(filename))[0]
-        out_img_file = osp.join(args.output_dir, "JPEGImages", base + ".jpg")
+        out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
 
         img = labelme.utils.img_data_to_arr(label_file.imageData)
         imgviz.io.imsave(out_img_file, img)
@@ -192,7 +192,7 @@ def main():
                     font_size=15,
                     line_width=2,
                 )
-            out_viz_file = osp.join(args.output_dir, "Visualization", base + ".jpg")
+            out_viz_file = osp.join(args.output_dir, "Visualization", f"{base}.jpg")
             imgviz.io.imsave(out_viz_file, viz)
 
     with open(out_ann_file, "w") as f:

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import argparse
 import glob

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -82,31 +82,31 @@ def main():
         label_file = labelme.LabelFile(filename=filename)
 
         base = osp.splitext(osp.basename(filename))[0]
-        out_img_file = osp.join(args.output_dir, "JPEGImages", base + ".jpg")
-        out_clsp_file = osp.join(args.output_dir, "SegmentationClass", base + ".png")
+        out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
+        out_clsp_file = osp.join(args.output_dir, "SegmentationClass", f"{base}.png")
         if not args.nonpy:
             out_cls_file = osp.join(
-                args.output_dir, "SegmentationClassNpy", base + ".npy"
+                args.output_dir, "SegmentationClassNpy", f"{base}.npy"
             )
         if not args.noviz:
             out_clsv_file = osp.join(
                 args.output_dir,
                 "SegmentationClassVisualization",
-                base + ".jpg",
+                f"{base}.jpg",
             )
         if not args.noobject:
             out_insp_file = osp.join(
-                args.output_dir, "SegmentationObject", base + ".png"
+                args.output_dir, "SegmentationObject", f"{base}.png"
             )
             if not args.nonpy:
                 out_ins_file = osp.join(
-                    args.output_dir, "SegmentationObjectNpy", base + ".npy"
+                    args.output_dir, "SegmentationObjectNpy", f"{base}.npy"
                 )
             if not args.noviz:
                 out_insv_file = osp.join(
                     args.output_dir,
                     "SegmentationObjectVisualization",
-                    base + ".jpg",
+                    f"{base}.jpg",
                 )
 
         img = labelme.utils.img_data_to_arr(label_file.imageData)

--- a/examples/tutorial/load_label_png.py
+++ b/examples/tutorial/load_label_png.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import os.path as osp
 
@@ -29,7 +28,7 @@ def main():
 
     print("label: label_name")
     for label, label_name in zip(labels, label_names):
-        print("%d: %s" % (label, label_name))
+        print(f"{label}: {label_name}")
 
 
 if __name__ == "__main__":

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -117,9 +117,7 @@ def main():
     parser.add_argument(
         "--config",
         dest="config",
-        help="config file or yaml-format string (default: {})".format(
-            default_config_file
-        ),
+        help=f"config file or yaml-format string (default: {default_config_file})",
         default=default_config_file,
     )
     # config for the gui
@@ -184,7 +182,7 @@ def main():
     args = parser.parse_args()
 
     if args.version:
-        print("{0} {1}".format(__appname__, __version__))
+        print(f"{__appname__} {__version__}")
         sys.exit(0)
 
     _setup_loguru(logger_level=args.logger_level.upper())
@@ -254,7 +252,7 @@ def main():
     )
 
     if reset_config:
-        logger.info("Resetting Qt config: %s" % win.settings.fileName())
+        logger.info("Resetting Qt config: %s", win.settings.fileName())
         win.settings.clear()
         sys.exit(0)
 

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -238,7 +238,7 @@ def main():
     translator = QtCore.QTranslator()
     translator.load(
         QtCore.QLocale.system().name(),
-        osp.dirname(osp.abspath(__file__)) + "/translate",
+        f"{osp.dirname(osp.abspath(__file__))}/translate",
     )
     app = QtWidgets.QApplication(sys.argv)
     app.setApplicationName(__appname__)

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -1,4 +1,5 @@
 import base64
+import builtins
 import contextlib
 import io
 import json
@@ -21,7 +22,7 @@ PIL.Image.MAX_IMAGE_PIXELS = None
 def open(name, mode):
     assert mode in ["r", "w"]
     encoding = "utf-8"
-    yield io.open(name, mode, encoding=encoding)
+    yield builtins.open(name, mode, encoding=encoding)
     return
 
 
@@ -124,7 +125,7 @@ class LabelFileError(Exception):
     pass
 
 
-class LabelFile(object):
+class LabelFile:
     shapes: list[ShapeDict]
     suffix = ".json"
 
@@ -140,8 +141,8 @@ class LabelFile(object):
     def load_image_file(filename):
         try:
             image_pil = PIL.Image.open(filename)
-        except IOError:
-            logger.error("Failed opening image file: {}".format(filename))
+        except OSError:
+            logger.error("Failed opening image file: %r", filename)
             return
 
         # apply orientation to image according to exif

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1234,10 +1234,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
             self._update_shape_color(shape)
             if shape.group_id is None:
+                r, g, b = shape.fill_color.getRgb()[:3]
                 item.setText(
-                    '{} <font color="#{:02x}{:02x}{:02x}">●</font>'.format(
-                        html.escape(shape.label), *shape.fill_color.getRgb()[:3]
-                    )
+                    f"{html.escape(shape.label)} "
+                    f'<font color="#{r:02x}{g:02x}{b:02x}">●</font>'
                 )
             else:
                 item.setText(f"{shape.label} ({shape.group_id})")
@@ -1306,10 +1306,9 @@ class MainWindow(QtWidgets.QMainWindow):
             action.setEnabled(True)
 
         self._update_shape_color(shape)
+        r, g, b = shape.fill_color.getRgb()[:3]
         label_list_item.setText(
-            '{} <font color="#{:02x}{:02x}{:02x}">●</font>'.format(
-                html.escape(text), *shape.fill_color.getRgb()[:3]
-            )
+            f'{html.escape(text)} <font color="#{r:02x}{g:02x}{b:02x}">●</font>'
         )
 
     def _update_shape_color(self, shape):

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import functools
 import html
 import math
@@ -93,7 +91,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Set point size from config file
         Shape.point_size = self._config["shape"]["point_size"]
 
-        super(MainWindow, self).__init__()
+        super().__init__()
         self.setWindowTitle(__appname__)
 
         # Whether we need to save or not.
@@ -912,7 +910,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def toolbar(self, title, actions=None):
         toolbar = ToolBar(title)
-        toolbar.setObjectName("%sToolBar" % title)
+        toolbar.setObjectName(f"{title}ToolBar")
         # toolbar.setOrientation(Qt.Vertical)
         toolbar.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         if actions:
@@ -960,7 +958,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actions.save.setEnabled(True)
         title = __appname__
         if self.filename is not None:
-            title = "{} - {}*".format(title, self.filename)
+            title = f"{title} - {self.filename}*"
         self.setWindowTitle(title)
 
     def setClean(self):
@@ -976,7 +974,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actions.createAiMaskMode.setEnabled(True)
         title = __appname__
         if self.filename is not None:
-            title = "{} - {}".format(title, self.filename)
+            title = f"{title} - {self.filename}"
         self.setWindowTitle(title)
 
         if self.hasLabelFile():
@@ -1138,7 +1136,7 @@ class MainWindow(QtWidgets.QMainWindow):
         for i, f in enumerate(files):
             icon = utils.newIcon("labels")
             action = QtWidgets.QAction(
-                icon, "&%d %s" % (i + 1, QtCore.QFileInfo(f).fileName()), self
+                icon, f"&{i + 1:d} {QtCore.QFileInfo(f).fileName()}", self
             )
             action.triggered.connect(functools.partial(self.loadRecent, f))
             menu.addAction(action)
@@ -1244,7 +1242,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     )
                 )
             else:
-                item.setText("{} ({})".format(shape.label, shape.group_id))
+                item.setText(f"{shape.label} ({shape.group_id})")
             self.setDirty()
             if self.uniqLabelList.findItemByLabel(shape.label) is None:
                 item = self.uniqLabelList.createItemFromLabel(shape.label)
@@ -1297,7 +1295,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if shape.group_id is None:
             text = shape.label
         else:
-            text = "{} ({})".format(shape.label, shape.group_id)
+            text = f"{shape.label} ({shape.group_id})"
         label_list_item = LabelListWidgetItem(text, shape)
         self.labelList.addItem(label_list_item)
         if self.uniqLabelList.findItemByLabel(shape.label) is None:
@@ -1675,7 +1673,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if image.isNull():
             formats = [
-                "*.{}".format(fmt.data().decode())
+                f"*.{fmt.data().decode()}"
                 for fmt in QtGui.QImageReader.supportedImageFormats()
             ]
             self.errorMessage(
@@ -1755,7 +1753,7 @@ class MainWindow(QtWidgets.QMainWindow):
             and self.zoomMode != self.MANUAL_ZOOM
         ):
             self.adjustScale()
-        super(MainWindow, self).resizeEvent(event)
+        super().resizeEvent(event)
 
     def paintCanvas(self):
         assert not self.image.isNull(), "cannot paint null image"
@@ -1803,7 +1801,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def dragEnterEvent(self, event):
         extensions = [
-            ".%s" % fmt.data().decode().lower()
+            f".{fmt.data().decode().lower()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
         if event.mimeData().hasUrls():
@@ -1884,11 +1882,11 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         path = osp.dirname(str(self.filename)) if self.filename else "."
         formats = [
-            "*.{}".format(fmt.data().decode())
+            f"*.{fmt.data().decode()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
         filters = self.tr("Image & Label files (%s)") % " ".join(
-            formats + ["*%s" % LabelFile.suffix]
+            formats + [f"*{LabelFile.suffix}"]
         )
         fileDialog = FileDialogPreview(self)
         fileDialog.setFileMode(FileDialogPreview.ExistingFile)
@@ -2017,7 +2015,7 @@ class MainWindow(QtWidgets.QMainWindow):
         label_file = self.getLabelFile()
         if osp.exists(label_file):
             os.remove(label_file)
-            logger.info("Label file is removed: {}".format(label_file))
+            logger.info("Label file is removed: %s", label_file)
 
             item = self.fileListWidget.currentItem()
             if item:
@@ -2064,7 +2062,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def errorMessage(self, title, message):
         return QtWidgets.QMessageBox.critical(
-            self, title, "<p><b>%s</b></p>%s" % (title, message)
+            self, title, f"<p><b>{title}</b></p>{message}"
         )
 
     def currentPath(self):
@@ -2140,7 +2138,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def importDroppedImageFiles(self, imageFiles):
         extensions = [
-            ".%s" % fmt.data().decode().lower()
+            f".{fmt.data().decode().lower()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
 
@@ -2199,7 +2197,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def scanAllImages(self, folderPath):
         extensions = [
-            ".%s" % fmt.data().decode().lower()
+            f".{fmt.data().decode().lower()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -497,9 +497,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     "{} and {} from the canvas."
                 )
             ).format(
-                utils.fmtShortcut(
-                    "{},{}".format(shortcuts["zoom_in"], shortcuts["zoom_out"])
-                ),
+                utils.fmtShortcut(f"{shortcuts['zoom_in']},{shortcuts['zoom_out']}"),
                 utils.fmtShortcut(self.tr("Ctrl+Wheel")),
             )
         )
@@ -948,7 +946,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actions.undo.setEnabled(self.canvas.isShapeRestorable)
 
         if self._config["auto_save"] or self.actions.saveAuto.isChecked():  # type: ignore[attr-defined]
-            label_file = osp.splitext(self.imagePath)[0] + ".json"  # type: ignore[arg-type]
+            label_file = f"{osp.splitext(self.imagePath)[0]}.json"  # type: ignore[arg-type]
             if self.output_dir:
                 label_file_without_path = osp.basename(label_file)
                 label_file = osp.join(self.output_dir, label_file_without_path)
@@ -1641,7 +1639,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return False
         # assumes same name, but json extension
         self.status(str(self.tr("Loading %s...")) % osp.basename(str(filename)))
-        label_file = osp.splitext(filename)[0] + ".json"
+        label_file = f"{osp.splitext(filename)[0]}.json"
         if self.output_dir:
             label_file_without_path = osp.basename(label_file)
             label_file = osp.join(self.output_dir, label_file_without_path)
@@ -1999,7 +1997,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.filename.lower().endswith(".json"):
             label_file = self.filename
         else:
-            label_file = osp.splitext(self.filename)[0] + ".json"
+            label_file = f"{osp.splitext(self.filename)[0]}.json"
 
         return label_file
 
@@ -2146,7 +2144,7 @@ class MainWindow(QtWidgets.QMainWindow):
         for file in imageFiles:
             if file in self.imageList or not file.lower().endswith(tuple(extensions)):
                 continue
-            label_file = osp.splitext(file)[0] + ".json"
+            label_file = f"{osp.splitext(file)[0]}.json"
             if self.output_dir:
                 label_file_without_path = osp.basename(label_file)
                 label_file = osp.join(self.output_dir, label_file_without_path)
@@ -2182,7 +2180,7 @@ class MainWindow(QtWidgets.QMainWindow):
             except re.error:
                 pass
         for filename in filenames:
-            label_file = osp.splitext(filename)[0] + ".json"
+            label_file = f"{osp.splitext(filename)[0]}.json"
             if self.output_dir:
                 label_file_without_path = osp.basename(label_file)
                 label_file = osp.join(self.output_dir, label_file_without_path)

--- a/labelme/cli/draw_label_png.py
+++ b/labelme/cli/draw_label_png.py
@@ -40,17 +40,14 @@ def main():
 
     unique_label_values = np.unique(label)
 
-    logger.info("Label image shape: {}".format(label.shape))
-    logger.info("Label values: {}".format(unique_label_values.tolist()))
+    logger.info("Label image shape: %s", label.shape)
+    logger.info("Label values: %s", unique_label_values.tolist())
     if label_names is not None:
-        logger.info(
-            "Label names: {}".format(
-                [
-                    "{}:{}".format(label_value, label_names[label_value])
-                    for label_value in unique_label_values
-                ]
-            )
-        )
+        names = [
+            f"{label_value}:{label_names[label_value]}"
+            for label_value in unique_label_values
+        ]
+        logger.info("Label names: %s", names)
 
     if args.image:
         num_cols = 2
@@ -74,7 +71,7 @@ def main():
             label_names=label_names,
             font_size=label.shape[1] // 30,
         )
-        plt.title("{}\n{}".format(args.label_png, args.image))
+        plt.title(f"{args.label_png}\n{args.image}")
         plt.imshow(label_viz_with_overlay)
 
     plt.tight_layout()

--- a/labelme/cli/export_json.py
+++ b/labelme/cli/export_json.py
@@ -58,7 +58,7 @@ def main():
         for lbl_name in label_names:
             f.write(lbl_name + "\n")  # type: ignore[operator]
 
-    logger.info("Saved to: {}".format(out_dir))
+    logger.info("Saved to: %s", out_dir)
 
 
 if __name__ == "__main__":

--- a/labelme/cli/export_json.py
+++ b/labelme/cli/export_json.py
@@ -56,7 +56,7 @@ def main():
 
     with open(osp.join(out_dir, "label_names.txt"), "w") as f:
         for lbl_name in label_names:
-            f.write(lbl_name + "\n")  # type: ignore[operator]
+            f.write(f"{lbl_name}\n")  # type: ignore[operator]
 
     logger.info("Saved to: %s", out_dir)
 

--- a/labelme/cli/on_docker.py
+++ b/labelme/cli/on_docker.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 import argparse
 import json
@@ -35,13 +34,13 @@ def get_ip():
 
 def labelme_on_docker(in_file, out_file):
     ip = get_ip()
-    cmd = "xhost + %s" % ip
+    cmd = f"xhost + {ip}"
     subprocess.check_output(shlex.split(cmd))
 
     if out_file:
         out_file = osp.abspath(out_file)
         if osp.exists(out_file):
-            raise RuntimeError("File exists: %s" % out_file)
+            raise RuntimeError(f"File exists: {out_file}")
         else:
             open(osp.abspath(out_file), "w")
 
@@ -63,10 +62,10 @@ def labelme_on_docker(in_file, out_file):
     if out_file:
         out_file_a = osp.abspath(out_file)
         out_file_b = osp.join("/home/developer", osp.basename(out_file))
-        cmd += " -v {0}:{1}".format(out_file_a, out_file_b)
-    cmd += " wkentaro/labelme labelme {0}".format(in_file_b)
+        cmd += f" -v {out_file_a}:{out_file_b}"
+    cmd += f" wkentaro/labelme labelme {in_file_b}"
     if out_file:
-        cmd += " -O {0}".format(out_file_b)
+        cmd += f" -O {out_file_b}"
     subprocess.call(shlex.split(cmd))
 
     if out_file:
@@ -92,7 +91,7 @@ def main():
     try:
         out_file = labelme_on_docker(args.in_file, args.output)
         if out_file:
-            print("Saved to: %s" % out_file)
+            print(f"Saved to: {out_file}")
     except RuntimeError as e:
         sys.stderr.write(e.__str__() + "\n")
         sys.exit(1)

--- a/labelme/cli/on_docker.py
+++ b/labelme/cli/on_docker.py
@@ -93,7 +93,7 @@ def main():
         if out_file:
             print(f"Saved to: {out_file}")
     except RuntimeError as e:
-        sys.stderr.write(e.__str__() + "\n")
+        sys.stderr.write(f"{e}\n")
         sys.exit(1)
 
 

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -12,7 +12,7 @@ def update_dict(target_dict, new_dict, validate_item=None):
         if validate_item:
             validate_item(key, value)
         if key not in target_dict:
-            logger.warning("Skipping unexpected key in config: {}".format(key))
+            logger.warning(f"Skipping unexpected key in config: {key}")
             continue
         if isinstance(target_dict[key], dict) and isinstance(value, dict):
             update_dict(target_dict[key], value, validate_item=validate_item)
@@ -34,24 +34,18 @@ def get_default_config():
         try:
             shutil.copy(config_file, user_config_file)
         except Exception:
-            logger.warning("Failed to save config: {}".format(user_config_file))
+            logger.warning(f"Failed to save config: {user_config_file}")
 
     return config
 
 
 def validate_config_item(key, value):
     if key == "validate_label" and value not in [None, "exact"]:
-        raise ValueError(
-            "Unexpected value for config key 'validate_label': {}".format(value)
-        )
+        raise ValueError(f"Unexpected value for config key 'validate_label': {value}")
     if key == "shape_color" and value not in [None, "auto", "manual"]:
-        raise ValueError(
-            "Unexpected value for config key 'shape_color': {}".format(value)
-        )
+        raise ValueError(f"Unexpected value for config key 'shape_color': {value}")
     if key == "labels" and value is not None and len(value) != len(set(value)):
-        raise ValueError(
-            "Duplicates are detected for config key 'labels': {}".format(value)
-        )
+        raise ValueError(f"Duplicates are detected for config key 'labels': {value}")
 
 
 def get_config(config_file_or_yaml=None, config_from_args=None):
@@ -63,7 +57,7 @@ def get_config(config_file_or_yaml=None, config_from_args=None):
         config_from_yaml = yaml.safe_load(config_file_or_yaml)
         if not isinstance(config_from_yaml, dict):
             with open(config_from_yaml) as f:
-                logger.info("Loading config file from: {}".format(config_from_yaml))
+                logger.info(f"Loading config file from: {config_from_yaml}")
                 config_from_yaml = yaml.safe_load(f)
         update_dict(config, config_from_yaml, validate_item=validate_config_item)
 

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -12,7 +12,7 @@ import labelme.utils
 # - [opt] Store paths instead of creating new ones at each paint.
 
 
-class Shape(object):
+class Shape:
     # Render handles as squares
     P_SQUARE = 0
 
@@ -112,7 +112,7 @@ class Shape(object):
             "points",
             "mask",
         ]:
-            raise ValueError("Unexpected shape_type: {}".format(value))
+            raise ValueError(f"Unexpected shape_type: {value}")
         self._shape_type = value
 
     def close(self):

--- a/labelme/utils/_io.py
+++ b/labelme/utils/_io.py
@@ -21,6 +21,6 @@ def lblsave(filename, lbl):
         lbl_pil.save(filename)
     else:
         raise ValueError(
-            "[%s] Cannot save the pixel-wise class label as PNG. "
-            "Please consider using the .npy format." % filename
+            f"[{filename}] Cannot save the pixel-wise class label as PNG. "
+            "Please consider using the .npy format."
         )

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -11,7 +11,7 @@ here = osp.dirname(osp.abspath(__file__))
 
 def newIcon(icon):
     icons_dir = osp.join(here, "../icons")
-    return QtGui.QIcon(osp.join(":/", icons_dir, "%s.png" % icon))
+    return QtGui.QIcon(osp.join(":/", icons_dir, f"{icon}.png"))
 
 
 def newButton(text, icon=None, slot=None):
@@ -90,4 +90,4 @@ def distancetoline(point, line):
 
 def fmtShortcut(text):
     mod, key = text.split("+", 1)
-    return "<b>%s</b>+<b>%s</b>" % (mod, key)
+    return f"<b>{mod}</b>+<b>{key}</b>"

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -111,11 +111,9 @@ def labelme_shapes_to_label(img_shape, shapes):
 
 def masks_to_bboxes(masks):
     if masks.ndim != 3:
-        raise ValueError("masks.ndim must be 3, but it is {}".format(masks.ndim))
+        raise ValueError(f"masks.ndim must be 3, but it is {masks.ndim}")
     if masks.dtype != bool:
-        raise ValueError(
-            "masks.dtype must be bool type, but it is {}".format(masks.dtype)
-        )
+        raise ValueError(f"masks.dtype must be bool type, but it is {masks.dtype}")
     bboxes = []
     for mask in masks:
         where = np.argwhere(mask)

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -9,7 +9,7 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
     _base_value = 50
 
     def __init__(self, img, callback, parent=None):
-        super(BrightnessContrastDialog, self).__init__(parent)
+        super().__init__(parent)
         self.setModal(True)
         self.setWindowTitle("Brightness/Contrast")
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -52,7 +52,7 @@ class Canvas(QtWidgets.QWidget):
         self.double_click = kwargs.pop("double_click", "close")
         if self.double_click not in [None, "close"]:
             raise ValueError(
-                "Unexpected value for double_click event: {}".format(self.double_click)
+                f"Unexpected value for double_click event: {self.double_click}"
             )
         self.num_backups = kwargs.pop("num_backups", 10)
         self._crosshair = kwargs.pop(
@@ -68,7 +68,7 @@ class Canvas(QtWidgets.QWidget):
                 "ai_mask": False,
             },
         )
-        super(Canvas, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Initialise local state.
         self.mode = self.EDIT
         self.shapes = []
@@ -133,7 +133,7 @@ class Canvas(QtWidgets.QWidget):
             "ai_polygon",
             "ai_mask",
         ]:
-            raise ValueError("Unsupported createMode: %s" % value)
+            raise ValueError(f"Unsupported createMode: {value}")
         self._createMode = value
 
     def set_ai_model_name(self, model_name: str) -> None:
@@ -655,7 +655,7 @@ class Canvas(QtWidgets.QWidget):
 
     def paintEvent(self, event: QtGui.QPaintEvent) -> None:
         if not self.pixmap:
-            return super(Canvas, self).paintEvent(event)
+            return super().paintEvent(event)
 
         p = self._painter
         p.begin(self)
@@ -745,7 +745,7 @@ class Canvas(QtWidgets.QWidget):
 
     def offsetToCenter(self) -> QtCore.QPointF:
         s = self.scale
-        area = super(Canvas, self).size()
+        area = super().size()
         w, h = self.pixmap.width() * s, self.pixmap.height() * s
         aw, ah = area.width(), area.height()
         x = (aw - w) / (2 * s) if aw > w else 0
@@ -844,7 +844,7 @@ class Canvas(QtWidgets.QWidget):
     def minimumSizeHint(self):
         if self.pixmap:
             return self.scale * self.pixmap.size()
-        return super(Canvas, self).minimumSizeHint()
+        return super().minimumSizeHint()
 
     def wheelEvent(self, ev):
         mods = ev.modifiers()

--- a/labelme/widgets/escapable_qlist_widget.py
+++ b/labelme/widgets/escapable_qlist_widget.py
@@ -4,6 +4,6 @@ from PyQt5.QtCore import Qt
 
 class EscapableQListWidget(QtWidgets.QListWidget):
     def keyPressEvent(self, event):
-        super(EscapableQListWidget, self).keyPressEvent(event)
+        super().keyPressEvent(event)
         if event.key() == Qt.Key_Escape:
             self.clearSelection()

--- a/labelme/widgets/file_dialog_preview.py
+++ b/labelme/widgets/file_dialog_preview.py
@@ -8,7 +8,7 @@ from PyQt5 import QtWidgets
 
 class ScrollAreaPreview(QtWidgets.QScrollArea):
     def __init__(self, *args, **kwargs):
-        super(ScrollAreaPreview, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.setWidgetResizable(True)
 
@@ -34,7 +34,7 @@ class ScrollAreaPreview(QtWidgets.QScrollArea):
 
 class FileDialogPreview(QtWidgets.QFileDialog):
     def __init__(self, *args, **kwargs):
-        super(FileDialogPreview, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setOption(self.DontUseNativeDialog, True)
 
         self.labelPreview = ScrollAreaPreview(self)
@@ -53,7 +53,7 @@ class FileDialogPreview(QtWidgets.QFileDialog):
 
     def onChange(self, path):
         if path.lower().endswith(".json"):
-            with open(path, "r") as f:
+            with open(path) as f:
                 data = json.load(f)
                 self.labelPreview.setText(json.dumps(data, indent=4, sort_keys=False))
             self.labelPreview.label.setAlignment(

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -20,7 +20,7 @@ class LabelQLineEdit(QtWidgets.QLineEdit):
         if e.key() in [QtCore.Qt.Key_Up, QtCore.Qt.Key_Down]:
             self.list_widget.keyPressEvent(e)
         else:
-            super(LabelQLineEdit, self).keyPressEvent(e)
+            super().keyPressEvent(e)
 
 
 class LabelDialog(QtWidgets.QDialog):
@@ -39,7 +39,7 @@ class LabelDialog(QtWidgets.QDialog):
             fit_to_content = {"row": False, "column": True}
         self._fit_to_content = fit_to_content
 
-        super(LabelDialog, self).__init__(parent)
+        super().__init__(parent)
         self.edit = LabelQLineEdit()
         self.edit.setPlaceholderText(text)
         self.edit.setValidator(labelme.utils.labelValidator())
@@ -110,7 +110,7 @@ class LabelDialog(QtWidgets.QDialog):
             completer.setCompletionMode(QtWidgets.QCompleter.PopupCompletion)
             completer.setFilterMode(QtCore.Qt.MatchContains)
         else:
-            raise ValueError("Unsupported completion: {}".format(completion))
+            raise ValueError(f"Unsupported completion: {completion}")
         completer.setModel(self.labelList.model())
         self.edit.setCompleter(completer)
 
@@ -233,7 +233,7 @@ class LabelDialog(QtWidgets.QDialog):
         items = self.labelList.findItems(text, QtCore.Qt.MatchFixedString)
         if items:
             if len(items) != 1:
-                logger.warning("Label list has duplicate '{}'".format(text))
+                logger.warning("Label list has duplicate %r", text)
             self.labelList.setCurrentItem(items[0])
             row = self.labelList.row(items[0])
             self.edit.completer().setCurrentRow(row)  # type: ignore[union-attr]

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import QStyle
 # https://stackoverflow.com/a/2039745/4158863
 class HTMLDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(self, parent=None):
-        super(HTMLDelegate, self).__init__()
+        super().__init__()
         self.doc = QtGui.QTextDocument(self)
 
     def paint(self, painter, option, index):
@@ -69,7 +69,7 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
 
 class LabelListWidgetItem(QtGui.QStandardItem):
     def __init__(self, text=None, shape=None):
-        super(LabelListWidgetItem, self).__init__()
+        super().__init__()
         self.setText(text or "")
         self.setShape(shape)
 
@@ -91,7 +91,7 @@ class LabelListWidgetItem(QtGui.QStandardItem):
         return id(self)
 
     def __repr__(self):
-        return '{}("{}")'.format(self.__class__.__name__, self.text())
+        return f'{self.__class__.__name__}("{self.text()}")'
 
 
 class StandardItemModel(QtGui.QStandardItemModel):
@@ -108,7 +108,7 @@ class LabelListWidget(QtWidgets.QListView):
     itemSelectionChanged = QtCore.pyqtSignal(list, list)
 
     def __init__(self):
-        super(LabelListWidget, self).__init__()
+        super().__init__()
         self._selectedItems = []
 
         self.setWindowFlags(Qt.Window)
@@ -177,7 +177,7 @@ class LabelListWidget(QtWidgets.QListView):
             item = cast(LabelListWidgetItem, item)
             if item.shape() == shape:
                 return item
-        raise ValueError("cannot find shape: {}".format(shape))
+        raise ValueError(f"cannot find shape: {shape}")
 
     def clear(self):
         self._model.clear()

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -4,7 +4,7 @@ from PyQt5 import QtWidgets
 
 class ToolBar(QtWidgets.QToolBar):
     def __init__(self, title):
-        super(ToolBar, self).__init__(title)
+        super().__init__(title)
         layout = self.layout()
         m = (0, 0, 0, 0)
         layout.setSpacing(0)
@@ -14,7 +14,7 @@ class ToolBar(QtWidgets.QToolBar):
 
     def addAction(self, action):  # type: ignore[override]
         if isinstance(action, QtWidgets.QWidgetAction):
-            return super(ToolBar, self).addAction(action)
+            return super().addAction(action)
         btn = QtWidgets.QToolButton()
         btn.setDefaultAction(action)
         btn.setToolButtonStyle(self.toolButtonStyle())

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import html
 
 from PyQt5 import QtWidgets
@@ -10,7 +8,7 @@ from .escapable_qlist_widget import EscapableQListWidget
 
 class UniqueLabelQListWidget(EscapableQListWidget):
     def mousePressEvent(self, event):
-        super(UniqueLabelQListWidget, self).mousePressEvent(event)
+        super().mousePressEvent(event)
         if not self.indexAt(event.pos()).isValid():
             self.clearSelection()
 
@@ -22,7 +20,7 @@ class UniqueLabelQListWidget(EscapableQListWidget):
 
     def createItemFromLabel(self, label):
         if self.findItemByLabel(label):
-            raise ValueError("Item for label '{}' already exists".format(label))
+            raise ValueError(f"Item for label '{label}' already exists")
 
         item = QtWidgets.QListWidgetItem()
         item.setData(Qt.UserRole, label)
@@ -31,7 +29,7 @@ class UniqueLabelQListWidget(EscapableQListWidget):
     def setItemLabel(self, item, label, color=None):
         qlabel = QtWidgets.QLabel()
         if color is None:
-            qlabel.setText("{}".format(label))
+            qlabel.setText(f"{label}")
         else:
             qlabel.setText(
                 '{} <font color="#{:02x}{:02x}{:02x}">●</font>'.format(

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -31,10 +31,9 @@ class UniqueLabelQListWidget(EscapableQListWidget):
         if color is None:
             qlabel.setText(f"{label}")
         else:
+            r, g, b = color
             qlabel.setText(
-                '{} <font color="#{:02x}{:02x}{:02x}">●</font>'.format(
-                    html.escape(label), *color
-                )
+                f'{html.escape(label)} <font color="#{r:02x}{g:02x}{b:02x}">●</font>'
             )
         qlabel.setAlignment(Qt.AlignBottom)
 

--- a/labelme/widgets/zoom_widget.py
+++ b/labelme/widgets/zoom_widget.py
@@ -5,7 +5,7 @@ from PyQt5 import QtWidgets
 
 class ZoomWidget(QtWidgets.QSpinBox):
     def __init__(self, value=100):
-        super(ZoomWidget, self).__init__()
+        super().__init__()
         self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
         self.setRange(1, 1000)
         self.setSuffix(" %")
@@ -15,7 +15,7 @@ class ZoomWidget(QtWidgets.QSpinBox):
         self.setAlignment(QtCore.Qt.AlignCenter)
 
     def minimumSizeHint(self):
-        height = super(ZoomWidget, self).minimumSizeHint().height()
+        height = super().minimumSizeHint().height()
         fm = QtGui.QFontMetrics(self.font())
         width = fm.width(str(self.maximum()))
         return QtCore.QSize(width, height)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,12 @@ markers = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = [
+  "E", # pycodestyle
+  "F", # pyflakes
+  "I", # isort
+  "UP", # pyupgrade
+]
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/tests/labelme_tests/widgets_tests/test_label_list_widget.py
+++ b/tests/labelme_tests/widgets_tests/test_label_list_widget.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import pytest
 
 from labelme.widgets import LabelListWidget


### PR DESCRIPTION
<del>`setup.py` declares that the app supports Pythons down to Python 3.5, but the CI flow doesn't test on that version, and that version has been EOL for multiple years anyway. This PR hikes the minimum support version to Python 3.8 (which will be EOL in 2 months),</del>

Python version compatibility changes were applied in #1541.

This PR:

* enables and mechanically applies the Ruff `UP` (Pyupgrade) auto-fixes.
* runs `flynt` to fix some remaining f-string usage, and follows up with manually fixing some remaining `.format()`s.
