### PR TITLE
Remove slight shifting from duplicate

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1480,10 +1480,8 @@ class MainWindow(QtWidgets.QMainWindow):
             return False
 
     def duplicateSelectedShape(self):
-        added_shapes = self.canvas.duplicateSelectedShapes()
-        for shape in added_shapes:
-            self.addLabel(shape)
-        self.setDirty()
+        self.copySelectedShape()
+        self.pasteSelectedShape()
 
     def pasteSelectedShape(self):
         self.loadShapes(self._copied_shapes, replace=False)

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -663,12 +663,6 @@ class Canvas(QtWidgets.QWidget):
         self.storeShapes()
         self.update()
 
-    def duplicateSelectedShapes(self):
-        if self.selectedShapes:
-            self.selectedShapesCopy = [s.copy() for s in self.selectedShapes]
-            self.endMove(copy=True)
-        return self.selectedShapes
-
     def paintEvent(self, event):
         if not self.pixmap:
             return super(Canvas, self).paintEvent(event)

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -666,19 +666,8 @@ class Canvas(QtWidgets.QWidget):
     def duplicateSelectedShapes(self):
         if self.selectedShapes:
             self.selectedShapesCopy = [s.copy() for s in self.selectedShapes]
-            self.boundedShiftShapes(self.selectedShapesCopy)
             self.endMove(copy=True)
         return self.selectedShapes
-
-    def boundedShiftShapes(self, shapes):
-        # Try to move in one direction, and if it fails in another.
-        # Give up if both fail.
-        point = shapes[0][0]
-        offset = QtCore.QPointF(2.0, 2.0)
-        self.offsets = QtCore.QPoint(), QtCore.QPoint()
-        self.prevPoint = point
-        if not self.boundedMoveShapes(shapes, point - offset):
-            self.boundedMoveShapes(shapes, point + offset)
 
     def paintEvent(self, event):
         if not self.pixmap:


### PR DESCRIPTION
## Why?

1. Slight shifting makes it hard to perfect-fit to the original polygon when annotating the same object
2. The opacity of multiple polygons already tells enough visual that there are multiple polygons there.

## Before -> After

https://github.com/user-attachments/assets/c96b7ba2-9965-47ee-8d02-4a601274c641


https://github.com/user-attachments/assets/e8745afa-53a2-47b7-8280-9b8bc4f86570

