### PR TITLE
fix: use loguru format style in logger calls

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1074,7 +1074,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.canvas.createMode
             not in _AI_TEXT_TO_ANNOTATION_CREATE_MODE_TO_SHAPE_TYPE
         ):
-            logger.warning("Unsupported createMode=%r", self.canvas.createMode)
+            logger.warning("Unsupported createMode={!r}", self.canvas.createMode)
             return
         shape_type: Literal["rectangle", "polygon", "mask"] = (
             _AI_TEXT_TO_ANNOTATION_CREATE_MODE_TO_SHAPE_TYPE[self.canvas.createMode]

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -71,7 +71,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         if default_model in model_ui_names:
             model_index = model_ui_names.index(default_model)
         else:
-            logger.warning("Default AI model is not found: %r", default_model)
+            logger.warning("Default AI model is not found: {!r}", default_model)
             model_index = 0
 
         self._model_combo.currentIndexChanged.connect(

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -736,7 +736,7 @@ class Canvas(QtWidgets.QWidget):
 
     def boundedMoveVertex(self, pos: QPointF, is_shift_pressed: bool) -> None:
         if self.hVertex is None:
-            logger.warning("hVertex is None, so cannot move vertex: pos=%r", pos)
+            logger.warning("hVertex is None, so cannot move vertex: pos={!r}", pos)
             return
         assert self.hShape is not None
 


### PR DESCRIPTION
## Summary
- Replace printf-style `%r` with loguru's str.format-style `{!r}` in 3 `logger.warning()` calls
- Affected files: `app.py`, `canvas.py`, `_ai_assisted_annotation_widget.py`

## Test plan
- [ ] Verify logger output renders correctly by triggering each warning path