### PR TITLE
refactor(canvas): split paintEvent into focused helpers

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -844,86 +844,102 @@ class Canvas(QtWidgets.QWidget):
         if not self.pixmap:
             return super().paintEvent(a0)
 
-        p = self._painter
-        p.begin(self)
-        p.setRenderHint(QtGui.QPainter.Antialiasing)
-        p.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
-        p.setRenderHint(QtGui.QPainter.SmoothPixmapTransform)
+        painter: QtGui.QPainter = self._painter
+        painter.begin(self)
+        try:
+            for hint in (
+                QtGui.QPainter.Antialiasing,
+                QtGui.QPainter.HighQualityAntialiasing,
+                QtGui.QPainter.SmoothPixmapTransform,
+            ):
+                painter.setRenderHint(hint)
+            painter.translate(self._compute_image_origin_offset() * self.scale)
+            self._paint_background(painter=painter)
+            self._paint_crosshair(painter=painter)
+            self._paint_shapes(painter=painter)
+            self._paint_current_shape_preview(painter=painter)
+        finally:
+            painter.end()
 
-        p.scale(self.scale, self.scale)
-        p.translate(self._compute_image_origin_offset())
+    def _paint_background(self, painter: QtGui.QPainter) -> None:
+        painter.save()
+        painter.scale(self.scale, self.scale)
+        painter.drawPixmap(0, 0, self.pixmap)
+        painter.restore()
 
-        p.drawPixmap(0, 0, self.pixmap)
-
-        p.scale(1 / self.scale, 1 / self.scale)
-
-        # draw crosshair
-        if (
-            self._crosshair[self._createMode]
-            and self.drawing()
-            and self.prevMovePoint is not None
-            and not self.outOfPixmap(self.prevMovePoint)
-        ):
-            p.setPen(QtGui.QColor(0, 0, 0))
-            p.drawLine(
-                0,
-                int(self.prevMovePoint.y() * self.scale),
-                int(self.pixmap.width() * self.scale) - 1,
-                int(self.prevMovePoint.y() * self.scale),
-            )
-            p.drawLine(
-                int(self.prevMovePoint.x() * self.scale),
-                0,
-                int(self.prevMovePoint.x() * self.scale),
-                int(self.pixmap.height() * self.scale) - 1,
-            )
-
-        Shape.scale = self.scale
-        for shape in self.shapes:
-            if (shape.selected or not self._hideBackground) and self.isVisible(shape):
-                shape.fill = shape.selected or shape == self.hShape
-                shape.paint(p)
-        if self.current:
-            self.current.paint(p)
-            assert len(self.line.points) == len(self.line.point_labels)
-            self.line.paint(p)
-        if self.selectedShapesCopy:
-            for s in self.selectedShapesCopy:
-                s.paint(p)
-
-        if not self.current or self.createMode not in [
-            "polygon",
-            "ai_points_to_shape",
-        ]:
-            p.end()
+    def _paint_crosshair(self, painter: QtGui.QPainter) -> None:
+        if not self._crosshair[self._createMode]:
+            return
+        if not self.drawing():
             return
 
-        drawing_shape: Shape = self.current.copy()
+        cursor: QPointF | None = self.prevMovePoint
+        if cursor is None or self.outOfPixmap(cursor):
+            return
+
+        painter.setPen(QtGui.QColor(0, 0, 0))
+        painter.drawLine(
+            0,
+            int(cursor.y() * self.scale),
+            int(self.pixmap.width() * self.scale) - 1,
+            int(cursor.y() * self.scale),
+        )
+        painter.drawLine(
+            int(cursor.x() * self.scale),
+            0,
+            int(cursor.x() * self.scale),
+            int(self.pixmap.height() * self.scale) - 1,
+        )
+
+    def _paint_shapes(self, painter: QtGui.QPainter) -> None:
+        Shape.scale = self.scale
+        for shape in self.shapes:
+            if not self.isVisible(shape):
+                continue
+            if not shape.selected and self._hideBackground:
+                continue
+            shape.fill = shape.selected or shape is self.hShape
+            shape.paint(painter)
+        if self.current is not None:
+            self.current.paint(painter)
+            assert len(self.line.points) == len(self.line.point_labels)
+            self.line.paint(painter)
+        for copy_shape in self.selectedShapesCopy:
+            copy_shape.paint(painter)
+
+    def _paint_current_shape_preview(self, painter: QtGui.QPainter) -> None:
+        if self.current is None or self.createMode not in (
+            "polygon",
+            "ai_points_to_shape",
+        ):
+            return
+
+        preview: Shape = self.current.copy()
         if self.createMode == "polygon":
-            if self.fillDrawing() and len(self.current.points) >= 2:
-                assert drawing_shape.fill_color is not None
-                if drawing_shape.fill_color.getRgb()[3] == 0:
+            if self.fillDrawing() and len(preview.points) >= 2:
+                assert preview.fill_color is not None
+                if preview.fill_color.getRgb()[3] == 0:
                     logger.warning(
                         "fill_drawing=true, but fill_color is transparent,"
                         " so forcing to be opaque."
                     )
-                    drawing_shape.fill_color.setAlpha(64)
-                drawing_shape.addPoint(self.line[1])
-        elif self.createMode == "ai_points_to_shape":
-            drawing_shape.addPoint(
+                    preview.fill_color.setAlpha(64)
+                preview.addPoint(point=self.line[1])
+        else:
+            assert self.createMode == "ai_points_to_shape"
+            preview.addPoint(
                 point=self.line.points[1],
                 label=self.line.point_labels[1],
             )
-            shapes = self._shapes_from_points_ai(
-                points=drawing_shape.points,
-                point_labels=drawing_shape.point_labels,
+            ai_shapes = self._shapes_from_points_ai(
+                points=preview.points,
+                point_labels=preview.point_labels,
             )
-            if shapes:
-                drawing_shape = shapes[0]
-        drawing_shape.fill = self.fillDrawing()
-        drawing_shape.selected = self.fillDrawing()
-        drawing_shape.paint(p)
-        p.end()
+            if ai_shapes:
+                preview = ai_shapes[0]
+        preview.fill = self.fillDrawing()
+        preview.selected = self.fillDrawing()
+        preview.paint(painter)
 
     def _transform_point_widget_to_image(self, point: QPointF) -> QPointF:
         return point / self.scale - self._compute_image_origin_offset()


### PR DESCRIPTION
## Summary

Stacked on #1970. ``paintEvent`` was an ~80-line method responsible for configuring the painter, drawing the background pixmap, rendering the crosshair, iterating over shape collections, and rendering the in-progress preview shape. Split into:

- ``_paint_background`` — scoped ``save``/``scale``/``restore`` around ``drawPixmap``
- ``_paint_crosshair`` — guarded crosshair rendering via early returns instead of a 4-condition ``and``
- ``_paint_shapes`` — committed shapes + in-progress ``current`` + ``selectedShapesCopy``, with early ``continue`` guards
- ``_paint_current_shape_preview`` — polygon and ``ai_points_to_shape`` previews

``paintEvent`` itself is now a ``try``/``finally`` around ``painter.begin()``/``painter.end()`` so that an exception in any helper still tears the painter down (previously an exception mid-paint would leak an active ``QPainter``).

The transform is also simplified: the old ``scale(s)`` → ``translate(offset)`` → ``drawPixmap`` → ``scale(1/s)`` dance reduces to a single ``translate(offset * self.scale)`` at the top, with the pixmap scale isolated inside ``_paint_background`` via ``save``/``restore``. Net effect on the painter transform is unchanged (``T(s·offset)``).

### Minor semantic changes (call out for review)

- ``shape == self.hShape`` → ``shape is self.hShape``. ``Shape`` does not override ``__eq__``, so this is a no-op today; identity is what was intended.
- ``if self.current:`` → ``if self.current is not None``. ``Shape`` defines ``__len__``, so a zero-point ``current`` was previously falsy and skipped. In practice ``self.current`` always carries ≥1 point during ``paintEvent``, but the guard is now strictly ``None``-vs-instance.

## Test plan

- [x] ``make test`` — 126/126 green
- [x] ``make lint`` — clean
- [x] Manual smoke: draw polygon, drag selection, AI-point preview