### PR TITLE
docs: add 14-language availability section to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
   <!-- | <a href="https://www.youtube.com/playlist?list=PLI6LvFw0iflh3o33YYnVIfOpaO0hc5Dzw"><b>Youtube FAQ</b></a> -->
 </div>
 
+<div align="center">
+  🌍 <b>Available in 14 Languages</b><br/>
+  English &middot; 日本語 &middot; 한국어 &middot; 简体中文 &middot; 繁體中文 &middot; Deutsch &middot; Français &middot; Español &middot; Italiano &middot; Português &middot; Nederlands &middot; Magyar &middot; Tiếng Việt &middot; فارسی
+</div>
+
 <br/>
 
 <div align="center">


### PR DESCRIPTION
## Summary

Adds a **🌍 Available in 14 Languages** line directly below the navigation links in README.md, listing all 14 supported locales in their native script.

## Why

Labelme's multilingual support (14 UI languages) is a genuine differentiator — especially for non-English communities — but it was buried in the Features checklist where most first-time visitors never scroll. Surfacing it in the header gives it visibility right at the top.

## What changed

- `README.md`: +5 lines — new `<div align="center">` block listing all 14 languages (English · 日本語 · 한국어 · 简体中文 · 繁體中文 · Deutsch · Français · Español · Italiano · Português · Nederlands · Magyar · Tiếng Việt · فارسی)

## Scope

Documentation only. No code changed. 1 file, 5 lines added.