### PR TITLE
Show AI model download progress in GUI

### DIFF
--- a/labelme/widgets/download.py
+++ b/labelme/widgets/download.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import importlib
 import types
 
 import osam
@@ -16,6 +18,52 @@ from PyQt5.QtWidgets import QProgressDialog
 class _AiModelDownloadSignals(QObject):
     finished = pyqtSignal()
     error = pyqtSignal(Exception)
+    progress = pyqtSignal(int, int, str)
+
+
+def _format_num_bytes(num_bytes: int) -> str:
+    size = float(num_bytes)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1024.0 or unit == "TB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    raise AssertionError("unreachable")
+
+
+def _format_download_label(
+    blob_index: int,
+    num_blobs: int,
+    *,
+    percent: int | None = None,
+    current_size: int | None = None,
+    total_size: int | None = None,
+) -> str:
+    part_suffix: str = (
+        f" ({blob_index}/{num_blobs})" if num_blobs > 1 else ""
+    )
+    if percent is None or current_size is None or total_size is None:
+        return (
+            f"Downloading AI model...{part_suffix}\n"
+            "(requires internet connection)"
+        )
+    return (
+        f"Downloading AI model...{part_suffix}\n"
+        f"{percent}% - {_format_num_bytes(current_size)} / "
+        f"{_format_num_bytes(total_size)}"
+    )
+
+
+@contextlib.contextmanager
+def _patched_gdown_tqdm(progress_factory):
+    gdown_download = importlib.import_module("gdown.download")
+    original_tqdm = gdown_download.tqdm.tqdm
+    gdown_download.tqdm.tqdm = progress_factory
+    try:
+        yield
+    finally:
+        gdown_download.tqdm.tqdm = original_tqdm
 
 
 class _AiModelDownloadWorker(QRunnable):
@@ -24,9 +72,88 @@ class _AiModelDownloadWorker(QRunnable):
         self.model_type = model_type
         self.signals = signals
 
+    def _download_blob(self, blob, blob_index: int, num_blobs: int) -> None:
+        self.signals.progress.emit(
+            0,
+            0,
+            _format_download_label(blob_index=blob_index, num_blobs=num_blobs),
+        )
+
+        worker = self
+
+        class _QtSignalTqdm:
+            def __init__(self, *args, total=None, initial=0, **kwargs):
+                del args, kwargs
+                self._total = total
+                self._current = initial
+                self._last_percent: int | None = None
+                self._emit_progress(force=True)
+
+            def update(self, amount=1):
+                self._current += amount
+                self._emit_progress()
+
+            def close(self):
+                self._emit_progress(force=True)
+
+            def _emit_progress(self, *, force: bool = False):
+                if not self._total:
+                    if force:
+                        worker.signals.progress.emit(
+                            0,
+                            0,
+                            _format_download_label(
+                                blob_index=blob_index, num_blobs=num_blobs
+                            ),
+                        )
+                    return
+
+                percent: int = max(
+                    0,
+                    min(
+                        100,
+                        int(round(self._current * 100 / self._total)),
+                    ),
+                )
+                if not force and percent == self._last_percent:
+                    return
+                self._last_percent = percent
+                worker.signals.progress.emit(
+                    100,
+                    percent,
+                    _format_download_label(
+                        blob_index=blob_index,
+                        num_blobs=num_blobs,
+                        percent=percent,
+                        current_size=min(self._current, self._total),
+                        total_size=self._total,
+                    ),
+                )
+
+        with _patched_gdown_tqdm(_QtSignalTqdm):
+            blob.pull()
+
+        self.signals.progress.emit(
+            100,
+            100,
+            _format_download_label(
+                blob_index=blob_index,
+                num_blobs=num_blobs,
+                percent=100,
+                current_size=blob.size or 0,
+                total_size=blob.size or 0,
+            ),
+        )
+
     def run(self):
         try:
-            self.model_type.pull()
+            blobs = list(self.model_type._blobs.values())
+            for blob_index, blob in enumerate(blobs, start=1):
+                self._download_blob(
+                    blob=blob,
+                    blob_index=blob_index,
+                    num_blobs=len(blobs),
+                )
             self.signals.finished.emit()
         except Exception as e:
             self.signals.error.emit(e)
@@ -42,17 +169,29 @@ def download_ai_model(model_name: str, parent: QtWidgets.QWidget) -> bool:
         "Downloading AI model...\n(requires internet connection)",
         None,  # type: ignore
         0,
-        0,
+        100,
         parent,
     )  # type: ignore[call-overload]
     dialog.setWindowModality(Qt.WindowModal)
     dialog.setMinimumDuration(0)
+    dialog.setAutoClose(False)
+    dialog.setAutoReset(False)
+    progress_bar = QtWidgets.QProgressBar(dialog)
+    progress_bar.setTextVisible(True)
+    progress_bar.setFormat("%p%")
+    dialog.setBar(progress_bar)
+    dialog.setValue(0)
 
     signals: _AiModelDownloadSignals = _AiModelDownloadSignals()
     worker: _AiModelDownloadWorker = _AiModelDownloadWorker(model_type, signals)
     pool = QThreadPool.globalInstance()
 
     handle_error_attrs = types.SimpleNamespace(e=None)
+
+    def handle_progress(maximum: int, value: int, label_text: str):
+        dialog.setLabelText(label_text)
+        dialog.setRange(0, maximum)
+        dialog.setValue(value)
 
     def handle_error(e: Exception):
         logger.error("Exception occurred: {}", e)
@@ -65,6 +204,7 @@ def download_ai_model(model_name: str, parent: QtWidgets.QWidget) -> bool:
 
     signals.finished.connect(dialog.close)
     signals.error.connect(handle_error)
+    signals.progress.connect(handle_progress)
 
     dialog.show()
     pool.start(worker)


### PR DESCRIPTION
The AI polygon model download flow previously exposed progress only in the terminal, while the GUI remained in an indeterminate loading state without showing a percentage.

This change bridges gdown download progress into the Qt download dialog by emitting progress updates from the background worker and applying them to a determinate QProgressDialog. 

The dialog now shows percentage and transferred size in real time.

For models made up of multiple blobs, the dialog also indicates which blob is being downloaded. Auto-close and auto-reset were disabled so the dialog stays visible until the full download completes, rather than closing after an intermediate 100% update.