### PR TITLE
fix: convert RGBA PNG to RGB in labelme2coco.py

### DIFF
--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -94,6 +94,8 @@ def main():
         out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
 
         img = labelme.utils.img_data_to_arr(label_file.imageData)
+        if img.ndim == 3 and img.shape[2] == 4:
+            img = imgviz.rgba2rgb(img)
         imgviz.io.imsave(out_img_file, img)
         data["images"].append(
             dict(


### PR DESCRIPTION
## Summary

When `labelme2coco.py` loads a PNG with an alpha channel (RGBA, 4 channels), `imgviz.io.imsave()` fails with an `OSError` because JPEG format does not support an alpha channel.

## Fix

After loading the image array, strip the alpha channel when the image has 4 channels:

```python
img = labelme.utils.img_data_to_arr(label_file.imageData)
if img.ndim == 3 and img.shape[2] == 4:
    img = img[:, :, :3]
```

## Changes

- `examples/instance_segmentation/labelme2coco.py`: drop alpha channel for RGBA images before saving

Closes #1653