### PR TITLE
fix: use canCloseShape for double-click finalization

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -685,9 +685,7 @@ class Canvas(QtWidgets.QWidget):
         if self.double_click != "close":
             return
 
-        if (
-            self.createMode == "polygon" and self.canCloseShape()
-        ) or self.createMode in ["ai_polygon", "ai_mask"]:
+        if self.canCloseShape():
             self.finalise()
 
     def selectShapes(self, shapes):


### PR DESCRIPTION
Close https://github.com/wkentaro/labelme/issues/1722