### PR TITLE
fix: select all shapes with Ctrl/Cmd+A on canvas

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1037,6 +1037,8 @@ class Canvas(QtWidgets.QWidget):
                 self.moveByKeyboard(QPointF(-MOVE_SPEED, 0.0))
             elif key == Qt.Key_Right:
                 self.moveByKeyboard(QPointF(MOVE_SPEED, 0.0))
+            elif a0.matches(QtGui.QKeySequence.SelectAll):
+                self.selectShapes(shapes=self.shapes[:])
         self._update_status()
 
     def keyReleaseEvent(self, a0: QtGui.QKeyEvent) -> None:

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -264,6 +264,26 @@ def test_move_shape_by_arrow_key(
 
 
 @pytest.mark.gui
+def test_select_all_shapes_from_canvas(
+    qtbot: QtBot,
+    _annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = _annotated_win._canvas_widgets.canvas
+    assert len(canvas.shapes) > 1
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
+    assert len(canvas.selectedShapes) == 1
+
+    qtbot.keyClick(canvas, Qt.Key_A, modifier=Qt.ControlModifier)
+    qtbot.wait(50)
+
+    assert set(map(id, canvas.selectedShapes)) == set(map(id, canvas.shapes))
+    assert len(_annotated_win._docks.label_list.selectedItems()) == len(canvas.shapes)
+
+    close_or_pause(qtbot=qtbot, widget=_annotated_win, pause=pause)
+
+
+@pytest.mark.gui
 def test_add_point_on_edge(
     qtbot: QtBot,
     _annotated_win: MainWindow,


### PR DESCRIPTION
## Summary
- Handle `QKeySequence.SelectAll` in `Canvas.keyPressEvent` while in edit mode so Ctrl/Cmd+A selects every shape.
- Reuses `self.selectShapes(self.shapes[:])` so the highlight repaint and label-list sync run through the existing path.
- Adds `test_select_all_shapes_from_canvas` covering the canvas-focused flow and label-list synchronization.

## Why
Ctrl/Cmd+A only worked when the shape list dock had focus (via `QListView`'s built-in select-all). Once a shape was clicked on the canvas, focus moved to the canvas and the shortcut silently did nothing.

## Test plan
- [x] `uv run pytest tests/e2e/canvas_interaction_test.py` — 18 passed, including the new `test_select_all_shapes_from_canvas`
- [x] `make lint` passes