### PR TITLE
Use shutil to load Docker

### DIFF
--- a/labelme/cli/on_docker.py
+++ b/labelme/cli/on_docker.py
@@ -3,12 +3,12 @@
 from __future__ import print_function
 
 import argparse
-import distutils.spawn
 import json
 import os
 import os.path as osp
 import platform
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -85,7 +85,7 @@ def main():
     parser.add_argument("-O", "--output")
     args = parser.parse_args()
 
-    if not distutils.spawn.find_executable("docker"):
+    if not shutil.which("docker"):
         print("Please install docker", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
# PR Summary
The `spawn.find_executable` method is deprecated from Python3.10 and removed in Python3.12. This small PR replaces it with the recommended `shutil.which` method (which is available since Python 3.3):
```python
DeprecationWarning: Use shutil.which instead of find_executable
```