### PR TITLE
fix import order of msvcp140.dll on windows

### DIFF
--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 import logging
+import onnxruntime
 
 
 __appname__ = "labelme"


### PR DESCRIPTION
fix #1564 