### PR TITLE
Fix missing stderr in gdown download in osam

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import codecs
+import contextlib
 import os
 import os.path as osp
 import sys
@@ -14,6 +15,15 @@ from labelme import __version__
 from labelme.app import MainWindow
 from labelme.config import get_config
 from labelme.utils import newIcon
+
+
+class _LoggerIO:
+    def write(self, message: str):
+        if message := message.strip():
+            logger.debug(message)
+
+    def flush(self):
+        pass
 
 
 def _setup_loguru(logger_level: str) -> None:
@@ -207,7 +217,7 @@ def main():
         win.settings.clear()
         sys.exit(0)
 
-    with logger.catch():
+    with logger.catch(), contextlib.redirect_stderr(new_target=_LoggerIO()):
         win.show()
         win.raise_()
         sys.exit(app.exec_())

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1,5 +1,3 @@
-import contextlib
-
 import imgviz
 from loguru import logger
 from PyQt5 import QtCore
@@ -138,18 +136,7 @@ class Canvas(QtWidgets.QWidget):
             logger.debug("AI model is already initialized: %r" % model.name)
         else:
             logger.debug("Initializing AI model: %r" % model.name)
-
-            class LoggerIO:
-                def write(self, message: str):
-                    if message := message.strip():
-                        logger.debug(message)
-
-                def flush(self):
-                    pass
-
-            # NOTE: gdown.download uses sys.stderr, so redirect it to logger.debug
-            with contextlib.redirect_stderr(new_target=LoggerIO()):
-                self._ai_model = model()
+            self._ai_model = model()
 
         if self.pixmap is None:
             logger.warning("Pixmap is not set yet")


### PR DESCRIPTION
## Why?

Pyinstaller App.exe can crash because stderr and stdout doesn't exist.

It happens when App is downloading a model using gdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error logging now automatically captures and records error messages for improved tracking.
- **Refactor**
	- Simplified the AI model initialization process by streamlining error handling for a more straightforward setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->