### PR TITLE
fix: don't fill linestrip internal area

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -268,7 +268,12 @@ class Shape(object):
             if vrtx_path.length() > 0:
                 painter.drawPath(vrtx_path)
                 painter.fillPath(vrtx_path, self._vertex_fill_color)  # type: ignore[has-type]
-            if self.fill and self.mask is None:
+            if self.fill and self.shape_type not in [
+                "line",
+                "linestrip",
+                "points",
+                "mask",
+            ]:
                 color = self.select_fill_color if self.selected else self.fill_color
                 painter.fillPath(line_path, color)
 
@@ -323,7 +328,9 @@ class Shape(object):
                 post_i = i
         return post_i
 
-    def containsPoint(self, point):
+    def containsPoint(self, point) -> bool:
+        if self.shape_type in ["line", "linestrip", "points"]:
+            return False
         if self.mask is not None:
             y = np.clip(
                 int(round(point.y() - self.points[0].y())),


### PR DESCRIPTION
## Why?

It looks like polygon and confusing.

Just like reported in discord: 
https://discord.com/channels/1211676013730209832/1243319469791776769/1412077904602464389

<img width="878" height="140" alt="image" src="https://github.com/user-attachments/assets/57e9177f-397b-4ed1-a1fc-4c6f7c27e9ed" />


## Before -> After

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/01d25a78-6409-481d-9ca7-1916dc067cc2" />

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/a8bfc305-b8a0-4be4-bb53-50d16857286e" />
