### PR TITLE
feat: highlight AI buttons on hover and equalize toolbar widths

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -13,6 +13,7 @@ import time
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
+from typing import Final
 from typing import Literal
 from typing import NamedTuple
 from typing import TypeAlias
@@ -934,6 +935,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 font_base=self.font(),
             ),
         )
+        self._ai_annotation.hover_highlight_requested.connect(
+            self._highlight_ai_buttons
+        )
 
     def _setup_app_state(
         self,
@@ -1372,6 +1376,22 @@ class MainWindow(QtWidgets.QMainWindow):
             self._ai_annotation.set_disabled_models(_AI_MODELS_WITHOUT_POINT_SUPPORT)
         else:
             self._ai_annotation.set_disabled_models(())
+
+    def _highlight_ai_buttons(self, highlight: bool) -> None:
+        HIGHLIGHT_COLOR: Final = "#FFFFCC"
+        BORDER_COLOR: Final = "#E6E6A0"
+        bg = HIGHLIGHT_COLOR if highlight else "transparent"
+        border = BORDER_COLOR if highlight else "transparent"
+        style = (
+            "QToolButton:!checked:!pressed {"
+            f" background-color: {bg}; border: 1px solid {border};"
+            " }"
+        )
+        for mode, action in self._actions.draw:
+            if mode in _AI_CREATE_MODES:
+                for widget in action.associatedWidgets():
+                    if isinstance(widget, QtWidgets.QToolButton):
+                        widget.setStyleSheet(style)
 
     def popLabelListMenu(self, point: QtCore.QPoint) -> None:
         # PyQt5 stubs type QMenu.exec() argument too narrowly

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -14,6 +14,8 @@ from ._info_button import InfoButton
 
 
 class AiAssistedAnnotationWidget(QtWidgets.QWidget):
+    hover_highlight_requested = QtCore.pyqtSignal(bool)
+
     _available_models: list[tuple[str, str]] = [
         ("efficientsam:10m", "EfficientSam (speed)"),
         ("efficientsam:latest", "EfficientSam (accuracy)"),
@@ -71,6 +73,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         layout.addLayout(header_layout)
 
         self._body = body = QtWidgets.QWidget()
+        self.installEventFilter(self)
         body.installEventFilter(self)
         body_layout = QtWidgets.QVBoxLayout()
         body_layout.setContentsMargins(0, 0, 0, 0)
@@ -123,9 +126,10 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
     def setEnabled(self, a0: bool) -> None:
         self._body.setEnabled(a0)
+        self.hover_highlight_requested.emit(False)
 
     def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent) -> bool:
-        if a0 == self._body and not self._body.isEnabled():
+        if a0 in (self, self._body) and not self._body.isEnabled():
             if a1.type() == QtCore.QEvent.Enter:
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),
@@ -133,6 +137,9 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
                         "Select 'AI-Points' or 'AI-Box' mode "
                         "to enable AI-Assisted Annotation"
                     ),
-                    self._body,
+                    self,
                 )
+                self.hover_highlight_requested.emit(True)
+            elif a1.type() == QtCore.QEvent.Leave:
+                self.hover_highlight_requested.emit(False)
         return super().eventFilter(a0, a1)

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -42,6 +42,8 @@ class ToolBar(QtWidgets.QToolBar):
                 " background: palette(mid); }"
             )
         utils.addActions(widget=self, actions=actions)
+        if orientation == Qt.Vertical:
+            self._equalize_button_widths()
 
     def addAction(self, action: QtWidgets.QAction) -> None:  # type: ignore[override]
         if isinstance(action, QtWidgets.QWidgetAction):
@@ -55,3 +57,19 @@ class ToolBar(QtWidgets.QToolBar):
         for i in range(self.layout().count()):
             if isinstance(self.layout().itemAt(i).widget(), QtWidgets.QToolButton):
                 self.layout().itemAt(i).setAlignment(QtCore.Qt.AlignCenter)
+
+    def _equalize_button_widths(self) -> None:
+        layout = self.layout()
+        buttons: list[QtWidgets.QToolButton] = []
+        for i in range(layout.count()):
+            widget = layout.itemAt(i).widget()
+            if isinstance(widget, QtWidgets.QToolButton):
+                buttons.append(widget)
+        if not buttons:
+            return
+        max_width = 0
+        for btn in buttons:
+            btn.ensurePolished()
+            max_width = max(max_width, btn.sizeHint().width())
+        for btn in buttons:
+            btn.setMinimumWidth(max_width)


### PR DESCRIPTION
## Summary
- Highlight AI-Points and AI-Box toolbar buttons with a yellow background and border when hovering the disabled AI-Assisted Annotation panel, guiding users to select the correct mode
- Tooltip and button highlight use matching `#FFFFCC` color for visual consistency
- Equalize button widths in the vertical toolbar for a cleaner layout

## Why
When the AI-Assisted Annotation widget is disabled, users need a visual hint about which toolbar buttons to click. The hover highlight draws attention to AI-Points and AI-Box buttons alongside the existing tooltip message.

## Test plan
- [x] Verified highlight color matches tooltip color visually
- [x] Verified no font size regression from stylesheet changes
- [x] Verified no flickering (transparent border applied when not highlighted)
- [x] Verified highlight triggers from header label area, not just combo boxes
- [x] Verified highlight clears on mouse leave and on mode switch