### PR TITLE
feat: add configurable UI language preference support

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -280,18 +280,37 @@ def main():
             )
         output_dir = output
 
+    # Pick UI language for this run.
+    # - Default: system locale
+    # - Override: `language:` in config (e.g. en_US, zh_CN, tr_TR)
+    requested_language: object | None = None
+    if isinstance(config_overrides, dict) and "language" in config_overrides:
+        requested_language = config_overrides.get("language")
+    elif config_file is not None:
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict) and "language" in loaded:
+                requested_language = loaded.get("language")
+        except Exception:
+            logger.warning("Failed to read `language` from config: {}", config_file)
+
+    if requested_language in (None, "system", "system locale"):
+        locale_name = QtCore.QLocale.system().name()
+    else:
+        locale_name = str(requested_language)
+
     translator = QtCore.QTranslator()
-    translator.load(
-        QtCore.QLocale.system().name(),
-        f"{osp.dirname(osp.abspath(__file__))}/translate",
-    )
+    translate_dir = f"{osp.dirname(osp.abspath(__file__))}/translate"
+    translator_loaded: bool = translator.load(locale_name, translate_dir)
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")  # for consistent appearance across platforms
     # Force light mode to avoid dark mode UI issues (e.g., invisible icons)
     app.setPalette(QtWidgets.QStyleFactory.create("Fusion").standardPalette())
     app.setApplicationName(__appname__)
     app.setWindowIcon(newIcon("icon"))
-    app.installTranslator(translator)
+    if translator_loaded:
+        app.installTranslator(translator)
     win = MainWindow(
         config_file=config_file,
         config_overrides=config_overrides,

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -22,6 +22,7 @@ import numpy as np
 import osam
 from loguru import logger
 from numpy.typing import NDArray
+import yaml
 from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
@@ -810,6 +811,38 @@ class MainWindow(QtWidgets.QMainWindow):
         help_menu = self.menu(self.tr("&Help"))
         recent_files = QtWidgets.QMenu(self.tr("Open &Recent"))
 
+        # Language selection for UI translations.
+        language_menu = QtWidgets.QMenu("Language", self)
+        current_language = self._config.get("language") or "system"
+        if current_language == "system locale":
+            current_language = "system"
+        self._language_menu_actions: list[QtWidgets.QAction] = []
+
+        system_locale_name = QtCore.QLocale.system().name()
+        system_label = f"System ({system_locale_name})"
+        system_action = action(system_label, slot=None)
+        system_action.setCheckable(True)
+        system_action.setChecked(current_language == "system")
+        system_action.triggered.connect(
+            lambda _checked=False: self._set_language_preference("system")
+        )
+        system_action.setData("system")
+        language_menu.addAction(system_action)
+        self._language_menu_actions.append(system_action)
+
+        translate_dir = Path(osp.dirname(osp.abspath(__file__))) / "translate"
+        available_locales = sorted([p.stem for p in translate_dir.glob("*.ts")])
+        for locale in available_locales:
+            locale_action = action(locale, slot=None)
+            locale_action.setCheckable(True)
+            locale_action.setChecked(current_language == locale)
+            locale_action.triggered.connect(
+                lambda _checked=False, loc=locale: self._set_language_preference(loc)
+            )
+            locale_action.setData(locale)
+            language_menu.addAction(locale_action)
+            self._language_menu_actions.append(locale_action)
+
         label_menu = QtWidgets.QMenu()
         utils.addActions(label_menu, (self._actions.edit, self._actions.delete))
         self._docks.label_list.setContextMenuPolicy(Qt.CustomContextMenu)
@@ -844,6 +877,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._docks.label_dock.toggleViewAction(),
                 self._docks.shape_dock.toggleViewAction(),
                 self._docks.file_dock.toggleViewAction(),
+                None,
+                language_menu,
                 None,
                 self._actions.reset_layout,
                 None,
@@ -886,6 +921,55 @@ class MainWindow(QtWidgets.QMainWindow):
             help=help_menu,
             recent_files=recent_files,
             label_list=label_menu,
+        )
+
+    def _set_language_preference(self, locale: str) -> None:
+        """
+        Persist UI language preference to config file.
+
+        Note: the translation is loaded during app startup, so this setting takes
+        effect on next launch.
+        """
+        if self._config_file is None:
+            QMessageBox.information(
+                self,
+                "Language preference not saved",
+                "Start Labelme with a config file to persist language preference.",
+            )
+            return
+
+        language_value = "system" if locale in ("system", "system locale") else locale
+
+        config_path: Path = self._config_file
+        try:
+            config_data: dict = {}
+            if config_path.exists():
+                loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+                if isinstance(loaded, dict):
+                    config_data = loaded
+            config_data["language"] = language_value
+            config_path.write_text(
+                yaml.safe_dump(config_data, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+        except Exception as e:
+            logger.warning("Failed to write language config: {}", e)
+            QMessageBox.information(
+                self,
+                "Language preference failed",
+                "Failed to save language preference. Please check permissions.",
+            )
+            return
+
+        # Update menu checkmarks immediately (translation will apply on next startup).
+        self._config["language"] = language_value
+        for a in getattr(self, "_language_menu_actions", []):
+            a.setChecked(a.data() == language_value)
+
+        QMessageBox.information(
+            self,
+            "Restart required",
+            "Language will take effect on next launch. Please restart Labelme.",
         )
 
     def _setup_toolbars(self) -> None:

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -5,6 +5,7 @@ keep_prev: false
 keep_prev_scale: false
 keep_prev_brightness_contrast: false
 logger_level: info
+language: system  # system / Qt locale name (e.g., en_US, zh_CN, tr_TR)
 
 flags: null
 label_flags: null


### PR DESCRIPTION

## ✅ PR Description

![8zxGxev6](https://github.com/user-attachments/assets/44118be4-8a61-4b19-b7ee-4df75d49239d)


### Summary

This PR introduces an experimental implementation that allows users to configure the UI language independently from the system locale.

Currently, Labelme determines the interface language based solely on the operating system locale.
However, in international environments or multilingual workflows, users may prefer a different UI language than their system setting.

This change provides a foundation for supporting user-selectable language preferences.

### Motivation

* Improve usability for international users
* Enable flexible language selection in multilingual teams
* Support workflows where system locale and application language requirements differ
* Prepare groundwork for future full i18n preference management

This feature was also discussed in issue #1806 and acknowledged as a useful direction by the maintainer.


### Implementation

* Introduced a configurable language preference override mechanism
* When a language preference is set, Labelme loads the corresponding translation instead of relying only on system locale
* Maintains backward compatibility with existing locale detection behavior
* Verified runtime translation loading with multiple languages (for example Greek UI testing)


### Usage (experimental)

Users can test this feature by installing the development branch:

```bash
pip install git+https://github.com/kancheng/labelme.git@feature/ui-language-selector
```

### Future Work

This PR focuses on enabling the core override mechanism.
Possible follow-up improvements include:

* Add language selector in Preferences dialog
* Persist language configuration in user config file
* Implement live UI language switching without restart
* Define fallback strategy for incomplete translations


### Notes

This is an initial step toward a more flexible internationalization system.
Feedback and design discussion are very welcome.