### PR TITLE
ci: activate venv in setup-uv v6 for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.10'
+          activate-environment: true
       - shell: bash
         run: |
           make setup


### PR DESCRIPTION
## Summary
- Add `activate-environment: true` to `setup-uv@v6` in the test workflow

## Why
`setup-uv@v5` automatically activated the venv when `python-version` was set, putting `.venv/bin` on `PATH`. In v6, this behavior was removed — venv activation is now opt-in via `activate-environment` (defaults to `false`). This caused the "Run examples" step to fail with `labelme: command not found`.

## Test plan
- [x] Identified root cause from [failed run](https://github.com/wkentaro/labelme/actions/runs/24517134809/job/71664260983)
- [x] CI passes on this PR