### PR TITLE
refactor: add from __future__ import annotations to AI widget files

### DIFF
--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 
 from loguru import logger

--- a/labelme/widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/widgets/_ai_text_to_annotation_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 
 from PyQt5 import QtCore


### PR DESCRIPTION
## Summary

Adds `from __future__ import annotations` as the first import in two AI widget files:

- `labelme/widgets/_ai_text_to_annotation_widget.py`
- `labelme/widgets/_ai_assisted_annotation_widget.py`

## Motivation

All major widget files already have this import for consistency and forward-compatibility with Python's PEP 563 postponed evaluation of annotations:
- `canvas.py` ✅
- `download.py` ✅
- `tool_bar.py` ✅
- `label_dialog.py` ✅

The two AI widget files were the only outliers. This makes the codebase uniform.

## Changes

- 2 files changed, 4 insertions (+)
- No logic changes whatsoever

## Tests

- 46 unit tests pass (`python -m pytest tests/unit/ --ignore=tests/unit/widgets`)