### PR TITLE
fix(app): use ascii bullet in status messages to fix shifting

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -270,7 +270,7 @@ class Canvas(QtWidgets.QWidget):
             messages.append(self.tr("Editing shapes"))
         if extra_messages:
             messages.extend(extra_messages)
-        self.statusUpdated.emit(" ー ".join(messages))
+        self.statusUpdated.emit(" • ".join(messages))
 
     def _get_create_mode_message(self) -> str:
         assert self.drawing()


### PR DESCRIPTION
otherwise, the height of status-bar changes, and the canvas shift happens depending on the height of character.