### PR TITLE
fix: clip crosshair guide lines to image bounds instead of widget bounds

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -838,14 +838,14 @@ class Canvas(QtWidgets.QWidget):
             p.drawLine(
                 0,
                 int(self.prevMovePoint.y() * self.scale),
-                self.width() - 1,
+                int(self.pixmap.width() * self.scale) - 1,
                 int(self.prevMovePoint.y() * self.scale),
             )
             p.drawLine(
                 int(self.prevMovePoint.x() * self.scale),
                 0,
                 int(self.prevMovePoint.x() * self.scale),
-                self.height() - 1,
+                int(self.pixmap.height() * self.scale) - 1,
             )
 
         Shape.scale = self.scale


### PR DESCRIPTION
## Problem

When zoomed in, the crosshair guide lines shown during rectangle/shape creation extend to the **widget edge** instead of stopping at the image boundary. The horizontal line uses `self.width() - 1` and the vertical line uses `self.height() - 1`, which are the canvas widget dimensions — not the pixmap (image) dimensions. This causes the crosshair to continue into the gray empty area around the image.

Fixes #1518. Community fix originally submitted by @windwhim.

## Solution

Replace widget dimensions with pixmap-scaled dimensions:

```python
# Before (widget bounds)
self.width() - 1       # horizontal line endpoint
self.height() - 1      # vertical line endpoint

# After (image bounds)
int(self.pixmap.width() * self.scale) - 1   # horizontal line endpoint
int(self.pixmap.height() * self.scale) - 1  # vertical line endpoint
```

The `self.pixmap` access is safe because:
1. There is an early return at the top of `paintEvent()` guarded by `if not self.pixmap`
2. The crosshair block is additionally gated by `not self.outOfPixmap(self.prevMovePoint)`, which requires a valid pixmap

## Changes
- `labelme/widgets/canvas.py`: 2 lines changed in `paintEvent()` crosshair drawing block

## Testing
- All 46 unit tests pass (`pytest tests/unit/ --ignore=tests/unit/widgets/`)
- Canvas widget tests require a display (X11) and abort in headless CI — this is pre-existing and unrelated to this change