### PR TITLE
test(canvas): pin middle-mouse drag-scroll behaviour

### DIFF
--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -4,11 +4,9 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5 import QtGui
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow
@@ -19,6 +17,7 @@ from labelme.widgets.label_dialog import LabelDialog
 from ..conftest import assert_labelfile_sanity
 from ..conftest import close_or_pause
 from .conftest import click_canvas_fraction
+from .conftest import drag_canvas
 from .conftest import image_to_widget_pos
 from .conftest import select_shape
 from .conftest import submit_label_dialog
@@ -37,20 +36,7 @@ def _hover_and_drag(
     end = image_to_widget_pos(canvas=canvas, image_pos=end_image_pos)
     qtbot.mouseMove(canvas, pos=start)
     qtbot.wait(50)
-    qtbot.mousePress(canvas, Qt.LeftButton, pos=start)
-    qtbot.wait(50)
-    # qtbot.mouseMove does not carry button state, so send a raw event
-    move_event = QtGui.QMouseEvent(
-        QtGui.QMouseEvent.MouseMove,
-        QPointF(end),
-        Qt.NoButton,
-        Qt.LeftButton,
-        Qt.NoModifier,
-    )
-    QApplication.sendEvent(canvas, move_event)
-    qtbot.wait(50)
-    qtbot.mouseRelease(canvas, Qt.LeftButton, pos=end)
-    qtbot.wait(50)
+    drag_canvas(qtbot=qtbot, canvas=canvas, button=Qt.LeftButton, start=start, end=end)
 
 
 def _cancel_label(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from PyQt5 import QtGui
 from PyQt5.QtCore import QPoint
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import QSettings
@@ -144,6 +145,29 @@ def click_canvas_fraction(
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)
     qtbot.mouseClick(canvas, Qt.LeftButton, modifier=modifier, pos=pos)
+    qtbot.wait(50)
+
+
+def drag_canvas(
+    qtbot: QtBot,
+    canvas: Canvas,
+    button: Qt.MouseButton,
+    start: QPoint,
+    end: QPoint,
+) -> None:
+    qtbot.mousePress(canvas, button, pos=start)
+    qtbot.wait(50)
+    # qtbot.mouseMove does not carry button state, so send a raw event
+    move_event = QtGui.QMouseEvent(
+        QtGui.QMouseEvent.MouseMove,
+        QPointF(end),
+        Qt.NoButton,
+        button,
+        Qt.NoModifier,
+    )
+    QApplication.sendEvent(canvas, move_event)
+    qtbot.wait(50)
+    qtbot.mouseRelease(canvas, button, pos=end)
     qtbot.wait(50)
 
 

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Final
+
+import pytest
+from PyQt5.QtCore import QPoint
+from PyQt5.QtCore import Qt
+from pytestqt.qtbot import QtBot
+
+from labelme.app import MainWindow
+from labelme.widgets.canvas import Canvas
+
+from ..conftest import close_or_pause
+from .conftest import drag_canvas
+
+_DRAG_OFFSET_PX: Final[int] = 40
+
+
+def _diagonal_drag_endpoints(canvas: Canvas) -> tuple[QPoint, QPoint]:
+    start = QPoint(canvas.width() // 2, canvas.height() // 2)
+    end = QPoint(start.x() + _DRAG_OFFSET_PX, start.y() + _DRAG_OFFSET_PX)
+    return start, end
+
+
+@pytest.mark.gui
+def test_middle_drag_emits_scroll_request(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    canvas.enable_dragging(enabled=True)
+
+    horizontal: list[int] = []
+    vertical: list[int] = []
+
+    def _on_scroll(delta: int, orientation: Qt.Orientation) -> None:
+        if orientation == Qt.Horizontal:
+            horizontal.append(delta)
+        else:
+            vertical.append(delta)
+
+    canvas.scroll_request.connect(_on_scroll)
+
+    start, end = _diagonal_drag_endpoints(canvas=canvas)
+    drag_canvas(
+        qtbot=qtbot,
+        canvas=canvas,
+        button=Qt.MiddleButton,
+        start=start,
+        end=end,
+    )
+
+    assert any(d != 0 for d in horizontal)
+    assert any(d != 0 for d in vertical)
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_middle_drag_disabled_is_noop(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    canvas.enable_dragging(enabled=False)
+
+    start, end = _diagonal_drag_endpoints(canvas=canvas)
+
+    with qtbot.assertNotEmitted(canvas.scroll_request):
+        drag_canvas(
+            qtbot=qtbot,
+            canvas=canvas,
+            button=Qt.MiddleButton,
+            start=start,
+            end=end,
+        )
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)


### PR DESCRIPTION
## Summary

- Pins middle-mouse drag-scroll behaviour on the canvas via the public \`scroll_request\` signal.

## Tests

- \`tests/e2e/middle_drag_scroll_test.py::test_middle_drag_emits_scroll_request\` — middle-button drag with dragging enabled emits non-zero horizontal and vertical \`scroll_request\` deltas.
- \`tests/e2e/middle_drag_scroll_test.py::test_middle_drag_disabled_is_noop\` — with \`canvas.enable_dragging(False)\`, the same drag emits no \`scroll_request\`.

## Notes

- \`qtbot.mouseMove\` cannot carry middle-button state. The move leg uses \`QApplication.sendEvent\` with a raw \`QMouseEvent(MouseMove, ..., buttons=Qt.MiddleButton)\` — same pattern as \`canvas_interaction_test.py\`.
- No public \"toggle mouse-drag\" QAction exists; \`canvas.enable_dragging(enabled: bool)\` is the public API and is used directly by the test.

## Test plan

- [x] \`make test\` passes locally.
- [x] \`make lint\` passes.