### PR TITLE
fix: create sparse ~/.labelmerc instead of copying full default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ labelme data_annotated/ --labels labels.txt  # specify label list with a file
 
 ### Command Line Arguments
 - `--output` specifies the location that annotations will be written to. If the location ends with .json, a single annotation will be written to this file. Only one image can be annotated if a location is specified with .json. If the location does not end with .json, the program will assume it is a directory. Annotations will be stored in this directory with a name that corresponds to the image that the annotation was made on.
-- The first time you run labelme, it will create a config file in `~/.labelmerc`. You can edit this file and the changes will be applied the next time that you launch labelme. If you would prefer to use a config file from another location, you can specify this file with the `--config` flag.
+- The first time you run labelme, it will create a config file at `~/.labelmerc`. Add only the settings you want to override. For all available options and their defaults, see [`default_config.yaml`](labelme/config/default_config.yaml). If you would prefer to use a config file from another location, you can specify this file with the `--config` flag.
 - Without the `--nosortlabels` flag, the program will list labels in alphabetical order. When the program is run with this flag, it will display labels in the order that they are provided.
 - Flags are assigned to an entire image. [Example](examples/classification)
 - Labels are assigned to a single polygon. [Example](examples/bbox_detection)

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -1,6 +1,5 @@
 import os.path as osp
 import re
-import shutil
 from pathlib import Path
 
 import yaml
@@ -61,7 +60,17 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
     user_config_file: str = osp.join(osp.expanduser("~"), ".labelmerc")
     if not osp.exists(user_config_file) and create_if_missing:
         try:
-            shutil.copy(osp.join(here, "default_config.yaml"), user_config_file)
+            with open(user_config_file, "w") as f:
+                f.write(
+                    "# Labelme config file.\n"
+                    "# Only add settings you want to override.\n"
+                    "# For all available options and defaults, see:\n"
+                    "#   https://github.com/wkentaro/labelme/blob/main/labelme/config/default_config.yaml\n"
+                    "#\n"
+                    "# Example:\n"
+                    "#   auto_save: true\n"
+                    "#   labels: [cat, dog]\n"
+                )
         except Exception:
             logger.warning("Failed to save config: {!r}", user_config_file)
     return user_config_file

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import yaml
+
+from labelme.config import get_user_config_file
+
+
+def test_get_user_config_file_creates_sparse(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_file = get_user_config_file()
+    content = Path(config_file).read_text()
+    assert content.startswith("# Labelme config file")
+    parsed = yaml.safe_load(content)
+    assert parsed is None
+
+
+def test_get_user_config_file_does_not_overwrite(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_path = tmp_path / ".labelmerc"
+    config_path.write_text("auto_save: true\n")
+    config_file = get_user_config_file()
+    content = Path(config_file).read_text()
+    assert content == "auto_save: true\n"
+
+
+def test_get_user_config_file_skip_creation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_file = get_user_config_file(create_if_missing=False)
+    assert not Path(config_file).exists()


### PR DESCRIPTION
## Summary
- `get_user_config_file()` now creates a minimal comment-only `~/.labelmerc` instead of copying the entire `default_config.yaml`
- Prevents user configs from going stale when upstream defaults change
- Existing users with a full `~/.labelmerc` are unaffected — `load_config()` already merges overrides onto defaults

## Test plan
- [x] New unit tests for sparse config creation, no-overwrite, and skip-creation
- [x] Existing e2e config tests pass
- [x] Lint passes
- [ ] Manual: `rm ~/.labelmerc && labelme` creates sparse file, app starts with all defaults
- [ ] Manual: Add `auto_save: true` to sparse `~/.labelmerc`, verify it takes effect