### PR TITLE
fix: select pasted shapes after cross-file paste

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1560,6 +1560,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def pasteSelectedShape(self):
         self._load_shapes(shapes=self._copied_shapes, replace=False)
+        self.canvas.selectShapes(self._copied_shapes)
         self.setDirty()
 
     def copySelectedShape(self):


### PR DESCRIPTION
## Problem

When copying an annotation from one file and pasting into another, the pasted shape appears on the canvas but `selectedShapes` is empty. This means:

- **Ctrl+E** (edit label) does nothing
- **Arrow keys** (move shape) do nothing
- User has to click the shape manually before they can interact with it

## Root Cause

`pasteSelectedShape()` calls `_load_shapes(replace=False)` which:
1. Calls `labelList.clearSelection()`
2. Calls `canvas.loadShapes()` — which never updates `selectedShapes`

So after paste, `canvas.selectedShapes = []` despite the shape being visible.

## Fix

Call `canvas.selectShapes()` after loading the pasted shapes:

```python
def pasteSelectedShape(self):
    self._load_shapes(shapes=self._copied_shapes, replace=False)
    self.canvas.selectShapes(self._copied_shapes)  # ← added
    self.setDirty()
```

## Testing

Manually verified: paste a shape into a different file → shape is immediately selectable, Ctrl+E and arrow keys work without clicking first.