### PR TITLE
fix(canvas): clear stale snap highlight after every paint

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -386,7 +386,6 @@ class Canvas(QtWidgets.QWidget):
                 self._update_status()
                 return
 
-            self.current.highlightClear()
             if self.outOfPixmap(pos):
                 # Don't allow the user to draw outside the pixmap.
                 # Project the point to the pixmap's edges.
@@ -860,6 +859,8 @@ class Canvas(QtWidgets.QWidget):
             self._paint_current_shape_preview(painter=painter)
         finally:
             painter.end()
+        if self.current is not None:
+            self.current.highlightClear()
 
     def _paint_background(self, painter: QtGui.QPainter) -> None:
         painter.save()


### PR DESCRIPTION
## Problem

The first-vertex snap highlight (white circle shown at vertex 0 while drawing a polygon) persisted on the canvas even after the cursor moved far outside the snap range.

<img width="1812" height="1011" alt="image" src="https://github.com/user-attachments/assets/df0f9fc5-9c5c-4a9a-a8f4-e9b4723a0551" />

## Cause

`Shape._highlightIndex` was set inside `mouseMoveEvent` when the cursor entered snap range, but the state lived on the shape between events. Any repaint triggered without a preceding `mouseMoveEvent` redrew the stale highlight, including:

- scrolling the canvas
- zooming / Fit Window
- window resize or re-expose
- cursor leaving the canvas widget

#1974 moved `highlightClear()` to the top of the draw branch so the snap highlight would survive the async paint, but left the "state persists between events" problem untouched.

## Fix

Clear `self.current._highlightIndex` at the end of `paintEvent`, after rendering. State is now guaranteed to be clean between paint events:

- `mouseMoveEvent` sets the highlight when the cursor is within snap range, then `update()`.
- `paintEvent` renders with the set state, then clears it.
- Any subsequent repaint without a mouse move sees cleared state — no stale highlight.
- Live snap still works because each mouse move re-sets the highlight before the next paint.

The clear-at-top from #1974 is no longer needed and was removed.

## Test plan

- [x] `make lint` passes
- [x] `uv run pytest tests/unit/widgets/canvas_test.py` — 18/18 passing
- [x] Manually verify: draw a polygon, snap to first vertex, scroll/zoom/resize — highlight should not linger
- [x] Manually verify: snap highlight still appears when cursor is actually within snap range