### PR TITLE
refactor: replace os.path with pathlib

### DIFF
--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -2,10 +2,8 @@
 
 
 import argparse
-import glob
-import os
-import os.path as osp
 import sys
+from pathlib import Path
 
 import imgviz
 
@@ -29,15 +27,16 @@ def main() -> None:
     parser.add_argument("--noviz", help="no visualization", action="store_true")
     args = parser.parse_args()
 
-    if osp.exists(args.output_dir):
-        print("Output directory already exists:", args.output_dir)
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        print("Output directory already exists:", output_dir)
         sys.exit(1)
-    os.makedirs(args.output_dir)
-    os.makedirs(osp.join(args.output_dir, "JPEGImages"))
-    os.makedirs(osp.join(args.output_dir, "Annotations"))
+    output_dir.mkdir(parents=True)
+    (output_dir / "JPEGImages").mkdir(parents=True)
+    (output_dir / "Annotations").mkdir(parents=True)
     if not args.noviz:
-        os.makedirs(osp.join(args.output_dir, "AnnotationsVisualization"))
-    print("Creating dataset:", args.output_dir)
+        (output_dir / "AnnotationsVisualization").mkdir(parents=True)
+    print("Creating dataset:", output_dir)
 
     class_names = []
     class_name_to_id = {}
@@ -53,23 +52,21 @@ def main() -> None:
         class_names.append(class_name)
     class_names = tuple(class_names)
     print("class_names:", class_names)
-    out_class_names_file = osp.join(args.output_dir, "class_names.txt")
+    out_class_names_file = output_dir / "class_names.txt"
     with open(out_class_names_file, "w") as f:
         f.writelines("\n".join(class_names))
     print("Saved class_names:", out_class_names_file)
 
-    for filename in glob.glob(osp.join(args.input_dir, "*.json")):
-        print("Generating dataset from:", filename)
+    for path in sorted(Path(args.input_dir).glob("*.json")):
+        print("Generating dataset from:", path)
 
-        label_file = labelme.LabelFile(filename=filename)
+        label_file = labelme.LabelFile(filename=str(path))
 
-        base = osp.splitext(osp.basename(filename))[0]
-        out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
-        out_xml_file = osp.join(args.output_dir, "Annotations", f"{base}.xml")
+        base = path.stem
+        out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
+        out_xml_file = output_dir / "Annotations" / f"{base}.xml"
         if not args.noviz:
-            out_viz_file = osp.join(
-                args.output_dir, "AnnotationsVisualization", f"{base}.jpg"
-            )
+            out_viz_file = output_dir / "AnnotationsVisualization" / f"{base}.jpg"
 
         assert label_file.imageData is not None
         img = labelme.utils.img_data_to_arr(label_file.imageData)

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -3,12 +3,10 @@
 import argparse
 import collections
 import datetime
-import glob
 import json
-import os
-import os.path as osp
 import sys
 import uuid
+from pathlib import Path
 from typing import Any
 
 import imgviz
@@ -33,14 +31,15 @@ def main() -> None:
     parser.add_argument("--noviz", help="no visualization", action="store_true")
     args = parser.parse_args()
 
-    if osp.exists(args.output_dir):
-        print("Output directory already exists:", args.output_dir)
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        print("Output directory already exists:", output_dir)
         sys.exit(1)
-    os.makedirs(args.output_dir)
-    os.makedirs(osp.join(args.output_dir, "JPEGImages"))
+    output_dir.mkdir(parents=True)
+    (output_dir / "JPEGImages").mkdir(parents=True)
     if not args.noviz:
-        os.makedirs(osp.join(args.output_dir, "Visualization"))
-    print("Creating dataset:", args.output_dir)
+        (output_dir / "Visualization").mkdir(parents=True)
+    print("Creating dataset:", output_dir)
 
     now = datetime.datetime.now()
 
@@ -84,15 +83,15 @@ def main() -> None:
             )
         )
 
-    out_ann_file = osp.join(args.output_dir, "annotations.json")
-    label_files = glob.glob(osp.join(args.input_dir, "*.json"))
-    for image_id, filename in enumerate(label_files):
-        print("Generating dataset from:", filename)
+    out_ann_file = output_dir / "annotations.json"
+    label_files = sorted(Path(args.input_dir).glob("*.json"))
+    for image_id, path in enumerate(label_files):
+        print("Generating dataset from:", path)
 
-        label_file = labelme.LabelFile(filename=filename)
+        label_file = labelme.LabelFile(filename=str(path))
 
-        base = osp.splitext(osp.basename(filename))[0]
-        out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
+        base = path.stem
+        out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
 
         assert label_file.imageData is not None
         img = labelme.utils.img_data_to_arr(label_file.imageData)
@@ -103,7 +102,7 @@ def main() -> None:
             dict(
                 license=0,
                 url=None,
-                file_name=osp.relpath(out_img_file, osp.dirname(out_ann_file)),
+                file_name=str(out_img_file.relative_to(output_dir)),
                 height=img.shape[0],
                 width=img.shape[1],
                 date_captured=None,
@@ -193,7 +192,7 @@ def main() -> None:
                     font_size=15,
                     line_width=2,
                 )
-            out_viz_file = osp.join(args.output_dir, "Visualization", f"{base}.jpg")
+            out_viz_file = output_dir / "Visualization" / f"{base}.jpg"
             imgviz.io.imsave(out_viz_file, viz)
 
     with open(out_ann_file, "w") as f:

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -2,10 +2,8 @@
 
 
 import argparse
-import glob
-import os
-import os.path as osp
 import sys
+from pathlib import Path
 
 import imgviz
 import numpy as np
@@ -33,25 +31,26 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if osp.exists(args.output_dir):
-        print("Output directory already exists:", args.output_dir)
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        print("Output directory already exists:", output_dir)
         sys.exit(1)
-    os.makedirs(args.output_dir)
-    os.makedirs(osp.join(args.output_dir, "JPEGImages"))
-    os.makedirs(osp.join(args.output_dir, "SegmentationClass"))
+    output_dir.mkdir(parents=True)
+    (output_dir / "JPEGImages").mkdir(parents=True)
+    (output_dir / "SegmentationClass").mkdir(parents=True)
     if not args.nonpy:
-        os.makedirs(osp.join(args.output_dir, "SegmentationClassNpy"))
+        (output_dir / "SegmentationClassNpy").mkdir(parents=True)
     if not args.noviz:
-        os.makedirs(osp.join(args.output_dir, "SegmentationClassVisualization"))
+        (output_dir / "SegmentationClassVisualization").mkdir(parents=True)
     if not args.noobject:
-        os.makedirs(osp.join(args.output_dir, "SegmentationObject"))
+        (output_dir / "SegmentationObject").mkdir(parents=True)
         if not args.nonpy:
-            os.makedirs(osp.join(args.output_dir, "SegmentationObjectNpy"))
+            (output_dir / "SegmentationObjectNpy").mkdir(parents=True)
         if not args.noviz:
-            os.makedirs(osp.join(args.output_dir, "SegmentationObjectVisualization"))
-    print("Creating dataset:", args.output_dir)
+            (output_dir / "SegmentationObjectVisualization").mkdir(parents=True)
+    print("Creating dataset:", output_dir)
 
-    if osp.exists(args.labels):
+    if Path(args.labels).exists():
         with open(args.labels) as f:
             labels = [label.strip() for label in f if label]
     else:
@@ -70,42 +69,32 @@ def main() -> None:
             assert class_name == "_background_"
         class_names.append(class_name)
     print("class_names:", class_names)
-    out_class_names_file = osp.join(args.output_dir, "class_names.txt")
+    out_class_names_file = output_dir / "class_names.txt"
     with open(out_class_names_file, "w") as f:
         f.writelines("\n".join(class_names))
     print("Saved class_names:", out_class_names_file)
 
-    for filename in sorted(glob.glob(osp.join(args.input_dir, "*.json"))):
-        print("Generating dataset from:", filename)
+    for path in sorted(Path(args.input_dir).glob("*.json")):
+        print("Generating dataset from:", path)
 
-        label_file = labelme.LabelFile(filename=filename)
+        label_file = labelme.LabelFile(filename=str(path))
 
-        base = osp.splitext(osp.basename(filename))[0]
-        out_img_file = osp.join(args.output_dir, "JPEGImages", f"{base}.jpg")
-        out_clsp_file = osp.join(args.output_dir, "SegmentationClass", f"{base}.png")
+        base = path.stem
+        out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
+        out_clsp_file = output_dir / "SegmentationClass" / f"{base}.png"
         if not args.nonpy:
-            out_cls_file = osp.join(
-                args.output_dir, "SegmentationClassNpy", f"{base}.npy"
-            )
+            out_cls_file = output_dir / "SegmentationClassNpy" / f"{base}.npy"
         if not args.noviz:
-            out_clsv_file = osp.join(
-                args.output_dir,
-                "SegmentationClassVisualization",
-                f"{base}.jpg",
+            out_clsv_file = (
+                output_dir / "SegmentationClassVisualization" / f"{base}.jpg"
             )
         if not args.noobject:
-            out_insp_file = osp.join(
-                args.output_dir, "SegmentationObject", f"{base}.png"
-            )
+            out_insp_file = output_dir / "SegmentationObject" / f"{base}.png"
             if not args.nonpy:
-                out_ins_file = osp.join(
-                    args.output_dir, "SegmentationObjectNpy", f"{base}.npy"
-                )
+                out_ins_file = output_dir / "SegmentationObjectNpy" / f"{base}.npy"
             if not args.noviz:
-                out_insv_file = osp.join(
-                    args.output_dir,
-                    "SegmentationObjectVisualization",
-                    f"{base}.jpg",
+                out_insv_file = (
+                    output_dir / "SegmentationObjectVisualization" / f"{base}.jpg"
                 )
 
         assert label_file.imageData is not None

--- a/examples/tutorial/draw_label_png.py
+++ b/examples/tutorial/draw_label_png.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import os
+from pathlib import Path
 
 import imgviz
 import matplotlib.pyplot as plt
@@ -23,7 +23,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.labels is not None:
-        if os.path.exists(args.labels):
+        if Path(args.labels).exists():
             with open(args.labels) as f:
                 label_names = [label.strip() for label in f]
         else:

--- a/examples/tutorial/export_json.py
+++ b/examples/tutorial/export_json.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import os
-import os.path as osp
+from pathlib import Path
 
 import imgviz
 import numpy as np
@@ -22,12 +21,8 @@ def main() -> None:
 
     json_file = args.json_file
 
-    if args.out is None:
-        out_dir = osp.splitext(osp.basename(json_file))[0]
-        out_dir = osp.join(osp.dirname(json_file), out_dir)
-    else:
-        out_dir = args.out
-    os.makedirs(out_dir, exist_ok=True)
+    out_dir = Path(json_file).with_suffix("") if args.out is None else Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     label_file: LabelFile = LabelFile(filename=json_file)
 
@@ -55,11 +50,11 @@ def main() -> None:
         loc="rb",
     )
 
-    PIL.Image.fromarray(image).save(osp.join(out_dir, "img.png"))
-    imgviz.io.lblsave(osp.join(out_dir, "label.png"), lbl.astype(np.uint8))
-    PIL.Image.fromarray(lbl_viz).save(osp.join(out_dir, "label_viz.png"))
+    PIL.Image.fromarray(image).save(out_dir / "img.png")
+    imgviz.io.lblsave(out_dir / "label.png", lbl.astype(np.uint8))
+    PIL.Image.fromarray(lbl_viz).save(out_dir / "label_viz.png")
 
-    with open(osp.join(out_dir, "label_names.txt"), "w") as f:
+    with open(out_dir / "label_names.txt", "w") as f:
         for lbl_name in label_names:
             f.write(f"{lbl_name}\n")
 

--- a/examples/tutorial/load_label_png.py
+++ b/examples/tutorial/load_label_png.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
 
 
-import os.path as osp
+from pathlib import Path
 
 import numpy as np
 import PIL.Image
 
-here = osp.dirname(osp.abspath(__file__))
+here = Path(__file__).resolve().parent
 
 
 def main() -> None:
-    label_png = osp.join(here, "apc2016_obj3/label.png")
+    label_png = here / "apc2016_obj3/label.png"
     print("Loading:", label_png)
     print()
 
     lbl = np.asarray(PIL.Image.open(label_png))
     labels = np.unique(lbl)
 
-    label_names_txt = osp.join(here, "apc2016_obj3/label_names.txt")
+    label_names_txt = here / "apc2016_obj3/label_names.txt"
     label_names = [name.strip() for name in open(label_names_txt)]
     print("# of labels:", len(labels))
     print("# of label_names:", len(label_names))

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -4,7 +4,6 @@ import argparse
 import contextlib
 import io
 import os
-import os.path as osp
 import sys
 import traceback
 import types
@@ -57,15 +56,14 @@ def _setup_loguru(logger_level: str) -> None:
     if sys.stderr:
         logger.add(sys.stderr, level=logger_level)
 
-    cache_dir: str
     if os.name == "nt":
-        cache_dir = os.path.join(os.environ["LOCALAPPDATA"], "labelme")
+        cache_dir = Path(os.environ["LOCALAPPDATA"]) / "labelme"
     else:
-        cache_dir = os.path.expanduser("~/.cache/labelme")
+        cache_dir = Path("~/.cache/labelme").expanduser()
 
-    os.makedirs(cache_dir, exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
 
-    log_file = os.path.join(cache_dir, "labelme.log")
+    log_file = cache_dir / "labelme.log"
     logger.add(
         log_file,
         colorize=True,
@@ -234,21 +232,21 @@ def main() -> None:
     sys.excepthook = _handle_exception
 
     if hasattr(args, "flags"):
-        if os.path.isfile(args.flags):
+        if Path(args.flags).is_file():
             with open(args.flags, encoding="utf-8") as f:
                 args.flags = [line.strip() for line in f if line.strip()]
         else:
             args.flags = [line for line in args.flags.split(",") if line]
 
     if hasattr(args, "labels"):
-        if os.path.isfile(args.labels):
+        if Path(args.labels).is_file():
             with open(args.labels, encoding="utf-8") as f:
                 args.labels = [line.strip() for line in f if line.strip()]
         else:
             args.labels = [line for line in args.labels.split(",") if line]
 
     if hasattr(args, "label_flags"):
-        if os.path.isfile(args.label_flags):
+        if Path(args.label_flags).is_file():
             with open(args.label_flags, encoding="utf-8") as f:
                 args.label_flags = yaml.safe_load(f)
         else:
@@ -289,7 +287,7 @@ def main() -> None:
     translator = QtCore.QTranslator()
     translator.load(
         QtCore.QLocale.system().name(),
-        f"{osp.dirname(osp.abspath(__file__))}/translate",
+        str(Path(__file__).resolve().parent / "translate"),
     )
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")  # for consistent appearance across platforms

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import base64
 import io
 import json
-import os.path as osp
 import time
+from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
 from typing import TypedDict
@@ -144,7 +144,7 @@ class LabelFile:
         image_pil = _imread(filename=filename)
 
         oriented: PIL.Image.Image = utils.apply_exif_orientation(image_pil)
-        ext = osp.splitext(filename)[1].lower()
+        ext = Path(filename).suffix.lower()
         if oriented is image_pil and ext in (".jpg", ".jpeg", ".png"):
             # no encoding needed
             with open(filename, "rb") as f:
@@ -182,9 +182,7 @@ class LabelFile:
                 imageData = base64.b64decode(data["imageData"])
             else:
                 # relative path from label file to relative path from cwd
-                imageData = self.load_image_file(
-                    osp.join(osp.dirname(filename), imagePath)
-                )
+                imageData = self.load_image_file(str(Path(filename).parent / imagePath))
             flags = data.get("flags") or {}
             self._check_image_height_and_width(
                 imageData,
@@ -272,14 +270,14 @@ class LabelFile:
 
     @staticmethod
     def is_label_file(filename: str) -> bool:
-        return osp.splitext(filename)[1].lower() == LabelFile.suffix
+        return Path(filename).suffix.lower() == LabelFile.suffix
 
 
 _DISPLAYABLE_MODES = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
 
 
 def _imread(filename: str) -> PIL.Image.Image:
-    ext: str = osp.splitext(filename)[1].lower()
+    ext: str = Path(filename).suffix.lower()
     try:
         image_pil = PIL.Image.open(filename)
         if image_pil.mode not in _DISPLAYABLE_MODES:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -5,7 +5,6 @@ import functools
 import html
 import math
 import os
-import os.path as osp
 import platform
 import re
 import subprocess
@@ -1718,10 +1717,10 @@ class MainWindow(QtWidgets.QMainWindow):
             flags[key] = flag
         try:
             assert self._image_path
-            imagePath = osp.relpath(self._image_path, osp.dirname(label_path))
+            label_dir = Path(label_path).parent
+            imagePath = os.path.relpath(self._image_path, label_dir)
             imageData = self.imageData if self._config["with_image_data"] else None
-            if osp.dirname(label_path) and not osp.exists(osp.dirname(label_path)):
-                os.makedirs(osp.dirname(label_path))
+            label_dir.mkdir(parents=True, exist_ok=True)
             lf.save(
                 filename=label_path,
                 shapes=shapes,
@@ -1972,10 +1971,9 @@ class MainWindow(QtWidgets.QMainWindow):
     def _get_label_path(self, image_or_label_path: str) -> str:
         if LabelFile.is_label_file(filename=image_or_label_path):
             return image_or_label_path
-        return osp.join(
-            self._output_dir or osp.dirname(image_or_label_path),
-            f"{osp.splitext(osp.basename(image_or_label_path))[0]}{LabelFile.suffix}",
-        )
+        image_path = Path(image_or_label_path)
+        parent = Path(self._output_dir) if self._output_dir else image_path.parent
+        return str(parent / f"{image_path.stem}{LabelFile.suffix}")
 
     def _load_file(self, image_or_label_path: str) -> None:
         # changing fileListWidget loads file
@@ -2007,7 +2005,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         # assumes same name, but json extension
         self.show_status_message(
-            self.tr("Loading %s...") % osp.basename(image_or_label_path)
+            self.tr("Loading %s...") % Path(image_or_label_path).name
         )
 
         t0_load_file = time.time()
@@ -2030,10 +2028,7 @@ class MainWindow(QtWidgets.QMainWindow):
             assert self._label_file is not None
             self.imageData = self._label_file.imageData
             assert self._label_file.imagePath
-            self._image_path = osp.join(
-                osp.dirname(label_path),
-                self._label_file.imagePath,
-            )
+            self._image_path = str(Path(label_path).parent / self._label_file.imagePath)
             self._other_data = self._label_file.otherData
         else:
             image_path: str = image_or_label_path
@@ -2106,9 +2101,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._paint_canvas()
         self.toggleActions(True)
         self._canvas_widgets.canvas.setFocus()
-        self.show_status_message(
-            self.tr("Loaded %s") % osp.basename(image_or_label_path)
-        )
+        self.show_status_message(self.tr("Loaded %s") % Path(image_or_label_path).name)
         logger.info(
             "Loaded file: {!r} in {:.0f}ms",
             image_or_label_path,
@@ -2213,7 +2206,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def _open_file_with_dialog(self, _value: bool = False) -> None:
         if not self._can_continue():
             return
-        path = osp.dirname(str(self._image_path)) if self._image_path else "."
+        path = self.currentPath()
         formats = [
             f"*.{fmt.data().decode()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
@@ -2237,7 +2230,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def changeOutputDirDialog(self, _value: bool = False) -> None:
         default_output_dir = self._output_dir
         if default_output_dir is None and self._image_path:
-            default_output_dir = osp.dirname(self._image_path)
+            default_output_dir = str(Path(self._image_path).parent)
         if default_output_dir is None:
             default_output_dir = self.currentPath()
 
@@ -2294,7 +2287,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dlg = QtWidgets.QFileDialog(
             parent=self,
             caption=caption,
-            directory=self._output_dir or osp.dirname(self._image_path),
+            directory=self._output_dir or str(Path(self._image_path).parent),
             filter=filters,
         )
         dlg.setDefaultSuffix(LabelFile.suffix[1:])
@@ -2321,7 +2314,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def getLabelFile(self) -> str:
         assert self._image_path is not None
-        return f"{osp.splitext(self._image_path)[0]}.json"
+        return str(Path(self._image_path).with_suffix(".json"))
 
     def deleteFile(self) -> None:
         msg = self.tr(
@@ -2336,11 +2329,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if answer != QtWidgets.QMessageBox.Yes:
             return
 
-        annotation_path = self.getLabelFile()
-        if not osp.exists(annotation_path):
+        annotation_path = Path(self.getLabelFile())
+        if not annotation_path.exists():
             return
 
-        os.remove(annotation_path)
+        annotation_path.unlink()
         logger.info(f"Label file is removed: {annotation_path}")
 
         item = self._docks.file_list.currentItem()
@@ -2387,7 +2380,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return False
 
         label_file = self.getLabelFile()
-        return osp.exists(label_file)
+        return Path(label_file).exists()
 
     def _can_continue(self) -> bool:
         if not self._is_changed:
@@ -2415,7 +2408,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def currentPath(self) -> str:
-        return osp.dirname(str(self._image_path)) if self._image_path else "."
+        return str(Path(self._image_path).parent) if self._image_path else "."
 
     def toggleKeepPrevMode(self) -> None:
         self._config["keep_prev"] = not self._config["keep_prev"]
@@ -2470,14 +2463,14 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.tr("File list is disabled when a label file is opened")
             )
             self._load_file(image_or_label_path=file_or_dir)
-        elif osp.isdir(file_or_dir):
+        elif Path(file_or_dir).is_dir():
             self._import_images_from_dir(
                 root_dir=file_or_dir, pattern=self._docks.file_search.text()
             )
             self._open_next_image()
         else:
             self._import_images_from_dir(
-                root_dir=osp.dirname(file_or_dir) or ".",
+                root_dir=str(Path(file_or_dir).parent),
                 pattern=self._docks.file_search.text(),
             )
             self._load_file(image_or_label_path=file_or_dir)
@@ -2487,11 +2480,11 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
         defaultOpenDirPath: str
-        if self._prev_opened_dir and osp.exists(self._prev_opened_dir):
+        if self._prev_opened_dir and Path(self._prev_opened_dir).exists():
             defaultOpenDirPath = self._prev_opened_dir
         else:
             defaultOpenDirPath = (
-                osp.dirname(self._image_path) if self._image_path else "."
+                str(Path(self._image_path).parent) if self._image_path else "."
             )
 
         dir_path = str(
@@ -2589,7 +2582,7 @@ def _scan_image_files(root_dir: str) -> list[str]:
     for root, dirs, files in os.walk(root_dir):
         for file in files:
             if file.lower().endswith(tuple(extensions)):
-                relativePath = os.path.normpath(osp.join(root, file))
+                relativePath = os.path.normpath(os.path.join(root, file))
                 images.append(relativePath)
 
     logger.debug("found {:d} images in {!r}", len(images), root_dir)

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os.path as osp
 import re
 from collections.abc import Callable
 from collections.abc import Sized
@@ -10,7 +9,7 @@ from typing import cast
 import yaml
 from loguru import logger
 
-here = osp.dirname(osp.abspath(__file__))
+here = Path(__file__).resolve().parent
 
 
 def _update_dict(
@@ -99,10 +98,10 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
 
 
 def get_user_config_file(create_if_missing: bool = True) -> str:
-    user_config_file: str = osp.join(osp.expanduser("~"), ".labelmerc")
-    if not osp.exists(user_config_file) and create_if_missing:
+    user_config_path = Path("~/.labelmerc").expanduser()
+    if not user_config_path.exists() and create_if_missing:
         try:
-            with open(user_config_file, "w") as f:
+            with open(user_config_path, "w") as f:
                 f.write(
                     "# Labelme config file.\n"
                     "# Only add settings you want to override.\n"
@@ -115,13 +114,13 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
                     "# labels: [cat, dog]\n"
                 )
         except Exception:
-            logger.warning("Failed to save config: {!r}", user_config_file)
-    return user_config_file
+            logger.warning("Failed to save config: {!r}", str(user_config_path))
+    return str(user_config_path)
 
 
 def load_config(config_file: Path | None, config_overrides: dict) -> dict:
     config: dict
-    with open(osp.join(here, "default_config.yaml")) as f:
+    with open(here / "default_config.yaml") as f:
         config = yaml.safe_load(f)
 
     if config_file is not None:

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os.path as osp
 from collections.abc import Callable
 from collections.abc import Sequence
 from math import sqrt
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -11,14 +11,13 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
-here = osp.dirname(osp.abspath(__file__))
+here = Path(__file__).resolve().parent
 
 
 def newIcon(icon_file_name: str) -> QtGui.QIcon:
-    if osp.splitext(icon_file_name)[1] == "":
+    if Path(icon_file_name).suffix == "":
         icon_file_name = f"{icon_file_name}.png"  # XXX: convention
-    icons_dir: str = osp.join(here, "../icons")
-    return QtGui.QIcon(osp.join(":/", icons_dir, icon_file_name))
+    return QtGui.QIcon(str(here.parent / "icons" / icon_file_name))
 
 
 def newButton(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import os.path as osp
 import shutil
 from pathlib import Path
 
@@ -40,17 +39,17 @@ def pause(request: pytest.FixtureRequest) -> bool:
 
 
 def assert_labelfile_sanity(filename: str) -> None:
-    assert osp.exists(filename)
+    label_path = Path(filename)
+    assert label_path.exists()
 
-    with open(filename) as f:
+    with open(label_path) as f:
         data = json.load(f)
 
     assert "imagePath" in data
     image_data = data.get("imageData", None)
     if image_data is None:
-        parent_dir = osp.dirname(filename)
-        img_file = osp.join(parent_dir, data["imagePath"])
-        assert osp.exists(img_file)
+        img_file = label_path.parent / data["imagePath"]
+        assert img_file.exists()
         img = imgviz.io.imread(img_file)
     else:
         img = labelme.utils.img_b64_to_arr(image_data)

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Literal
 
@@ -226,8 +225,8 @@ def test_ai_model_download(
     def patched_path(self: osam.types._blob.Blob) -> str:
         if self.attachments:
             safe_hash = self.hash.replace("sha256:", "sha256-")
-            return os.path.join(blob_base, safe_hash, self.filename)
-        return os.path.join(blob_base, self.hash)
+            return str(Path(blob_base) / safe_hash / self.filename)
+        return str(Path(blob_base) / self.hash)
 
     monkeypatch.setattr(osam.types._blob.Blob, "path", property(patched_path))
 


### PR DESCRIPTION
## Summary
- Replace `os.path` / `import os.path as osp` with `pathlib.Path` across `labelme/`, `tests/`, and `examples/`.
- Drop redundant `str()` casts; only retain them at PyQt5 boundaries (which require `str`), `str`-annotated parameters/returns (`_image_path`, `LabelFile.filename`, `_get_label_path`, etc.), and JSON serialization sites.
- Replace `glob.glob(...)` with `Path.glob(...) + sorted(...)` in example scripts (deterministic ordering).
- Use `Path.relative_to` where the descendant relationship holds (`labelme2coco.py`); keep `os.path.relpath` in `labelme/app.py` because image and label paths can be siblings and Python 3.10 lacks `Path.relative_to(walk_up=True)`.
- Keep `os.path.normpath(os.path.join(...))` in `_scan_image_files` for consistency with the `os.walk` string boundary.

## Why
`pathlib.Path` is the modern, more readable API for path manipulation, and it composes better than the string-based `os.path` functions. This branch finishes the migration with the smallest diff that preserves behavior.

## Test plan
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos) — all green
- [x] `make test` — 131/131 passing
- [x] Five rounds of fresh-context code review (`/review-fix`) — clean
- [x] Verified PyQt5 boundaries still receive `str` (QIcon, QFileDialog, QTranslator, QFile.exists, findItems)
- [x] Verified `_image_path` field remains `str` (used as Qt arg, dict key, hash input)
- [x] Verified `qt.py` icon path is behaviorally equivalent to the old `os.path.join(":/", abs_dir, name)` (`:/` was silently dropped on POSIX before; same now)

## Notes
- `examples/instance_segmentation/labelme2coco.py` now sorts `Path.glob` output before enumerating, so existing COCO files have different `image_id` orderings vs the previous unsorted `glob.glob`. This is a deterministic-ordering improvement, but worth noting for downstream consumers.