### PR TITLE
docs: add Contributing section with CLA mention to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ pyinstaller labelme/labelme/__main__.py \
 ```
 
 
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines.
+Contributions require signing the [CLA](CLA.md).
+
 ## Acknowledgement
 
 This repo is the fork of [mpitid/pylabelme](https://github.com/mpitid/pylabelme).


### PR DESCRIPTION
## Summary

Adds a `## Contributing` section to README.md mentioning the CLA requirement.

## Changes
- Added `## Contributing` section before `## Acknowledgement` (1 file, 5 lines)
- Links to `.github/CONTRIBUTING.md` (added in #1848) and `CLA.md` (added in #1847)

## Dependencies
- Depends on #1847 (CLA.md) and #1848 (CONTRIBUTING.md) being merged first

## Size
- 1 file changed, 5 lines added