### PR TITLE
fix(app): tweak epsilon for scaleFitWidth to better hide scrollbar

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1853,8 +1853,8 @@ class MainWindow(QtWidgets.QMainWindow):
         return w1 / w2 if a2 >= a1 else h1 / h2
 
     def scaleFitWidth(self):
-        # The epsilon does not seem to work too well here.
-        w = self.centralWidget().width() - 2.0
+        EPSILON_TO_HIDE_SCROLLBAR: float = 15.0
+        w = self.centralWidget().width() - EPSILON_TO_HIDE_SCROLLBAR
         return w / self.canvas.pixmap.width()
 
     def enableSaveImageWithData(self, enabled):


### PR DESCRIPTION
## Before -> After

<img width="3054" height="1628" alt="image" src="https://github.com/user-attachments/assets/43afa43d-c317-4858-a869-cb7765b694d9" />

<img width="3054" height="1628" alt="image" src="https://github.com/user-attachments/assets/c9757cec-fbf5-446c-801e-eeff33778d4a" />
