### PR TITLE
fix: clear Canvas.shapes so that it won't be rendered after reset

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1685,6 +1685,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self.fileListWidget.repaint()
             return
 
+        prev_shapes: list[Shape] = (
+            self.canvas.shapes if self._config["keep_prev"] else []
+        )
         self.resetState()
         self.canvas.setEnabled(False)
         if filename is None:
@@ -1747,8 +1750,6 @@ class MainWindow(QtWidgets.QMainWindow):
             return False
         self.image = image
         self.filename = filename
-        if self._config["keep_prev"]:
-            prev_shapes = self.canvas.shapes
         self.canvas.loadPixmap(QtGui.QPixmap.fromImage(image))
         flags = {k: False for k in self._config["flags"] or []}
         if self.labelFile:
@@ -1756,7 +1757,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if self.labelFile.flags is not None:
                 flags.update(self.labelFile.flags)
         self.loadFlags(flags)
-        if self._config["keep_prev"] and self.noShapes():
+        if prev_shapes and self.noShapes():
             self.loadShapes(prev_shapes, replace=False)
             self.setDirty()
         else:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1078,6 +1078,7 @@ class Canvas(QtWidgets.QWidget):
     def resetState(self):
         self.restoreCursor()
         self.pixmap = QtGui.QPixmap()
+        self.shapes = []
         self.shapesBackups = []
         self.update()
 


### PR DESCRIPTION
regression by https://github.com/wkentaro/labelme/pull/1632

otherwise, it gets like:

1, load

<img width="3466" height="2186" alt="image" src="https://github.com/user-attachments/assets/fd6cb4c7-4e72-4f35-9cf6-39e87416da4f" />

2, cmd/ctr-w

<img width="3466" height="2186" alt="image" src="https://github.com/user-attachments/assets/2e7a17f5-429a-47d5-b437-3b616053e9dc" />

/cc @akx 
