### PR TITLE
docs: link to new install-labelme-terminal doc (using uv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are 3 options to install labelme:
 
 ### Option 1: Using pip
 
-For more detail, check ["Install Labelme using Pip"](https://www.labelme.io/docs/install-labelme-pip).
+For more detail, check ["Install Labelme using Terminal"](https://www.labelme.io/docs/install-labelme-terminal)
 
 ```bash
 pip install labelme


### PR DESCRIPTION
Close https://github.com/wkentaro/labelme/issues/1564
Close https://github.com/wkentaro/labelme/pull/1620

/cc @clouds56

## Why?

Users had reported issues on Anaconda installation on Windows around dynamic links. As uv got matured, I find it more stable to use and recommend as installation guide.

I've updated the doc here: https://labelme.io/docs/install-labelme-terminal

<img width="624" height="191" alt="image" src="https://github.com/user-attachments/assets/7645cd8e-5288-4a48-a123-153139966c79" />
