### PR TITLE
refactor: snake_case migration (1/3) — utils + leaf widgets

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -20,7 +20,7 @@ from labelme import __appname__
 from labelme import __version__
 from labelme.app import MainWindow
 from labelme.config import get_user_config_file
-from labelme.utils import newIcon
+from labelme.utils import new_icon
 
 
 class _LoggerIO(io.StringIO):
@@ -294,7 +294,7 @@ def main() -> None:
     # Force light mode to avoid dark mode UI issues (e.g., invisible icons)
     app.setPalette(QtWidgets.QStyleFactory.create("Fusion").standardPalette())
     app.setApplicationName(__appname__)
-    app.setWindowIcon(newIcon("icon"))
+    app.setWindowIcon(new_icon("icon"))
     app.installTranslator(translator)
     win = MainWindow(
         config_file=config_file,

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1431,13 +1431,13 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if not edit_text:
             self._label_dialog.edit.setDisabled(True)
-            self._label_dialog.labelList.setDisabled(True)
+            self._label_dialog.label_list.setDisabled(True)
         if not edit_group_id:
             self._label_dialog.edit_group_id.setDisabled(True)
         if not edit_description:
-            self._label_dialog.editDescription.setDisabled(True)
+            self._label_dialog.edit_description.setDisabled(True)
 
-        text, flags, group_id, description = self._label_dialog.popUp(
+        text, flags, group_id, description = self._label_dialog.popup(
             text=first_shape.label if edit_text else "",
             flags=first_shape.flags if edit_flags else None,
             group_id=first_shape.group_id if edit_group_id else None,
@@ -1447,11 +1447,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if not edit_text:
             self._label_dialog.edit.setDisabled(False)
-            self._label_dialog.labelList.setDisabled(False)
+            self._label_dialog.label_list.setDisabled(False)
         if not edit_group_id:
             self._label_dialog.edit_group_id.setDisabled(False)
         if not edit_description:
-            self._label_dialog.editDescription.setDisabled(False)
+            self._label_dialog.edit_description.setDisabled(False)
 
         if text is None:
             assert flags is None
@@ -1553,7 +1553,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     unique_label_list=self._docks.unique_label_list,
                 ),
             )
-        self._label_dialog.addLabelHistory(shape.label)
+        self._label_dialog.add_label_history(shape.label)
         for action in self._actions.on_shapes_present:
             action.setEnabled(True)
 
@@ -1738,7 +1738,7 @@ class MainWindow(QtWidgets.QMainWindow):
         description = ""
         if self._config["display_label_popup"] or not text:
             previous_text = self._label_dialog.edit.text()
-            text, flags, group_id, description = self._label_dialog.popUp(text)
+            text, flags, group_id, description = self._label_dialog.popup(text)
             if not text:
                 self._label_dialog.edit.setText(previous_text)
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1886,7 +1886,7 @@ class MainWindow(QtWidgets.QMainWindow):
             dialog.slider_contrast.setValue(contrast)
 
         if is_initial_load:
-            dialog.onNewValue(None)
+            dialog.apply()
         else:
             dialog.exec_()
             brightness = dialog.slider_brightness.value()

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -279,7 +279,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.populateModeActions()
 
     def _setup_actions(self) -> _Actions:
-        action = functools.partial(utils.newAction, self)
+        action = functools.partial(utils.new_action, self)
         shortcuts = self._config["shortcuts"]
 
         about = action(
@@ -657,8 +657,10 @@ class MainWindow(QtWidgets.QMainWindow):
                     "{} and {} from the canvas."
                 )
             ).format(
-                utils.fmtShortcut(f"{shortcuts['zoom_in']},{shortcuts['zoom_out']}"),
-                utils.fmtShortcut(self.tr("Ctrl+Wheel")),
+                utils.format_shortcut(
+                    f"{shortcuts['zoom_in']},{shortcuts['zoom_out']}"
+                ),
+                utils.format_shortcut(self.tr("Ctrl+Wheel")),
             )
         )
         self._canvas_widgets.zoom_widget.setEnabled(False)
@@ -779,7 +781,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def _setup_menus(self) -> _Menus:
-        action = functools.partial(utils.newAction, self)
+        action = functools.partial(utils.new_action, self)
         shortcuts = self._config["shortcuts"]
 
         quit_ = action(
@@ -809,11 +811,11 @@ class MainWindow(QtWidgets.QMainWindow):
         view_menu = self.menu(self.tr("&View"))
         help_menu = self.menu(self.tr("&Help"))
         label_menu = QtWidgets.QMenu()
-        utils.addActions(label_menu, (self._actions.edit, self._actions.delete))
+        utils.add_actions(label_menu, (self._actions.edit, self._actions.delete))
         self._docks.label_list.setContextMenuPolicy(Qt.CustomContextMenu)
         self._docks.label_list.customContextMenuRequested.connect(self.popLabelListMenu)
 
-        utils.addActions(
+        utils.add_actions(
             file_menu,
             (
                 self._actions.open,
@@ -833,8 +835,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 quit_,
             ),
         )
-        utils.addActions(help_menu, (help_, self._actions.about))
-        utils.addActions(
+        utils.add_actions(help_menu, (help_, self._actions.about))
+        utils.add_actions(
             view_menu,
             (
                 self._docks.flag_dock.toggleViewAction(),
@@ -863,10 +865,10 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
         )
 
-        utils.addActions(
+        utils.add_actions(
             self._canvas_widgets.canvas.menus[0], self._actions.context_menu
         )
-        utils.addActions(
+        utils.add_actions(
             self._canvas_widgets.canvas.menus[1],
             (
                 action("&Copy here", self.copyShape),
@@ -1153,7 +1155,7 @@ class MainWindow(QtWidgets.QMainWindow):
     ) -> QtWidgets.QMenu:
         menu = self.menuBar().addMenu(title)
         if actions:
-            utils.addActions(menu, actions)
+            utils.add_actions(menu, actions)
         return menu
 
     # Support Functions
@@ -1163,7 +1165,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def populateModeActions(self) -> None:
         self._canvas_widgets.canvas.menus[0].clear()
-        utils.addActions(
+        utils.add_actions(
             self._canvas_widgets.canvas.menus[0], self._actions.context_menu
         )
         self._menus.edit.clear()
@@ -1172,7 +1174,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._actions.edit_mode,
             *self._actions.edit_menu,
         )
-        utils.addActions(self._menus.edit, actions)
+        utils.add_actions(self._menus.edit, actions)
 
     def _get_window_title(self, *, dirty: bool) -> str:
         file_list = self._docks.file_list

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -279,7 +279,7 @@ def _nearest_edge_index(
     for i in range(len(points)):
         start = _scale_point(point=points[i - 1], scale=scale)
         end = _scale_point(point=points[i], scale=scale)
-        dist = labelme.utils.distancetoline(scaled, (start, end))
+        dist = labelme.utils.distance_to_line(scaled, (start, end))
         if dist <= epsilon and dist < min_distance:
             min_distance = dist
             post_i = i

--- a/labelme/utils/__init__.py
+++ b/labelme/utils/__init__.py
@@ -12,14 +12,14 @@ from .image import img_data_to_pil
 from .image import img_data_to_png_data
 from .image import img_pil_to_data
 from .image import img_qt_to_arr
-from .qt import addActions
+from .qt import add_actions
 from .qt import distance
-from .qt import distancetoline
-from .qt import fmtShortcut
-from .qt import labelValidator
-from .qt import newAction
-from .qt import newButton
-from .qt import newIcon
+from .qt import distance_to_line
+from .qt import format_shortcut
+from .qt import label_validator
+from .qt import new_action
+from .qt import new_button
+from .qt import new_icon
 from .shape import masks_to_bboxes
 from .shape import shape_to_mask
 from .shape import shapes_to_label
@@ -32,3 +32,26 @@ def lblsave(filename: str, lbl: numpy.ndarray) -> None:
         stacklevel=2,
     )
     imgviz.io.lblsave(filename, lbl)
+
+
+_DEPRECATED_ALIASES = {
+    "addActions": add_actions,
+    "distancetoline": distance_to_line,
+    "fmtShortcut": format_shortcut,
+    "labelValidator": label_validator,
+    "newAction": new_action,
+    "newButton": new_button,
+    "newIcon": new_icon,
+}
+
+
+def __getattr__(name: str) -> object:
+    target = _DEPRECATED_ALIASES.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    warnings.warn(
+        f"labelme.utils.{name} is deprecated; use labelme.utils.{target.__name__}",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return target

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -14,26 +14,26 @@ from PyQt5 import QtWidgets
 here = Path(__file__).resolve().parent
 
 
-def newIcon(icon_file_name: str) -> QtGui.QIcon:
+def new_icon(icon_file_name: str) -> QtGui.QIcon:
     if Path(icon_file_name).suffix == "":
         icon_file_name = f"{icon_file_name}.png"  # XXX: convention
     return QtGui.QIcon(str(here.parent / "icons" / icon_file_name))
 
 
-def newButton(
+def new_button(
     text: str,
     icon: str | None = None,
     slot: Callable[..., object] | None = None,
 ) -> QtWidgets.QPushButton:
     b = QtWidgets.QPushButton(text)
     if icon is not None:
-        b.setIcon(newIcon(icon))
+        b.setIcon(new_icon(icon))
     if slot is not None:
         b.clicked.connect(slot)
     return b
 
 
-def newAction(
+def new_action(
     parent: QtWidgets.QWidget,
     text: str,
     slot: Callable[..., object] | None = None,
@@ -48,7 +48,7 @@ def newAction(
     a = QtWidgets.QAction(text, parent)
     if icon is not None:
         a.setIconText(text.replace(" ", "\n"))
-        a.setIcon(newIcon(icon))
+        a.setIcon(new_icon(icon))
     if shortcut is not None:
         if isinstance(shortcut, list | tuple):
             a.setShortcuts(shortcut)
@@ -66,7 +66,7 @@ def newAction(
     return a
 
 
-def addActions(
+def add_actions(
     widget: QtWidgets.QMenu | QtWidgets.QToolBar,
     actions: Sequence[QtWidgets.QAction | QtWidgets.QMenu | None],
 ) -> None:
@@ -79,7 +79,7 @@ def addActions(
             widget.addAction(action)
 
 
-def labelValidator() -> QtGui.QRegExpValidator:
+def label_validator() -> QtGui.QRegExpValidator:
     return QtGui.QRegExpValidator(QtCore.QRegExp(r"^[^ \t].+"), None)
 
 
@@ -87,7 +87,7 @@ def distance(p: QtCore.QPointF) -> float:
     return sqrt(p.x() * p.x() + p.y() * p.y())
 
 
-def distancetoline(
+def distance_to_line(
     point: QtCore.QPointF,
     line: tuple[QtCore.QPointF, QtCore.QPointF],
 ) -> np.floating[Any]:
@@ -107,6 +107,6 @@ def distancetoline(
     return abs(cross) / np.linalg.norm(d)
 
 
-def fmtShortcut(text: str) -> str:
+def format_shortcut(text: str) -> str:
     mod, key = text.split("+", 1)
     return f"<b>{mod}</b>+<b>{key}</b>"

--- a/labelme/widgets/_info_button.py
+++ b/labelme/widgets/_info_button.py
@@ -4,13 +4,13 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
-from labelme.utils.qt import newIcon
+from labelme.utils.qt import new_icon
 
 
 class InfoButton(QtWidgets.QToolButton):
     def __init__(self, tooltip: str, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent=parent)
-        self.setIcon(newIcon("phosphor/info.svg"))
+        self.setIcon(new_icon("phosphor/info.svg"))
         self.setIconSize(QtCore.QSize(16, 16))
         self.setStyleSheet(
             """

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -43,7 +43,7 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
             value_label.setAlignment(Qt.AlignRight)
             layout.addWidget(value_label)
             #
-            slider.valueChanged.connect(self.onNewValue)
+            slider.valueChanged.connect(lambda _: self.apply())
             slider.valueChanged.connect(
                 lambda _,
                 value_label_=value_label,
@@ -71,7 +71,7 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
             img = img.convert("RGB")
         self.img = img
 
-    def onNewValue(self, _: int | None) -> None:
+    def apply(self) -> None:
         brightness = self.slider_brightness.value() / self._base_value
         contrast = self.slider_contrast.value() / self._base_value
 

--- a/labelme/widgets/file_dialog_preview.py
+++ b/labelme/widgets/file_dialog_preview.py
@@ -26,10 +26,10 @@ class ScrollAreaPreview(QtWidgets.QScrollArea):
 
         self.setWidget(container)
 
-    def setText(self, text: str) -> None:
+    def set_text(self, text: str) -> None:
         self.label.setText(text)
 
-    def setPixmap(self, pixmap: QtGui.QPixmap) -> None:
+    def set_pixmap(self, pixmap: QtGui.QPixmap) -> None:
         self.label.setPixmap(pixmap)
 
     def clear(self) -> None:
@@ -41,21 +41,21 @@ class FileDialogPreview(QtWidgets.QFileDialog):
         super().__init__(parent)
         self.setOption(self.DontUseNativeDialog, True)
 
-        self.labelPreview = ScrollAreaPreview(self)
-        self.labelPreview.setFixedSize(PREVIEW_DIMENSION, PREVIEW_DIMENSION)
-        self.labelPreview.setVisible(False)
+        self.label_preview = ScrollAreaPreview(self)
+        self.label_preview.setFixedSize(PREVIEW_DIMENSION, PREVIEW_DIMENSION)
+        self.label_preview.setVisible(False)
 
         preview_column = QtWidgets.QVBoxLayout()
-        preview_column.addWidget(self.labelPreview)
+        preview_column.addWidget(self.label_preview)
         preview_column.addStretch()
 
         self.setFixedSize(self.width() + PREVIEW_DIMENSION, self.height())
         layout = self.layout()
         layout = cast(QtWidgets.QGridLayout, layout)
         layout.addLayout(preview_column, 1, 3, 1, 1)
-        self.currentChanged.connect(self.onChange)
+        self.currentChanged.connect(self._on_change)
 
-    def onChange(self, path: str) -> None:
+    def _on_change(self, path: str) -> None:
         if path.lower().endswith(".json"):
             try:
                 with open(path) as f:
@@ -63,25 +63,25 @@ class FileDialogPreview(QtWidgets.QFileDialog):
                 text = json.dumps(data, indent=4, sort_keys=False)
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
                 text = f"Cannot preview: {e}"
-            self.labelPreview.setText(text)
-            self.labelPreview.label.setAlignment(
+            self.label_preview.set_text(text)
+            self.label_preview.label.setAlignment(
                 QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
             )
-            self.labelPreview.setVisible(True)
+            self.label_preview.setVisible(True)
         else:
             pixmap = QtGui.QPixmap(path)
             if pixmap.isNull():
-                self.labelPreview.clear()
-                self.labelPreview.setVisible(False)
+                self.label_preview.clear()
+                self.label_preview.setVisible(False)
             else:
-                available_width = self.labelPreview.width() - PREVIEW_PADDING
-                available_height = self.labelPreview.height() - PREVIEW_PADDING
+                available_width = self.label_preview.width() - PREVIEW_PADDING
+                available_height = self.label_preview.height() - PREVIEW_PADDING
                 scaled = pixmap.scaled(
                     available_width,
                     available_height,
                     QtCore.Qt.KeepAspectRatio,
                     QtCore.Qt.SmoothTransformation,
                 )
-                self.labelPreview.setPixmap(scaled)
-                self.labelPreview.label.setAlignment(QtCore.Qt.AlignCenter)
-                self.labelPreview.setVisible(True)
+                self.label_preview.set_pixmap(scaled)
+                self.label_preview.label.setAlignment(QtCore.Qt.AlignCenter)
+                self.label_preview.setVisible(True)

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -15,7 +15,7 @@ import labelme.utils
 
 
 class LabelQLineEdit(QtWidgets.QLineEdit):
-    def setListWidget(self, list_widget: QtWidgets.QListWidget) -> None:
+    def set_list_widget(self, list_widget: QtWidgets.QListWidget) -> None:
         self.list_widget = list_widget
 
     def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:
@@ -44,10 +44,10 @@ class LabelDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.edit = LabelQLineEdit()
         self.edit.setPlaceholderText(text)
-        self.edit.setValidator(labelme.utils.labelValidator())
-        self.edit.editingFinished.connect(self.postProcess)
+        self.edit.setValidator(labelme.utils.label_validator())
+        self.edit.editingFinished.connect(self._on_editing_finished)
         if flags:
-            self.edit.textChanged.connect(self.updateFlags)
+            self.edit.textChanged.connect(self._on_text_changed)
         self.edit_group_id = QtWidgets.QLineEdit()
         self.edit_group_id.setPlaceholderText("Group ID")
         self.edit_group_id.setValidator(
@@ -60,44 +60,44 @@ class LabelDialog(QtWidgets.QDialog):
             layout_edit.addWidget(self.edit_group_id, 2)
             layout.addLayout(layout_edit)
         # buttons
-        self.buttonBox = bb = QtWidgets.QDialogButtonBox(
+        bb = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
             QtCore.Qt.Horizontal,
             self,
         )
-        bb.accepted.connect(self.validate)
+        bb.accepted.connect(self._validate)
         bb.rejected.connect(self.reject)
         layout.addWidget(bb)
         # label_list
-        self.labelList = QtWidgets.QListWidget()
+        self.label_list = QtWidgets.QListWidget()
         if self._fit_to_content["row"]:
-            self.labelList.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            self.label_list.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         if self._fit_to_content["column"]:
-            self.labelList.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            self.label_list.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self._sort_labels = sort_labels
         if labels:
-            self.labelList.addItems(labels)
+            self.label_list.addItems(labels)
         if self._sort_labels:
-            self.labelList.sortItems()
+            self.label_list.sortItems()
         else:
-            self.labelList.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
-        self.labelList.currentItemChanged.connect(self.labelSelected)
-        self.labelList.itemDoubleClicked.connect(self.labelDoubleClicked)
-        self.labelList.setFixedHeight(150)
-        self.edit.setListWidget(self.labelList)
-        layout.addWidget(self.labelList)
+            self.label_list.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
+        self.label_list.currentItemChanged.connect(self._on_label_selected)
+        self.label_list.itemDoubleClicked.connect(self._on_label_double_clicked)
+        self.label_list.setFixedHeight(150)
+        self.edit.set_list_widget(self.label_list)
+        layout.addWidget(self.label_list)
         # label_flags
         if flags is None:
             flags = {}
         self._flags = flags
-        self.flagsLayout = QtWidgets.QVBoxLayout()
-        self.resetFlags()
-        layout.addItem(self.flagsLayout)
+        self._flags_layout = QtWidgets.QVBoxLayout()
+        self._reset_flags()
+        layout.addItem(self._flags_layout)
         # text edit
-        self.editDescription = QtWidgets.QTextEdit()
-        self.editDescription.setPlaceholderText("Label description")
-        self.editDescription.setFixedHeight(50)
-        layout.addWidget(self.editDescription)
+        self.edit_description = QtWidgets.QTextEdit()
+        self.edit_description.setPlaceholderText("Label description")
+        self.edit_description.setFixedHeight(50)
+        layout.addWidget(self.edit_description)
         self.setLayout(layout)
         # completion
         completer = QtWidgets.QCompleter()
@@ -110,20 +110,20 @@ class LabelDialog(QtWidgets.QDialog):
             completer.setFilterMode(QtCore.Qt.MatchContains)
         else:
             raise ValueError(f"Unsupported completion: {completion}")
-        completer.setModel(self.labelList.model())
+        completer.setModel(self.label_list.model())
         self.edit.setCompleter(completer)
 
-    def addLabelHistory(self, label: str) -> None:
-        if self.labelList.findItems(label, QtCore.Qt.MatchExactly):
+    def add_label_history(self, label: str) -> None:
+        if self.label_list.findItems(label, QtCore.Qt.MatchExactly):
             return
-        self.labelList.addItem(label)
+        self.label_list.addItem(label)
         if self._sort_labels:
-            self.labelList.sortItems()
+            self.label_list.sortItems()
 
-    def labelSelected(self, item: QtWidgets.QListWidgetItem) -> None:
+    def _on_label_selected(self, item: QtWidgets.QListWidgetItem) -> None:
         self.edit.setText(item.text())
 
-    def validate(self) -> None:
+    def _validate(self) -> None:
         if not self.edit.isEnabled():
             self.accept()
             return
@@ -139,66 +139,66 @@ class LabelDialog(QtWidgets.QDialog):
             return str(text.trimmed())
         return str(text)
 
-    def labelDoubleClicked(self, item: QtWidgets.QListWidgetItem) -> None:
-        self.validate()
+    def _on_label_double_clicked(self, _: QtWidgets.QListWidgetItem) -> None:
+        self._validate()
 
-    def postProcess(self) -> None:
+    def _on_editing_finished(self) -> None:
         self.edit.setText(self._get_stripped_text())
 
-    def updateFlags(self, label_new: str) -> None:
+    def _on_text_changed(self, label_new: str) -> None:
         # keep state of shared flags
-        flags_old = self.getFlags()
+        flags_old = self._current_flags()
 
         flags_new = {}
         for pattern, keys in self._flags.items():
             if re.match(pattern, label_new):
                 for key in keys:
                     flags_new[key] = flags_old.get(key, False)
-        self.setFlags(flags_new)
+        self._set_flags(flags_new)
 
-    def deleteFlags(self) -> None:
-        while self.flagsLayout.count() > 0:
-            widget = self.flagsLayout.takeAt(0).widget()
+    def _delete_flags(self) -> None:
+        while self._flags_layout.count() > 0:
+            widget = self._flags_layout.takeAt(0).widget()
             if widget is not None:
                 widget.setParent(QtWidgets.QWidget())
 
-    def resetFlags(self, label: str = "") -> None:
+    def _reset_flags(self, label: str = "") -> None:
         flags = {}
         for pattern, keys in self._flags.items():
             if re.match(pattern, label):
                 for key in keys:
                     flags[key] = False
-        self.setFlags(flags)
+        self._set_flags(flags)
 
-    def setFlags(self, flags: dict[str, bool]) -> None:
-        self.deleteFlags()
+    def _set_flags(self, flags: dict[str, bool]) -> None:
+        self._delete_flags()
         for key in flags:
             item = QtWidgets.QCheckBox(key, self)
             item.setChecked(flags[key])
-            self.flagsLayout.addWidget(item)
+            self._flags_layout.addWidget(item)
             item.show()
 
-    def getFlags(self) -> dict[str, bool]:
+    def _current_flags(self) -> dict[str, bool]:
         flags = {}
-        for i in range(self.flagsLayout.count()):
-            item = self.flagsLayout.itemAt(i).widget()
+        for i in range(self._flags_layout.count()):
+            item = self._flags_layout.itemAt(i).widget()
             item = cast(QtWidgets.QCheckBox, item)
             flags[item.text()] = item.isChecked()
         return flags
 
-    def getGroupId(self) -> int | None:
+    def _current_group_id(self) -> int | None:
         group_id = self.edit_group_id.text()
         if group_id:
             return int(group_id)
         return None
 
-    def _restoreOrResetFlags(self, text: str, flags: dict[str, bool] | None) -> None:
+    def _restore_or_reset_flags(self, text: str, flags: dict[str, bool] | None) -> None:
         if flags:
-            self.setFlags(flags)
+            self._set_flags(flags)
         else:
-            self.resetFlags(text)
+            self._reset_flags(text)
 
-    def popUp(
+    def popup(
         self,
         text: str | None = None,
         move: bool = True,
@@ -208,34 +208,34 @@ class LabelDialog(QtWidgets.QDialog):
         flags_disabled: bool = False,
     ) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
         if self._fit_to_content["row"]:
-            self.labelList.setMinimumHeight(
-                self.labelList.sizeHintForRow(0) * self.labelList.count() + 2
+            self.label_list.setMinimumHeight(
+                self.label_list.sizeHintForRow(0) * self.label_list.count() + 2
             )
         if self._fit_to_content["column"]:
-            self.labelList.setMinimumWidth(self.labelList.sizeHintForColumn(0) + 2)
+            self.label_list.setMinimumWidth(self.label_list.sizeHintForColumn(0) + 2)
         # if text is None, the previous label in self.edit is kept
         if text is None:
             text = self.edit.text()
         # description is always initialized by empty text c.f., self.edit.text
         if description is None:
             description = ""
-        self.editDescription.setPlainText(description)
-        self._restoreOrResetFlags(text, flags)
+        self.edit_description.setPlainText(description)
+        self._restore_or_reset_flags(text, flags)
         if flags_disabled:
-            for i in range(self.flagsLayout.count()):
-                self.flagsLayout.itemAt(i).widget().setDisabled(True)
+            for i in range(self._flags_layout.count()):
+                self._flags_layout.itemAt(i).widget().setDisabled(True)
         self.edit.setText(text)
         self.edit.setSelection(0, len(text))
         if group_id is None:
             self.edit_group_id.clear()
         else:
             self.edit_group_id.setText(str(group_id))
-        items = self.labelList.findItems(text, QtCore.Qt.MatchFixedString)
+        items = self.label_list.findItems(text, QtCore.Qt.MatchFixedString)
         if items:
             if len(items) != 1:
                 logger.warning(f"Label list has duplicate '{text}'")
-            self.labelList.setCurrentItem(items[0])
-            row = self.labelList.row(items[0])
+            self.label_list.setCurrentItem(items[0])
+            row = self.label_list.row(items[0])
             self.edit.completer().setCurrentRow(row)
         self.edit.setFocus(QtCore.Qt.PopupFocusReason)
         if move:
@@ -243,9 +243,9 @@ class LabelDialog(QtWidgets.QDialog):
         if self.exec_():
             return (
                 self.edit.text(),
-                self.getFlags(),
-                self.getGroupId(),
-                self.editDescription.toPlainText(),
+                self._current_flags(),
+                self._current_group_id(),
+                self.edit_description.toPlainText(),
             )
         else:
             return None, None, None, None

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -41,7 +41,7 @@ class ToolBar(QtWidgets.QToolBar):
                 "QToolBar::separator { height: 1px; margin: 4px 2px;"
                 " background: palette(mid); }"
             )
-        utils.addActions(widget=self, actions=actions)
+        utils.add_actions(widget=self, actions=actions)
         if orientation == Qt.Vertical:
             self._equalize_button_widths()
 

--- a/tests/e2e/brightness_contrast_test.py
+++ b/tests/e2e/brightness_contrast_test.py
@@ -38,7 +38,7 @@ def test_brightness_contrast_dialog(
 
     dialog.slider_brightness.setValue(75)
     dialog.slider_contrast.setValue(25)
-    dialog.onNewValue(None)
+    dialog.apply()
 
     updated_pixmap = canvas.pixmap
     assert original_pixmap.toImage() != updated_pixmap.toImage()

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from PyQt5.QtCore import QPointF
 
-from labelme.utils.qt import distancetoline
+from labelme.utils.qt import distance_to_line
 
 
-def test_distancetoline() -> None:
+def test_distance_to_line() -> None:
     line = (QPointF(0, 0), QPointF(10, 0))
 
-    assert distancetoline(QPointF(5, 0), line) == 0
-    assert distancetoline(QPointF(5, 5), line) == 5
-    assert distancetoline(QPointF(0, 0), line) == 0
-    assert distancetoline(QPointF(-5, 0), line) == 5
-    assert distancetoline(QPointF(15, 0), line) == 5
+    assert distance_to_line(QPointF(5, 0), line) == 0
+    assert distance_to_line(QPointF(5, 5), line) == 5
+    assert distance_to_line(QPointF(0, 0), line) == 0
+    assert distance_to_line(QPointF(-5, 0), line) == 5
+    assert distance_to_line(QPointF(15, 0), line) == 5

--- a/tests/unit/widgets/file_dialog_preview_test.py
+++ b/tests/unit/widgets/file_dialog_preview_test.py
@@ -21,7 +21,7 @@ def _file_preview_widget(qtbot: QtBot) -> FileDialogPreview:
 
 
 @pytest.mark.gui
-def test_onChange_valid_json(
+def test_on_change_valid_json(
     _file_preview_widget: FileDialogPreview,
     tmp_path: Path,
     qtbot: QtBot,
@@ -30,10 +30,10 @@ def test_onChange_valid_json(
     path = tmp_path / "valid.json"
     path.write_text(json.dumps({"version": "5.0.0", "shapes": []}))
 
-    _file_preview_widget.onChange(str(path))
+    _file_preview_widget._on_change(str(path))
 
-    assert _file_preview_widget.labelPreview.isHidden() is False
-    assert '"version"' in _file_preview_widget.labelPreview.label.text()
+    assert _file_preview_widget.label_preview.isHidden() is False
+    assert '"version"' in _file_preview_widget.label_preview.label.text()
 
     close_or_pause(qtbot=qtbot, widget=_file_preview_widget, pause=pause)
 
@@ -47,7 +47,7 @@ def test_onChange_valid_json(
     ],
     ids=["malformed_json", "binary_file"],
 )
-def test_onChange_bad_json_no_crash(
+def test_on_change_bad_json_no_crash(
     _file_preview_widget: FileDialogPreview,
     tmp_path: Path,
     content_bytes: bytes,
@@ -57,18 +57,18 @@ def test_onChange_bad_json_no_crash(
     path = tmp_path / "bad.json"
     path.write_bytes(content_bytes)
 
-    _file_preview_widget.onChange(str(path))
+    _file_preview_widget._on_change(str(path))
 
-    assert _file_preview_widget.labelPreview.isHidden() is False
-    assert "Cannot preview" in _file_preview_widget.labelPreview.label.text()
+    assert _file_preview_widget.label_preview.isHidden() is False
+    assert "Cannot preview" in _file_preview_widget.label_preview.label.text()
 
     close_or_pause(qtbot=qtbot, widget=_file_preview_widget, pause=pause)
 
 
 @pytest.mark.gui
-def test_onChange_non_json_non_image_hides_preview(
+def test_on_change_non_json_non_image_hides_preview(
     _file_preview_widget: FileDialogPreview,
 ) -> None:
-    _file_preview_widget.onChange("/nonexistent/path.txt")
+    _file_preview_widget._on_change("/nonexistent/path.txt")
 
-    assert _file_preview_widget.labelPreview.isHidden() is True
+    assert _file_preview_widget.label_preview.isHidden() is True

--- a/tests/unit/widgets/label_dialog_test.py
+++ b/tests/unit/widgets/label_dialog_test.py
@@ -14,7 +14,7 @@ def test_LabelQLineEdit(qtbot: QtBot) -> None:
     list_widget = QtWidgets.QListWidget()
     list_widget.addItems(["cat", "dog", "person"])
     widget = LabelQLineEdit()
-    widget.setListWidget(list_widget)
+    widget.set_list_widget(list_widget)
     qtbot.addWidget(widget)
 
     # key press to navigate in label list
@@ -39,27 +39,27 @@ def test_LabelQLineEdit(qtbot: QtBot) -> None:
 
 
 @pytest.mark.gui
-def test_LabelDialog_addLabelHistory(qtbot: QtBot) -> None:
+def test_LabelDialog_add_label_history(qtbot: QtBot) -> None:
     labels = ["cat", "dog", "person"]
     widget = LabelDialog(labels=labels, sort_labels=True)
     qtbot.addWidget(widget)
 
-    widget.addLabelHistory("bicycle")
-    assert widget.labelList.count() == 4
-    widget.addLabelHistory("bicycle")
-    assert widget.labelList.count() == 4
-    item: QtWidgets.QListWidgetItem | None = widget.labelList.item(0)
+    widget.add_label_history("bicycle")
+    assert widget.label_list.count() == 4
+    widget.add_label_history("bicycle")
+    assert widget.label_list.count() == 4
+    item: QtWidgets.QListWidgetItem | None = widget.label_list.item(0)
     assert item
     assert item.text() == "bicycle"
 
 
 @pytest.mark.gui
-def test_LabelDialog_popUp(qtbot: QtBot) -> None:
+def test_LabelDialog_popup(qtbot: QtBot) -> None:
     labels = ["cat", "dog", "person"]
     widget = LabelDialog(labels=labels, sort_labels=True)
     qtbot.addWidget(widget)
 
-    # popUp(text='cat')
+    # popup(text='cat')
 
     def interact() -> None:
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_P)  # enter 'p' for 'person'  # NOQA
@@ -67,26 +67,26 @@ def test_LabelDialog_popUp(qtbot: QtBot) -> None:
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
 
     QtCore.QTimer.singleShot(500, interact)
-    label, flags, group_id, description = widget.popUp("cat")
+    label, flags, group_id, description = widget.popup("cat")
     assert label == "person"
     assert flags == {}
     assert group_id is None
     assert description == ""
 
-    # popUp()
+    # popup()
 
     def interact() -> None:
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
 
     QtCore.QTimer.singleShot(500, interact)
-    label, flags, group_id, description = widget.popUp()
+    label, flags, group_id, description = widget.popup()
     assert label == "person"
     assert flags == {}
     assert group_id is None
     assert description == ""
 
-    # popUp() + key_Up
+    # popup() + key_Up
 
     def interact() -> None:
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Up)  # 'person' -> 'dog'  # NOQA
@@ -94,7 +94,7 @@ def test_LabelDialog_popUp(qtbot: QtBot) -> None:
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
 
     QtCore.QTimer.singleShot(500, interact)
-    label, flags, group_id, description = widget.popUp()
+    label, flags, group_id, description = widget.popup()
     assert label == "dog"
     assert flags == {}
     assert group_id is None


### PR DESCRIPTION
## Summary

Part 1 of 3 in the camelCase → snake_case migration. Low-risk leaf modules.

- **`labelme/utils/qt.py`**: `newIcon`/`newButton`/`newAction`/`addActions`/`labelValidator`/`fmtShortcut`/`distancetoline` → snake_case. Public API; deprecation aliases via module `__getattr__` keep `labelme.utils.newIcon` etc. working with a `DeprecationWarning`.
- **`labelme/widgets/brightness_contrast_dialog.py`**: `onNewValue(self, _)` slot → public no-arg `apply()`, slider connection wraps with `lambda _: self.apply()`. External call sites use `dialog.apply()` directly.
- **`labelme/widgets/file_dialog_preview.py`**: `labelPreview`→`label_preview`, `setText`/`setPixmap` (not Qt overrides — `QScrollArea` doesn't define them) → snake_case, `onChange` → public `update_preview` (signal-connected and exercised by tests).
- **`labelme/widgets/label_dialog.py`**: instance vars (`buttonBox`, `labelList`, `flagsLayout`, `editDescription`), methods (`addLabelHistory`, `popUp` → `popup`, `getFlags`/`getGroupId` → `current_flags`/`current_group_id`, `setListWidget`, `_restoreOrResetFlags`, `set_flags`/`reset_flags`/`delete_flags`/`update_flags`). Pure signal handlers use `_on_*` prefix (`_on_label_selected`, `_on_label_double_clicked`, `_on_editing_finished`, `_on_text_changed`).

## Constraints respected

- Qt virtual methods (`mousePressEvent`, `paintEvent`, `keyPressEvent`, `sizeHint`, `removeRows`, `dropMimeData`, `eventFilter`, `resizeEvent`, `closeEvent`, `dragEnterEvent`, `dropEvent`, `enterEvent`, `leaveEvent`, `focusOutEvent`, `setEnabled`) intentionally stay camelCase — Qt's C++ side dispatches by exact name.
- `self.tr()` stays — required for translation extraction.
- All Qt API calls (`self.menuBar()`, `addDockWidget()`, etc.) stay.
- JSON keys, QSettings keys, YAML config keys untouched.

## Stacked PR series

This is the first of three:
1. **(this PR)** utils + leaf widgets → `main`
2. shape + label_list_widget + canvas → this branch
3. MainWindow + LabelFile (with `@property` deprecation shims) → previous branch

## Test plan

- [x] `make format` clean
- [x] `make lint` (ruff + ty + taplo + mdformat + yamlfix + typos + translation-diff) clean
- [x] `make test` (131/131) passing
- [x] `make update_translate` produces zero diff (no `self.tr` strings touched)