### PR TITLE
feat: allows dragging to move around the canvas

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1611,6 +1611,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.actions.fitWidth.setChecked(self._zoom_mode == _ZoomMode.FIT_WIDTH)
         self.actions.fitWindow.setChecked(self._zoom_mode == _ZoomMode.FIT_WINDOW)
+        self.canvas.enableDragging(
+            enabled=value > int(self.scalers[_ZoomMode.FIT_WINDOW]() * 100)
+        )
         self.zoomWidget.setValue(value)  # triggers self._paint_canvas
         self._zoom_values[self.filename] = (self._zoom_mode, value)
 


### PR DESCRIPTION
This enables holding down the middle mouse button to drag the canvas in order to move the scroll wheels.

Also, adds additional space to min-size so that the edges of the image can be more centered. (Not a Qt expert, but setting a layout didn't seem to fix the issue and this was the least intrusive option)