### PR TITLE
fix: guard against out-of-range hVertex in boundedMoveVertex

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -740,6 +740,14 @@ class Canvas(QtWidgets.QWidget):
             return
         assert self.hShape is not None
 
+        if self.hVertex >= len(self.hShape.points):
+            logger.warning(
+                "hVertex is out of range: hVertex={:d}, len(points)={:d}",
+                self.hVertex,
+                len(self.hShape.points),
+            )
+            return
+
         if self.outOfPixmap(pos):
             pos = self.intersectionPoint(self.hShape[self.hVertex], pos)
 


### PR DESCRIPTION
## Problem

When fast-clicking to remove polygon points, `hVertex` can become stale and point beyond the current length of `hShape.points`. This triggers an `IndexError` that crashes the app:

```
IndexError: list index out of range
  File "labelme/widgets/canvas.py", in boundedMoveVertex
    point = shape[index]
  File "labelme/shape.py", in __getitem__
    return self.points[key]
```

Fixes #1669

## Fix

Added an early-return bounds check in `boundedMoveVertex()` that mirrors the existing `hVertex is None` guard directly above it:

```python
if self.hVertex >= len(self.hShape.points):
    logger.warning(
        "hVertex is out of range: hVertex=%d, len(points)=%d",
        self.hVertex,
        len(self.hShape.points),
    )
    return
```

## Changes

- **1 file changed, 8 lines added** — `labelme/widgets/canvas.py`
- No behaviour change for normal use; only adds a safe guard for the race-condition case where a point is deleted while the mouse is still moving.