### PR TITLE
Fix flags locking when group editing and inconsistent flags

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1202,9 +1202,6 @@ class MainWindow(QtWidgets.QMainWindow):
         if not edit_text:
             self.labelDialog.edit.setDisabled(True)
             self.labelDialog.labelList.setDisabled(True)
-        if not edit_flags:
-            for i in range(self.labelDialog.flagsLayout.count()):
-                self.labelDialog.flagsLayout.itemAt(i).setDisabled(True)  # type: ignore[union-attr]
         if not edit_group_id:
             self.labelDialog.edit_group_id.setDisabled(True)
         if not edit_description:
@@ -1215,14 +1212,12 @@ class MainWindow(QtWidgets.QMainWindow):
             flags=shape.flags if edit_flags else None,
             group_id=shape.group_id if edit_group_id else None,
             description=shape.description if edit_description else None,
+            flags_disabled=not edit_flags,
         )
 
         if not edit_text:
             self.labelDialog.edit.setDisabled(False)
             self.labelDialog.labelList.setDisabled(False)
-        if not edit_flags:
-            for i in range(self.labelDialog.flagsLayout.count()):
-                self.labelDialog.flagsLayout.itemAt(i).setDisabled(False)  # type: ignore[union-attr]
         if not edit_group_id:
             self.labelDialog.edit_group_id.setDisabled(False)
         if not edit_description:

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -193,7 +193,15 @@ class LabelDialog(QtWidgets.QDialog):
             return int(group_id)
         return None
 
-    def popUp(self, text=None, move=True, flags=None, group_id=None, description=None):
+    def popUp(
+        self,
+        text=None,
+        move=True,
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled: bool = False,
+    ):
         if self._fit_to_content["row"]:
             self.labelList.setMinimumHeight(
                 self.labelList.sizeHintForRow(0) * self.labelList.count() + 2
@@ -211,6 +219,9 @@ class LabelDialog(QtWidgets.QDialog):
             self.setFlags(flags)
         else:
             self.resetFlags(text)
+        if flags_disabled:
+            for i in range(self.flagsLayout.count()):
+                self.flagsLayout.itemAt(i).widget().setDisabled(True)
         self.edit.setText(text)
         self.edit.setSelection(0, len(text))
         if group_id is None:


### PR DESCRIPTION
## Why?

Because flags widgets are dynamically created, so locking has to happen after creation.