### PR TITLE
docs: add numpy<2.0 pin to standalone executable build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ labelme data_annotated/ --labels labels.txt  # specify label list with a file
 ```bash
 LABELME_PATH=./labelme
 OSAM_PATH=$(python -c 'import os, osam; print(os.path.dirname(osam.__file__))')
+pip install 'numpy<2.0'  # numpy>=2.0 causes build errors (see #1532)
 pyinstaller labelme/labelme/__main__.py \
   --name=Labelme \
   --windowed \


### PR DESCRIPTION
## Summary

Adds `pip install 'numpy<2.0'` to the README's standalone executable build instructions, immediately before the `pyinstaller` command.

## Problem

numpy ≥ 2.0 causes build errors when using PyInstaller to create the standalone executable. Users were hitting this and having to figure out the fix themselves. Reported in #1532.

## Change

```diff
+pip install 'numpy<2.0'  # numpy>=2.0 causes build errors (see #1532)
 pyinstaller labelme/labelme/__main__.py \
```

**Files changed:** 1 (README.md)  
**Lines changed:** +1

Fixes #1532