### PR TITLE
fix: horizontal scroll when shift modifier is pressed

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -908,6 +908,9 @@ class Canvas(QtWidgets.QWidget):
                 # with Ctrl/Command key
                 # zoom
                 self.zoomRequest.emit(delta.y(), ev.pos())
+            elif QtCore.Qt.ShiftModifier == int(mods):
+                # Convert wheel y(up down) direction to horizontal scroll with Shift key
+                self.scrollRequest.emit(delta.y(), QtCore.Qt.Horizontal)
             else:
                 # scroll
                 self.scrollRequest.emit(delta.x(), QtCore.Qt.Horizontal)


### PR DESCRIPTION
## Issue:

Both Scroll and Shift+Scroll resulted in vertical(up-down) scrolling in QT5.

It seems the else(QT5) condition properly handle the shift+scroll condition, ref: https://github.com/ardiya/labelme/blob/57fbf2b9a749cd77ac5f03f005ee6206d671ece8/labelme/widgets/canvas.py#L928-L929 So I just need to handle the QT5 condition.

## Expected result:

In Qt5, the Shift+Scroll should result in horizontal(left-right) scroll.

## Proposed Fix: This PR

When Shift modifier is pressed, use the y dimension of the scroll and use it to scroll horizontally.

Tested with shift and without shift, the code changes produces expected behavior.