### PR TITLE
fix: add deprecation shim for labelme.utils.lblsave

### DIFF
--- a/labelme/utils/__init__.py
+++ b/labelme/utils/__init__.py
@@ -1,3 +1,8 @@
+import warnings
+
+import imgviz.io
+import numpy
+
 from .image import apply_exif_orientation
 from .image import img_arr_to_b64
 from .image import img_arr_to_data
@@ -18,3 +23,12 @@ from .qt import newIcon
 from .shape import masks_to_bboxes
 from .shape import shape_to_mask
 from .shape import shapes_to_label
+
+
+def lblsave(filename: str, lbl: numpy.ndarray) -> None:
+    warnings.warn(
+        "labelme.utils.lblsave is deprecated; use imgviz.io.lblsave",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    imgviz.io.lblsave(filename, lbl)


### PR DESCRIPTION
## Summary
- Add a deprecation shim for `labelme.utils.lblsave` that delegates to `imgviz.io.lblsave` with a `DeprecationWarning`

## Why
`labelme.utils.lblsave` was removed in favor of `imgviz.io.lblsave`, but many external scripts (labelme2voc derivatives, tutorials, community projects) still import it directly. This shim keeps those scripts working while guiding users to migrate.

GitHub code search shows 20+ external repos importing `labelme.utils.lblsave`.

## Test plan
- [x] `labelme.utils.lblsave(...)` works and emits `DeprecationWarning`
- [x] `make lint` passes
- [x] `make test` passes (125 tests)

Closes #1956