### PR TITLE
fix(canvas): restore first-vertex snap highlight when closing polygon

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -386,6 +386,7 @@ class Canvas(QtWidgets.QWidget):
                 self._update_status()
                 return
 
+            self.current.highlightClear()
             if self.outOfPixmap(pos):
                 # Don't allow the user to draw outside the pixmap.
                 # Project the point to the pixmap's edges.
@@ -434,7 +435,6 @@ class Canvas(QtWidgets.QWidget):
                 self.line.close()
             assert len(self.line.points) == len(self.line.point_labels)
             self.update()
-            self.current.highlightClear()
             self._update_status()
             return
 


### PR DESCRIPTION
## Summary
- Move `self.current.highlightClear()` to the top of the draw branch in `mouseMoveEvent`, before the snap check, instead of after `self.update()`.

## Why
The snap highlight (large circle on the first vertex when the cursor is close enough to close a polygon) regressed in v6.1.0. Commit 2a61ea6 replaced `self.repaint()` with `self.update()` in `mouseMoveEvent`, but left `highlightClear()` immediately after it. `repaint()` is synchronous, so the NEAR_VERTEX highlight was rendered before being cleared. `update()` schedules the paint asynchronously, so `highlightClear()` ran first and the paint event fired with no highlight left to draw.

Clearing at the top of the draw branch keeps the paint-event-time state correct: every mouse move starts clean, the snap check sets the highlight only when close enough, and the scheduled paint finds the highlight still set.

## Test plan
- [x] `make lint` passes
- [x] Manually verify: draw a polygon, move the cursor near the first vertex — the first vertex should enlarge (NEAR_VERTEX highlight) indicating the polygon will close on click.