### PR TITLE
Refactor moveVertexBy to take absolute position

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -367,8 +367,8 @@ class Shape:
     def moveBy(self, offset):
         self.points = [p + offset for p in self.points]
 
-    def moveVertexBy(self, i, offset):
-        self.points[i] = self.points[i] + offset
+    def moveVertex(self, i, pos):
+        self.points[i] = pos
 
     def highlightVertex(self, i, action):
         """Highlight a vertex appropriately based on the current action

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -739,17 +739,15 @@ class Canvas(QtWidgets.QWidget):
             return
         assert self.hShape is not None
 
-        point: QPointF = self.hShape[self.hVertex]
-
         if self.outOfPixmap(pos):
-            pos = self.intersectionPoint(point, pos)
+            pos = self.intersectionPoint(self.hShape[self.hVertex], pos)
 
         if is_shift_pressed and self.hShape.shape_type == "rectangle":
             pos = _snap_cursor_pos_for_square(
                 pos=pos, opposite_vertex=self.hShape[1 - self.hVertex]
             )
 
-        self.hShape.moveVertexBy(i=self.hVertex, offset=pos - point)
+        self.hShape.moveVertex(i=self.hVertex, pos=pos)
 
     def boundedMoveShapes(self, shapes, pos):
         if self.outOfPixmap(pos):


### PR DESCRIPTION
# Description
The `offset` argument of the `moveVertexBy` function can be reduced to `pos`.