### PR TITLE
test(app): pin label-list and canvas selection sync

### DIFF
--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -5,7 +5,6 @@ from typing import Final
 
 import pytest
 from PyQt5 import QtGui
-from PyQt5.QtCore import QPoint
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import QTimer
@@ -19,8 +18,10 @@ from labelme.widgets.label_dialog import LabelDialog
 
 from ..conftest import assert_labelfile_sanity
 from ..conftest import close_or_pause
+from .conftest import click_canvas_fraction
 from .conftest import image_to_widget_pos
 from .conftest import select_shape
+from .conftest import submit_label_dialog
 
 _TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
 _SHAPE_INDEX: Final[int] = 0
@@ -50,39 +51,6 @@ def _hover_and_drag(
     qtbot.wait(50)
     qtbot.mouseRelease(canvas, Qt.LeftButton, pos=end)
     qtbot.wait(50)
-
-
-def _click_canvas_fraction(
-    qtbot: QtBot,
-    canvas: Canvas,
-    xy: tuple[float, float],
-    modifier: Qt.KeyboardModifier = Qt.NoModifier,
-) -> None:
-    canvas_size = canvas.size()
-    pos = QPoint(
-        int(canvas_size.width() * xy[0]),
-        int(canvas_size.height() * xy[1]),
-    )
-    qtbot.mouseMove(canvas, pos=pos)
-    qtbot.wait(50)
-    qtbot.mouseClick(canvas, Qt.LeftButton, modifier=modifier, pos=pos)
-    qtbot.wait(50)
-
-
-def _enter_label(
-    qtbot: QtBot,
-    label_dialog: LabelDialog,
-    label: str,
-) -> None:
-    def _poll() -> None:
-        if not label_dialog.isVisible():
-            QTimer.singleShot(50, _poll)
-            return
-        qtbot.keyClicks(label_dialog.edit, label)
-        qtbot.wait(50)
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
-
-    QTimer.singleShot(0, _poll)
 
 
 def _cancel_label(
@@ -263,10 +231,12 @@ def test_add_point_on_edge(
     label = "big_rect"
     corners = [(0.2, 0.2), (0.8, 0.2), (0.8, 0.8), (0.2, 0.8)]
     for xy in corners:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
-    _enter_label(qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label)
-    _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=corners[0])
+    submit_label_dialog(
+        qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label
+    )
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=corners[0])
 
     def _shape_labeled() -> None:
         assert any(s.label == label for s in canvas.shapes)
@@ -323,7 +293,7 @@ def test_cancel_drawing_with_escape(
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3)]:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     assert canvas.current is not None
 
@@ -347,7 +317,7 @@ def test_undo_last_point_while_drawing(
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     assert canvas.current is not None
     assert len(canvas.current.points) == 3
@@ -359,14 +329,16 @@ def test_undo_last_point_while_drawing(
     assert len(canvas.current.points) == 2
 
     for xy in [(0.6, 0.6), (0.3, 0.6)]:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     assert len(canvas.current.points) == 4
 
     label = "undo_polygon"
-    _enter_label(qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label)
+    submit_label_dialog(
+        qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label
+    )
 
-    _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=(0.3, 0.3))
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=(0.3, 0.3))
 
     def _shape_labeled() -> None:
         assert any(s.label == label for s in canvas.shapes)
@@ -393,12 +365,14 @@ def test_finalize_polygon_with_enter(
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     assert canvas.current is not None
 
     label = "enter_shape"
-    _enter_label(qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label)
+    submit_label_dialog(
+        qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label
+    )
 
     qtbot.keyPress(canvas, Qt.Key_Return)
     qtbot.wait(200)
@@ -423,12 +397,14 @@ def test_undo_shape_creation(
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     assert canvas.current is not None
 
     label = "undo_target"
-    _enter_label(qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label)
+    submit_label_dialog(
+        qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label
+    )
 
     qtbot.keyPress(canvas, Qt.Key_Return)
     qtbot.wait(200)
@@ -467,11 +443,11 @@ def test_select_nonpolygon_shape(
     raw_win._switch_canvas_mode(edit=False, create_mode=create_mode)
     qtbot.wait(50)
 
-    _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=setup_click)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=setup_click)
 
     label = f"test_{create_mode}"
-    _enter_label(qtbot=qtbot, label_dialog=raw_win._label_dialog, label=label)
-    _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=finalize_click)
+    submit_label_dialog(qtbot=qtbot, label_dialog=raw_win._label_dialog, label=label)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=finalize_click)
 
     shape = _wait_for_shape(qtbot=qtbot, canvas=canvas, label=label)
     assert shape.shape_type == create_mode
@@ -504,12 +480,12 @@ def test_cancel_label_reopens_shape(
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3), (0.6, 0.6)]:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     assert canvas.current is not None
 
     _cancel_label(qtbot=qtbot, label_dialog=raw_win._label_dialog)
-    _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=(0.3, 0.3))
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=(0.3, 0.3))
 
     def shape_reopened() -> None:
         assert len(canvas.shapes) == num_shapes_before
@@ -564,11 +540,11 @@ def test_remove_point_blocked_at_minimum(
     qtbot.wait(50)
 
     for xy in setup_clicks:
-        _click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
     label = f"min_{create_mode}"
-    _enter_label(qtbot=qtbot, label_dialog=raw_win._label_dialog, label=label)
-    _click_canvas_fraction(
+    submit_label_dialog(qtbot=qtbot, label_dialog=raw_win._label_dialog, label=label)
+    click_canvas_fraction(
         qtbot=qtbot, canvas=canvas, xy=finalize_click, modifier=finalize_modifier
     )
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,7 @@ from PyQt5.QtCore import QPoint
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import QSettings
 from PyQt5.QtCore import Qt
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QApplication
 from pytestqt.qtbot import QtBot
 
@@ -18,6 +19,7 @@ import labelme.app
 from labelme.__main__ import main
 from labelme.app import MainWindow
 from labelme.widgets.canvas import Canvas
+from labelme.widgets.label_dialog import LabelDialog
 
 
 @pytest.fixture(scope="session")
@@ -126,6 +128,40 @@ def main_win(
             win.close()
         except RuntimeError:
             pass
+
+
+def click_canvas_fraction(
+    qtbot: QtBot,
+    canvas: Canvas,
+    xy: tuple[float, float],
+    modifier: Qt.KeyboardModifier = Qt.NoModifier,
+) -> None:
+    canvas_size = canvas.size()
+    pos = QPoint(
+        int(canvas_size.width() * xy[0]),
+        int(canvas_size.height() * xy[1]),
+    )
+    qtbot.mouseMove(canvas, pos=pos)
+    qtbot.wait(50)
+    qtbot.mouseClick(canvas, Qt.LeftButton, modifier=modifier, pos=pos)
+    qtbot.wait(50)
+
+
+def submit_label_dialog(
+    qtbot: QtBot,
+    label_dialog: LabelDialog,
+    label: str,
+) -> None:
+    def _poll() -> None:
+        if not label_dialog.isVisible():
+            QTimer.singleShot(50, _poll)
+            return
+        label_dialog.edit.clear()
+        qtbot.keyClicks(label_dialog.edit, label)
+        qtbot.wait(50)
+        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+
+    QTimer.singleShot(0, _poll)
 
 
 def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+import pytest
+from PyQt5.QtWidgets import QMessageBox
+from pytestqt.qtbot import QtBot
+
+from labelme.app import MainWindow
+from labelme.widgets.canvas import Canvas
+
+from ..conftest import close_or_pause
+from .conftest import MainWinFactory
+from .conftest import click_canvas_fraction
+from .conftest import select_shape
+from .conftest import show_window_and_wait_for_imagedata
+from .conftest import submit_label_dialog
+
+
+def _draw_polygon(
+    qtbot: QtBot,
+    win: MainWindow,
+    canvas: Canvas,
+    label: str,
+) -> None:
+    POLYGON_XY: Final = [
+        (0.2, 0.2),
+        (0.5, 0.2),
+        (0.5, 0.5),
+    ]
+    win._switch_canvas_mode(edit=False, create_mode="polygon")
+    qtbot.wait(50)
+
+    for xy in POLYGON_XY:
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+
+    submit_label_dialog(qtbot=qtbot, label_dialog=win._label_dialog, label=label)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=POLYGON_XY[0])
+
+    def _assert_shape_created() -> None:
+        assert any(s.label == label for s in canvas.shapes)
+
+    qtbot.waitUntil(_assert_shape_created, timeout=3000)
+
+
+@pytest.mark.gui
+def test_draw_shape_appears_in_label_list(
+    qtbot: QtBot,
+    raw_win: MainWindow,
+    pause: bool,
+) -> None:
+    win = raw_win
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+
+    count_before = len(label_list)
+    label = "test_shape"
+    _draw_polygon(qtbot=qtbot, win=win, canvas=canvas, label=label)
+
+    assert len(label_list) == count_before + 1
+    shape_labels = [s.label for item in label_list if (s := item.shape()) is not None]
+    assert label in shape_labels
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_click_label_list_entry_selects_canvas_shape(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    win = annotated_win
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+
+    assert len(canvas.shapes) > 0
+    assert len(label_list) == len(canvas.shapes)
+
+    canvas.deselect_shape()
+    qtbot.waitUntil(lambda: not canvas.selected_shapes)
+
+    first_item = label_list[0]
+    expected_shape = first_item.shape()
+    assert expected_shape is not None
+
+    label_list.select_item(first_item)
+    qtbot.waitUntil(lambda: expected_shape in canvas.selected_shapes)
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_click_canvas_shape_selects_label_list_entry(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    win = annotated_win
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+
+    assert len(canvas.shapes) > 0
+
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
+
+    selected_canvas_shape = canvas.selected_shapes[0]
+    selected_list_items = label_list.selected_items()
+
+    assert len(selected_list_items) == 1
+    assert selected_list_items[0].shape() is selected_canvas_shape
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_rename_via_label_dialog_updates_shape_and_list(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    win = annotated_win
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+
+    assert len(canvas.shapes) > 0
+
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
+
+    first_item = label_list[0]
+    first_shape = first_item.shape()
+    assert first_shape is not None
+    assert first_shape.label is not None
+    new_label = f"{first_shape.label}_renamed"
+
+    submit_label_dialog(qtbot=qtbot, label_dialog=win._label_dialog, label=new_label)
+    label_list.item_double_clicked.emit(first_item)
+
+    def _assert_renamed() -> None:
+        item = label_list[0]
+        shape = item.shape()
+        assert shape is not None
+        assert shape.label == new_label
+        assert new_label in item.text()
+
+    qtbot.waitUntil(_assert_renamed, timeout=3000)
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_delete_shape_removes_label_list_entry(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    win = annotated_win
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+
+    count_before = len(label_list)
+    assert count_before > 0
+
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
+
+    monkeypatch.setattr(
+        QMessageBox,
+        "warning",
+        lambda *args, **kwargs: QMessageBox.Yes,
+    )
+    win.delete_selected_shapes()
+    qtbot.waitUntil(lambda: len(label_list) == count_before - 1)
+    assert len(canvas.shapes) == count_before - 1
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_open_different_file_repopulates_label_list(
+    qtbot: QtBot,
+    main_win: MainWinFactory,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(file_or_dir=str(data_path / "annotated"))
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+
+    shapes_first = len(canvas.shapes)
+    assert shapes_first > 0
+    assert len(label_list) == shapes_first
+
+    image_path_before = win._image_path
+    win._open_next_image()
+
+    def _assert_next_image_loaded() -> None:
+        assert win._image_path is not None
+        assert win._image_path != image_path_before
+
+    qtbot.waitUntil(_assert_next_image_loaded, timeout=5000)
+
+    def _assert_label_list_repopulated() -> None:
+        assert len(label_list) == len(canvas.shapes)
+
+    qtbot.waitUntil(_assert_label_list_repopulated, timeout=3000)
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)


### PR DESCRIPTION
## Summary

Pins the user-visible bidirectional sync between the label list and the canvas, plus rename, deletion, and repopulation on file navigation.

## Tests

- `test_draw_shape_appears_in_label_list` — draw a polygon -> its label entry appears in the label list.
- `test_click_label_list_entry_selects_canvas_shape` — selecting a list entry selects the corresponding shape on the canvas.
- `test_click_canvas_shape_selects_label_list_entry` — clicking a shape on the canvas highlights the matching list entry.
- `test_rename_via_label_dialog_updates_shape_and_list` — double-click rename via label dialog updates both `Shape.label` and the list entry text.
- `test_delete_shape_removes_label_list_entry` — deleting the selected shape removes its list entry; remaining count is consistent.
- `test_open_different_file_repopulates_label_list` — navigating to the next image clears and repopulates the list to match the new file's shapes.

Visibility-checkbox toggling is already pinned by `visibility_test.py::test_toggle_individual_shape` and is not duplicated here.

## Notes

- The rename test emits `label_list.item_double_clicked` directly because Qt's `offscreen` platform does not deliver double-click events through the model-view item layer. The signal path being exercised is identical to the one a real double-click would take.
- Tests access `win._docks.label_list` directly, matching the convention in `visibility_test.py`.

## Test plan

- [x] `make test` passes locally.
- [x] `make lint` passes for this file.
- [x] No private-helper assertions; all assertions go through user-visible state.