### PR TITLE
Handle when shape["flags"] is None

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1372,7 +1372,7 @@ class MainWindow(QtWidgets.QMainWindow):
             label = shape["label"]
             points = shape["points"]
             shape_type = shape["shape_type"]
-            flags = shape["flags"]
+            flags: dict = shape["flags"] or {}
             description = shape.get("description", "")
             group_id = shape["group_id"]
             other_data = shape["other_data"]


### PR DESCRIPTION
It happens when AI-text-to-rectangle is used, because Shape class flags is default None.

Close https://github.com/wkentaro/labelme/issues/1386

Thanks @dkuncik @skoczo @pliverani @Code-Now-QD for reporting this issue.