### PR TITLE
fix: guard against ValueError when hShape/selectedShape is removed from shapes

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -629,7 +629,7 @@ class Canvas(QtWidgets.QWidget):
             self._is_dragging = False
             self.restoreCursor()
 
-        if self.movingShape and self.hShape:
+        if self.movingShape and self.hShape and self.hShape in self.shapes:
             index = self.shapes.index(self.hShape)
             if self.shapesBackups[-1][index].points != self.shapes[index].points:
                 self.storeShapes()
@@ -1061,7 +1061,11 @@ class Canvas(QtWidgets.QWidget):
             if int(modifiers) == 0:
                 self.snapping = True
         elif self.editing():
-            if self.movingShape and self.selectedShapes:
+            if (
+                self.movingShape
+                and self.selectedShapes
+                and self.selectedShapes[0] in self.shapes
+            ):
                 index = self.shapes.index(self.selectedShapes[0])
                 if self.shapesBackups[-1][index].points != self.shapes[index].points:
                     self.storeShapes()


### PR DESCRIPTION
## Summary

Fixes a `ValueError` crash that occurs when `self.shapes.index(self.hShape)` is called but `hShape` is no longer in `self.shapes`. This can happen if a shape is deleted (e.g. via undo) between the mouse-press and mouse-release events.

Fixes #1488

## Changes

**`mouseReleaseEvent()`** — guard the `.index()` call with an `in` check:
```python
# Before
if self.movingShape and self.hShape:
    index = self.shapes.index(self.hShape)

# After
if self.movingShape and self.hShape and self.hShape in self.shapes:
    index = self.shapes.index(self.hShape)
```

**`keyReleaseEvent()`** — same pattern for `selectedShapes[0]`:
```python
# Before
if self.movingShape and self.selectedShapes:
    index = self.shapes.index(self.selectedShapes[0])

# After
if (
    self.movingShape
    and self.selectedShapes
    and self.selectedShapes[0] in self.shapes
):
    index = self.shapes.index(self.selectedShapes[0])
```

## Testing

- All 46 unit tests pass (`python -m pytest tests/unit/ -x`)