### PR TITLE
test: add unit tests for utils/_io.py (lblsave)

### DIFF
--- a/tests/unit/utils/_io_test.py
+++ b/tests/unit/utils/_io_test.py
@@ -1,0 +1,50 @@
+# MIT License
+# Copyright (c) Kentaro Wada
+
+import os
+
+import numpy as np
+import PIL.Image
+import pytest
+
+from labelme.utils._io import lblsave
+
+
+def test_lblsave_valid_uint8_labels(tmp_path):
+    """Labels in [0, 254] range should be saved as P-mode PNG with colormap."""
+    lbl = np.zeros((10, 10), dtype=np.int32)
+    lbl[0, 0] = 254
+    out = str(tmp_path / "label.png")
+    lblsave(out, lbl)
+    assert os.path.isfile(out)
+    img = PIL.Image.open(out)
+    assert img.mode == "P"
+
+
+def test_lblsave_adds_png_extension(tmp_path):
+    """Filename without .png extension should have .png appended automatically."""
+    lbl = np.zeros((5, 5), dtype=np.int32)
+    out_base = str(tmp_path / "label")
+    lblsave(out_base, lbl)
+    assert os.path.isfile(out_base + ".png")
+    assert not os.path.isfile(out_base)
+
+
+def test_lblsave_invalid_labels_raises(tmp_path):
+    """lbl.max() >= 255 should raise ValueError."""
+    lbl = np.zeros((5, 5), dtype=np.int32)
+    lbl[0, 0] = 255
+    out = str(tmp_path / "label.png")
+    with pytest.raises(ValueError, match="Cannot save"):
+        lblsave(out, lbl)
+
+
+def test_lblsave_negative_one_labels_ok(tmp_path):
+    """lbl.min() == -1 with lbl.max() < 255 should save successfully."""
+    lbl = np.full((8, 8), -1, dtype=np.int32)
+    lbl[4, 4] = 100
+    out = str(tmp_path / "label.png")
+    lblsave(out, lbl)
+    assert os.path.isfile(out)
+    img = PIL.Image.open(out)
+    assert img.mode == "P"


### PR DESCRIPTION
## Summary

`lblsave` in `labelme/utils/_io.py` was the only utility function with no dedicated test file. This PR adds `tests/unit/utils/_io_test.py` with 4 tests covering its full behavior.

## Tests Added

- `test_lblsave_valid_uint8_labels` — labels in `[0, 254]` range are saved as a P-mode PNG with a colormap
- `test_lblsave_adds_png_extension` — filename without `.png` extension gets `.png` appended automatically
- `test_lblsave_invalid_labels_raises` — `lbl.max() >= 255` raises `ValueError`
- `test_lblsave_negative_one_labels_ok` — `lbl.min() == -1` with `lbl.max() < 255` saves successfully

All 4 tests pass. No behavior changes — tests only.