### PR TITLE
fix: clamp LabelDialog position to screen bounds

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -8,9 +8,6 @@ from PyQt5 import QtWidgets
 
 import labelme.utils
 
-# TODO(unknown):
-# - Calculate optimal position so as not to go out of screen area.
-
 
 class LabelQLineEdit(QtWidgets.QLineEdit):
     def setListWidget(self, list_widget):
@@ -235,7 +232,15 @@ class LabelDialog(QtWidgets.QDialog):
             self.edit.completer().setCurrentRow(row)
         self.edit.setFocus(QtCore.Qt.PopupFocusReason)
         if move:
-            self.move(QtGui.QCursor.pos())
+            pos = QtGui.QCursor.pos()
+            screen = QtWidgets.QApplication.screenAt(pos)
+            if screen is not None:
+                geom = screen.availableGeometry()
+                pos.setX(min(pos.x(), geom.right() - self.width()))
+                pos.setY(min(pos.y(), geom.bottom() - self.height()))
+                pos.setX(max(pos.x(), geom.left()))
+                pos.setY(max(pos.y(), geom.top()))
+            self.move(pos)
         if self.exec_():
             return (
                 self.edit.text(),


### PR DESCRIPTION
## Problem

When the cursor is near the bottom-right corner of a screen, `LabelDialog.popUp()` was moving the dialog directly to the cursor position. This could place the dialog partially or fully off-screen, making it inaccessible.

This was tracked by a 4-year-old TODO comment in the file:
```
# TODO(unknown):
# - Calculate optimal position so as not to go out of screen area.
```

## Fix

Before calling `self.move(pos)`, the position is now clamped to the screen's available geometry using `QApplication.screenAt()`:

```python
if move:
    pos = QtGui.QCursor.pos()
    screen = QtWidgets.QApplication.screenAt(pos)
    if screen is not None:
        geom = screen.availableGeometry()
        pos.setX(min(pos.x(), geom.right() - self.width()))
        pos.setY(min(pos.y(), geom.bottom() - self.height()))
        pos.setX(max(pos.x(), geom.left()))
        pos.setY(max(pos.y(), geom.top()))
    self.move(pos)
```

The clamping:
- Prevents the right edge from going past the screen's right bound
- Prevents the bottom edge from going past the screen's bottom bound  
- Prevents the left/top edges from going off the left/top side
- Handles multi-monitor setups correctly via `screenAt()`
- Falls back gracefully (no clamp) if `screenAt()` returns None

## Testing

```
QT_QPA_PLATFORM=offscreen python3 -m pytest tests/unit/ -x -q
# 63 passed
```

Also removes the long-standing TODO comment since this resolves it.