### PR TITLE
fix: Use asynchronous repainting for the Canvas

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -245,7 +245,7 @@ class Canvas(QtWidgets.QWidget):
         self.mode = CanvasMode.EDIT if value else CanvasMode.CREATE
         if self.mode == CanvasMode.EDIT:
             # CREATE -> EDIT
-            self.repaint()  # clear crosshair
+            self.update()  # clear crosshair
         else:
             # EDIT -> CREATE
             need_update: bool = self._set_highlight(
@@ -357,7 +357,7 @@ class Canvas(QtWidgets.QWidget):
 
             self.overrideCursor(CURSOR_DRAW)
             if not self.current:
-                self.repaint()  # draw crosshair
+                self.update()  # draw crosshair
                 self._update_status()
                 return
 
@@ -406,7 +406,7 @@ class Canvas(QtWidgets.QWidget):
                 self.line.point_labels = [1]
                 self.line.close()
             assert len(self.line.points) == len(self.line.point_labels)
-            self.repaint()
+            self.update()
             self.current.highlightClear()
             self._update_status()
             return
@@ -416,10 +416,10 @@ class Canvas(QtWidgets.QWidget):
             if self.selectedShapesCopy and self.prevPoint is not None:
                 self.overrideCursor(CURSOR_MOVE)
                 self.boundedMoveShapes(self.selectedShapesCopy, pos)
-                self.repaint()
+                self.update()
             elif self.selectedShapes:
                 self.selectedShapesCopy = [s.copy() for s in self.selectedShapes]
-                self.repaint()
+                self.update()
             self._update_status()
             return
 
@@ -427,12 +427,12 @@ class Canvas(QtWidgets.QWidget):
         if Qt.LeftButton & a0.buttons():
             if self.selectedVertex():
                 self.boundedMoveVertex(pos, is_shift_pressed=is_shift_pressed)
-                self.repaint()
+                self.update()
                 self.movingShape = True
             elif self.selectedShapes and self.prevPoint is not None:
                 self.overrideCursor(CURSOR_MOVE)
                 self.boundedMoveShapes(self.selectedShapes, pos)
-                self.repaint()
+                self.update()
                 self.movingShape = True
             return
 
@@ -592,14 +592,14 @@ class Canvas(QtWidgets.QWidget):
                 group_mode = int(a0.modifiers()) == Qt.ControlModifier
                 self.selectShapePoint(pos, multiple_selection_mode=group_mode)
                 self.prevPoint = pos
-                self.repaint()
+                self.update()
         elif a0.button() == Qt.RightButton and self.editing():
             group_mode = int(a0.modifiers()) == Qt.ControlModifier
             if not self.selectedShapes or (
                 self.hShape is not None and self.hShape not in self.selectedShapes
             ):
                 self.selectShapePoint(pos, multiple_selection_mode=group_mode)
-                self.repaint()
+                self.update()
             self.prevPoint = pos
         elif a0.button() == Qt.MiddleButton and self._is_dragging_enabled:
             self.overrideCursor(CURSOR_GRAB)
@@ -614,7 +614,7 @@ class Canvas(QtWidgets.QWidget):
             if not menu.exec_(self.mapToGlobal(a0.pos())) and self.selectedShapesCopy:  # type: ignore
                 # Cancel the move by deleting the shadow copy.
                 self.selectedShapesCopy = []
-                self.repaint()
+                self.update()
         elif a0.button() == Qt.LeftButton:
             if self.editing():
                 if (
@@ -650,7 +650,7 @@ class Canvas(QtWidgets.QWidget):
             for i, shape in enumerate(self.selectedShapesCopy):
                 self.selectedShapes[i].points = shape.points
         self.selectedShapesCopy = []
-        self.repaint()
+        self.update()
         self.storeShapes()
         return True
 
@@ -1026,7 +1026,7 @@ class Canvas(QtWidgets.QWidget):
     def moveByKeyboard(self, offset):
         if self.selectedShapes:
             self.boundedMoveShapes(self.selectedShapes, self.prevPoint + offset)
-            self.repaint()
+            self.update()
             self.movingShape = True
 
     def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:


### PR DESCRIPTION
Forum post explaining the difference between repaint() and update(): [link](https://www.qtcentre.org/threads/59290-What-s-the-difference-between-calling-QWidget-update()-and-QWidget-repaint())

Current behavior. The synchronous repainting of the canvas widget results in dramatic buffering.
![Screencast_20260311_160351](https://github.com/user-attachments/assets/5347b879-5ef6-4064-863c-350d39742783)
Fixed behavior.
![Screencast_20260311_160252](https://github.com/user-attachments/assets/768ff86a-827c-4f0e-a65d-b64eb4e7eff7)

Note that I am using Wayland on Linux, which I believe forces VSync on desktop applications.