### PR TITLE
fix: normalize 16-bit grayscale to uint8 in export_json

### DIFF
--- a/labelme/cli/export_json.py
+++ b/labelme/cli/export_json.py
@@ -46,9 +46,7 @@ def main():
     for name, value in label_name_to_value.items():
         label_names[value] = name
 
-    img_gray = imgviz.asgray(image)
-    if img_gray.dtype != np.uint8:
-        img_gray = (img_gray / (img_gray.max() / 255.0)).astype(np.uint8)
+    img_gray = imgviz.normalize(imgviz.asgray(image))
     lbl_viz = imgviz.label2rgb(lbl, img_gray, label_names=label_names, loc="rb")
 
     PIL.Image.fromarray(image).save(osp.join(out_dir, "img.png"))


### PR DESCRIPTION
## Summary

When  processes 16-bit grayscale images,  returns a `uint16` array. Passing this directly to `imgviz.label2rgb()` causes a crash because the function expects `uint8` input.

## Fix

Normalize `img_gray` to `uint8` before calling `label2rgb` when the dtype is not already `uint8`:

```python
img_gray = imgviz.asgray(image)
if img_gray.dtype != np.uint8:
    img_gray = (img_gray / (img_gray.max() / 255.0)).astype(np.uint8)
lbl_viz = imgviz.label2rgb(lbl, img_gray, label_names=label_names, loc="rb")
```

## Changes

- `labelme/cli/export_json.py`: extract `asgray()` result, normalize to uint8 if needed

Fixes #1528