### PR TITLE
Fix undefined logger.warn for loguru

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -845,7 +845,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.statusBar().show()
 
         if output_file is not None and self._config["auto_save"]:
-            logger.warn(
+            logger.warning(
                 "If `auto_save` argument is True, `output_file` argument "
                 "is ignored and output filename is automatically "
                 "set as IMAGE_BASENAME.json."

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -12,7 +12,7 @@ def update_dict(target_dict, new_dict, validate_item=None):
         if validate_item:
             validate_item(key, value)
         if key not in target_dict:
-            logger.warn("Skipping unexpected key in config: {}".format(key))
+            logger.warning("Skipping unexpected key in config: {}".format(key))
             continue
         if isinstance(target_dict[key], dict) and isinstance(value, dict):
             update_dict(target_dict[key], value, validate_item=validate_item)
@@ -34,7 +34,7 @@ def get_default_config():
         try:
             shutil.copy(config_file, user_config_file)
         except Exception:
-            logger.warn("Failed to save config: {}".format(user_config_file))
+            logger.warning("Failed to save config: {}".format(user_config_file))
 
     return config
 

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -75,7 +75,7 @@ def shapes_to_label(img_shape, shapes, label_name_to_value):
 
 
 def labelme_shapes_to_label(img_shape, shapes):
-    logger.warn(
+    logger.warning(
         "labelme_shapes_to_label is deprecated, so please use " "shapes_to_label."
     )
 

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -106,7 +106,7 @@ class LabelDialog(QtWidgets.QDialog):
         # completion
         completer = QtWidgets.QCompleter()
         if not QT5 and completion != "startswith":
-            logger.warn(
+            logger.warning(
                 "completion other than 'startswith' is only "
                 "supported with Qt5. Using 'startswith'"
             )


### PR DESCRIPTION
## Why?

Regression by https://github.com/wkentaro/labelme/pull/1523

loguru doesn't have `logger.warn`

```
Traceback (most recent call last):
  File "labelme\__main__.py", line 218, in <module>
  File "labelme\__main__.py", line 171, in main
  File "labelme\config\__init__.py", line 68, in get_config
  File "labelme\config\__init__.py", line 15, in update_dict
AttributeError: 'Logger' object has no attribute 'warn'
```

