### PR TITLE
refactor: use importlib.metadata to get version

### DIFF
--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import logging
 
 __appname__ = "Labelme"
@@ -7,7 +8,7 @@ __appname__ = "Labelme"
 # 2. MINOR version when you add functionality in a backwards-compatible manner;
 # 3. PATCH version when you make backwards-compatible bug fixes.
 # e.g., 1.0.0a0, 1.0.0a1, 1.0.0b0, 1.0.0rc0, 1.0.0, 1.0.0.post0
-__version__ = "5.10.0"
+__version__ = importlib.metadata.version("labelme")
 
 # XXX: has to be imported before PyQt5 to load dlls in order on Windows
 # https://github.com/wkentaro/labelme/issues/1564


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__` string with dynamic version lookup using `importlib.metadata.version()`
- This ensures the version is always in sync with the package metadata from `pyproject.toml`

## Test plan
- [x] Verify `labelme.__version__` returns the correct version
- [x] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)