### PR TITLE
fix: respect "Save Automatically" checkbox when auto_save defaults to true

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1188,7 +1188,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Even if we autosave the file, we keep the ability to undo
         self._actions.undo.setEnabled(self._canvas_widgets.canvas.isShapeRestorable)
 
-        if self._config["auto_save"] or self._actions.save_auto.isChecked():
+        if self._actions.save_auto.isChecked():
             assert self._image_path is not None
             self.saveLabels(
                 label_path=self._get_label_path(image_or_label_path=self._image_path)


### PR DESCRIPTION
## Summary
- Fix `setDirty()` to only check the UI checkbox state (`save_auto.isChecked()`), removing the redundant `self._config["auto_save"]` check that was always `True` from `default_config.yaml`.

## Why
Since #1815 changed `auto_save` default from `false` to `true`, unchecking "Save Automatically" in the UI had no effect — the `or` condition in `setDirty()` short-circuited on `self._config["auto_save"]` being `True`. The checkbox is already initialized from the config at startup, so checking the config separately is redundant.

## Test plan
- [x] All 125 tests pass
- [ ] Open labelme, uncheck "Save Automatically", edit annotation, switch image — should not auto-save
- [ ] Open labelme with `--no-auto-save`, verify no auto-save
- [ ] Open labelme (default config), verify auto-save works when checkbox is checked

Closes #1950