### PR TITLE
Revert "chore: use overrideCursor for immediate cursor change"

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1042,7 +1042,7 @@ class Canvas(QtWidgets.QWidget):
         QtWidgets.QApplication.setOverrideCursor(cursor)
 
     def restoreCursor(self):
-        self.overrideCursor(CURSOR_DEFAULT)
+        QtWidgets.QApplication.restoreOverrideCursor()
 
     def resetState(self):
         self.restoreCursor()


### PR DESCRIPTION
This reverts commit f15cd663a7b1dc664c72bab40c1afc4f2f3f846d.

otherwise, the widget adjustment cursor won't appear.