### PR TITLE
fix(app): handle high-dpi scaling issue on Qt applications

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -51,6 +51,13 @@ from . import utils
 # TODO(unknown):
 # - Zoom is too "steppy".
 
+# handle high-dpi scaling issue
+# https://leomoon.com/journal/python/high-dpi-scaling-in-pyqt5
+if hasattr(QtCore.Qt, "AA_EnableHighDpiScaling"):
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+if hasattr(QtCore.Qt, "AA_UseHighDpiPixmaps"):
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
+
 
 LABEL_COLORMAP: NDArray[np.uint8] = imgviz.label_colormap()
 


### PR DESCRIPTION
test started failing on 4k linux.

## Before -> After

<img width="30%" height="" alt="image" src="https://github.com/user-attachments/assets/e15bf329-1102-4e1e-af72-4b3b7941c822" />

<img width="40%" height="" alt="image" src="https://github.com/user-attachments/assets/e0da67f7-fa4d-4780-8af6-43dda39f4bf1" />
