### PR TITLE
Fix index error due to missing previously selected shapes in current image

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -963,7 +963,11 @@ class Canvas(QtWidgets.QWidget):
             if int(modifiers) == 0:
                 self.snapping = True
         elif self.editing():
-            if self.movingShape and self.selectedShapes:
+            if (
+                self.movingShape
+                and self.selectedShapes
+                and self.selectedShapes[0] in self.shapes
+            ):
                 index = self.shapes.index(self.selectedShapes[0])
                 if self.shapesBackups[-1][index].points != self.shapes[index].points:
                     self.storeShapes()


### PR DESCRIPTION
The problem can be reproduced by selecting a shape in current image `a`, and go on next image `b` then press backspace to delete point. `self.selectedShapes` is in image `a` thus it doesn't exist in any shapes in image `b`.

Another possible solution is to clear selected shapes after loading a new image, but user may want to go back to original image and use those selected shapes.