### PR TITLE
feat: show finish hint in status bar when polygon/linestrip has ≥3 points

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -312,10 +312,11 @@ class Canvas(QtWidgets.QWidget):
         if self.createMode == "linestrip":
             if isNew:
                 return self.tr("Click start point for linestrip")
-            else:
+            if self.current and len(self.current) >= 3:
                 return self.tr(
-                    "Click next point or finish by Ctrl/Cmd+Click for linestrip"
+                    "Click next point, or double-click / Enter to finish"
                 )
+            return self.tr("Click next point or finish by Ctrl/Cmd+Click for linestrip")
         if self.createMode == "circle":
             if isNew:
                 return self.tr("Click center point for circle")
@@ -326,6 +327,9 @@ class Canvas(QtWidgets.QWidget):
                 return self.tr("Click first corner for rectangle")
             else:
                 return self.tr("Click opposite corner for rectangle (Shift for square)")
+        # Default: polygon
+        if not isNew and self.current and len(self.current) >= 3:
+            return self.tr("Click to add point, or double-click / Enter to finish")
         return self.tr("Click to add point")
 
     def mouseMoveEvent(self, a0: QtGui.QMouseEvent) -> None:

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -6,7 +6,8 @@ import pytest
 from PyQt5 import QtGui
 from PyQt5.QtCore import QPointF
 
-from labelme.widgets.canvas import Canvas
+from labelme.shape import Shape
+from labelme.widgets.canvas import Canvas, CanvasMode
 
 _WIDTH: Final = 100
 _HEIGHT: Final = 50
@@ -69,3 +70,49 @@ def test_intersectionPoint(
     canvas: Canvas, p1: QPointF, p2: QPointF, pt_intersection: QPointF
 ):
     assert canvas.intersectionPoint(p1, p2) == pt_intersection
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("create_mode", "num_points", "expect_finish_hint"),
+    [
+        # polygon: no hint with < 3 points
+        ("polygon", 0, False),
+        ("polygon", 2, False),
+        # polygon: finish hint appears at ≥ 3 points
+        ("polygon", 3, True),
+        ("polygon", 5, True),
+        # linestrip: no hint with < 3 points
+        ("linestrip", 1, False),
+        ("linestrip", 2, False),
+        # linestrip: finish hint appears at ≥ 3 points
+        ("linestrip", 3, True),
+        # other modes: never show finish hint
+        ("line", 1, False),
+        ("circle", 1, False),
+        ("rectangle", 1, False),
+    ],
+)
+def test_get_create_mode_message_finish_hint(
+    canvas: Canvas,
+    create_mode: str,
+    num_points: int,
+    expect_finish_hint: bool,
+):
+    """Verify that a double-click/Enter finish hint appears when ≥ 3 points exist."""
+    canvas.mode = CanvasMode.CREATE
+    canvas.createMode = create_mode
+
+    if num_points > 0:
+        canvas.current = Shape(shape_type=create_mode)
+        for i in range(num_points):
+            canvas.current.addPoint(QPointF(float(i * 10), float(i * 10)))
+    else:
+        canvas.current = None
+
+    msg = canvas._get_create_mode_message()
+    has_finish_hint = "double-click" in msg.lower() or "to finish" in msg.lower()
+    assert has_finish_hint is expect_finish_hint, (
+        f"Mode={create_mode!r}, points={num_points}: "
+        f"expected finish_hint={expect_finish_hint}, got message={msg!r}"
+    )


### PR DESCRIPTION
## Summary

When drawing a polygon or linestrip with ≥3 points, users often don't realize they can double-click (or press Enter) to finish the shape. The status bar now shows a contextual hint at that moment.

## Changes

**`labelme/widgets/canvas.py`** — `_get_create_mode_message()`

- **polygon** with ≥3 points drawn: `"Click to add point, or double-click / Enter to finish"`
- **linestrip** with ≥3 points drawn: `"Click next point, or double-click / Enter to finish"`
- All other modes (line, circle, rectangle, ai_polygon, ai_mask): existing messages unchanged

**`tests/unit/widgets/canvas_test.py`**

- Adds `test_get_create_mode_message_finish_hint` with 11 parametrized cases covering:
  - polygon at 0, 2, 3, and 5 points
  - linestrip at 1, 2, and 3 points
  - line, circle, rectangle at 1 point (no finish hint expected)

## Before / After

| Scenario | Before | After |
|---|---|---|
| Drawing polygon, 2 points | `Click to add point` | `Click to add point` (unchanged) |
| Drawing polygon, 3+ points | `Click to add point` | `Click to add point, or double-click / Enter to finish` |
| Drawing linestrip, 3+ points | `Click next point or finish by Ctrl/Cmd+Click for linestrip` | `Click next point, or double-click / Enter to finish` |