### PR TITLE
fix: handle natsort.os_sorted OSError on macOS with Unicode paths

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2562,4 +2562,11 @@ def _scan_image_files(root_dir: str) -> list[str]:
                 images.append(relativePath)
 
     logger.debug("found {:d} images in {!r}", len(images), root_dir)
-    return natsort.os_sorted(images)
+    try:
+        return natsort.os_sorted(images)
+    except OSError:
+        logger.warning(
+            "natsort.os_sorted failed (known macOS strxfrm bug), "
+            "falling back to locale-unaware natural sort"
+        )
+        return natsort.natsorted(images)


### PR DESCRIPTION
## Summary

On macOS 15.0–15.4 (Sequoia), Apple's `wcsxfrm()` has a bug that causes `OSError` when `locale.strxfrm()` encounters non-Latin-1 Unicode characters in NFD form. Since APFS uses NFD normalization, Japanese and other Unicode filenames trigger this crash in `natsort.os_sorted()`.

This adds a try/except fallback to `natsort.natsorted()`, which skips locale-aware sorting but still provides correct natural sort order (e.g., `img_2` before `img_10`).

Closes #1672

## References

- [CPython issue #130567](https://github.com/python/cpython/issues/130567) — `strxfrm` fails on macOS 15
- [natsort issue #182](https://github.com/SethMMorton/natsort/issues/182) — Potential segfault with `os_sorted`
- Apple fixed `wcsxfrm` in macOS 15.5+, but users on older versions still need this guard

## Test plan

- [x] All 74 tests pass
- [x] Verified `natsort.natsorted()` produces correct natural sort order as fallback
- [x] Fallback only triggers on `OSError` (specific to the macOS bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)