### PR TITLE
fix: remove unused add_point_to_edge shortcut from default config

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -113,7 +113,6 @@ shortcuts:
   paste_polygon: Ctrl+V
   undo: Ctrl+Z
   undo_last_point: Ctrl+Z
-  add_point_to_edge: Ctrl+Shift+P
   edit_label: Ctrl+E
   toggle_keep_prev_mode: Ctrl+P
   remove_selected_point: [Meta+H, Backspace]


### PR DESCRIPTION
For https://github.com/wkentaro/labelme/discussions/1793#discussioncomment-15655955

The shortcut was never wired to a menu action in app.py. The addPointToEdge functionality remains accessible via Alt+Click.