### PR TITLE
refactor: snake_case migration (2/3) — Shape, LabelListWidget, Canvas

### DIFF
--- a/labelme/_automation/bbox_from_text.py
+++ b/labelme/_automation/bbox_from_text.py
@@ -147,6 +147,6 @@ def get_shapes_from_bboxes(
             description=json.dumps(dict(score=score.item(), text=text)),
         )
         for point in points:
-            shape.addPoint(QtCore.QPointF(point[0], point[1]))
+            shape.add_point(QtCore.QPointF(point[0], point[1]))
         shapes.append(shape)
     return shapes

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -431,7 +431,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         undo_last_point = action(
             self.tr("Undo last point"),
-            self._canvas_widgets.canvas.undoLastPoint,
+            self._canvas_widgets.canvas.undo_last_point,
             shortcuts["undo_last_point"],
             icon="phosphor/arrow-u-up-left.svg",
             tip=self.tr("Undo last drawn point"),
@@ -455,7 +455,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_mode = action(
             text=self.tr("Polygon"),
-            slot=lambda: self._switch_canvas_mode(edit=False, createMode="polygon"),
+            slot=lambda: self._switch_canvas_mode(edit=False, create_mode="polygon"),
             shortcut=shortcuts["create_polygon"],
             icon="phosphor/polygon.svg",
             tip=self.tr("Start drawing polygons"),
@@ -471,7 +471,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_rectangle_mode = action(
             text=self.tr("Rectangle"),
-            slot=lambda: self._switch_canvas_mode(edit=False, createMode="rectangle"),
+            slot=lambda: self._switch_canvas_mode(edit=False, create_mode="rectangle"),
             shortcut=shortcuts["create_rectangle"],
             icon="phosphor/rectangle.svg",
             tip=self.tr("Start drawing rectangles"),
@@ -479,7 +479,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_circle_mode = action(
             text=self.tr("Circle"),
-            slot=lambda: self._switch_canvas_mode(edit=False, createMode="circle"),
+            slot=lambda: self._switch_canvas_mode(edit=False, create_mode="circle"),
             shortcut=shortcuts["create_circle"],
             icon="phosphor/circle.svg",
             tip=self.tr("Start drawing circles"),
@@ -487,7 +487,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_line_mode = action(
             text=self.tr("Line"),
-            slot=lambda: self._switch_canvas_mode(edit=False, createMode="line"),
+            slot=lambda: self._switch_canvas_mode(edit=False, create_mode="line"),
             shortcut=shortcuts["create_line"],
             icon="phosphor/line-segment.svg",
             tip=self.tr("Start drawing lines"),
@@ -495,7 +495,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_point_mode = action(
             text=self.tr("Point"),
-            slot=lambda: self._switch_canvas_mode(edit=False, createMode="point"),
+            slot=lambda: self._switch_canvas_mode(edit=False, create_mode="point"),
             shortcut=shortcuts["create_point"],
             icon="phosphor/circles-four.svg",
             tip=self.tr("Start drawing points"),
@@ -503,7 +503,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_line_strip_mode = action(
             text=self.tr("LineStrip"),
-            slot=lambda: self._switch_canvas_mode(edit=False, createMode="linestrip"),
+            slot=lambda: self._switch_canvas_mode(edit=False, create_mode="linestrip"),
             shortcut=shortcuts["create_linestrip"],
             icon="phosphor/line-segments.svg",
             tip=self.tr("Start drawing linestrip. Ctrl+LeftClick ends creation."),
@@ -512,7 +512,7 @@ class MainWindow(QtWidgets.QMainWindow):
         create_ai_points_to_shape_mode = action(
             self.tr("AI-Points"),
             lambda: self._switch_canvas_mode(
-                edit=False, createMode="ai_points_to_shape"
+                edit=False, create_mode="ai_points_to_shape"
             ),
             None,
             "ai-points.svg",
@@ -521,7 +521,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         create_ai_box_to_shape_mode = action(
             self.tr("AI-Box"),
-            lambda: self._switch_canvas_mode(edit=False, createMode="ai_box_to_shape"),
+            lambda: self._switch_canvas_mode(edit=False, create_mode="ai_box_to_shape"),
             None,
             "ai-box.svg",
             self.tr("Draw a bounding box to segment object."),
@@ -608,7 +608,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         fill_drawing = action(
             self.tr("Fill Drawing Polygon"),
-            self._canvas_widgets.canvas.setFillDrawing,
+            self._canvas_widgets.canvas.set_fill_drawing,
             None,
             icon="phosphor/paint-bucket.svg",
             tip=self.tr("Fill polygon while drawing"),
@@ -668,7 +668,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._zoom_mode = _ZoomMode.FIT_WINDOW
         fit_window.setChecked(Qt.Checked)
 
-        self._canvas_widgets.canvas.vertexSelected.connect(remove_point.setEnabled)
+        self._canvas_widgets.canvas.vertex_selected.connect(remove_point.setEnabled)
 
         draw = [
             ("polygon", create_mode),
@@ -1007,9 +1007,9 @@ class MainWindow(QtWidgets.QMainWindow):
             num_backups=self._config["canvas"]["num_backups"],
             crosshair=self._config["canvas"]["crosshair"],
         )
-        canvas.zoomRequest.connect(self._zoom_requested)
-        canvas.mouseMoved.connect(self._update_status_stats)
-        canvas.statusUpdated.connect(
+        canvas.zoom_request.connect(self._zoom_requested)
+        canvas.mouse_moved.connect(self._update_status_stats)
+        canvas.status_updated.connect(
             lambda text: self._status_bar.message.setText(text)
         )
 
@@ -1020,12 +1020,12 @@ class MainWindow(QtWidgets.QMainWindow):
             Qt.Vertical: scroll_area.verticalScrollBar(),
             Qt.Horizontal: scroll_area.horizontalScrollBar(),
         }
-        canvas.scrollRequest.connect(self.scrollRequest)
+        canvas.scroll_request.connect(self.scrollRequest)
 
-        canvas.newShape.connect(self.newShape)
-        canvas.shapeMoved.connect(self.setDirty)
-        canvas.selectionChanged.connect(self.shapeSelectionChanged)
-        canvas.drawingPolygon.connect(self.toggleDrawingSensitive)
+        canvas.new_shape.connect(self.newShape)
+        canvas.shape_moved.connect(self.setDirty)
+        canvas.selection_changed.connect(self.shapeSelectionChanged)
+        canvas.drawing_polygon.connect(self.toggleDrawingSensitive)
 
         self.setCentralWidget(scroll_area)
 
@@ -1188,7 +1188,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def setDirty(self) -> None:
         # Even if we autosave the file, we keep the ability to undo
-        self._actions.undo.setEnabled(self._canvas_widgets.canvas.isShapeRestorable)
+        self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
 
         if self._actions.save_auto.isChecked():
             assert self._image_path is not None
@@ -1229,13 +1229,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.statusBar().showMessage(message, delay)
 
     def _submit_ai_prompt(self, _: bool) -> None:
-        create_mode = self._canvas_widgets.canvas.createMode
+        create_mode = self._canvas_widgets.canvas.create_mode
         shape_type = _resolve_text_annotation_shape_type(
             create_mode=create_mode,
             ai_output_format=self._ai_annotation.output_format,
         )
         if shape_type is None:
-            logger.warning("Unsupported createMode={!r}", create_mode)
+            logger.warning("Unsupported create_mode={!r}", create_mode)
             return
 
         texts = self._ai_text.get_text_prompt().split(",")
@@ -1294,7 +1294,7 @@ class MainWindow(QtWidgets.QMainWindow):
             shape_type=shape_type,
         )
 
-        self._canvas_widgets.canvas.storeShapes()
+        self._canvas_widgets.canvas.backup_shapes()
         self._load_shapes(shapes, replace=False)
         self.setDirty()
 
@@ -1304,7 +1304,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.imageData = None
         self._label_file = None
         self._other_data = None
-        self._canvas_widgets.canvas.resetState()
+        self._canvas_widgets.canvas.reset_state()
 
     def currentItem(self) -> LabelListWidgetItem | None:
         items = self._docks.label_list.selected_items()
@@ -1315,10 +1315,10 @@ class MainWindow(QtWidgets.QMainWindow):
     # Callbacks
 
     def undoShapeEdit(self) -> None:
-        self._canvas_widgets.canvas.restoreShape()
+        self._canvas_widgets.canvas.restore_last_shape()
         self._docks.label_list.clear()
         self._load_shapes(self._canvas_widgets.canvas.shapes)
-        self._actions.undo.setEnabled(self._canvas_widgets.canvas.isShapeRestorable)
+        self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
 
     def tutorial(self) -> None:
         url = "https://github.com/labelmeai/labelme/tree/main/examples/tutorial"  # NOQA
@@ -1335,9 +1335,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._actions.delete.setEnabled(not drawing)
 
     def _switch_canvas_mode(
-        self, edit: bool = True, createMode: str | None = None
+        self, edit: bool = True, create_mode: str | None = None
     ) -> None:
-        if createMode == "ai_points_to_shape":
+        if create_mode == "ai_points_to_shape":
             model_name = self._canvas_widgets.canvas.get_ai_model_name()
             if model_name in _AI_MODELS_WITHOUT_POINT_SUPPORT:
                 QtWidgets.QMessageBox.warning(
@@ -1350,23 +1350,23 @@ class MainWindow(QtWidgets.QMainWindow):
                     % model_name,
                 )
                 return
-        self._canvas_widgets.canvas.setEditing(edit)
-        if createMode is not None:
-            self._canvas_widgets.canvas.createMode = createMode
+        self._canvas_widgets.canvas.set_editing(edit)
+        if create_mode is not None:
+            self._canvas_widgets.canvas.create_mode = create_mode
         if edit:
             for _, draw_action in self._actions.draw:
                 draw_action.setEnabled(True)
         else:
             for draw_mode, draw_action in self._actions.draw:
-                draw_action.setEnabled(createMode != draw_mode)
+                draw_action.setEnabled(create_mode != draw_mode)
         self._actions.edit_mode.setEnabled(not edit)
         self._ai_text.setEnabled(
             not edit
-            and createMode
+            and create_mode
             in (*get_args(_TextToAnnotationCreateMode), *_AI_CREATE_MODES)
         )
-        self._ai_annotation.setEnabled(not edit and createMode in _AI_CREATE_MODES)
-        if createMode == "ai_points_to_shape":
+        self._ai_annotation.setEnabled(not edit and create_mode in _AI_CREATE_MODES)
+        if create_mode == "ai_points_to_shape":
             self._ai_annotation.set_disabled_models(_AI_MODELS_WITHOUT_POINT_SUPPORT)
         else:
             self._ai_annotation.set_disabled_models(())
@@ -1468,7 +1468,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             return
 
-        self._canvas_widgets.canvas.storeShapes()
+        self._canvas_widgets.canvas.backup_shapes()
         for item in items:
             shape = item.shape()
             assert shape is not None
@@ -1519,11 +1519,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
         )
-        for shape in self._canvas_widgets.canvas.selectedShapes:
+        for shape in self._canvas_widgets.canvas.selected_shapes:
             shape.selected = False
         self._docks.label_list.clearSelection()
-        self._canvas_widgets.canvas.selectedShapes = selected_shapes
-        for shape in self._canvas_widgets.canvas.selectedShapes:
+        self._canvas_widgets.canvas.selected_shapes = selected_shapes
+        for shape in self._canvas_widgets.canvas.selected_shapes:
             shape.selected = True
             item = self._docks.label_list.find_item_by_shape(shape)
             self._docks.label_list.select_item(item)
@@ -1621,7 +1621,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.label_list.item_selection_changed.connect(
             self._label_selection_changed
         )
-        self._canvas_widgets.canvas.loadShapes(shapes=shapes, replace=replace)
+        self._canvas_widgets.canvas.load_shapes(shapes=shapes, replace=replace)
 
     def _load_flags(
         self,
@@ -1687,12 +1687,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def pasteSelectedShape(self) -> None:
         self._load_shapes(shapes=self._copied_shapes, replace=False)
-        self._canvas_widgets.canvas.selectShapes(self._copied_shapes)
+        self._canvas_widgets.canvas.select_shapes(self._copied_shapes)
         self.setDirty()
 
     def copySelectedShape(self) -> None:
         self._copied_shapes = [
-            s.copy() for s in self._canvas_widgets.canvas.selectedShapes
+            s.copy() for s in self._canvas_widgets.canvas.selected_shapes
         ]
         self._actions.paste.setEnabled(len(self._copied_shapes) > 0)
 
@@ -1703,15 +1703,15 @@ class MainWindow(QtWidgets.QMainWindow):
             assert shape is not None
             selected_shapes.append(shape)
         if selected_shapes:
-            self._canvas_widgets.canvas.selectShapes(selected_shapes)
+            self._canvas_widgets.canvas.select_shapes(selected_shapes)
         else:
-            if self._canvas_widgets.canvas.deSelectShape():
+            if self._canvas_widgets.canvas.deselect_shape():
                 self._canvas_widgets.canvas.update()
 
     def labelItemChanged(self, item: LabelListWidgetItem) -> None:
         shape = item.shape()
         assert shape is not None
-        self._canvas_widgets.canvas.setShapeVisible(
+        self._canvas_widgets.canvas.set_shape_visible(
             shape, item.checkState() == Qt.Checked
         )
 
@@ -1720,7 +1720,7 @@ class MainWindow(QtWidgets.QMainWindow):
         shapes = [
             s for item in self._docks.label_list if (s := item.shape()) is not None
         ]
-        self._canvas_widgets.canvas.loadShapes(shapes)
+        self._canvas_widgets.canvas.load_shapes(shapes)
 
     # Callback functions:
 
@@ -1753,7 +1753,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if text:
             self._docks.label_list.clearSelection()
             assert isinstance(flags, dict)
-            shapes = self._canvas_widgets.canvas.setLastLabel(text, flags)
+            shapes = self._canvas_widgets.canvas.set_last_label(text, flags)
             for shape in shapes:
                 shape.group_id = group_id
                 shape.description = description
@@ -1763,8 +1763,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self._actions.undo.setEnabled(True)
             self.setDirty()
         else:
-            self._canvas_widgets.canvas.undoLastLine()
-            self._canvas_widgets.canvas.shapesBackups.pop()
+            self._canvas_widgets.canvas.undo_last_line()
+            self._canvas_widgets.canvas.shape_backups.pop()
 
     def scrollRequest(self, delta: int, orientation: Qt.Orientation) -> None:
         units = -delta * 0.1  # natural scroll
@@ -1790,7 +1790,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._actions.fit_width.setChecked(self._zoom_mode == _ZoomMode.FIT_WIDTH)
         self._actions.fit_window.setChecked(self._zoom_mode == _ZoomMode.FIT_WINDOW)
-        self._canvas_widgets.canvas.enableDragging(
+        self._canvas_widgets.canvas.enable_dragging(
             enabled=value > int(self._scalers[_ZoomMode.FIT_WINDOW]() * 100)
         )
         self._canvas_widgets.zoom_widget.setValue(value)  # triggers self._paint_canvas
@@ -1846,7 +1846,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._actions.keep_prev_scale.setChecked(enabled)
 
     def onNewBrightnessContrast(self, qimage: QtGui.QImage) -> None:
-        self._canvas_widgets.canvas.loadPixmap(
+        self._canvas_widgets.canvas.load_pixmap(
             QtGui.QPixmap.fromImage(qimage), clear_shapes=False
         )
 
@@ -2002,7 +2002,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self._image = image
         t0 = time.time()
-        self._canvas_widgets.canvas.loadPixmap(QtGui.QPixmap.fromImage(image))
+        self._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
         logger.debug("Loaded pixmap in {:.0f}ms", (time.time() - t0) * 1000)
         flags = {k: False for k in self._config["flags"] or []}
         if self._label_file:
@@ -2354,14 +2354,16 @@ class MainWindow(QtWidgets.QMainWindow):
         self._config["keep_prev"] = not self._config["keep_prev"]
 
     def removeSelectedPoint(self) -> None:
-        self._canvas_widgets.canvas.removeSelectedPoint()
+        self._canvas_widgets.canvas.remove_selected_point()
         self._canvas_widgets.canvas.update()
         if (
-            self._canvas_widgets.canvas.hShape
-            and not self._canvas_widgets.canvas.hShape.points
+            self._canvas_widgets.canvas.hovered_shape
+            and not self._canvas_widgets.canvas.hovered_shape.points
         ):
-            self._canvas_widgets.canvas.deleteShape(self._canvas_widgets.canvas.hShape)
-            self.remLabels([self._canvas_widgets.canvas.hShape])
+            self._canvas_widgets.canvas.delete_shape(
+                self._canvas_widgets.canvas.hovered_shape
+            )
+            self.remLabels([self._canvas_widgets.canvas.hovered_shape])
             if self.noShapes():
                 for action in self._actions.on_shapes_present:
                     action.setEnabled(False)
@@ -2371,25 +2373,25 @@ class MainWindow(QtWidgets.QMainWindow):
         yes, no = QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No
         msg = self.tr(
             "You are about to permanently delete {} shapes, proceed anyway?"
-        ).format(len(self._canvas_widgets.canvas.selectedShapes))
+        ).format(len(self._canvas_widgets.canvas.selected_shapes))
         if yes == QtWidgets.QMessageBox.warning(
             self, self.tr("Attention"), msg, yes | no, yes
         ):
-            self.remLabels(self._canvas_widgets.canvas.deleteSelected())
+            self.remLabels(self._canvas_widgets.canvas.delete_selected())
             self.setDirty()
             if self.noShapes():
                 for action in self._actions.on_shapes_present:
                     action.setEnabled(False)
 
     def copyShape(self) -> None:
-        self._canvas_widgets.canvas.endMove(copy=True)
-        for shape in self._canvas_widgets.canvas.selectedShapes:
+        self._canvas_widgets.canvas.end_move(copy=True)
+        for shape in self._canvas_widgets.canvas.selected_shapes:
             self.addLabel(shape)
         self._docks.label_list.clearSelection()
         self.setDirty()
 
     def moveShape(self) -> None:
-        self._canvas_widgets.canvas.endMove(copy=False)
+        self._canvas_widgets.canvas.end_move(copy=False)
         self.setDirty()
 
     def _load_from_file_or_dir(self, file_or_dir: str) -> None:

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2533,7 +2533,7 @@ def _shapes_from_dicts(
             mask=shape_dict["mask"],
         )
         for x, y in shape_dict["points"]:
-            shape.addPoint(QtCore.QPointF(x, y))
+            shape.add_point(QtCore.QPointF(x, y))
         shape.close()
 
         default_flags: dict[str, bool] = {}

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1048,10 +1048,10 @@ class MainWindow(QtWidgets.QMainWindow):
         flag_list.itemChanged.connect(self.setDirty)
 
         label_list = LabelListWidget()
-        label_list.itemSelectionChanged.connect(self._label_selection_changed)
-        label_list.itemDoubleClicked.connect(self._edit_label)
-        label_list.itemChanged.connect(self.labelItemChanged)
-        label_list.itemDropped.connect(self.labelOrderChanged)
+        label_list.item_selection_changed.connect(self._label_selection_changed)
+        label_list.item_double_clicked.connect(self._edit_label)
+        label_list.item_changed.connect(self.labelItemChanged)
+        label_list.item_dropped.connect(self.labelOrderChanged)
         shape = QtWidgets.QDockWidget(self.tr("Annotation List"), self)
         shape.setObjectName("Labels")
         shape.setWidget(label_list)
@@ -1307,7 +1307,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.resetState()
 
     def currentItem(self) -> LabelListWidgetItem | None:
-        items = self._docks.label_list.selectedItems()
+        items = self._docks.label_list.selected_items()
         if items:
             return items[0]
         return None
@@ -1406,7 +1406,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def _edit_label(self, value: object | None = None) -> None:
-        items = self._docks.label_list.selectedItems()
+        items = self._docks.label_list.selected_items()
         if not items:
             logger.warning("No label is selected, so cannot edit label.")
             return
@@ -1516,7 +1516,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     # React to canvas signals.
     def shapeSelectionChanged(self, selected_shapes: list[Shape]) -> None:
-        self._docks.label_list.itemSelectionChanged.disconnect(
+        self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
         )
         for shape in self._canvas_widgets.canvas.selectedShapes:
@@ -1525,10 +1525,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.selectedShapes = selected_shapes
         for shape in self._canvas_widgets.canvas.selectedShapes:
             shape.selected = True
-            item = self._docks.label_list.findItemByShape(shape)
-            self._docks.label_list.selectItem(item)
-            self._docks.label_list.scrollToItem(item)
-        self._docks.label_list.itemSelectionChanged.connect(
+            item = self._docks.label_list.find_item_by_shape(shape)
+            self._docks.label_list.select_item(item)
+            self._docks.label_list.scroll_to_item(item)
+        self._docks.label_list.item_selection_changed.connect(
             self._label_selection_changed
         )
         n_selected = len(selected_shapes) > 0
@@ -1544,7 +1544,7 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             text = f"{shape.label} ({shape.group_id})"
         label_list_item = LabelListWidgetItem(text, shape)
-        self._docks.label_list.addItem(label_list_item)
+        self._docks.label_list.add_item(label_list_item)
         if self._docks.unique_label_list.find_label_item(shape.label) is None:
             self._docks.unique_label_list.add_label_item(
                 label=shape.label,
@@ -1604,21 +1604,21 @@ class MainWindow(QtWidgets.QMainWindow):
         return (0, 255, 0)
 
     def remLabels(self, shapes: list[Shape]) -> None:
-        self._docks.label_list.itemDropped.disconnect(self.labelOrderChanged)
+        self._docks.label_list.item_dropped.disconnect(self.labelOrderChanged)
         for shape in shapes:
-            item = self._docks.label_list.findItemByShape(shape)
-            self._docks.label_list.removeItem(item)
-        self._docks.label_list.itemDropped.connect(self.labelOrderChanged)
+            item = self._docks.label_list.find_item_by_shape(shape)
+            self._docks.label_list.remove_item(item)
+        self._docks.label_list.item_dropped.connect(self.labelOrderChanged)
 
     def _load_shapes(self, shapes: list[Shape], replace: bool = True) -> None:
-        self._docks.label_list.itemSelectionChanged.disconnect(
+        self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
         )
         shape: Shape
         for shape in shapes:
             self.addLabel(shape)
         self._docks.label_list.clearSelection()
-        self._docks.label_list.itemSelectionChanged.connect(
+        self._docks.label_list.item_selection_changed.connect(
             self._label_selection_changed
         )
         self._canvas_widgets.canvas.loadShapes(shapes=shapes, replace=replace)
@@ -1698,7 +1698,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _label_selection_changed(self) -> None:
         selected_shapes: list[Shape] = []
-        for item in self._docks.label_list.selectedItems():
+        for item in self._docks.label_list.selected_items():
             shape = item.shape()
             assert shape is not None
             selected_shapes.append(shape)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -71,7 +71,7 @@ class Shape:
             # Per-instance line color override (used for the pending line).
             self.line_color = line_color
 
-    def setShapeRefined(
+    def refine(
         self,
         shape_type: str,
         points: list[QtCore.QPointF],
@@ -84,7 +84,7 @@ class Shape:
         self.point_labels = point_labels
         self.mask = mask
 
-    def restoreShapeRaw(self) -> None:
+    def unrefine(self) -> None:
         if self._shape_raw is None:
             return
         self.shape_type, self.points, self.point_labels = self._shape_raw
@@ -114,29 +114,29 @@ class Shape:
     def close(self) -> None:
         self._closed = True
 
-    def addPoint(self, point: QtCore.QPointF, label: int = 1) -> None:
+    def add_point(self, point: QtCore.QPointF, label: int = 1) -> None:
         if self.points and self.points[0] == point:
             self.close()
             return
         self.points.append(point)
         self.point_labels.append(label)
 
-    def canAddPoint(self) -> bool:
+    def can_add_point(self) -> bool:
         return self.shape_type in ["polygon", "linestrip"]
 
-    def popPoint(self) -> QtCore.QPointF | None:
+    def pop_point(self) -> QtCore.QPointF | None:
         if not self.points:
             return None
         if self.point_labels:
             self.point_labels.pop()
         return self.points.pop()
 
-    def insertPoint(self, i: int, point: QtCore.QPointF, label: int = 1) -> None:
+    def insert_point(self, i: int, point: QtCore.QPointF, label: int = 1) -> None:
         self.points.insert(i, point)
         self.point_labels.insert(i, label)
 
-    def canRemovePoint(self) -> bool:
-        if not self.canAddPoint():
+    def can_remove_point(self) -> bool:
+        if not self.can_add_point():
             return False
 
         if self.shape_type == "polygon" and len(self.points) <= 3:
@@ -147,8 +147,8 @@ class Shape:
 
         return True
 
-    def removePoint(self, i: int) -> None:
-        if not self.canRemovePoint():
+    def remove_point(self, i: int) -> None:
+        if not self.can_remove_point():
             logger.warning(
                 "Cannot remove point from: shape_type=%r, len(points)=%d",
                 self.shape_type,
@@ -159,26 +159,26 @@ class Shape:
         self.points.pop(i)
         self.point_labels.pop(i)
 
-    def isClosed(self) -> bool:
+    def is_closed(self) -> bool:
         return self._closed
 
-    def setOpen(self) -> None:
+    def open(self) -> None:
         self._closed = False
 
     def paint(self, painter: QtGui.QPainter) -> None:
         _paint_shape(painter=painter, shape=self)
 
-    def nearestVertex(self, point: QtCore.QPointF, epsilon: float) -> int | None:
+    def nearest_vertex(self, point: QtCore.QPointF, epsilon: float) -> int | None:
         return _nearest_vertex_index(
             point=point, points=self.points, scale=self.scale, epsilon=epsilon
         )
 
-    def nearestEdge(self, point: QtCore.QPointF, epsilon: float) -> int | None:
+    def nearest_edge(self, point: QtCore.QPointF, epsilon: float) -> int | None:
         return _nearest_edge_index(
             point=point, points=self.points, scale=self.scale, epsilon=epsilon
         )
 
-    def containsPoint(self, point: QtCore.QPointF) -> bool:
+    def contains_point(self, point: QtCore.QPointF) -> bool:
         return _shape_contains_point(
             point=point,
             shape_type=self.shape_type,
@@ -187,22 +187,22 @@ class Shape:
             point_size=self.point_size,
         )
 
-    def makePath(self) -> QtGui.QPainterPath:
+    def to_path(self) -> QtGui.QPainterPath:
         return _make_shape_path(shape_type=self.shape_type, points=self.points)
 
-    def boundingRect(self) -> QtCore.QRectF:
-        return self.makePath().boundingRect()
+    def bounding_rect(self) -> QtCore.QRectF:
+        return self.to_path().boundingRect()
 
-    def moveBy(self, offset: QtCore.QPointF) -> None:
+    def move_by(self, offset: QtCore.QPointF) -> None:
         self.points = [p + offset for p in self.points]
 
-    def moveVertex(self, i: int, pos: QtCore.QPointF) -> None:
+    def move_vertex(self, i: int, pos: QtCore.QPointF) -> None:
         self.points[i] = pos
 
-    def highlightVertex(self, i: int, action: int) -> None:
+    def highlight_vertex(self, i: int, action: int) -> None:
         self.highlight = _Highlight(index=i, mode=action)
 
-    def highlightClear(self) -> None:
+    def clear_highlight(self) -> None:
         self.highlight = None
 
     def copy(self) -> Shape:
@@ -485,5 +485,5 @@ def _build_shape_paths(
         for i, p in enumerate(shape.points):
             line_path.lineTo(_scale_point(point=p, scale=shape.scale))
             _add_shape_vertex(vrtx_path, shape=shape, vertex_index=i)
-        if shape.isClosed():
+        if shape.is_closed():
             line_path.lineTo(_scale_point(point=shape.points[0], scale=shape.scale))

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -281,7 +281,7 @@ class Canvas(QtWidgets.QWidget):
         previous_shape: Shape | None = self.hShape
         need_update: bool = hShape is not None
         if previous_shape is not None:
-            previous_shape.highlightClear()
+            previous_shape.clear_highlight()
             need_update = True
         # NOTE: Store last highlighted for adding/removing points.
         self._lasthShape = previous_shape if hShape is None else hShape
@@ -424,7 +424,7 @@ class Canvas(QtWidgets.QWidget):
         ):
             pos = current[0]
             self._apply_cursor(CURSOR_POINT)
-            current.highlightVertex(i=0, action=Shape.NEAR_VERTEX)
+            current.highlight_vertex(i=0, action=Shape.NEAR_VERTEX)
 
         pos = self._update_drawing_line(pos=pos, is_shift_pressed=is_shift_pressed)
         assert len(self.line.points) == len(self.line.point_labels)
@@ -501,13 +501,13 @@ class Canvas(QtWidgets.QWidget):
         ]
 
         for shape in ordered_shapes:
-            index: int | None = shape.nearestVertex(pos, self.epsilon)
+            index: int | None = shape.nearest_vertex(pos, self.epsilon)
             if index is not None:
                 self._set_highlight(hShape=shape, hEdge=None, hVertex=index)
-                shape.highlightVertex(i=index, action=shape.MOVE_VERTEX)
+                shape.highlight_vertex(i=index, action=shape.MOVE_VERTEX)
                 self._apply_cursor(CURSOR_POINT)
                 status_messages.append(self.tr("Click & drag to move point"))
-                if shape.canRemovePoint():
+                if shape.can_remove_point():
                     status_messages.append(
                         self.tr("ALT + SHIFT + Click to delete point")
                     )
@@ -515,8 +515,8 @@ class Canvas(QtWidgets.QWidget):
                 return
 
         for shape in ordered_shapes:
-            index_edge: int | None = shape.nearestEdge(pos, self.epsilon)
-            if index_edge is not None and shape.canAddPoint():
+            index_edge: int | None = shape.nearest_edge(pos, self.epsilon)
+            if index_edge is not None and shape.can_add_point():
                 self._set_highlight(hShape=shape, hEdge=index_edge, hVertex=None)
                 self._apply_cursor(CURSOR_POINT)
                 status_messages.append(self.tr("ALT + Click to create point on shape"))
@@ -524,7 +524,7 @@ class Canvas(QtWidgets.QWidget):
                 return
 
         for shape in ordered_shapes:
-            if shape.containsPoint(pos):
+            if shape.contains_point(pos):
                 self._set_highlight(hShape=shape, hEdge=None, hVertex=None)
                 status_messages.extend(
                     [
@@ -546,8 +546,8 @@ class Canvas(QtWidgets.QWidget):
         point = self.prevMovePoint
         if shape is None or index is None or point is None:
             return
-        shape.insertPoint(index, point)
-        shape.highlightVertex(i=index, action=shape.MOVE_VERTEX)
+        shape.insert_point(index, point)
+        shape.highlight_vertex(i=index, action=shape.MOVE_VERTEX)
         self.hShape = shape
         self.hVertex = index
         self.hEdge = None
@@ -558,8 +558,8 @@ class Canvas(QtWidgets.QWidget):
         index = self._lasthVertex
         if shape is None or index is None:
             return
-        shape.removePoint(index)
-        shape.highlightClear()
+        shape.remove_point(index)
+        shape.clear_highlight()
         self.hShape = shape
         self._lasthVertex = None
         self.movingShape = True  # Save changes
@@ -609,21 +609,21 @@ class Canvas(QtWidgets.QWidget):
         mode = self.createMode
         modifiers = event.modifiers()
         if mode == "polygon":
-            current.addPoint(self.line[1])
+            current.add_point(self.line[1])
             self.line[0] = current[-1]
-            if current.isClosed():
+            if current.is_closed():
                 self.finalise()
         elif mode in ("rectangle", "circle", "line", "ai_box_to_shape"):
             assert len(current.points) == 1
             current.points = self.line.points
             self.finalise()
         elif mode == "linestrip":
-            current.addPoint(self.line[1])
+            current.add_point(self.line[1])
             self.line[0] = current[-1]
             if int(modifiers) == Qt.ControlModifier:
                 self.finalise()
         elif mode == "ai_points_to_shape":
-            current.addPoint(
+            current.add_point(
                 self.line.points[1],
                 label=self.line.point_labels[1],
             )
@@ -649,7 +649,7 @@ class Canvas(QtWidgets.QWidget):
             "ai_box_to_shape": "rectangle",
         }.get(mode, mode)
         new_shape = Shape(shape_type=initial_shape_type)
-        new_shape.addPoint(pos, label=0 if is_shift_pressed else 1)
+        new_shape.add_point(pos, label=0 if is_shift_pressed else 1)
         self.current = new_shape
 
         if mode == "point":
@@ -782,11 +782,11 @@ class Canvas(QtWidgets.QWidget):
         """Select the first shape created which contains this point."""
         if self.hVertex is not None:
             assert self.hShape is not None
-            self.hShape.highlightVertex(i=self.hVertex, action=self.hShape.MOVE_VERTEX)
+            self.hShape.highlight_vertex(i=self.hVertex, action=self.hShape.MOVE_VERTEX)
         else:
             shape: Shape
             for shape in reversed(self.shapes):
-                if self.isVisible(shape) and shape.containsPoint(point):
+                if self.isVisible(shape) and shape.contains_point(point):
                     self.setHiding()
                     if shape not in self.selectedShapes:
                         if multiple_selection_mode:
@@ -806,7 +806,7 @@ class Canvas(QtWidgets.QWidget):
             self.offsets = QPointF(0.0, 0.0), QPointF(0.0, 0.0)
             return
 
-        rects = [s.boundingRect() for s in self.selectedShapes]
+        rects = [s.bounding_rect() for s in self.selectedShapes]
         left = min(r.left() for r in rects)
         top = min(r.top() for r in rects)
         right = max(r.right() for r in rects)
@@ -838,7 +838,7 @@ class Canvas(QtWidgets.QWidget):
                 pos=pos, opposite_vertex=shape[1 - vertex_index]
             )
 
-        shape.moveVertex(i=vertex_index, pos=pos)
+        shape.move_vertex(i=vertex_index, pos=pos)
 
     def boundedMoveShapes(self, shapes: list[Shape], pos: QPointF) -> bool:
         if self.outOfPixmap(pos):
@@ -860,7 +860,7 @@ class Canvas(QtWidgets.QWidget):
             return False
 
         for shape in shapes:
-            shape.moveBy(dp)
+            shape.move_by(dp)
         self.prevPoint = pos
         return True
 
@@ -913,7 +913,7 @@ class Canvas(QtWidgets.QWidget):
         finally:
             painter.end()
         if self.current is not None:
-            self.current.highlightClear()
+            self.current.clear_highlight()
 
     def _paint_background(self, painter: QtGui.QPainter) -> None:
         painter.save()
@@ -978,10 +978,10 @@ class Canvas(QtWidgets.QWidget):
                         " so forcing to be opaque."
                     )
                     preview.fill_color.setAlpha(64)
-                preview.addPoint(point=self.line[1])
+                preview.add_point(point=self.line[1])
         else:
             assert self.createMode == "ai_points_to_shape"
-            preview.addPoint(
+            preview.add_point(
                 point=self.line.points[1],
                 label=self.line.point_labels[1],
             )
@@ -1157,8 +1157,8 @@ class Canvas(QtWidgets.QWidget):
             self._cancel_current_shape()
             return
         self.current = self.shapes.pop()
-        self.current.setOpen()
-        self.current.restoreShapeRaw()
+        self.current.open()
+        self.current.unrefine()
         if self.createMode in ("polygon", "linestrip"):
             self.line.points = [self.current[-1], self.current[0]]
         elif self.createMode in ("rectangle", "line", "circle", "ai_box_to_shape"):
@@ -1169,9 +1169,9 @@ class Canvas(QtWidgets.QWidget):
 
     def undoLastPoint(self) -> None:
         current = self.current
-        if current is None or current.isClosed():
+        if current is None or current.is_closed():
             return
-        current.popPoint()
+        current.pop_point()
         if len(current) > 0:
             self.line[0] = current[-1]
             self.update()
@@ -1252,7 +1252,7 @@ def _shape_from_annotation(
             return None
         bb = annotation.bounding_box
         shape = Shape()
-        shape.setShapeRefined(
+        shape.refine(
             shape_type="mask",
             points=[QPointF(bb.xmin, bb.ymin), QPointF(bb.xmax, bb.ymax)],
             point_labels=[1, 1],
@@ -1268,7 +1268,7 @@ def _shape_from_annotation(
             bb = annotation.bounding_box
             points = points + np.array([bb.xmin, bb.ymin], dtype=np.float32)
         shape = Shape()
-        shape.setShapeRefined(
+        shape.refine(
             shape_type="polygon",
             points=[QPointF(point[0], point[1]) for point in points],
             point_labels=[1] * len(points),

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -42,37 +42,37 @@ class Canvas(QtWidgets.QWidget):
     _pixmap_hash: int | None
     _cursor: QtCore.Qt.CursorShape
     shapes: list[Shape]
-    shapesBackups: collections.deque[list[Shape]]
-    movingShape: bool
-    selectedShapes: list[Shape]
-    selectedShapesCopy: list[Shape]
+    shape_backups: collections.deque[list[Shape]]
+    is_moving_shape: bool
+    selected_shapes: list[Shape]
+    selected_shapes_copy: list[Shape]
     current: Shape | None
-    hShape: Shape | None
-    _lasthShape: Shape | None
-    hVertex: int | None
-    _lasthVertex: int | None
-    hEdge: int | None
-    _lasthEdge: int | None
+    hovered_shape: Shape | None
+    _last_hovered_shape: Shape | None
+    hovered_vertex: int | None
+    _last_hovered_vertex: int | None
+    hovered_edge: int | None
+    _last_hovered_edge: int | None
 
-    zoomRequest = QtCore.pyqtSignal(int, QPointF)
-    scrollRequest = QtCore.pyqtSignal(int, int)
-    newShape = QtCore.pyqtSignal()
-    selectionChanged = QtCore.pyqtSignal(list)
-    shapeMoved = QtCore.pyqtSignal()
-    drawingPolygon = QtCore.pyqtSignal(bool)
-    vertexSelected = QtCore.pyqtSignal(bool)
-    mouseMoved = QtCore.pyqtSignal(QPointF)
-    statusUpdated = QtCore.pyqtSignal(str)
+    zoom_request = QtCore.pyqtSignal(int, QPointF)
+    scroll_request = QtCore.pyqtSignal(int, int)
+    new_shape = QtCore.pyqtSignal()
+    selection_changed = QtCore.pyqtSignal(list)
+    shape_moved = QtCore.pyqtSignal()
+    drawing_polygon = QtCore.pyqtSignal(bool)
+    vertex_selected = QtCore.pyqtSignal(bool)
+    mouse_moved = QtCore.pyqtSignal(QPointF)
+    status_updated = QtCore.pyqtSignal(str)
 
     mode: CanvasMode = CanvasMode.EDIT
 
     # polygon, rectangle, line, or point
-    _createMode = "polygon"
+    _create_mode = "polygon"
 
     _fill_drawing = False
 
-    prevPoint: QPointF
-    prevMovePoint: QPointF
+    prev_point: QPointF
+    prev_move_point: QPointF
     offsets: tuple[QPointF, QPointF]
 
     _dragging_start_pos: QPointF
@@ -107,24 +107,24 @@ class Canvas(QtWidgets.QWidget):
         super().__init__(*args, **kwargs)
 
         self._cursor = CURSOR_DEFAULT
-        self.resetState()
+        self.reset_state()
 
         # self.line represents:
-        #   - createMode == 'polygon': edge from last point to current
-        #   - createMode == 'rectangle': diagonal line of the rectangle
-        #   - createMode == 'line': the line
-        #   - createMode == 'point': the point
+        #   - create_mode == 'polygon': edge from last point to current
+        #   - create_mode == 'rectangle': diagonal line of the rectangle
+        #   - create_mode == 'line': the line
+        #   - create_mode == 'point': the point
         self.line = Shape()
-        self.prevPoint = QPointF()
-        self.prevMovePoint = QPointF()
+        self.prev_point = QPointF()
+        self.prev_move_point = QPointF()
         self.offsets = QPointF(), QPointF()
         self.scale: float = 1.0
         self._osam_session = None
         self.visible: dict = {}
-        self._hideBackground: bool = False
-        self.hideBackground: bool = False
+        self._hide_background: bool = False
+        self.hide_background: bool = False
         self.snapping = True
-        self.hShapeIsSelected: bool = False
+        self.hovered_shape_is_selected: bool = False
         self._painter = QtGui.QPainter()
         self._dragging_start_pos = QPointF()
         self._is_dragging = False
@@ -136,18 +136,18 @@ class Canvas(QtWidgets.QWidget):
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.WheelFocus)
 
-    def fillDrawing(self) -> bool:
+    def fill_drawing(self) -> bool:
         return self._fill_drawing
 
-    def setFillDrawing(self, value: bool) -> None:
+    def set_fill_drawing(self, value: bool) -> None:
         self._fill_drawing = value
 
     @property
-    def createMode(self) -> str:
-        return self._createMode
+    def create_mode(self) -> str:
+        return self._create_mode
 
-    @createMode.setter
-    def createMode(self, value: str) -> None:
+    @create_mode.setter
+    def create_mode(self, value: str) -> None:
         if value not in [
             "polygon",
             "rectangle",
@@ -158,8 +158,8 @@ class Canvas(QtWidgets.QWidget):
             "ai_points_to_shape",
             "ai_box_to_shape",
         ]:
-            raise ValueError(f"Unsupported createMode: {value}")
-        self._createMode = value
+            raise ValueError(f"Unsupported create_mode: {value}")
+        self._create_mode = value
 
     def get_ai_model_name(self) -> str:
         return self._osam_session_model_name
@@ -209,31 +209,30 @@ class Canvas(QtWidgets.QWidget):
             output_format=self._ai_output_format,
         )
 
-    def storeShapes(self) -> None:
-        self.shapesBackups.append([s.copy() for s in self.shapes])
+    def backup_shapes(self) -> None:
+        self.shape_backups.append([s.copy() for s in self.shapes])
 
     @property
-    def isShapeRestorable(self) -> bool:
+    def can_restore_shape(self) -> bool:
         # We save the state AFTER each edit (not before) so for an
         # edit to be undoable, we expect the CURRENT and the PREVIOUS state
         # to be in the undo stack.
-        if len(self.shapesBackups) < 2:
+        if len(self.shape_backups) < 2:
             return False
         return True
 
-    def restoreShape(self) -> None:
+    def restore_last_shape(self) -> None:
         # This does _part_ of the job of restoring shapes.
         # The complete process is also done in app.py::undoShapeEdit
-        # and app.py::loadShapes and our own Canvas::loadShapes function.
-        if not self.isShapeRestorable:
+        # and app.py::load_shapes and our own Canvas::load_shapes function.
+        if not self.can_restore_shape:
             return
-        self.shapesBackups.pop()  # latest
+        self.shape_backups.pop()  # latest
 
-        # The application will eventually call Canvas.loadShapes which will
+        # The application will eventually call Canvas.load_shapes which will
         # push this right back onto the stack.
-        shapesBackup = self.shapesBackups.pop()
-        self.shapes = shapesBackup
-        self.selectedShapes = []
+        self.shapes = self.shape_backups.pop()
+        self.selected_shapes = []
         for shape in self.shapes:
             shape.selected = False
         self.update()
@@ -243,7 +242,9 @@ class Canvas(QtWidgets.QWidget):
         self._update_status()
 
     def leaveEvent(self, a0: QtCore.QEvent) -> None:
-        if self._set_highlight(hShape=None, hEdge=None, hVertex=None):
+        if self._set_highlight(
+            hovered_shape=None, hovered_edge=None, hovered_vertex=None
+        ):
             self.update()
         self._release_cursor()
         self._update_status()
@@ -252,7 +253,7 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self._update_status()
 
-    def isVisible(self, shape: Shape) -> bool:  # ty: ignore[invalid-method-override]
+    def is_shape_visible(self, shape: Shape) -> bool:
         return self.visible.get(shape, True)
 
     def drawing(self) -> bool:
@@ -261,7 +262,7 @@ class Canvas(QtWidgets.QWidget):
     def editing(self) -> bool:
         return self.mode == CanvasMode.EDIT
 
-    def setEditing(self, value: bool = True) -> None:
+    def set_editing(self, value: bool = True) -> None:
         self.mode = CanvasMode.EDIT if value else CanvasMode.CREATE
         if self.mode == CanvasMode.EDIT:
             # CREATE -> EDIT
@@ -269,83 +270,92 @@ class Canvas(QtWidgets.QWidget):
         else:
             # EDIT -> CREATE
             need_update: bool = self._set_highlight(
-                hShape=None, hEdge=None, hVertex=None
+                hovered_shape=None, hovered_edge=None, hovered_vertex=None
             )
-            need_update |= self.deSelectShape()
+            need_update |= self.deselect_shape()
             if need_update:
                 self.update()
 
     def _set_highlight(
-        self, hShape: Shape | None, hEdge: int | None, hVertex: int | None
+        self,
+        hovered_shape: Shape | None,
+        hovered_edge: int | None,
+        hovered_vertex: int | None,
     ) -> bool:
-        previous_shape: Shape | None = self.hShape
-        need_update: bool = hShape is not None
+        previous_shape: Shape | None = self.hovered_shape
+        need_update: bool = hovered_shape is not None
         if previous_shape is not None:
             previous_shape.clear_highlight()
             need_update = True
         # NOTE: Store last highlighted for adding/removing points.
-        self._lasthShape = previous_shape if hShape is None else hShape
-        self._lasthVertex = self.hVertex if hVertex is None else hVertex
-        self._lasthEdge = self.hEdge if hEdge is None else hEdge
-        self.hShape = hShape
-        self.hVertex = hVertex
-        self.hEdge = hEdge
+        self._last_hovered_shape = (
+            previous_shape if hovered_shape is None else hovered_shape
+        )
+        self._last_hovered_vertex = (
+            self.hovered_vertex if hovered_vertex is None else hovered_vertex
+        )
+        self._last_hovered_edge = (
+            self.hovered_edge if hovered_edge is None else hovered_edge
+        )
+        self.hovered_shape = hovered_shape
+        self.hovered_vertex = hovered_vertex
+        self.hovered_edge = hovered_edge
         return need_update
 
-    def selectedVertex(self) -> bool:
-        return self.hVertex is not None
+    def is_vertex_selected(self) -> bool:
+        return self.hovered_vertex is not None
 
-    def selectedEdge(self) -> bool:
-        return self.hEdge is not None
+    def is_edge_selected(self) -> bool:
+        return self.hovered_edge is not None
 
     def _update_status(self, extra_messages: list[str] | None = None) -> None:
         messages: list[str] = []
         if self.drawing():
-            messages.append(self.tr("Creating %r") % self.createMode)
+            messages.append(self.tr("Creating %r") % self.create_mode)
             messages.append(self._get_create_mode_message())
             if self.current:
                 messages.append(self.tr("ESC to cancel"))
-            if self.canCloseShape():
+            if self.can_close_shape():
                 messages.append(self.tr("Enter or Space to finalize"))
         else:
             assert self.editing()
             messages.append(self.tr("Editing shapes"))
         if extra_messages:
             messages.extend(extra_messages)
-        self.statusUpdated.emit(" • ".join(messages))
+        self.status_updated.emit(" • ".join(messages))
 
     def _get_create_mode_message(self) -> str:
         assert self.drawing()
-        isNew: bool = self.current is None
-        if self.createMode == "ai_points_to_shape":
+        is_new: bool = self.current is None
+        if self.create_mode == "ai_points_to_shape":
             return self.tr(
                 "Click points to include or Shift+Click to exclude."
                 " Ctrl+LeftClick ends creation."
             )
-        if self.createMode == "ai_box_to_shape":
-            if isNew:
+        if self.create_mode == "ai_box_to_shape":
+            if is_new:
                 return self.tr("Click first corner of bbox for AI segmentation")
             else:
                 return self.tr("Click opposite corner to segment object")
-        if self.createMode == "line":
-            if isNew:
+        if self.create_mode == "line":
+            if is_new:
                 return self.tr("Click start point for line")
             else:
                 return self.tr("Click end point for line")
-        if self.createMode == "linestrip":
-            if isNew:
+        if self.create_mode == "linestrip":
+            if is_new:
                 return self.tr("Click start point for linestrip")
             else:
                 return self.tr(
                     "Click next point or finish by Ctrl/Cmd+Click for linestrip"
                 )
-        if self.createMode == "circle":
-            if isNew:
+        if self.create_mode == "circle":
+            if is_new:
                 return self.tr("Click center point for circle")
             else:
                 return self.tr("Click point on circumference for circle")
-        if self.createMode == "rectangle":
-            if isNew:
+        if self.create_mode == "rectangle":
+            if is_new:
                 return self.tr("Click first corner for rectangle")
             else:
                 return self.tr("Click opposite corner for rectangle (Shift for square)")
@@ -357,8 +367,8 @@ class Canvas(QtWidgets.QWidget):
         except AttributeError:
             return
 
-        self.mouseMoved.emit(pos)
-        self.prevMovePoint = pos
+        self.mouse_moved.emit(pos)
+        self.prev_move_point = pos
 
         is_shift_pressed = a0.modifiers() & Qt.ShiftModifier
 
@@ -385,19 +395,19 @@ class Canvas(QtWidgets.QWidget):
 
         status_messages: list[str] = []
         self._highlight_hover_shape(pos=pos, status_messages=status_messages)
-        self.vertexSelected.emit(self.hVertex is not None)
+        self.vertex_selected.emit(self.hovered_vertex is not None)
         self._update_status(extra_messages=status_messages)
 
     def _handle_mouse_drag_scroll(self, pos: QPointF) -> None:
         self._apply_cursor(CURSOR_GRAB)
         delta: QPointF = pos - self._dragging_start_pos
-        self.scrollRequest.emit(int(delta.x()), Qt.Horizontal)
-        self.scrollRequest.emit(int(delta.y()), Qt.Vertical)
+        self.scroll_request.emit(int(delta.x()), Qt.Horizontal)
+        self.scroll_request.emit(int(delta.y()), Qt.Vertical)
 
     def _handle_mouse_move_while_drawing(
         self, pos: QPointF, is_shift_pressed: bool
     ) -> None:
-        mode = self.createMode
+        mode = self.create_mode
         if mode == "ai_points_to_shape":
             self.line.shape_type = "points"
         elif mode == "ai_box_to_shape":
@@ -412,7 +422,7 @@ class Canvas(QtWidgets.QWidget):
             self._update_status()
             return
 
-        if self.outOfPixmap(pos):
+        if self.is_out_of_pixmap(pos):
             pos = _compute_intersection_edges_image(
                 current[-1], pos, image_size=self.pixmap.size()
             )
@@ -420,7 +430,7 @@ class Canvas(QtWidgets.QWidget):
             self.snapping
             and len(current) > 1
             and mode == "polygon"
-            and self.closeEnough(pos, current[0])
+            and self.is_close_enough(pos, current[0])
         ):
             pos = current[0]
             self._apply_cursor(CURSOR_POINT)
@@ -434,7 +444,7 @@ class Canvas(QtWidgets.QWidget):
     def _update_drawing_line(self, pos: QPointF, is_shift_pressed: bool) -> QPointF:
         current = self.current
         assert current is not None
-        mode = self.createMode
+        mode = self.create_mode
         if mode in ("polygon", "linestrip"):
             self.line.points = [current[-1], pos]
             self.line.point_labels = [1, 1]
@@ -447,7 +457,7 @@ class Canvas(QtWidgets.QWidget):
         elif mode in ("rectangle", "ai_box_to_shape"):
             if is_shift_pressed:
                 pos = _snap_cursor_pos_for_square(pos=pos, opposite_vertex=current[0])
-                self.prevMovePoint = pos
+                self.prev_move_point = pos
             self.line.points = [current[0], pos]
             self.line.point_labels = [1, 1]
             self.line.close()
@@ -466,44 +476,50 @@ class Canvas(QtWidgets.QWidget):
         return pos
 
     def _handle_mouse_right_button_drag(self, pos: QPointF) -> None:
-        if self.selectedShapesCopy and self.prevPoint is not None:
+        if self.selected_shapes_copy and self.prev_point is not None:
             self._apply_cursor(CURSOR_MOVE)
-            self.boundedMoveShapes(self.selectedShapesCopy, pos)
+            self.bounded_move_shapes(self.selected_shapes_copy, pos)
             self.update()
-        elif self.selectedShapes:
-            self.selectedShapesCopy = [s.copy() for s in self.selectedShapes]
+        elif self.selected_shapes:
+            self.selected_shapes_copy = [s.copy() for s in self.selected_shapes]
             self.update()
         self._update_status()
 
     def _handle_mouse_left_button_drag(
         self, pos: QPointF, is_shift_pressed: bool
     ) -> None:
-        if self.selectedVertex():
-            assert self.hVertex is not None
-            assert self.hShape is not None
-            self.boundedMoveVertex(
-                self.hShape,
-                self.hVertex,
+        if self.is_vertex_selected():
+            assert self.hovered_vertex is not None
+            assert self.hovered_shape is not None
+            self.bounded_move_vertex(
+                self.hovered_shape,
+                self.hovered_vertex,
                 pos,
                 is_shift_pressed=is_shift_pressed,
             )
             self.update()
-            self.movingShape = True
-        elif self.selectedShapes and self.prevPoint is not None:
+            self.is_moving_shape = True
+        elif self.selected_shapes and self.prev_point is not None:
             self._apply_cursor(CURSOR_MOVE)
-            self.boundedMoveShapes(self.selectedShapes, pos)
+            self.bounded_move_shapes(self.selected_shapes, pos)
             self.update()
-            self.movingShape = True
+            self.is_moving_shape = True
 
     def _highlight_hover_shape(self, pos: QPointF, status_messages: list[str]) -> None:
-        ordered_shapes: list[Shape] = ([self.hShape] if self.hShape else []) + [
-            s for s in reversed(self.shapes) if self.isVisible(s) and s != self.hShape
+        ordered_shapes: list[Shape] = (
+            [self.hovered_shape] if self.hovered_shape else []
+        ) + [
+            s
+            for s in reversed(self.shapes)
+            if self.is_shape_visible(s) and s != self.hovered_shape
         ]
 
         for shape in ordered_shapes:
             index: int | None = shape.nearest_vertex(pos, self.epsilon)
             if index is not None:
-                self._set_highlight(hShape=shape, hEdge=None, hVertex=index)
+                self._set_highlight(
+                    hovered_shape=shape, hovered_edge=None, hovered_vertex=index
+                )
                 shape.highlight_vertex(i=index, action=shape.MOVE_VERTEX)
                 self._apply_cursor(CURSOR_POINT)
                 status_messages.append(self.tr("Click & drag to move point"))
@@ -517,7 +533,9 @@ class Canvas(QtWidgets.QWidget):
         for shape in ordered_shapes:
             index_edge: int | None = shape.nearest_edge(pos, self.epsilon)
             if index_edge is not None and shape.can_add_point():
-                self._set_highlight(hShape=shape, hEdge=index_edge, hVertex=None)
+                self._set_highlight(
+                    hovered_shape=shape, hovered_edge=index_edge, hovered_vertex=None
+                )
                 self._apply_cursor(CURSOR_POINT)
                 status_messages.append(self.tr("ALT + Click to create point on shape"))
                 self.update()
@@ -525,7 +543,9 @@ class Canvas(QtWidgets.QWidget):
 
         for shape in ordered_shapes:
             if shape.contains_point(pos):
-                self._set_highlight(hShape=shape, hEdge=None, hVertex=None)
+                self._set_highlight(
+                    hovered_shape=shape, hovered_edge=None, hovered_vertex=None
+                )
                 status_messages.extend(
                     [
                         self.tr("Click & drag to move shape"),
@@ -537,32 +557,34 @@ class Canvas(QtWidgets.QWidget):
                 return
 
         self._release_cursor()
-        if self._set_highlight(hShape=None, hEdge=None, hVertex=None):
+        if self._set_highlight(
+            hovered_shape=None, hovered_edge=None, hovered_vertex=None
+        ):
             self.update()
 
-    def addPointToEdge(self) -> None:
-        shape = self._lasthShape
-        index = self._lasthEdge
-        point = self.prevMovePoint
+    def add_point_to_edge(self) -> None:
+        shape = self._last_hovered_shape
+        index = self._last_hovered_edge
+        point = self.prev_move_point
         if shape is None or index is None or point is None:
             return
         shape.insert_point(index, point)
         shape.highlight_vertex(i=index, action=shape.MOVE_VERTEX)
-        self.hShape = shape
-        self.hVertex = index
-        self.hEdge = None
-        self.movingShape = True
+        self.hovered_shape = shape
+        self.hovered_vertex = index
+        self.hovered_edge = None
+        self.is_moving_shape = True
 
-    def removeSelectedPoint(self) -> None:
-        shape = self._lasthShape
-        index = self._lasthVertex
+    def remove_selected_point(self) -> None:
+        shape = self._last_hovered_shape
+        index = self._last_hovered_vertex
         if shape is None or index is None:
             return
         shape.remove_point(index)
         shape.clear_highlight()
-        self.hShape = shape
-        self._lasthVertex = None
-        self.movingShape = True  # Save changes
+        self.hovered_shape = shape
+        self._last_hovered_vertex = None
+        self.is_moving_shape = True  # Save changes
 
     def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
         pos: QPointF = self._transform_point_widget_to_image(a0.localPos())
@@ -601,12 +623,12 @@ class Canvas(QtWidgets.QWidget):
         if current is not None:
             self._extend_current_shape(current=current, event=event)
             return
-        if self.outOfPixmap(pos):
+        if self.is_out_of_pixmap(pos):
             return
         self._start_new_shape(pos=pos, event=event, is_shift_pressed=is_shift_pressed)
 
     def _extend_current_shape(self, current: Shape, event: QtGui.QMouseEvent) -> None:
-        mode = self.createMode
+        mode = self.create_mode
         modifiers = event.modifiers()
         if mode == "polygon":
             current.add_point(self.line[1])
@@ -638,7 +660,7 @@ class Canvas(QtWidgets.QWidget):
         event: QtGui.QMouseEvent,
         is_shift_pressed: bool,
     ) -> None:
-        mode = self.createMode
+        mode = self.create_mode
         if mode in ("ai_points_to_shape", "ai_box_to_shape") and not download_ai_model(
             model_name=self._osam_session_model_name, parent=self
         ):
@@ -665,33 +687,36 @@ class Canvas(QtWidgets.QWidget):
         self.line.point_labels = (
             [0, 0] if mode == "ai_points_to_shape" and is_shift_pressed else [1, 1]
         )
-        self.setHiding()
-        self.drawingPolygon.emit(True)
+        self.set_hide_background()
+        self.drawing_polygon.emit(True)
         self.update()
 
     def _handle_mouse_left_press_while_editing(
         self, pos: QPointF, event: QtGui.QMouseEvent
     ) -> None:
         modifiers = event.modifiers()
-        if self.selectedEdge() and modifiers == Qt.AltModifier:
-            self.addPointToEdge()
-        elif self.selectedVertex() and modifiers == (Qt.AltModifier | Qt.ShiftModifier):
-            self.removeSelectedPoint()
+        if self.is_edge_selected() and modifiers == Qt.AltModifier:
+            self.add_point_to_edge()
+        elif self.is_vertex_selected() and modifiers == (
+            Qt.AltModifier | Qt.ShiftModifier
+        ):
+            self.remove_selected_point()
 
         group_mode = int(modifiers) == Qt.ControlModifier
-        self.selectShapePoint(pos, multiple_selection_mode=group_mode)
-        self.prevPoint = pos
+        self.select_shape_point(pos, multiple_selection_mode=group_mode)
+        self.prev_point = pos
         self.update()
 
     def _handle_mouse_right_press(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         group_mode = int(event.modifiers()) == Qt.ControlModifier
         clicked_outside_selection = (
-            self.hShape is not None and self.hShape not in self.selectedShapes
+            self.hovered_shape is not None
+            and self.hovered_shape not in self.selected_shapes
         )
-        if not self.selectedShapes or clicked_outside_selection:
-            self.selectShapePoint(pos, multiple_selection_mode=group_mode)
+        if not self.selected_shapes or clicked_outside_selection:
+            self.select_shape_point(pos, multiple_selection_mode=group_mode)
             self.update()
-        self.prevPoint = pos
+        self.prev_point = pos
 
     def _handle_mouse_middle_press(self, pos: QPointF) -> None:
         self._apply_cursor(CURSOR_GRAB)
@@ -700,69 +725,73 @@ class Canvas(QtWidgets.QWidget):
 
     def mouseReleaseEvent(self, a0: QtGui.QMouseEvent) -> None:
         if a0.button() == Qt.RightButton:
-            menu = self.menus[len(self.selectedShapesCopy) > 0]
+            menu = self.menus[len(self.selected_shapes_copy) > 0]
             self._release_cursor()
-            if not menu.exec_(self.mapToGlobal(a0.pos())) and self.selectedShapesCopy:  # type: ignore
+            if not menu.exec_(self.mapToGlobal(a0.pos())) and self.selected_shapes_copy:  # type: ignore
                 # Cancel the move by deleting the shadow copy.
-                self.selectedShapesCopy = []
+                self.selected_shapes_copy = []
                 self.update()
         elif a0.button() == Qt.LeftButton:
             if self.editing():
                 if (
-                    self.hShape is not None
-                    and self.hShapeIsSelected
-                    and not self.movingShape
+                    self.hovered_shape is not None
+                    and self.hovered_shape_is_selected
+                    and not self.is_moving_shape
                 ):
-                    self.selectionChanged.emit(
-                        [x for x in self.selectedShapes if x != self.hShape]
+                    self.selection_changed.emit(
+                        [x for x in self.selected_shapes if x != self.hovered_shape]
                     )
         elif a0.button() == Qt.MiddleButton:
             self._is_dragging = False
             self._release_cursor()
 
-        if self.movingShape and self.hShape and self.hShape in self.shapes:
-            index = self.shapes.index(self.hShape)
-            if self.shapesBackups[-1][index].points != self.shapes[index].points:
-                self.storeShapes()
-                self.shapeMoved.emit()
+        if (
+            self.is_moving_shape
+            and self.hovered_shape
+            and self.hovered_shape in self.shapes
+        ):
+            index = self.shapes.index(self.hovered_shape)
+            if self.shape_backups[-1][index].points != self.shapes[index].points:
+                self.backup_shapes()
+                self.shape_moved.emit()
 
-            self.movingShape = False
+            self.is_moving_shape = False
         self._update_status()
 
-    def endMove(self, copy: bool) -> bool:
-        assert self.selectedShapes and self.selectedShapesCopy
-        assert len(self.selectedShapesCopy) == len(self.selectedShapes)
+    def end_move(self, copy: bool) -> bool:
+        assert self.selected_shapes and self.selected_shapes_copy
+        assert len(self.selected_shapes_copy) == len(self.selected_shapes)
         if copy:
-            for i, shape in enumerate(self.selectedShapesCopy):
+            for i, shape in enumerate(self.selected_shapes_copy):
                 self.shapes.append(shape)
-                self.selectedShapes[i].selected = False
-                self.selectedShapes[i] = shape
+                self.selected_shapes[i].selected = False
+                self.selected_shapes[i] = shape
         else:
-            for i, shape in enumerate(self.selectedShapesCopy):
-                self.selectedShapes[i].points = shape.points
-        self.selectedShapesCopy = []
+            for i, shape in enumerate(self.selected_shapes_copy):
+                self.selected_shapes[i].points = shape.points
+        self.selected_shapes_copy = []
         self.update()
-        self.storeShapes()
+        self.backup_shapes()
         return True
 
-    def hideBackgroundShapes(self, value: bool) -> None:
-        self.hideBackground = value
-        if not self.selectedShapes:
+    def hide_background_shapes(self, value: bool) -> None:
+        self.hide_background = value
+        if not self.selected_shapes:
             return
-        self.setHiding(True)
+        self.set_hide_background(True)
         self.update()
 
-    def setHiding(self, enable: bool = True) -> None:
-        self._hideBackground = self.hideBackground if enable else False
+    def set_hide_background(self, enable: bool = True) -> None:
+        self._hide_background = self.hide_background if enable else False
 
-    def canCloseShape(self) -> bool:
+    def can_close_shape(self) -> bool:
         if not self.drawing():
             return False
         if not self.current:
             return False
-        if self.createMode == "ai_points_to_shape":
+        if self.create_mode == "ai_points_to_shape":
             return True
-        if self.createMode == "linestrip":
+        if self.create_mode == "linestrip":
             return len(self.current) >= 2
         return len(self.current) >= 3
 
@@ -770,43 +799,45 @@ class Canvas(QtWidgets.QWidget):
         if self.double_click != "close":
             return
 
-        if self.canCloseShape():
+        if self.can_close_shape():
             self.finalise()
 
-    def selectShapes(self, shapes: list[Shape]) -> None:
-        self.setHiding()
-        self.selectionChanged.emit(shapes)
+    def select_shapes(self, shapes: list[Shape]) -> None:
+        self.set_hide_background()
+        self.selection_changed.emit(shapes)
         self.update()
 
-    def selectShapePoint(self, point: QPointF, multiple_selection_mode: bool) -> None:
+    def select_shape_point(self, point: QPointF, multiple_selection_mode: bool) -> None:
         """Select the first shape created which contains this point."""
-        if self.hVertex is not None:
-            assert self.hShape is not None
-            self.hShape.highlight_vertex(i=self.hVertex, action=self.hShape.MOVE_VERTEX)
+        if self.hovered_vertex is not None:
+            assert self.hovered_shape is not None
+            self.hovered_shape.highlight_vertex(
+                i=self.hovered_vertex, action=self.hovered_shape.MOVE_VERTEX
+            )
         else:
             shape: Shape
             for shape in reversed(self.shapes):
-                if self.isVisible(shape) and shape.contains_point(point):
-                    self.setHiding()
-                    if shape not in self.selectedShapes:
+                if self.is_shape_visible(shape) and shape.contains_point(point):
+                    self.set_hide_background()
+                    if shape not in self.selected_shapes:
                         if multiple_selection_mode:
-                            self.selectionChanged.emit(self.selectedShapes + [shape])
+                            self.selection_changed.emit(self.selected_shapes + [shape])
                         else:
-                            self.selectionChanged.emit([shape])
-                        self.hShapeIsSelected = False
+                            self.selection_changed.emit([shape])
+                        self.hovered_shape_is_selected = False
                     else:
-                        self.hShapeIsSelected = True
-                    self.calculateOffsets(point)
+                        self.hovered_shape_is_selected = True
+                    self.calculate_offsets(point)
                     return
-        if self.deSelectShape():
+        if self.deselect_shape():
             self.update()
 
-    def calculateOffsets(self, point: QPointF) -> None:
-        if not self.selectedShapes:
+    def calculate_offsets(self, point: QPointF) -> None:
+        if not self.selected_shapes:
             self.offsets = QPointF(0.0, 0.0), QPointF(0.0, 0.0)
             return
 
-        rects = [s.bounding_rect() for s in self.selectedShapes]
+        rects = [s.bounding_rect() for s in self.selected_shapes]
         left = min(r.left() for r in rects)
         top = min(r.top() for r in rects)
         right = max(r.right() for r in rects)
@@ -817,7 +848,7 @@ class Canvas(QtWidgets.QWidget):
             QPointF(right - point.x(), bottom - point.y()),
         )
 
-    def boundedMoveVertex(
+    def bounded_move_vertex(
         self, shape: Shape, vertex_index: int, pos: QPointF, is_shift_pressed: bool
     ) -> None:
         if vertex_index >= len(shape.points):
@@ -828,7 +859,7 @@ class Canvas(QtWidgets.QWidget):
             )
             return
 
-        if self.outOfPixmap(pos):
+        if self.is_out_of_pixmap(pos):
             pos = _compute_intersection_edges_image(
                 shape[vertex_index], pos, image_size=self.pixmap.size()
             )
@@ -840,56 +871,56 @@ class Canvas(QtWidgets.QWidget):
 
         shape.move_vertex(i=vertex_index, pos=pos)
 
-    def boundedMoveShapes(self, shapes: list[Shape], pos: QPointF) -> bool:
-        if self.outOfPixmap(pos):
+    def bounded_move_shapes(self, shapes: list[Shape], pos: QPointF) -> bool:
+        if self.is_out_of_pixmap(pos):
             return False
 
         tl = pos + self.offsets[0]
-        if self.outOfPixmap(tl):
+        if self.is_out_of_pixmap(tl):
             pos -= QPointF(min(0, tl.x()), min(0, tl.y()))
 
         br = pos + self.offsets[1]
-        if self.outOfPixmap(br):
+        if self.is_out_of_pixmap(br):
             pos += QPointF(
                 min(0, self.pixmap.width() - br.x()),
                 min(0, self.pixmap.height() - br.y()),
             )
 
-        dp = pos - self.prevPoint
+        dp = pos - self.prev_point
         if dp.isNull():
             return False
 
         for shape in shapes:
             shape.move_by(dp)
-        self.prevPoint = pos
+        self.prev_point = pos
         return True
 
-    def deSelectShape(self) -> bool:
+    def deselect_shape(self) -> bool:
         need_update: bool = False
-        if self.selectedShapes:
-            self.setHiding(False)
-            self.selectionChanged.emit([])
-            self.hShapeIsSelected = False
+        if self.selected_shapes:
+            self.set_hide_background(False)
+            self.selection_changed.emit([])
+            self.hovered_shape_is_selected = False
             need_update = True
         return need_update
 
-    def deleteSelected(self) -> list[Shape]:
+    def delete_selected(self) -> list[Shape]:
         deleted_shapes = []
-        if self.selectedShapes:
-            for shape in self.selectedShapes:
+        if self.selected_shapes:
+            for shape in self.selected_shapes:
                 self.shapes.remove(shape)
                 deleted_shapes.append(shape)
-            self.storeShapes()
-            self.selectedShapes = []
+            self.backup_shapes()
+            self.selected_shapes = []
             self.update()
         return deleted_shapes
 
-    def deleteShape(self, shape: Shape) -> None:
-        if shape in self.selectedShapes:
-            self.selectedShapes.remove(shape)
+    def delete_shape(self, shape: Shape) -> None:
+        if shape in self.selected_shapes:
+            self.selected_shapes.remove(shape)
         if shape in self.shapes:
             self.shapes.remove(shape)
-        self.storeShapes()
+        self.backup_shapes()
         self.update()
 
     def paintEvent(self, a0: QtGui.QPaintEvent) -> None:
@@ -922,13 +953,13 @@ class Canvas(QtWidgets.QWidget):
         painter.restore()
 
     def _paint_crosshair(self, painter: QtGui.QPainter) -> None:
-        if not self._crosshair[self._createMode]:
+        if not self._crosshair[self._create_mode]:
             return
         if not self.drawing():
             return
 
-        cursor: QPointF | None = self.prevMovePoint
-        if cursor is None or self.outOfPixmap(cursor):
+        cursor: QPointF | None = self.prev_move_point
+        if cursor is None or self.is_out_of_pixmap(cursor):
             return
 
         painter.setPen(QtGui.QColor(0, 0, 0))
@@ -948,29 +979,29 @@ class Canvas(QtWidgets.QWidget):
     def _paint_shapes(self, painter: QtGui.QPainter) -> None:
         Shape.scale = self.scale
         for shape in self.shapes:
-            if not self.isVisible(shape):
+            if not self.is_shape_visible(shape):
                 continue
-            if not shape.selected and self._hideBackground:
+            if not shape.selected and self._hide_background:
                 continue
-            shape.fill = shape.selected or shape is self.hShape
+            shape.fill = shape.selected or shape is self.hovered_shape
             shape.paint(painter)
         if self.current is not None:
             self.current.paint(painter)
             assert len(self.line.points) == len(self.line.point_labels)
             self.line.paint(painter)
-        for copy_shape in self.selectedShapesCopy:
+        for copy_shape in self.selected_shapes_copy:
             copy_shape.paint(painter)
 
     def _paint_current_shape_preview(self, painter: QtGui.QPainter) -> None:
-        if self.current is None or self.createMode not in (
+        if self.current is None or self.create_mode not in (
             "polygon",
             "ai_points_to_shape",
         ):
             return
 
         preview: Shape = self.current.copy()
-        if self.createMode == "polygon":
-            if self.fillDrawing() and len(preview.points) >= 2:
+        if self.create_mode == "polygon":
+            if self.fill_drawing() and len(preview.points) >= 2:
                 assert preview.fill_color is not None
                 if preview.fill_color.getRgb()[3] == 0:
                     logger.warning(
@@ -980,7 +1011,7 @@ class Canvas(QtWidgets.QWidget):
                     preview.fill_color.setAlpha(64)
                 preview.add_point(point=self.line[1])
         else:
-            assert self.createMode == "ai_points_to_shape"
+            assert self.create_mode == "ai_points_to_shape"
             preview.add_point(
                 point=self.line.points[1],
                 label=self.line.point_labels[1],
@@ -991,14 +1022,14 @@ class Canvas(QtWidgets.QWidget):
             )
             if ai_shapes:
                 preview = ai_shapes[0]
-        preview.fill = self.fillDrawing()
-        preview.selected = self.fillDrawing()
+        preview.fill = self.fill_drawing()
+        preview.selected = self.fill_drawing()
         preview.paint(painter)
 
     def _transform_point_widget_to_image(self, point: QPointF) -> QPointF:
         return point / self.scale - self._compute_image_origin_offset()
 
-    def enableDragging(self, enabled: bool) -> None:
+    def enable_dragging(self, enabled: bool) -> None:
         self._is_dragging_enabled = enabled
 
     def _compute_image_origin_offset(self) -> QPointF:
@@ -1009,7 +1040,7 @@ class Canvas(QtWidgets.QWidget):
         slack_h = max(area.height() - scaled_h, 0.0)
         return QPointF(slack_w, slack_h) / (2.0 * self.scale)
 
-    def outOfPixmap(self, p: QPointF) -> bool:
+    def is_out_of_pixmap(self, p: QPointF) -> bool:
         w = self.pixmap.width()
         h = self.pixmap.height()
         return not (0 <= p.x() <= w and 0 <= p.y() <= h)
@@ -1021,33 +1052,33 @@ class Canvas(QtWidgets.QWidget):
             self.current = None
             return
         self.shapes.extend(new_shapes)
-        self.storeShapes()
+        self.backup_shapes()
         self._reset_after_shape_creation()
 
     def _build_new_shapes_from_current(self) -> list[Shape]:
         assert self.current is not None
-        if self.createMode == "ai_points_to_shape":
+        if self.create_mode == "ai_points_to_shape":
             return self._shapes_from_points_ai(
                 points=self.current.points,
                 point_labels=self.current.point_labels,
             )
-        if self.createMode == "ai_box_to_shape":
+        if self.create_mode == "ai_box_to_shape":
             return self._shapes_from_bbox_ai(bbox_points=self.current.points)
         self.current.close()
         return [self.current]
 
     def _reset_after_shape_creation(self) -> None:
         self.current = None
-        self.setHiding(False)
-        self.newShape.emit()
+        self.set_hide_background(False)
+        self.new_shape.emit()
         self.update()
 
     def _cancel_current_shape(self) -> None:
         self.current = None
-        self.drawingPolygon.emit(False)
+        self.drawing_polygon.emit(False)
         self.update()
 
-    def closeEnough(self, p1: QPointF, p2: QPointF) -> bool:
+    def is_close_enough(self, p1: QPointF, p2: QPointF) -> bool:
         # d = distance(p1 - p2)
         # m = (p1-p2).manhattanLength()
         # print "d %.2f, m %d, %.2f" % (d, m, d - m)
@@ -1076,18 +1107,18 @@ class Canvas(QtWidgets.QWidget):
         if Qt.ControlModifier == int(mods):
             # with Ctrl/Command key
             # zoom
-            self.zoomRequest.emit(delta.y(), a0.posF())
+            self.zoom_request.emit(delta.y(), a0.posF())
         else:
             # scroll
-            self.scrollRequest.emit(delta.x(), Qt.Horizontal)
-            self.scrollRequest.emit(delta.y(), Qt.Vertical)
+            self.scroll_request.emit(delta.x(), Qt.Horizontal)
+            self.scroll_request.emit(delta.y(), Qt.Vertical)
         a0.accept()
 
-    def moveByKeyboard(self, offset: QPointF) -> None:
-        if self.selectedShapes:
-            self.boundedMoveShapes(self.selectedShapes, self.prevPoint + offset)
+    def move_by_keyboard(self, offset: QPointF) -> None:
+        if self.selected_shapes:
+            self.bounded_move_shapes(self.selected_shapes, self.prev_point + offset)
             self.update()
-            self.movingShape = True
+            self.is_moving_shape = True
 
     def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:
         modifiers = a0.modifiers()
@@ -1097,22 +1128,22 @@ class Canvas(QtWidgets.QWidget):
                 self._cancel_current_shape()
             elif (
                 key in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Space)
-                and self.canCloseShape()
+                and self.can_close_shape()
             ):
                 self.finalise()
             elif modifiers == Qt.AltModifier:
                 self.snapping = False
         elif self.editing():
             if key == Qt.Key_Up:
-                self.moveByKeyboard(QPointF(0.0, -MOVE_SPEED))
+                self.move_by_keyboard(QPointF(0.0, -MOVE_SPEED))
             elif key == Qt.Key_Down:
-                self.moveByKeyboard(QPointF(0.0, MOVE_SPEED))
+                self.move_by_keyboard(QPointF(0.0, MOVE_SPEED))
             elif key == Qt.Key_Left:
-                self.moveByKeyboard(QPointF(-MOVE_SPEED, 0.0))
+                self.move_by_keyboard(QPointF(-MOVE_SPEED, 0.0))
             elif key == Qt.Key_Right:
-                self.moveByKeyboard(QPointF(MOVE_SPEED, 0.0))
+                self.move_by_keyboard(QPointF(MOVE_SPEED, 0.0))
             elif a0.matches(QtGui.QKeySequence.SelectAll):
-                self.selectShapes(shapes=self.shapes[:])
+                self.select_shapes(shapes=self.shapes[:])
         self._update_status()
 
     def keyReleaseEvent(self, a0: QtGui.QKeyEvent) -> None:
@@ -1122,18 +1153,18 @@ class Canvas(QtWidgets.QWidget):
                 self.snapping = True
         elif self.editing():
             if (
-                self.movingShape
-                and self.selectedShapes
-                and self.selectedShapes[0] in self.shapes
+                self.is_moving_shape
+                and self.selected_shapes
+                and self.selected_shapes[0] in self.shapes
             ):
-                index = self.shapes.index(self.selectedShapes[0])
-                if self.shapesBackups[-1][index].points != self.shapes[index].points:
-                    self.storeShapes()
-                    self.shapeMoved.emit()
+                index = self.shapes.index(self.selected_shapes[0])
+                if self.shape_backups[-1][index].points != self.shapes[index].points:
+                    self.backup_shapes()
+                    self.shape_moved.emit()
 
-                self.movingShape = False
+                self.is_moving_shape = False
 
-    def setLastLabel(self, text: str, flags: dict[str, bool]) -> list[Shape]:
+    def set_last_label(self, text: str, flags: dict[str, bool]) -> list[Shape]:
         assert text
         shapes = []
         for shape in reversed(self.shapes):
@@ -1144,13 +1175,13 @@ class Canvas(QtWidgets.QWidget):
         for shape in shapes:
             shape.label = text
             shape.flags = flags
-        self.shapesBackups.pop()
-        self.storeShapes()
+        self.shape_backups.pop()
+        self.backup_shapes()
         return shapes
 
-    def undoLastLine(self) -> None:
+    def undo_last_line(self) -> None:
         assert self.shapes
-        if self.createMode in ("ai_points_to_shape", "ai_box_to_shape"):
+        if self.create_mode in ("ai_points_to_shape", "ai_box_to_shape"):
             # Remove all unlabeled shapes at the tail (added by AI in one shot)
             while self.shapes and self.shapes[-1].label is None:
                 self.shapes.pop()
@@ -1159,15 +1190,15 @@ class Canvas(QtWidgets.QWidget):
         self.current = self.shapes.pop()
         self.current.open()
         self.current.unrefine()
-        if self.createMode in ("polygon", "linestrip"):
+        if self.create_mode in ("polygon", "linestrip"):
             self.line.points = [self.current[-1], self.current[0]]
-        elif self.createMode in ("rectangle", "line", "circle", "ai_box_to_shape"):
+        elif self.create_mode in ("rectangle", "line", "circle", "ai_box_to_shape"):
             self.current.points = self.current.points[0:1]
-        elif self.createMode == "point":
+        elif self.create_mode == "point":
             self.current = None
-        self.drawingPolygon.emit(True)
+        self.drawing_polygon.emit(True)
 
-    def undoLastPoint(self) -> None:
+    def undo_last_point(self) -> None:
         current = self.current
         if current is None or current.is_closed():
             return
@@ -1178,7 +1209,7 @@ class Canvas(QtWidgets.QWidget):
         else:
             self._cancel_current_shape()
 
-    def loadPixmap(self, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
+    def load_pixmap(self, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
         self.pixmap = pixmap
         self._pixmap_hash = hash(
             labelme.utils.img_qt_to_arr(img_qt=self.pixmap.toImage()).tobytes()
@@ -1187,19 +1218,19 @@ class Canvas(QtWidgets.QWidget):
             self.shapes = []
         self.update()
 
-    def loadShapes(self, shapes: list[Shape], replace: bool = True) -> None:
+    def load_shapes(self, shapes: list[Shape], replace: bool = True) -> None:
         if replace:
             self.shapes = list(shapes)
         else:
             self.shapes.extend(shapes)
-        self.storeShapes()
+        self.backup_shapes()
         self.current = None
-        self.hShape = None
-        self.hVertex = None
-        self.hEdge = None
+        self.hovered_shape = None
+        self.hovered_vertex = None
+        self.hovered_edge = None
         self.update()
 
-    def setShapeVisible(self, shape: Shape, value: bool) -> None:
+    def set_shape_visible(self, shape: Shape, value: bool) -> None:
         self.visible[shape] = value
         self.update()
 
@@ -1219,22 +1250,22 @@ class Canvas(QtWidgets.QWidget):
         self._cursor = CURSOR_DEFAULT
         QtWidgets.QApplication.restoreOverrideCursor()
 
-    def resetState(self) -> None:
+    def reset_state(self) -> None:
         self._release_cursor()
         self.pixmap = QtGui.QPixmap()
         self._pixmap_hash = None
         self.shapes = []
-        self.shapesBackups = collections.deque(maxlen=self.num_backups)
-        self.movingShape = False
-        self.selectedShapes = []
-        self.selectedShapesCopy = []
+        self.shape_backups = collections.deque(maxlen=self.num_backups)
+        self.is_moving_shape = False
+        self.selected_shapes = []
+        self.selected_shapes_copy = []
         self.current = None
-        self.hShape = None
-        self._lasthShape = None
-        self.hVertex = None
-        self._lasthVertex = None
-        self.hEdge = None
-        self._lasthEdge = None
+        self.hovered_shape = None
+        self._last_hovered_shape = None
+        self.hovered_vertex = None
+        self._last_hovered_vertex = None
+        self.hovered_edge = None
+        self._last_hovered_edge = None
         self.update()
 
 

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -80,7 +80,7 @@ class LabelListWidgetItem(QtGui.QStandardItem):
     def __init__(self, text: str | None = None, shape: Shape | None = None) -> None:
         super().__init__()
         self.setText(text or "")
-        self.setShape(shape)
+        self.set_shape(shape)
 
         self.setCheckable(True)
         self.setCheckState(Qt.Checked)
@@ -90,7 +90,7 @@ class LabelListWidgetItem(QtGui.QStandardItem):
     def clone(self) -> LabelListWidgetItem:
         return LabelListWidgetItem(self.text(), self.shape())
 
-    def setShape(self, shape: Shape | None) -> None:
+    def set_shape(self, shape: Shape | None) -> None:
         self.setData(shape, Qt.UserRole)
 
     def shape(self) -> Shape | None:
@@ -104,7 +104,7 @@ class LabelListWidgetItem(QtGui.QStandardItem):
 
 
 class _ItemModel(QtGui.QStandardItemModel):
-    itemDropped = QtCore.pyqtSignal()
+    item_dropped = QtCore.pyqtSignal()
 
     def removeRows(
         self,
@@ -113,7 +113,7 @@ class _ItemModel(QtGui.QStandardItemModel):
         parent: QtCore.QModelIndex = QtCore.QModelIndex(),
     ) -> bool:
         ret = super().removeRows(row, count, parent)
-        self.itemDropped.emit()
+        self.item_dropped.emit()
         return ret
 
     def dropMimeData(
@@ -141,12 +141,11 @@ class _ItemModel(QtGui.QStandardItemModel):
 
 
 class LabelListWidget(QtWidgets.QListView):
-    itemDoubleClicked = QtCore.pyqtSignal(LabelListWidgetItem)
-    itemSelectionChanged = QtCore.pyqtSignal(list, list)
+    item_double_clicked = QtCore.pyqtSignal(LabelListWidgetItem)
+    item_selection_changed = QtCore.pyqtSignal(list, list)
 
     def __init__(self) -> None:
         super().__init__()
-        self._selectedItems: list[LabelListWidgetItem] = []
 
         self.setWindowFlags(Qt.Window)
 
@@ -159,8 +158,8 @@ class LabelListWidget(QtWidgets.QListView):
         self.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
         self.setDefaultDropAction(Qt.MoveAction)
 
-        self.doubleClicked.connect(self.itemDoubleClickedEvent)
-        self.selectionModel().selectionChanged.connect(self.itemSelectionChangedEvent)
+        self.doubleClicked.connect(self._on_item_double_clicked)
+        self.selectionModel().selectionChanged.connect(self._on_item_selection_changed)
 
     def __len__(self) -> int:
         return self._model.rowCount()
@@ -173,49 +172,49 @@ class LabelListWidget(QtWidgets.QListView):
             yield self[i]
 
     @property
-    def itemDropped(self) -> QtCore.pyqtBoundSignal:
-        return self._model.itemDropped
+    def item_dropped(self) -> QtCore.pyqtBoundSignal:
+        return self._model.item_dropped
 
     @property
-    def itemChanged(self) -> QtCore.pyqtBoundSignal:
+    def item_changed(self) -> QtCore.pyqtBoundSignal:
         return self._model.itemChanged
 
-    def itemSelectionChangedEvent(
+    def _on_item_selection_changed(
         self,
         selected: QtCore.QItemSelection,
         deselected: QtCore.QItemSelection,
     ) -> None:
         selected_items = [self._model.itemFromIndex(i) for i in selected.indexes()]
         deselected_items = [self._model.itemFromIndex(i) for i in deselected.indexes()]
-        self.itemSelectionChanged.emit(selected_items, deselected_items)
+        self.item_selection_changed.emit(selected_items, deselected_items)
 
-    def itemDoubleClickedEvent(self, index: QtCore.QModelIndex) -> None:
-        self.itemDoubleClicked.emit(self._model.itemFromIndex(index))
+    def _on_item_double_clicked(self, index: QtCore.QModelIndex) -> None:
+        self.item_double_clicked.emit(self._model.itemFromIndex(index))
 
-    def selectedItems(self) -> list[LabelListWidgetItem]:
+    def selected_items(self) -> list[LabelListWidgetItem]:
         return [
             cast(LabelListWidgetItem, self._model.itemFromIndex(i))
             for i in self.selectedIndexes()
         ]
 
-    def scrollToItem(self, item: LabelListWidgetItem) -> None:
+    def scroll_to_item(self, item: LabelListWidgetItem) -> None:
         self.scrollTo(self._model.indexFromItem(item))
 
-    def addItem(self, item: LabelListWidgetItem) -> None:
+    def add_item(self, item: LabelListWidgetItem) -> None:
         if not isinstance(item, LabelListWidgetItem):
             raise TypeError("item must be LabelListWidgetItem")
         self._model.setItem(self._model.rowCount(), 0, item)
         item.setSizeHint(self.itemDelegate().sizeHint(None, None))  # ty: ignore[invalid-argument-type]
 
-    def removeItem(self, item: LabelListWidgetItem) -> None:
+    def remove_item(self, item: LabelListWidgetItem) -> None:
         index = self._model.indexFromItem(item)
         self._model.removeRows(index.row(), 1)
 
-    def selectItem(self, item: LabelListWidgetItem) -> None:
+    def select_item(self, item: LabelListWidgetItem) -> None:
         index = self._model.indexFromItem(item)
         self.selectionModel().select(index, QtCore.QItemSelectionModel.Select)
 
-    def findItemByShape(self, shape: Shape) -> LabelListWidgetItem:
+    def find_item_by_shape(self, shape: Shape) -> LabelListWidgetItem:
         for row in range(self._model.rowCount()):
             item = self._model.item(row, 0)
             item = cast(LabelListWidgetItem, item)

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -91,7 +91,7 @@ def _run_text_prompt(
     create_mode: str,
     score_threshold: float = 0.1,
 ) -> None:
-    win._switch_canvas_mode(edit=False, createMode=create_mode)
+    win._switch_canvas_mode(edit=False, create_mode=create_mode)
     qtbot.wait(50)
 
     win._ai_text._text_input.setText(text)

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -153,7 +153,7 @@ def test_annotate_shape_types(
             int(canvas_size.height() * xy[1]),
         )
 
-    win._switch_canvas_mode(edit=False, createMode=create_mode)
+    win._switch_canvas_mode(edit=False, create_mode=create_mode)
     qtbot.wait(50)
 
     def click(
@@ -214,7 +214,7 @@ def test_ai_model_download(
     canvas.set_ai_model_name(_AI_MODEL)
     canvas.set_ai_output_format("polygon")
 
-    win._switch_canvas_mode(edit=False, createMode="ai_box_to_shape")
+    win._switch_canvas_mode(edit=False, create_mode="ai_box_to_shape")
     qtbot.wait(50)
 
     # Redirect osam blob storage to a temp directory so it thinks the model is not

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -47,14 +47,14 @@ def test_auto_save_on_shape_move(
 
     canvas = _auto_save_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
-    original_center = QPointF(canvas.selectedShapes[0].bounding_rect().center())
+    original_center = QPointF(canvas.selected_shapes[0].bounding_rect().center())
 
     qtbot.keyPress(canvas, Qt.Key_Right)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, Qt.Key_Right)
     qtbot.wait(50)
 
-    new_center = canvas.selectedShapes[0].bounding_rect().center()
+    new_center = canvas.selected_shapes[0].bounding_rect().center()
     assert abs((new_center.x() - original_center.x()) - 5.0) < 1.0
 
     assert label_file.exists()

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -47,14 +47,14 @@ def test_auto_save_on_shape_move(
 
     canvas = _auto_save_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
-    original_center = QPointF(canvas.selectedShapes[0].boundingRect().center())
+    original_center = QPointF(canvas.selectedShapes[0].bounding_rect().center())
 
     qtbot.keyPress(canvas, Qt.Key_Right)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, Qt.Key_Right)
     qtbot.wait(50)
 
-    new_center = canvas.selectedShapes[0].boundingRect().center()
+    new_center = canvas.selectedShapes[0].bounding_rect().center()
     assert abs((new_center.x() - original_center.x()) - 5.0) < 1.0
 
     assert label_file.exists()

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -184,7 +184,7 @@ def test_move_shape_by_drag(
     shape = canvas.shapes[_SHAPE_INDEX]
     original_points = [QPointF(p) for p in shape.points]
 
-    center = shape.boundingRect().center()
+    center = shape.bounding_rect().center()
     offset = QPointF(15, 10)
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     _hover_and_drag(
@@ -249,14 +249,14 @@ def test_move_shape_by_arrow_key(
     canvas = _annotated_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     shape = canvas.selectedShapes[0]
-    original_center = QPointF(shape.boundingRect().center())
+    original_center = QPointF(shape.bounding_rect().center())
 
     qtbot.keyPress(canvas, key)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, key)
     qtbot.wait(50)
 
-    new_center = shape.boundingRect().center()
+    new_center = shape.bounding_rect().center()
     assert abs((new_center.x() - original_center.x()) - expected_dx) < 1.0
     assert abs((new_center.y() - original_center.y()) - expected_dy) < 1.0
 
@@ -514,7 +514,7 @@ def test_select_nonpolygon_shape(
     _raw_win._switch_canvas_mode(edit=True)
     qtbot.wait(50)
 
-    click_pos = shape.boundingRect().center() + QPointF(*select_offset)
+    click_pos = shape.bounding_rect().center() + QPointF(*select_offset)
     click_widget = image_to_widget_pos(canvas=canvas, image_pos=click_pos)
     qtbot.mouseMove(canvas, pos=click_widget)
     qtbot.wait(50)

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -278,7 +278,7 @@ def test_select_all_shapes_from_canvas(
     qtbot.wait(50)
 
     assert set(map(id, canvas.selectedShapes)) == set(map(id, canvas.shapes))
-    assert len(_annotated_win._docks.label_list.selectedItems()) == len(canvas.shapes)
+    assert len(_annotated_win._docks.label_list.selected_items()) == len(canvas.shapes)
 
     close_or_pause(qtbot=qtbot, widget=_annotated_win, pause=pause)
 

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -248,7 +248,7 @@ def test_move_shape_by_arrow_key(
 ) -> None:
     canvas = _annotated_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
-    shape = canvas.selectedShapes[0]
+    shape = canvas.selected_shapes[0]
     original_center = QPointF(shape.bounding_rect().center())
 
     qtbot.keyPress(canvas, key)
@@ -272,12 +272,12 @@ def test_select_all_shapes_from_canvas(
     canvas = _annotated_win._canvas_widgets.canvas
     assert len(canvas.shapes) > 1
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
-    assert len(canvas.selectedShapes) == 1
+    assert len(canvas.selected_shapes) == 1
 
     qtbot.keyClick(canvas, Qt.Key_A, modifier=Qt.ControlModifier)
     qtbot.wait(50)
 
-    assert set(map(id, canvas.selectedShapes)) == set(map(id, canvas.shapes))
+    assert set(map(id, canvas.selected_shapes)) == set(map(id, canvas.shapes))
     assert len(_annotated_win._docks.label_list.selected_items()) == len(canvas.shapes)
 
     close_or_pause(qtbot=qtbot, widget=_annotated_win, pause=pause)
@@ -291,7 +291,7 @@ def test_add_point_on_edge(
     pause: bool,
 ) -> None:
     canvas = _annotated_win._canvas_widgets.canvas
-    _annotated_win._switch_canvas_mode(edit=False, createMode="polygon")
+    _annotated_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     # Large polygon so edge midpoints are far from vertices at any canvas scale
@@ -354,7 +354,7 @@ def test_cancel_drawing_with_escape(
     pause: bool,
 ) -> None:
     canvas = _annotated_win._canvas_widgets.canvas
-    _annotated_win._switch_canvas_mode(edit=False, createMode="polygon")
+    _annotated_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3)]:
@@ -378,7 +378,7 @@ def test_undo_last_point_while_drawing(
 ) -> None:
     canvas = _annotated_win._canvas_widgets.canvas
     num_shapes_before = len(canvas.shapes)
-    _annotated_win._switch_canvas_mode(edit=False, createMode="polygon")
+    _annotated_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
@@ -387,7 +387,7 @@ def test_undo_last_point_while_drawing(
     assert canvas.current is not None
     assert len(canvas.current.points) == 3
 
-    canvas.undoLastPoint()
+    canvas.undo_last_point()
     qtbot.wait(50)
 
     assert canvas.current is not None
@@ -424,7 +424,7 @@ def test_finalize_polygon_with_enter(
 ) -> None:
     canvas = _annotated_win._canvas_widgets.canvas
     num_shapes_before = len(canvas.shapes)
-    _annotated_win._switch_canvas_mode(edit=False, createMode="polygon")
+    _annotated_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
@@ -454,7 +454,7 @@ def test_undo_shape_creation(
 ) -> None:
     canvas = _annotated_win._canvas_widgets.canvas
     num_shapes_before = len(canvas.shapes)
-    _annotated_win._switch_canvas_mode(edit=False, createMode="polygon")
+    _annotated_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
@@ -499,7 +499,7 @@ def test_select_nonpolygon_shape(
     select_offset: tuple[float, float],
 ) -> None:
     canvas = _raw_win._canvas_widgets.canvas
-    _raw_win._switch_canvas_mode(edit=False, createMode=create_mode)
+    _raw_win._switch_canvas_mode(edit=False, create_mode=create_mode)
     qtbot.wait(50)
 
     _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=setup_click)
@@ -521,7 +521,7 @@ def test_select_nonpolygon_shape(
     qtbot.mouseClick(canvas, Qt.LeftButton, pos=click_widget)
     qtbot.wait(50)
 
-    assert shape in canvas.selectedShapes
+    assert shape in canvas.selected_shapes
 
     _save_and_check(win=_raw_win, tmp_path=tmp_path)
     close_or_pause(qtbot=qtbot, widget=_raw_win, pause=pause)
@@ -535,7 +535,7 @@ def test_cancel_label_reopens_shape(
 ) -> None:
     canvas = _raw_win._canvas_widgets.canvas
     num_shapes_before = len(canvas.shapes)
-    _raw_win._switch_canvas_mode(edit=False, createMode="polygon")
+    _raw_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
@@ -595,7 +595,7 @@ def test_remove_point_blocked_at_minimum(
     expected_points: int,
 ) -> None:
     canvas = _raw_win._canvas_widgets.canvas
-    _raw_win._switch_canvas_mode(edit=False, createMode=create_mode)
+    _raw_win._switch_canvas_mode(edit=False, create_mode=create_mode)
     qtbot.wait(50)
 
     for xy in setup_clicks:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -135,7 +135,7 @@ def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
     qtbot.wait(50)
     qtbot.mouseClick(canvas, Qt.LeftButton, pos=pos)
     qtbot.wait(50)
-    assert len(canvas.selectedShapes) == 1
+    assert len(canvas.selected_shapes) == 1
 
 
 def show_window_and_wait_for_imagedata(qtbot: QtBot, win: MainWindow) -> None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -129,7 +129,7 @@ def main_win(
 
 
 def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
-    shape_center = canvas.shapes[shape_index].boundingRect().center()
+    shape_center = canvas.shapes[shape_index].bounding_rect().center()
     pos = image_to_widget_pos(canvas=canvas, image_pos=shape_center)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -63,7 +63,7 @@ def test_select_shape(
         main_win=main_win, qtbot=qtbot, data_path=data_path
     )
 
-    assert canvas.selectedShapes[0].label == "person"
+    assert canvas.selected_shapes[0].label == "person"
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 
@@ -84,7 +84,7 @@ def test_copy_paste_shape(
         output_dir=str(tmp_path),
     )
 
-    original_label = canvas.selectedShapes[0].label
+    original_label = canvas.selected_shapes[0].label
     num_shapes_before = len(canvas.shapes)
 
     win.copySelectedShape()

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -37,7 +37,7 @@ def test_toggle_all_shapes(
 
     assert len(canvas.shapes) == 5
     for shape in canvas.shapes:
-        assert canvas.isVisible(shape)
+        assert canvas.is_shape_visible(shape)
 
     _win.toggleShapes(False)
     qtbot.wait(50)
@@ -45,7 +45,7 @@ def test_toggle_all_shapes(
     for item in label_list:
         assert item.checkState() == Qt.Unchecked
     for shape in canvas.shapes:
-        assert not canvas.isVisible(shape)
+        assert not canvas.is_shape_visible(shape)
 
     _win.toggleShapes(True)
     qtbot.wait(50)
@@ -53,7 +53,7 @@ def test_toggle_all_shapes(
     for item in label_list:
         assert item.checkState() == Qt.Checked
     for shape in canvas.shapes:
-        assert canvas.isVisible(shape)
+        assert canvas.is_shape_visible(shape)
 
     close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
 
@@ -72,14 +72,14 @@ def test_toggle_individual_shape(
     first_item = label_list[0]
     first_shape = first_item.shape()
     assert first_shape is not None
-    assert canvas.isVisible(first_shape)
+    assert canvas.is_shape_visible(first_shape)
 
     first_item.setCheckState(Qt.Unchecked)
     qtbot.wait(50)
-    assert not canvas.isVisible(first_shape)
+    assert not canvas.is_shape_visible(first_shape)
 
     first_item.setCheckState(Qt.Checked)
     qtbot.wait(50)
-    assert canvas.isVisible(first_shape)
+    assert canvas.is_shape_visible(first_shape)
 
     close_or_pause(qtbot=qtbot, widget=_win, pause=pause)

--- a/tests/unit/shape_contains_point_test.py
+++ b/tests/unit/shape_contains_point_test.py
@@ -8,38 +8,38 @@ from labelme.shape import Shape
 def _make_point_shape(x: float, y: float) -> Shape:
     """Create a point shape with a single point at (x, y)."""
     shape = Shape(shape_type="point")
-    shape.addPoint(QtCore.QPointF(x, y))
+    shape.add_point(QtCore.QPointF(x, y))
     return shape
 
 
 def test_point_shape_contains_center() -> None:
     """Clicking exactly on a point shape should return True."""
     shape = _make_point_shape(100.0, 200.0)
-    assert shape.containsPoint(QtCore.QPointF(100.0, 200.0)) is True
+    assert shape.contains_point(QtCore.QPointF(100.0, 200.0)) is True
 
 
 def test_point_shape_contains_within_radius() -> None:
     """Clicking within point_size/2 of the center should return True."""
     shape = _make_point_shape(100.0, 200.0)
     # point_size defaults to 8, so radius = 4. A point 3px away should hit.
-    assert shape.containsPoint(QtCore.QPointF(103.0, 200.0)) is True
+    assert shape.contains_point(QtCore.QPointF(103.0, 200.0)) is True
 
 
 def test_point_shape_at_exact_boundary() -> None:
     """Clicking exactly at point_size/2 distance should return True (inclusive)."""
     shape = _make_point_shape(100.0, 200.0)
     # point_size defaults to 8, so radius = 4. Exactly 4px away should hit.
-    assert shape.containsPoint(QtCore.QPointF(104.0, 200.0)) is True
+    assert shape.contains_point(QtCore.QPointF(104.0, 200.0)) is True
 
 
 def test_point_shape_outside_radius() -> None:
     """Clicking more than point_size/2 away should return False."""
     shape = _make_point_shape(100.0, 200.0)
     # 10px away, well outside the radius of 4
-    assert shape.containsPoint(QtCore.QPointF(110.0, 200.0)) is False
+    assert shape.contains_point(QtCore.QPointF(110.0, 200.0)) is False
 
 
 def test_point_shape_empty_points() -> None:
     """A point shape with no points should return False, not raise."""
     shape = Shape(shape_type="point")
-    assert shape.containsPoint(QtCore.QPointF(0.0, 0.0)) is False
+    assert shape.contains_point(QtCore.QPointF(0.0, 0.0)) is False

--- a/tests/unit/shape_test.py
+++ b/tests/unit/shape_test.py
@@ -13,8 +13,8 @@ def _make_mask_shape(
 ) -> Shape:
     shape = Shape(shape_type="mask")
     h, w = mask.shape
-    shape.addPoint(QtCore.QPointF(origin_x, origin_y))
-    shape.addPoint(QtCore.QPointF(origin_x + w, origin_y + h))
+    shape.add_point(QtCore.QPointF(origin_x, origin_y))
+    shape.add_point(QtCore.QPointF(origin_x + w, origin_y + h))
     shape.mask = mask
     return shape
 
@@ -32,4 +32,4 @@ def _make_mask_shape(
 def test_mask_contains_point(point: tuple[int, int], expected: bool) -> None:
     mask = np.ones((5, 5), dtype=bool)
     shape = _make_mask_shape(mask, origin_x=0, origin_y=0)
-    assert shape.containsPoint(QtCore.QPointF(*point)) is expected
+    assert shape.contains_point(QtCore.QPointF(*point)) is expected

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -37,8 +37,8 @@ def canvas(qtbot: QtBot) -> Canvas:
         (QPointF(_WIDTH / 2, -0.1), True),
     ],
 )
-def test_outOfPixmap(canvas: Canvas, point: QPointF, is_outside: bool) -> None:
-    assert canvas.outOfPixmap(point) is is_outside
+def test_is_out_of_pixmap(canvas: Canvas, point: QPointF, is_outside: bool) -> None:
+    assert canvas.is_out_of_pixmap(point) is is_outside
 
 
 @pytest.mark.gui

--- a/tests/unit/widgets/label_list_widget_test.py
+++ b/tests/unit/widgets/label_list_widget_test.py
@@ -14,9 +14,9 @@ def test_LabelListWidget(qtbot: QtBot, pause: bool) -> None:
     widget = LabelListWidget()
 
     item = LabelListWidgetItem(text="person <font color='red'>●</fon>")
-    widget.addItem(item)
+    widget.add_item(item)
     item = LabelListWidgetItem(text="dog <font color='blue'>●</fon>")
-    widget.addItem(item)
+    widget.add_item(item)
 
     qtbot.addWidget(widget)
     widget.show()


### PR DESCRIPTION
## Summary

Part 2 of 3 in the camelCase → snake_case migration. Renames identifiers in the foundational `Shape` type and two core widgets (`LabelListWidget`, `Canvas`).

## `labelme/shape.py`

Mechanical snake_case for: `add_point`, `pop_point`, `insert_point`, `remove_point`, `can_add_point`, `can_remove_point`, `is_closed`, `nearest_vertex`, `nearest_edge`, `contains_point`, `bounding_rect`, `move_by`, `move_vertex`, `highlight_vertex`.

Semantic improvements:

- `setOpen` → `open` (symmetric with the existing `close()` mutator)
- `makePath` → `to_path` (Pythonic convert convention)
- `highlightClear` → `clear_highlight` (verb-noun)
- `setShapeRefined` / `restoreShapeRaw` → `refine` / `unrefine` (symmetric verb pair)

`QRegion.boundingRect()` at `labelme/app.py:1787` stays — that's Qt's API, not `Shape`'s.

## `labelme/widgets/label_list_widget.py`

Methods: `set_shape`, `find_item_by_shape`, `add_item`, `remove_item`, `select_item`, `scroll_to_item`, `selected_items`.

Signals: `item_dropped`, `item_double_clicked`, `item_selection_changed`.

Pure slot handlers: `_on_item_selection_changed`, `_on_item_double_clicked`.

The proxy property `item_changed` continues to return Qt's native `QStandardItemModel.itemChanged` signal — that Qt-side name stays. Drops the dead `_selectedItems` field.

Caller updates apply only to `self._docks.label_list.*` (the labelme `LabelListWidget`); `_label_dialog.label_list` and `unique_label_list` are real `QListWidget`s and remain on Qt's API.

## `labelme/widgets/canvas.py` (largest)

- **9 signals**: `zoom_request`, `scroll_request`, `new_shape`, `selection_changed`, `shape_moved`, `drawing_polygon`, `vertex_selected`, `mouse_moved`, `status_updated`.
- **~35 methods**, including semantic improvements:
  - `storeShapes` → `backup_shapes`
  - `isShapeRestorable` → `can_restore_shape`
  - `restoreShape` → `restore_last_shape`
  - `setHiding` → `set_hide_background`
  - `outOfPixmap` → `is_out_of_pixmap`
  - `closeEnough` → `is_close_enough`
  - `deSelectShape` → `deselect_shape`
  - `selectedVertex` / `selectedEdge` → `is_vertex_selected` / `is_edge_selected`
- **Resolves Qt name collision**: `Canvas.isVisible(shape)` → `is_shape_visible(shape)`. Drops the `# ty: ignore[invalid-method-override]` suppression.
- **~12 instance vars**:
  - `hShape` / `hVertex` / `hEdge` → `hovered_shape` / `hovered_vertex` / `hovered_edge` (cryptic `h_` was the worst readability hit)
  - `movingShape` → `is_moving_shape` (predicate flag)
  - `shapesBackups` → `shape_backups` (pluralization fix)
  - Plus `prev_point`, `prev_move_point`, `selected_shapes`, `selected_shapes_copy`, `hovered_shape_is_selected`, `hide_background`, `_create_mode`, and the `_last_hovered_*` triple.

`MainWindow` slot methods (`self.scrollRequest`, `self.newShape`, `self.removeSelectedPoint`, `self.resetState`) are deferred to PR 3 — they will pick up `_on_*` prefixes there to disambiguate from the renamed Canvas signals.

## Constraints respected

- Qt virtuals stay (`mousePressEvent`, `paintEvent`, etc.).
- `self.tr()` stays.
- JSON keys stay.
- `Canvas.addPointToEdge` and `Canvas.moveByKeyboard` are renamed to `add_point_to_edge` and `move_by_keyboard` inside the canvas commit (compound canvas operations, not `Shape` methods).

## Stacked PR series

1. utils + leaf widgets → `main` (#1987, merged)
2. **(this PR)** Shape + LabelListWidget + Canvas
3. MainWindow + LabelFile (next)

## Test plan

- [x] `make format` clean
- [x] `make lint` clean (the `isVisible(shape)` rename drops the `ty: ignore`)
- [x] `make test` (131/131) passing
- [x] `make update_translate` produces zero diff
