### PR TITLE
refactor!: default auto_save to true and rename --autosave to --no-autosave

### DIFF
--- a/examples/bbox_detection/README.md
+++ b/examples/bbox_detection/README.md
@@ -4,7 +4,7 @@
 ## Usage
 
 ```bash
-labelme data_annotated --labels labels.txt --autosave
+labelme data_annotated --labels labels.txt
 ```
 
 ![](.readme/annotation.jpg)

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -137,10 +137,17 @@ def main():
         default=argparse.SUPPRESS,
     )
     parser.add_argument(
-        "--autosave",
+        "--no-autosave",
         dest="auto_save",
+        action="store_false",
+        help="disable auto save",
+        default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--autosave",
+        dest="_deprecated_autosave",
         action="store_true",
-        help="auto save",
+        help=argparse.SUPPRESS,
         default=argparse.SUPPRESS,
     )
     parser.add_argument(
@@ -198,6 +205,15 @@ def main():
             stacklevel=1,
         )
         del args._deprecated_nodata
+
+    if hasattr(args, "_deprecated_autosave"):
+        warnings.warn(
+            "--autosave is deprecated and will be removed in a future version. "
+            "Auto save is now enabled by default. Use --no-autosave to disable it.",
+            FutureWarning,
+            stacklevel=1,
+        )
+        del args._deprecated_autosave
 
     if args.version:
         print(f"{__appname__} {__version__}")

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -73,7 +73,7 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
                     "#\n"
                     "# Example:\n"
                     "# with_image_data: true\n"
-                    "# auto_save: true\n"
+                    "# auto_save: false\n"
                     "# labels: [cat, dog]\n"
                 )
         except Exception:

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -1,4 +1,4 @@
-auto_save: false
+auto_save: true
 display_label_popup: true
 with_image_data: false
 keep_prev: false

--- a/tests/e2e/config_test.py
+++ b/tests/e2e/config_test.py
@@ -24,11 +24,11 @@ def test_MainWindow_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_file: Path | None = None
-    auto_save: bool = False
+    auto_save: bool = True
     if with_config_file:
         config_file = tmp_path / "labelmerc.yaml"
-        config_file.write_text("auto_save: true\nlabels: [cat, dog]\n")
-        auto_save = True
+        config_file.write_text("auto_save: false\nlabels: [cat, dog]\n")
+        auto_save = False
 
     win: labelme.app.MainWindow = labelme.app.MainWindow(
         config_file=config_file,


### PR DESCRIPTION
Auto save is now enabled by default. The --autosave CLI flag is replaced by --no-autosave to disable it. The old --autosave flag is kept as a deprecated alias with a FutureWarning guiding users to the new default.