### PR TITLE
Drop qtpy and primarily support PyQt5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.9']
-        PYTEST_QT_API: [pyqt5]
 
     steps:
     - uses: actions/checkout@v2
@@ -53,7 +52,6 @@ jobs:
       shell: bash -l {0}
       if: matrix.os == 'ubuntu-latest'
       env:
-        PYTEST_QT_API: ${{ matrix.PYTEST_QT_API }}
         MPLBACKEND: 'agg'
       run: |
         sudo apt-get update

--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from qtpy import QT_VERSION
-
 
 __appname__ = "labelme"
 
@@ -13,10 +11,6 @@ __appname__ = "labelme"
 # 3. PATCH version when you make backwards-compatible bug fixes.
 # e.g., 1.0.0a0, 1.0.0a1, 1.0.0b0, 1.0.0rc0, 1.0.0, 1.0.0.post0
 __version__ = "5.6.1"
-
-QT4 = QT_VERSION[0] == "4"
-QT5 = QT_VERSION[0] == "5"
-del QT_VERSION
 
 from labelme.label_file import LabelFile
 from labelme import testing

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -6,8 +6,8 @@ import sys
 
 import yaml
 from loguru import logger
-from qtpy import QtCore
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtWidgets
 
 from labelme import __appname__
 from labelme import __version__

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -12,10 +12,10 @@ import imgviz
 import natsort
 import numpy as np
 from loguru import logger
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
 
 from labelme import __appname__
 from labelme import ai

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -3,8 +3,8 @@ import copy
 import numpy as np
 import skimage.measure
 from loguru import logger
-from qtpy import QtCore
-from qtpy import QtGui
+from PyQt5 import QtCore
+from PyQt5 import QtGui
 
 import labelme.utils
 

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -2,9 +2,9 @@ import os.path as osp
 from math import sqrt
 
 import numpy as np
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
 here = osp.dirname(osp.abspath(__file__))
 

--- a/labelme/widgets/ai_prompt_widget.py
+++ b/labelme/widgets/ai_prompt_widget.py
@@ -1,4 +1,4 @@
-from qtpy import QtWidgets
+from PyQt5 import QtWidgets
 
 
 class AiPromptWidget(QtWidgets.QWidget):

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -1,8 +1,8 @@
 import PIL.Image
 import PIL.ImageEnhance
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QImage
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QImage
 
 
 class BrightnessContrastDialog(QtWidgets.QDialog):

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -2,9 +2,9 @@ import contextlib
 
 import imgviz
 from loguru import logger
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
 import labelme.ai
 import labelme.utils
@@ -24,14 +24,14 @@ MOVE_SPEED = 5.0
 
 
 class Canvas(QtWidgets.QWidget):
-    zoomRequest = QtCore.Signal(int, QtCore.QPoint)
-    scrollRequest = QtCore.Signal(int, int)
-    newShape = QtCore.Signal()
-    selectionChanged = QtCore.Signal(list)
-    shapeMoved = QtCore.Signal()
-    drawingPolygon = QtCore.Signal(bool)
-    vertexSelected = QtCore.Signal(bool)
-    mouseMoved = QtCore.Signal(QtCore.QPointF)
+    zoomRequest = QtCore.pyqtSignal(int, QtCore.QPoint)
+    scrollRequest = QtCore.pyqtSignal(int, int)
+    newShape = QtCore.pyqtSignal()
+    selectionChanged = QtCore.pyqtSignal(list)
+    shapeMoved = QtCore.pyqtSignal()
+    drawingPolygon = QtCore.pyqtSignal(bool)
+    vertexSelected = QtCore.pyqtSignal(bool)
+    mouseMoved = QtCore.pyqtSignal(QtCore.QPointF)
 
     CREATE, EDIT = 0, 1
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -8,7 +8,6 @@ from qtpy import QtWidgets
 
 import labelme.ai
 import labelme.utils
-from labelme import QT5
 from labelme.shape import Shape
 
 # TODO(unknown):
@@ -241,10 +240,7 @@ class Canvas(QtWidgets.QWidget):
     def mouseMoveEvent(self, ev):
         """Update line with last point and current coordinates."""
         try:
-            if QT5:
-                pos = self.transformPos(ev.localPos())
-            else:
-                pos = self.transformPos(ev.posF())
+            pos = self.transformPos(ev.localPos())
         except AttributeError:
             return
 
@@ -420,10 +416,7 @@ class Canvas(QtWidgets.QWidget):
         self.movingShape = True  # Save changes
 
     def mousePressEvent(self, ev):
-        if QT5:
-            pos = self.transformPos(ev.localPos())
-        else:
-            pos = self.transformPos(ev.posF())
+        pos = self.transformPos(ev.localPos())
 
         is_shift_pressed = ev.modifiers() & QtCore.Qt.ShiftModifier
 
@@ -914,32 +907,16 @@ class Canvas(QtWidgets.QWidget):
         return super(Canvas, self).minimumSizeHint()
 
     def wheelEvent(self, ev):
-        if QT5:
-            mods = ev.modifiers()
-            delta = ev.angleDelta()
-            if QtCore.Qt.ControlModifier == int(mods):
-                # with Ctrl/Command key
-                # zoom
-                self.zoomRequest.emit(delta.y(), ev.pos())
-            else:
-                # scroll
-                self.scrollRequest.emit(delta.x(), QtCore.Qt.Horizontal)
-                self.scrollRequest.emit(delta.y(), QtCore.Qt.Vertical)
+        mods = ev.modifiers()
+        delta = ev.angleDelta()
+        if QtCore.Qt.ControlModifier == int(mods):
+            # with Ctrl/Command key
+            # zoom
+            self.zoomRequest.emit(delta.y(), ev.pos())
         else:
-            if ev.orientation() == QtCore.Qt.Vertical:
-                mods = ev.modifiers()
-                if QtCore.Qt.ControlModifier == int(mods):
-                    # with Ctrl/Command key
-                    self.zoomRequest.emit(ev.delta(), ev.pos())
-                else:
-                    self.scrollRequest.emit(
-                        ev.delta(),
-                        QtCore.Qt.Horizontal
-                        if (QtCore.Qt.ShiftModifier == int(mods))
-                        else QtCore.Qt.Vertical,
-                    )
-            else:
-                self.scrollRequest.emit(ev.delta(), QtCore.Qt.Horizontal)
+            # scroll
+            self.scrollRequest.emit(delta.x(), QtCore.Qt.Horizontal)
+            self.scrollRequest.emit(delta.y(), QtCore.Qt.Vertical)
         ev.accept()
 
     def moveByKeyboard(self, offset):

--- a/labelme/widgets/color_dialog.py
+++ b/labelme/widgets/color_dialog.py
@@ -1,4 +1,4 @@
-from qtpy import QtWidgets
+from PyQt5 import QtWidgets
 
 
 class ColorDialog(QtWidgets.QColorDialog):

--- a/labelme/widgets/escapable_qlist_widget.py
+++ b/labelme/widgets/escapable_qlist_widget.py
@@ -1,5 +1,5 @@
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
 
 
 class EscapableQListWidget(QtWidgets.QListWidget):

--- a/labelme/widgets/file_dialog_preview.py
+++ b/labelme/widgets/file_dialog_preview.py
@@ -1,8 +1,8 @@
 import json
 
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
 
 class ScrollAreaPreview(QtWidgets.QScrollArea):

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -1,15 +1,11 @@
 import re
 
 from loguru import logger
-from qtpy import QT_VERSION
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
 
 import labelme.utils
-
-QT5 = QT_VERSION[0] == "5"
-
 
 # TODO(unknown):
 # - Calculate optimal position so as not to go out of screen area.
@@ -105,12 +101,6 @@ class LabelDialog(QtWidgets.QDialog):
         self.setLayout(layout)
         # completion
         completer = QtWidgets.QCompleter()
-        if not QT5 and completion != "startswith":
-            logger.warning(
-                "completion other than 'startswith' is only "
-                "supported with Qt5. Using 'startswith'"
-            )
-            completion = "startswith"
         if completion == "startswith":
             completer.setCompletionMode(QtWidgets.QCompleter.InlineCompletion)
             # Default settings.

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -1,9 +1,9 @@
 import re
 
 from loguru import logger
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
 import labelme.utils
 

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -1,9 +1,9 @@
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QPalette
-from qtpy.QtWidgets import QStyle
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPalette
+from PyQt5.QtWidgets import QStyle
 
 
 # https://stackoverflow.com/a/2039745/4158863
@@ -93,7 +93,7 @@ class LabelListWidgetItem(QtGui.QStandardItem):
 
 
 class StandardItemModel(QtGui.QStandardItemModel):
-    itemDropped = QtCore.Signal()
+    itemDropped = QtCore.pyqtSignal()
 
     def removeRows(self, *args, **kwargs):
         ret = super().removeRows(*args, **kwargs)
@@ -102,8 +102,8 @@ class StandardItemModel(QtGui.QStandardItemModel):
 
 
 class LabelListWidget(QtWidgets.QListView):
-    itemDoubleClicked = QtCore.Signal(LabelListWidgetItem)
-    itemSelectionChanged = QtCore.Signal(list, list)
+    itemDoubleClicked = QtCore.pyqtSignal(LabelListWidgetItem)
+    itemSelectionChanged = QtCore.pyqtSignal(list, list)
 
     def __init__(self):
         super(LabelListWidget, self).__init__()

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -1,5 +1,5 @@
-from qtpy import QtCore
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtWidgets
 
 
 class ToolBar(QtWidgets.QToolBar):

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -2,8 +2,8 @@
 
 import html
 
-from qtpy import QtWidgets
-from qtpy.QtCore import Qt
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
 
 from .escapable_qlist_widget import EscapableQListWidget
 

--- a/labelme/widgets/zoom_widget.py
+++ b/labelme/widgets/zoom_widget.py
@@ -1,6 +1,6 @@
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
 
 class ZoomWidget(QtWidgets.QSpinBox):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+qt_api=pyqt5
 markers =
   gui

--- a/setup.py
+++ b/setup.py
@@ -31,38 +31,10 @@ def get_install_requires():
         "osam>=0.2.2",
         "Pillow>=2.8",
         "PyYAML",
-        "qtpy!=1.11.2",
         "scikit-image",
         "termcolor",
+        "PyQt5>=5.14.0",
     ]
-
-    # Find python binding for qt with priority:
-    # PyQt5 -> PySide2
-    # and PyQt5 is automatically installed on Python3.
-    QT_BINDING = None
-
-    try:
-        import PyQt5  # NOQA
-
-        QT_BINDING = "pyqt5"
-    except ImportError:
-        pass
-
-    if QT_BINDING is None:
-        try:
-            import PySide2  # NOQA
-
-            QT_BINDING = "pyside2"
-        except ImportError:
-            pass
-
-    if QT_BINDING is None:
-        # PyQt5 can be installed via pip for Python3
-        # 5.15.3, 5.15.4 won't work with PyInstaller
-        install_requires.append("PyQt5!=5.15.3,!=5.15.4")
-        QT_BINDING = "pyqt5"
-
-    del QT_BINDING
 
     if os.name == "nt":  # Windows
         install_requires.append("colorama")

--- a/tests/labelme_tests/widgets_tests/test_label_dialog.py
+++ b/tests/labelme_tests/widgets_tests/test_label_dialog.py
@@ -1,6 +1,6 @@
 import pytest
-from qtpy import QtCore
-from qtpy import QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtWidgets
 
 from labelme.widgets import LabelDialog
 from labelme.widgets import LabelQLineEdit


### PR DESCRIPTION
## Why?

Supporting PySide and PyQt5 makes Labelme unstable. Hard to test, install, migrate to pyproject.toml and uv.