### PR TITLE
fix: handle Windows-style paths in LabelFile (#1725)

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 import os.path as osp
+from pathlib import PureWindowsPath
 from typing import TypedDict
 
 import numpy as np
@@ -171,14 +172,17 @@ class LabelFile:
             with open(filename, "r") as f:
                 data = json.load(f)
 
+            # Normalize Windows-style backslash paths to POSIX forward slashes
+            imagePath = PureWindowsPath(data["imagePath"]).as_posix()
+
             if data["imageData"] is not None:
                 imageData = base64.b64decode(data["imageData"])
             else:
                 # relative path from label file to relative path from cwd
-                imagePath = osp.join(osp.dirname(filename), data["imagePath"])
-                imageData = self.load_image_file(imagePath)
+                imageData = self.load_image_file(
+                    osp.join(osp.dirname(filename), imagePath)
+                )
             flags = data.get("flags") or {}
-            imagePath = data["imagePath"]
             self._check_image_height_and_width(
                 base64.b64encode(imageData).decode("utf-8"),
                 data.get("imageHeight"),

--- a/tests/labelme_tests/test__label_file.py
+++ b/tests/labelme_tests/test__label_file.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from labelme._label_file import LabelFile
+
+
+def test_LabelFile_load_windows_path(data_path: Path, tmp_path: Path) -> None:
+    """Test that LabelFile can load JSON with Windows-style backslash paths.
+
+    Regression test for https://github.com/wkentaro/labelme/issues/1725
+    """
+    (tmp_path / "images").mkdir()
+    shutil.copy(
+        data_path / "annotated" / "2011_000003.jpg",
+        tmp_path / "images" / "2011_000003.jpg",
+    )
+
+    json_file = tmp_path / "annotations" / "2011_000003.json"
+    json_file.parent.mkdir()
+    with open(data_path / "annotated" / "2011_000003.json") as f:
+        json_data = json.load(f)
+    json_data["imagePath"] = "..\\images\\2011_000003.jpg"
+    with open(json_file, "w") as f:
+        json.dump(json_data, f)
+
+    label_file = LabelFile(str(json_file))
+    assert label_file.imagePath == "../images/2011_000003.jpg"
+    assert label_file.imageData is not None


### PR DESCRIPTION
Happens when loading JSON files created on Windows systems.

Close #1725