### PR TITLE
fix: apply EXIF orientation in labelme_json_to_dataset export

### DIFF
--- a/labelme/cli/export_json.py
+++ b/labelme/cli/export_json.py
@@ -1,10 +1,12 @@
 import argparse
+import io
 import os
 import os.path as osp
 
 import imgviz
 import numpy as np
 import PIL.Image
+import PIL.ImageOps
 from loguru import logger
 from numpy.typing import NDArray
 
@@ -30,7 +32,11 @@ def main():
 
     label_file: LabelFile = LabelFile(filename=json_file)
 
-    image: NDArray[np.uint8] = utils.img_data_to_arr(label_file.imageData)
+    _pil: PIL.Image.Image = PIL.Image.open(io.BytesIO(label_file.imageData))
+    _pil = PIL.ImageOps.exif_transpose(_pil)
+    if _pil.mode not in ("RGB", "RGBA"):
+        _pil = _pil.convert("RGB")
+    image: NDArray[np.uint8] = np.array(_pil)
 
     label_name_to_value: dict[str, int] = {"_background_": 0}
     for shape in sorted(label_file.shapes, key=lambda x: x["label"]):


### PR DESCRIPTION
## Problem

Rotated JPEGs with EXIF orientation tags (orientation != 1) were exported without the rotation applied by `labelme_json_to_dataset`. This caused `img.png` to be saved in the raw (unrotated) orientation, misaligning it with the label masks.

Fixes #1529.

## Solution

Replace `utils.img_data_to_arr()` with explicit PIL loading + `PIL.ImageOps.exif_transpose()` before converting to a numpy array. Non-RGB/RGBA modes are converted to RGB for consistency.

```python
# Before
image: NDArray[np.uint8] = utils.img_data_to_arr(label_file.imageData)

# After
_pil: PIL.Image.Image = PIL.Image.open(io.BytesIO(label_file.imageData))
_pil = PIL.ImageOps.exif_transpose(_pil)
if _pil.mode not in ("RGB", "RGBA"):
    _pil = _pil.convert("RGB")
image: NDArray[np.uint8] = np.array(_pil)
```

## Changes

- `labelme/cli/export_json.py`: Apply EXIF transpose before exporting (`import io`, `import PIL.ImageOps` added; 5 lines changed)

## Tests

`python3 -m pytest tests/unit/ --ignore=tests/unit/widgets -q` — 46 passed