### PR TITLE
fix: warn and skip unknown config keys instead of crashing

### DIFF
--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -10,10 +10,11 @@ here = osp.dirname(osp.abspath(__file__))
 
 def _update_dict(target_dict, new_dict, validate_item=None):
     for key, value in new_dict.items():
+        if key not in target_dict:
+            logger.warning("Ignoring unexpected key in config file: {!r}", key)
+            continue
         if validate_item:
             validate_item(key, value)
-        if key not in target_dict:
-            raise ValueError(f"Unexpected key in config: {key}")
         if isinstance(target_dict[key], dict) and isinstance(value, dict):
             _update_dict(target_dict[key], value, validate_item=validate_item)
         else:

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -92,3 +92,29 @@ def test_migrate_polygon_shortcut_skips_when_new_key_exists():
     _migrate_config_from_file(config)
     assert config["shortcuts"]["edit_shape"] == "Ctrl+Y"
     assert "edit_polygon" in config["shortcuts"]
+
+
+def test_unknown_config_key_warns_and_does_not_raise(tmp_path):
+    """Unknown keys in .labelmerc should warn and be ignored, not crash."""
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("unknown_key: true\n")
+    # Must not raise; labelme should open normally
+    config = load_config(config_file=config_file, config_overrides={})
+    assert "unknown_key" not in config
+
+
+def test_unknown_config_key_does_not_affect_valid_keys(tmp_path):
+    """Unknown keys should be silently skipped; valid keys still applied."""
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("unknown_key: 42\nauto_save: true\n")
+    config = load_config(config_file=config_file, config_overrides={})
+    assert config["auto_save"] is True
+    assert "unknown_key" not in config
+
+
+def test_invalid_value_for_known_key_still_raises(tmp_path):
+    """Bad values for *known* keys should still raise ValueError."""
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("validate_label: bad_value\n")
+    with pytest.raises(ValueError, match="validate_label"):
+        load_config(config_file=config_file, config_overrides={})


### PR DESCRIPTION
## Problem

Old or custom `.labelmerc` files containing unrecognized keys crash labelme with a confusing `ValueError: Unexpected key in config: <key>` traceback. This affects users who upgrade from older versions (stale keys) or who have typos in their config.

Closes #1526, #1465

## Solution

In `_update_dict()`, replace the `raise ValueError` for unknown keys with a `logger.warning` + `continue`:

```python
# Before
if key not in target_dict:
    raise ValueError(f"Unexpected key in config: {key}")

# After
if key not in target_dict:
    logger.warning("Ignoring unexpected key in config file: {!r}", key)
    continue
```

Bad *values* for known keys (e.g. `validate_label: bad_value`) still raise `ValueError` as before — only the unknown-key path changes.

## Tests

Three new tests added to `tests/unit/config_test.py`:
- `test_unknown_config_key_warns_and_does_not_raise` — a `.labelmerc` with `unknown_key: true` does not raise; labelme opens normally
- `test_unknown_config_key_does_not_affect_valid_keys` — unknown keys are skipped; valid keys that follow are still applied
- `test_invalid_value_for_known_key_still_raises` — `validate_label: bad_value` still raises `ValueError`

All 31 non-GUI unit tests pass.