### PR TITLE
refactor!: rename store_data to with_image_data and default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ labelme  # just open gui
 cd examples/tutorial
 labelme apc2016_obj3.jpg  # specify image file
 labelme apc2016_obj3.jpg --output annotations/  # save annotation JSON files to a directory
-labelme apc2016_obj3.jpg --nodata  # not include image data but relative image path in JSON file
+labelme apc2016_obj3.jpg --with-image-data  # include image data in JSON file
 labelme apc2016_obj3.jpg \
   --labels highland_6539_self_stick_notes,mead_index_cards,kong_air_dog_squeakair_tennis_ball  # specify label list
 

--- a/examples/bbox_detection/README.md
+++ b/examples/bbox_detection/README.md
@@ -4,7 +4,7 @@
 ## Usage
 
 ```bash
-labelme data_annotated --labels labels.txt --nodata --autosave
+labelme data_annotated --labels labels.txt --autosave
 ```
 
 ![](.readme/annotation.jpg)

--- a/examples/classification/README.md
+++ b/examples/classification/README.md
@@ -4,7 +4,7 @@
 ## Usage
 
 ```bash
-labelme data_annotated --flags flags.txt --nodata
+labelme data_annotated --flags flags.txt
 ```
 
 <img src=".readme/annotation_cat.jpg" width="100%" />

--- a/examples/instance_segmentation/README.md
+++ b/examples/instance_segmentation/README.md
@@ -3,8 +3,8 @@
 ## Annotation
 
 ```bash
-labelme data_annotated --labels labels.txt --nodata --validatelabel exact --config '{shift_auto_shape_color: -2}'
-labelme data_annotated --labels labels.txt --nodata --labelflags '{.*: [occluded, truncated], person: [male]}'
+labelme data_annotated --labels labels.txt --validatelabel exact --config '{shift_auto_shape_color: -2}'
+labelme data_annotated --labels labels.txt --labelflags '{.*: [occluded, truncated], person: [male]}'
 ```
 
 ![](.readme/annotation.jpg)

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -3,7 +3,7 @@
 ## Annotation
 
 ```bash
-labelme data_annotated --labels labels.txt --nodata --validatelabel exact --config '{shift_auto_shape_color: -2}'
+labelme data_annotated --labels labels.txt --validatelabel exact --config '{shift_auto_shape_color: -2}'
 ```
 
 ![](.readme/annotation.jpg)

--- a/examples/video_annotation/README.md
+++ b/examples/video_annotation/README.md
@@ -4,7 +4,7 @@
 ## Annotation
 
 ```bash
-labelme data_annotated --labels labels.txt --nodata --keep-prev --config '{shift_auto_shape_color: -2}'
+labelme data_annotated --labels labels.txt --keep-prev --config '{shift_auto_shape_color: -2}'
 ```
 
 <img src=".readme/00000100.jpg" width="49%" /> <img src=".readme/00000101.jpg" width="49%" />

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -122,10 +122,10 @@ def main():
     )
     # config for the gui
     parser.add_argument(
-        "--nodata",
-        dest="store_data",
-        action="store_false",
-        help="stop storing image data to JSON file",
+        "--with-image-data",
+        dest="with_image_data",
+        action="store_true",
+        help="store image data in JSON file",
         default=argparse.SUPPRESS,
     )
     parser.add_argument(

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -341,7 +341,7 @@ class MainWindow(QtWidgets.QMainWindow):
             slot=self.enableSaveImageWithData,
             tip=self.tr("Save image data in label file"),
             checkable=True,
-            checked=self._config["store_data"],
+            checked=self._config["with_image_data"],
         )
 
         close = action(
@@ -1522,7 +1522,7 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             assert self.imagePath
             imagePath = osp.relpath(self.imagePath, osp.dirname(filename))
-            imageData = self.imageData if self._config["store_data"] else None
+            imageData = self.imageData if self._config["with_image_data"] else None
             if osp.dirname(filename) and not osp.exists(osp.dirname(filename)):
                 os.makedirs(osp.dirname(filename))
             lf.save(
@@ -1931,7 +1931,7 @@ class MainWindow(QtWidgets.QMainWindow):
         return w / self.canvas.pixmap.width()
 
     def enableSaveImageWithData(self, enabled):
-        self._config["store_data"] = enabled
+        self._config["with_image_data"] = enabled
         self.actions.saveWithImageData.setChecked(enabled)
 
     def closeEvent(self, a0: QtGui.QCloseEvent) -> None:

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -41,6 +41,10 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         )
         config_from_yaml["keep_prev_brightness_contrast"] = True
 
+    if "store_data" in config_from_yaml:
+        logger.info("Migrating old config: store_data -> with_image_data")
+        config_from_yaml["with_image_data"] = config_from_yaml.pop("store_data")
+
     if config_from_yaml.get("shortcuts", {}).pop("add_point_to_edge", None):
         logger.info("Migrating old config: removing shortcuts.add_point_to_edge")
 
@@ -68,8 +72,8 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
                     "#   https://github.com/wkentaro/labelme/blob/main/labelme/config/default_config.yaml\n"
                     "#\n"
                     "# Example:\n"
+                    "# with_image_data: true\n"
                     "# auto_save: true\n"
-                    "# store_data: false\n"
                     "# labels: [cat, dog]\n"
                 )
         except Exception:

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -1,6 +1,6 @@
 auto_save: false
 display_label_popup: true
-store_data: true
+with_image_data: false
 keep_prev: false
 keep_prev_scale: false
 keep_prev_brightness_contrast: false

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
+import pytest
 import yaml
 
 from labelme.config import get_user_config_file
+from labelme.config import load_config
 
 
 def test_get_user_config_file_creates_sparse(tmp_path, monkeypatch):
@@ -27,3 +29,12 @@ def test_get_user_config_file_skip_creation(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     config_file = get_user_config_file(create_if_missing=False)
     assert not Path(config_file).exists()
+
+
+@pytest.mark.parametrize("old_value", [True, False])
+def test_migrate_store_data_to_with_image_data(tmp_path, old_value):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(f"store_data: {str(old_value).lower()}\n")
+    config = load_config(config_file=config_file, config_overrides={})
+    assert config["with_image_data"] is old_value
+    assert "store_data" not in config


### PR DESCRIPTION
Replace --nodata (store_false) with --with-image-data (store_true) and flip the default so image data is no longer embedded in JSON files unless explicitly requested. Add config migration for existing ~/.labelmerc files and update all documentation examples.