### PR TITLE
test: set QT_QPA_PLATFORM=offscreen in conftest with --headed opt-out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ format:  # Format code
 	$(call exec,uv run yamlfix $(shell git ls-files "*.yml" "*.yaml"))
 
 test:  # Run tests
-	$(call exec,QT_QPA_PLATFORM=offscreen uv run pytest -v tests/ $(PYTEST_ARGS))
+	$(call exec,uv run pytest -v tests/ $(PYTEST_ARGS))
 
 update_translate:
 	$(call exec,uv run --no-sync tools/update_translate.py)
 
 coverage:  # Run tests with coverage
-	$(call exec,QT_QPA_PLATFORM=offscreen uv run pytest -v tests/ --numprocesses=auto --cov=labelme --cov-report=term-missing)
+	$(call exec,uv run pytest -v tests/ --numprocesses=auto --cov=labelme --cov-report=term-missing)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import os.path as osp
 import shutil
 from pathlib import Path
@@ -20,6 +21,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Pause after each GUI test until the window is closed manually.",
     )
+    parser.addoption(
+        "--headed",
+        action="store_true",
+        default=False,
+        help="Run GUI tests with a visible window (skip QT_QPA_PLATFORM=offscreen).",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if not config.getoption("--headed"):
+        os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Move `QT_QPA_PLATFORM=offscreen` from `Makefile` test/coverage targets into `pytest_configure` in `tests/conftest.py`.
- Add a `--headed` pytest flag to opt back into a visible window.

## Why
Running `pytest` directly (without `make test`) silently dropped the offscreen platform, so any tool or agent invoking pytest hit GUI-related failures. Setting it inside `pytest_configure` makes headless the default everywhere, with one explicit knob (`--headed`) to opt out — instead of an implicit env var.

## Test plan
- [x] `uv run pytest tests/unit/widgets/label_dialog_test.py::test_LabelDialog_addLabelHistory` passes (offscreen by default, no Makefile wrapper).
- [x] `uv run ruff check tests/conftest.py` passes.
- [x] `make test` still runs green in CI.
- [x] `uv run pytest tests/ --headed` opens visible windows on a developer machine.