### PR TITLE
fix: replace deprecated np.bool with np.bool_ in _label_file.py

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -35,7 +35,7 @@ class ShapeDict(TypedDict):
     flags: dict[str, bool]
     description: str
     group_id: int | None
-    mask: NDArray[np.bool] | None
+    mask: NDArray[np.bool_] | None
     other_data: dict
 
 
@@ -100,7 +100,7 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
         )
         group_id = shape_json_obj["group_id"]
 
-    mask: NDArray[np.bool] | None = None
+    mask: NDArray[np.bool_] | None = None
     if shape_json_obj.get("mask") is not None:
         assert isinstance(shape_json_obj["mask"], str), (
             f"mask must be base64-encoded PNG: {shape_json_obj['mask']}"


### PR DESCRIPTION
## Summary

`np.bool` was deprecated in NumPy 1.20 and **removed in NumPy 1.24**. Using it raises an `AttributeError` in NumPy 2.0+, which breaks type annotations at runtime in type-checked environments.

## Fix

Replace both occurrences of `NDArray[np.bool]` with `NDArray[np.bool_]`:

- `labelme/_label_file.py` line 38: `ShapeDict.mask` TypedDict field
- `labelme/_label_file.py` line 103: local variable annotation in `_load_shape_json_obj`

## Changes

- `labelme/_label_file.py`: 2 occurrences `NDArray[np.bool]` → `NDArray[np.bool_]`