### PR TITLE
fix: apply file_search config filter on startup

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -943,7 +943,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if self._config["file_search"]:
             self.fileSearch.setText(self._config["file_search"])
-            self.fileSearchChanged()
 
         # XXX: Could be completely declarative.
         # Restore application settings.
@@ -960,7 +959,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if filename:
             if osp.isdir(filename):
-                self._import_images_from_dir(root_dir=filename)
+                self._import_images_from_dir(
+                    root_dir=filename, pattern=self.fileSearch.text()
+                )
                 self._open_next_image()
             else:
                 self._load_file(filename=filename)

--- a/tests/e2e/smoke_test.py
+++ b/tests/e2e/smoke_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pytestqt.qtbot import QtBot
 
@@ -11,4 +13,23 @@ def test_MainWindow_open(qtbot: QtBot) -> None:
     win: labelme.app.MainWindow = labelme.app.MainWindow()
     qtbot.addWidget(win)
     win.show()
+    win.close()
+
+
+@pytest.mark.gui
+def test_file_search_config_filters_on_startup(qtbot: QtBot, data_path: Path) -> None:
+    raw_dir = data_path / "raw"
+    all_images = list(raw_dir.glob("*.jpg"))
+    assert len(all_images) == 3
+
+    win = labelme.app.MainWindow(
+        config_overrides={"file_search": "2011_000003"},
+        filename=str(raw_dir),
+    )
+    qtbot.addWidget(win)
+    win.show()
+
+    assert win.fileSearch.text() == "2011_000003"
+    assert win.fileListWidget.count() == 1
+
     win.close()


### PR DESCRIPTION
The file_search config value was filling the search text box but not actually filtering files until the user typed a key. This was because _import_images_from_dir was called without the pattern parameter.

- Pass pattern to _import_images_from_dir when opening directory
- Remove no-op fileSearchChanged() call during initialization