### PR TITLE
fix: ensure rectangle points are ordered top-left to bottom-right

### DIFF
--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -115,6 +115,11 @@ def main():
         segmentations = collections.defaultdict(list)  # for segmentation
         for shape in label_file.shapes:
             points = shape["points"]
+            if len(shape["points"])==2:
+                if points[0][0] > points[1][0]:
+                    points[0][0], points[1][0] = points[1][0], points[0][0]
+                if points[0][1] > points[1][1]:
+                    points[0][1], points[1][1] = points[1][1], points[0][1]
             label = shape["label"]
             group_id = shape.get("group_id")
             shape_type = shape.get("shape_type", "polygon")


### PR DESCRIPTION
fix: ensure rectangle points are ordered top-left to bottom-right

Ensure that when drawing rectangles in Labelme, the two points are
always interpreted as top-left and bottom-right, regardless of the
dragging direction. This prevents incorrect bbox/segmentation when
the user draws from bottom-right to top-left.
