### PR TITLE
fix: support transparent images (RGBA, LA) in BrightnessContrastDialog

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1729,7 +1729,7 @@ class MainWindow(QtWidgets.QMainWindow):
             contrast,
         )
         dialog = BrightnessContrastDialog(
-            utils.img_data_to_pil(self.imageData).convert("RGB"),
+            utils.img_data_to_pil(self.imageData),
             self.onNewBrightnessContrast,
             parent=self,
         )

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -53,8 +53,11 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         del layouts
         self.setLayout(v_layout)
 
+        self._alpha = None
+        if "A" in img.getbands():
+            self._alpha = img.getchannel("A")
         if img.mode != "RGB":
-            raise ValueError("Image mode must be RGB")
+            img = img.convert("RGB")
         self.img = img
         self.callback = callback
 
@@ -68,7 +71,15 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         if contrast != 1:
             img = PIL.ImageEnhance.Contrast(img).enhance(contrast)
 
+        fmt: QImage.Format
+        if self._alpha is None:
+            fmt = QImage.Format_RGB888
+        else:
+            img = img.convert("RGBA")
+            img.putalpha(self._alpha)
+            fmt = QImage.Format_RGBA8888
+
         qimage = QImage(
-            img.tobytes(), img.width, img.height, img.width * 3, QImage.Format_RGB888
+            img.tobytes(), img.width, img.height, img.width * len(img.getbands()), fmt
         )
         self.callback(qimage)


### PR DESCRIPTION
## Summary

Opening the Brightness/Contrast dialog on a transparent PNG (RGBA or LA mode) crashed with:
```
ValueError: Image mode must be RGB
```

## Fix

- In `__init__()`, detect images with alpha channel (RGBA, LA), split out the alpha, store it as `self._alpha`, and convert to RGB for `ImageEnhance` compatibility
- In `onNewValue()`, reattach the saved alpha before building the `QImage`, using `Format_RGBA8888` so transparency is preserved in the canvas preview
- Move mode conversion from `app.py` into the dialog so it handles all modes (L, LA, RGB, RGBA) internally

## Changes

- `labelme/widgets/brightness_contrast_dialog.py`: handle alpha channel separation and reattachment
- `labelme/app.py`: remove `.convert("RGB")` call, let dialog handle mode conversion

Fixes #1660