### PR TITLE
refactor(canvas): rename to _compute_image_origin_offset

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -851,7 +851,7 @@ class Canvas(QtWidgets.QWidget):
         p.setRenderHint(QtGui.QPainter.SmoothPixmapTransform)
 
         p.scale(self.scale, self.scale)
-        p.translate(self._compute_offset_to_image_center())
+        p.translate(self._compute_image_origin_offset())
 
         p.drawPixmap(0, 0, self.pixmap)
 
@@ -926,12 +926,12 @@ class Canvas(QtWidgets.QWidget):
         p.end()
 
     def _transform_point_widget_to_image(self, point: QPointF) -> QPointF:
-        return point / self.scale - self._compute_offset_to_image_center()
+        return point / self.scale - self._compute_image_origin_offset()
 
     def enableDragging(self, enabled: bool) -> None:
         self._is_dragging_enabled = enabled
 
-    def _compute_offset_to_image_center(self) -> QPointF:
+    def _compute_image_origin_offset(self) -> QPointF:
         area = super().size()
         scaled_w = self.pixmap.width() * self.scale
         scaled_h = self.pixmap.height() * self.scale

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -26,7 +26,7 @@ def session_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 def image_to_widget_pos(canvas: Canvas, image_pos: QPointF) -> QPoint:
-    widget_pos = (image_pos + canvas._compute_offset_to_image_center()) * canvas.scale
+    widget_pos = (image_pos + canvas._compute_image_origin_offset()) * canvas.scale
     return QPoint(int(widget_pos.x()), int(widget_pos.y()))
 
 


### PR DESCRIPTION
## Summary
- Rename `Canvas._compute_offset_to_image_center` to `_compute_image_origin_offset` to accurately describe what it returns.
- Update the single call site in `_transform_point_widget_to_image` and the test helper in `tests/e2e/conftest.py`.

## Why
The previous name implied the helper returned the center of the image in widget space, but it actually returns the offset from the widget origin to the top-left (origin) of the image. Renaming to `_compute_image_origin_offset` makes the intent match the math.

## Test plan
- [x] `make test`
- [x] `make lint`