### PR TITLE
refactor: Allow boundedMoveVertex to take a shape and vertex id as parameters

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -454,6 +454,8 @@ class Canvas(QtWidgets.QWidget):
         # Polygon/Vertex moving.
         if Qt.LeftButton & a0.buttons():
             if self.selectedVertex():
+                assert self.hVertex is not None
+                assert self.hShape is not None
                 self.boundedMoveVertex(
                     self.hShape, self.hVertex, pos, is_shift_pressed=is_shift_pressed
                 )
@@ -773,11 +775,6 @@ class Canvas(QtWidgets.QWidget):
     def boundedMoveVertex(
         self, shape: Shape, vertex_index: int, pos: QPointF, is_shift_pressed: bool
     ) -> None:
-        if vertex_index is None:
-            logger.warning("vertex_index is None, so cannot move vertex: pos={!r}", pos)
-            return
-        assert shape is not None
-
         if vertex_index >= len(shape.points):
             logger.warning(
                 "vertex_index is out of range: vertex_index={:d}, len(points)={:d}",


### PR DESCRIPTION
# Description
Allow passing a different shape than `hShape` to `boundedMoveVertex`.

Removed the `self.hVertex is None` check from inside the function as it was impossible to reach with the current usage anyway.

# Context
The upcoming [rectangle rotation](https://github.com/wkentaro/labelme/discussions/1374) feature ([PR](https://github.com/wkentaro/labelme/pull/1778)) will share the vertex interaction logic for both drawing (by passing `self.current`) and editing (by passing `self.hShape`).