### PR TITLE
Fix closure issue in brightness/contrast slider label update

### DIFF
--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -32,7 +32,9 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
             #
             slider.valueChanged.connect(self.onNewValue)
             slider.valueChanged.connect(
-                lambda: value_label.setText(f"{slider.value() / self._base_value:.2f}")
+                lambda _, s=slider, l=value_label: l.setText(
+                    f"{s.value() / self._base_value:.2f}"
+                )
             )
             layouts[title] = layout
             sliders[title] = slider

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -32,8 +32,8 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
             #
             slider.valueChanged.connect(self.onNewValue)
             slider.valueChanged.connect(
-                lambda _, s=slider, l=value_label: l.setText(
-                    f"{s.value() / self._base_value:.2f}"
+                lambda _, _slider=slider, _label=value_label: _label.setText(
+                    f"{_slider.value() / self._base_value:.2f}"
                 )
             )
             layouts[title] = layout

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -32,8 +32,10 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
             #
             slider.valueChanged.connect(self.onNewValue)
             slider.valueChanged.connect(
-                lambda _, _slider=slider, _label=value_label: _label.setText(
-                    f"{_slider.value() / self._base_value:.2f}"
+                lambda _,
+                value_label_=value_label,
+                slider_=slider: value_label_.setText(
+                    f"{slider_.value() / self._base_value:.2f}"
                 )
             )
             layouts[title] = layout


### PR DESCRIPTION
The lambda function bound to Brightness/Contrast was always capturing the Contrast widget reference.