### PR TITLE
fix: rewrite relative image paths to absolute URLs for PyPI README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dynamic = ["readme", "version"]
 content-type = "text/markdown"
 fragments = [{ path = "README.md" }]
 
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = 'src="(?!https?://)([^"]+)"'
+replacement = 'src="https://raw.githubusercontent.com/wkentaro/labelme/main/\1"'
+
 [tool.hatch.version]
 source = "vcs"
 


### PR DESCRIPTION
## Summary
- Add a `hatch-fancy-pypi-readme` substitution rule that rewrites relative `src="..."` attributes to absolute `raw.githubusercontent.com` URLs
- Already-absolute URLs (shields.io badges, GitHub user-attachments) are left untouched via negative lookahead

## Why
Images in the PyPI README are broken because relative paths like `src="labelme/icons/icon-256.png"` don't resolve on pypi.org. They need to be rewritten to absolute GitHub raw URLs at build time.

<img width="600" alt="broken PyPI readme" src="https://github.com/user-attachments/assets/53bf09db-b097-48b7-9f32-ab490da5ac53"/>

## Test plan
- [x] `uv build` succeeds
- [x] `twine check` passes on built artifacts
- [x] Verified `PKG-INFO` in built tarball — all relative paths rewritten, absolute URLs unchanged