### PR TITLE
Fix of a hang up at natsort sort func when opening file paths include '@' symbol.

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2231,6 +2231,6 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             images = os_sorted(images)
         except Exception as e:
-            logger.warning(f"natsort's sort failed, falling back to the custom sort method: {e}")
+            logger.debug(f"natsort's sort failed, falling back to the custom sort method: {e}")
             images = self.custom_natsorted(images)
         return images


### PR DESCRIPTION
This was fixed for  a hang up at natsort sort func when opening file paths include '@' symbol.

MacOS file system can have '@' symbol inside a file path. But conventional labelme occurred exception due to that.