### PR TITLE
test: add unit tests for _load_shape_json_obj error paths

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -35,7 +35,7 @@ class ShapeDict(TypedDict):
     flags: dict[str, bool]
     description: str
     group_id: int | None
-    mask: NDArray[np.bool] | None
+    mask: NDArray[np.bool_] | None
     other_data: dict
 
 
@@ -100,7 +100,7 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
         )
         group_id = shape_json_obj["group_id"]
 
-    mask: NDArray[np.bool] | None = None
+    mask: NDArray[np.bool_] | None = None
     if shape_json_obj.get("mask") is not None:
         assert isinstance(shape_json_obj["mask"], str), (
             f"mask must be base64-encoded PNG: {shape_json_obj['mask']}"

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -4,7 +4,10 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
+
 from labelme._label_file import LabelFile
+from labelme._label_file import _load_shape_json_obj
 
 
 def test_LabelFile_load_windows_path(data_path: Path, tmp_path: Path) -> None:
@@ -29,3 +32,95 @@ def test_LabelFile_load_windows_path(data_path: Path, tmp_path: Path) -> None:
     label_file = LabelFile(str(json_file))
     assert label_file.imagePath == "../images/2011_000003.jpg"
     assert label_file.imageData is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests for _load_shape_json_obj error paths and happy paths
+# ---------------------------------------------------------------------------
+
+_MINIMAL_VALID_SHAPE: dict = {
+    "label": "cat",
+    "points": [[10.0, 20.0], [30.0, 40.0]],
+    "shape_type": "polygon",
+}
+
+
+def test_load_shape_missing_label() -> None:
+    """Missing 'label' key must raise an error."""
+    shape = {
+        "points": [[10.0, 20.0]],
+        "shape_type": "polygon",
+    }
+    # Accepts AssertionError (current code) or ValueError (after PR #1835 merge)
+    with pytest.raises((AssertionError, ValueError)):
+        _load_shape_json_obj(shape)
+
+
+def test_load_shape_invalid_label_type() -> None:
+    """Non-string label must raise an error."""
+    shape = {
+        "label": 42,
+        "points": [[10.0, 20.0]],
+        "shape_type": "polygon",
+    }
+    with pytest.raises((AssertionError, TypeError, ValueError)):
+        _load_shape_json_obj(shape)
+
+
+def test_load_shape_invalid_points_empty() -> None:
+    """Empty points list must raise an error."""
+    shape = {
+        "label": "cat",
+        "points": [],
+        "shape_type": "polygon",
+    }
+    with pytest.raises((AssertionError, ValueError)):
+        _load_shape_json_obj(shape)
+
+
+def test_load_shape_invalid_points_type() -> None:
+    """Points given as a string instead of a list must raise an error."""
+    shape = {
+        "label": "cat",
+        "points": "[[10, 20]]",
+        "shape_type": "polygon",
+    }
+    with pytest.raises((AssertionError, TypeError, ValueError)):
+        _load_shape_json_obj(shape)
+
+
+def test_load_shape_missing_shape_type() -> None:
+    """Missing 'shape_type' key must raise an error."""
+    shape = {
+        "label": "cat",
+        "points": [[10.0, 20.0]],
+    }
+    with pytest.raises((AssertionError, ValueError)):
+        _load_shape_json_obj(shape)
+
+
+def test_load_shape_valid_minimal() -> None:
+    """Minimal valid shape dict should load without error."""
+    result = _load_shape_json_obj(_MINIMAL_VALID_SHAPE)
+    assert result["label"] == "cat"
+    assert result["points"] == [[10.0, 20.0], [30.0, 40.0]]
+    assert result["shape_type"] == "polygon"
+    assert result["flags"] == {}
+    assert result["description"] == ""
+    assert result["group_id"] is None
+    assert result["mask"] is None
+    assert result["other_data"] == {}
+
+
+def test_load_shape_other_data_passthrough() -> None:
+    """Unknown keys in shape JSON should be collected in 'other_data'."""
+    shape = {
+        **_MINIMAL_VALID_SHAPE,
+        "custom_field": "hello",
+        "score": 0.95,
+    }
+    result = _load_shape_json_obj(shape)
+    assert result["other_data"] == {"custom_field": "hello", "score": 0.95}
+    # Known keys must NOT appear in other_data
+    assert "label" not in result["other_data"]
+    assert "points" not in result["other_data"]


### PR DESCRIPTION
## Summary

Adds 7 unit tests for `_load_shape_json_obj` in `tests/unit/_label_file_test.py`, covering error paths and happy paths.

Also fixes `np.bool` → `np.bool_` deprecation in `labelme/_label_file.py` (needed to import the module under NumPy ≥ 1.24; same fix as PR #1831).

## Tests added

| Test | What it covers |
|------|---------------|
| `test_load_shape_missing_label` | `label` key absent → error |
| `test_load_shape_invalid_label_type` | `label` is int instead of str → error |
| `test_load_shape_invalid_points_empty` | `points` is empty list → error |
| `test_load_shape_invalid_points_type` | `points` is a string → error |
| `test_load_shape_missing_shape_type` | `shape_type` key absent → error |
| `test_load_shape_valid_minimal` | Minimal valid shape loads correctly |
| `test_load_shape_other_data_passthrough` | Unknown keys collected in `other_data` |

Error tests use `pytest.raises((AssertionError, ValueError))` to remain compatible with both the current assert-based code and the ValueError migration in PR #1835.

## Checklist
- [x] All 8 tests in `_label_file_test.py` pass (`python3 -m pytest tests/unit/_label_file_test.py -v`)
- [x] No logic changes — test additions only (plus 2-line NumPy deprecation fix)