### PR TITLE
refactor: fold check_translate into lint target

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,4 +3,5 @@
 - use `uv` to run Python commands (e.g., `uv run python`, `uv run pytest`).
 - use `make test` to run tests.
 - use `make update_translate` to update translation files (`.ts` and `.qm`).
-- use `make lint` for format and `make format` to auto-fix.
+- use `make lint` to check formatting, linting, and translations.
+- use `make format` to auto-fix formatting.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
           packages: qttools5-dev
           version: 1.0
       - run: make setup
-      - run: make check
+      - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq ($(OS),Windows_NT)
 	SHELL := bash
 endif
 
-.PHONY: help setup format lint test coverage
+.PHONY: help setup format lint test coverage update_translate
 .DEFAULT_GOAL := help
 
 PYTEST_ARGS ?= --numprocesses=auto
@@ -18,7 +18,7 @@ help:
 setup:  # Setup the development environment
 	$(call exec,uv sync)
 
-lint:  # Lint code
+lint: update_translate  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
 	$(call exec,uv run ty check --no-progress)
@@ -26,6 +26,11 @@ lint:  # Lint code
 	$(call exec,uv run mdformat --check $(shell git ls-files "*.md"))
 	$(call exec,uv run yamlfix --check $(shell git ls-files "*.yml" "*.yaml"))
 	$(call exec,uv run typos)
+	$(call exec,git diff --exit-code labelme/translate)
+	@if grep -r 'type="unfinished"' labelme/translate/*.ts; then \
+		printf '\033[1;31mError: unfinished translations found\033[0m\n'; \
+		exit 1; \
+	fi
 
 format:  # Format code
 	$(call exec,uv run ruff format)
@@ -33,15 +38,6 @@ format:  # Format code
 	$(call exec,uv run taplo fmt $(shell git ls-files "*.toml"))
 	$(call exec,uv run mdformat $(shell git ls-files "*.md"))
 	$(call exec,uv run yamlfix $(shell git ls-files "*.yml" "*.yaml"))
-
-check_translate: update_translate
-	$(call exec,git diff --exit-code labelme/translate)
-	@if grep -r 'type="unfinished"' labelme/translate/*.ts; then \
-		echo "$(RED)Error: unfinished translations found$(NC)"; \
-		exit 1; \
-	fi
-
-check: lint check_translate # Run checks
 
 test:  # Run tests
 	$(call exec,QT_QPA_PLATFORM=offscreen uv run pytest -v tests/ $(PYTEST_ARGS))

--- a/tools/update_translate.py
+++ b/tools/update_translate.py
@@ -44,37 +44,35 @@ def main() -> None:
         logger.warning("lrelease version is not 5.15.x, skipping .qm generation")
         return
 
-    languages: list[str] = sorted(
-        [ts_file.stem for ts_file in labelme_translate_path.glob("*.ts")]
-    )
-    for lang in languages:
-        ts_path: Path = labelme_translate_path / f"{lang}.ts"
-        subprocess.check_call(
-            [
-                "pylupdate5",
-                "-noobsolete",
-                *labelme_files,
-                "-ts",
-                str(ts_path),
-            ]
-        )
-        assert ts_path.exists()
+    ts_paths: list[Path] = sorted(labelme_translate_path.glob("*.ts"))
 
+    # Batch all languages into a single pylupdate5 call (~10x faster)
+    subprocess.check_call(
+        [
+            "pylupdate5",
+            "-noobsolete",
+            *labelme_files,
+            "-ts",
+            *ts_paths,
+        ]
+    )
+
+    for ts_path in ts_paths:
         # Zero out line numbers to reduce unnecessary diffs in .ts file
         ts_content: str = ts_path.read_text()
         new_ts_content: str = re.sub(r'line="\d+"', 'line="0"', ts_content)
         assert ts_content.strip() != new_ts_content.strip()
         ts_path.write_text(new_ts_content)
-        logger.info("updated .ts file: {}", ts_path)
 
-        qm_path: Path = labelme_translate_path / f"{lang}.qm"
+        qm_path: Path = ts_path.with_suffix(".qm")
         subprocess.check_call(
             ["lrelease", ts_path, "-qm", qm_path],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
         assert qm_path.exists()
-        logger.info("updated .qm file: {}", qm_path)
+
+    logger.info("updated {} languages", len(ts_paths))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Batch all 19 `pylupdate5` calls into a single invocation (~4x faster)
- Fold `check_translate` into `lint` target, remove `check` target
- Update `lint.yml` workflow to run `make lint` instead of `make check`
- Fix undefined `$(RED)`/`$(NC)` variables in Makefile error message

## Why
`check_translate` was kept separate from `lint` because it was slower. After batching `pylupdate5` (1.3s → 0.35s), there's no reason to keep them apart. One `make lint` target is simpler to remember and run.

## Test plan
- [x] `make lint` passes locally
- [x] Translation files unchanged after round-trip
- [x] CI lint job passes