### PR TITLE
test(e2e): pin label-dialog validation, whitespace, and flags

### DIFF
--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -6,7 +6,6 @@ from typing import Final
 import pytest
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QTimer
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow
@@ -19,6 +18,7 @@ from ..conftest import close_or_pause
 from .conftest import click_canvas_fraction
 from .conftest import drag_canvas
 from .conftest import image_to_widget_pos
+from .conftest import schedule_on_dialog
 from .conftest import select_shape
 from .conftest import submit_label_dialog
 
@@ -43,13 +43,10 @@ def _cancel_label(
     qtbot: QtBot,
     label_dialog: LabelDialog,
 ) -> None:
-    def poll() -> None:
-        if not label_dialog.isVisible():
-            QTimer.singleShot(50, poll)
-            return
-        qtbot.keyClick(label_dialog, Qt.Key_Escape)
-
-    QTimer.singleShot(0, poll)
+    schedule_on_dialog(
+        label_dialog=label_dialog,
+        action=lambda: qtbot.keyClick(label_dialog, Qt.Key_Escape),
+    )
 
 
 def _wait_for_shape(qtbot: QtBot, canvas: Canvas, label: str) -> Shape:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -171,21 +171,47 @@ def drag_canvas(
     qtbot.wait(50)
 
 
-def submit_label_dialog(
-    qtbot: QtBot,
+def schedule_on_dialog(
     label_dialog: LabelDialog,
-    label: str,
+    action: Callable[[], None],
 ) -> None:
     def _poll() -> None:
         if not label_dialog.isVisible():
             QTimer.singleShot(50, _poll)
             return
+        action()
+
+    QTimer.singleShot(0, _poll)
+
+
+def submit_label_dialog(
+    qtbot: QtBot,
+    label_dialog: LabelDialog,
+    label: str,
+) -> None:
+    def _action() -> None:
         label_dialog.edit.clear()
         qtbot.keyClicks(label_dialog.edit, label)
         qtbot.wait(50)
         qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
 
-    QTimer.singleShot(0, _poll)
+    schedule_on_dialog(label_dialog=label_dialog, action=_action)
+
+
+def draw_triangle(
+    qtbot: QtBot,
+    win: MainWindow,
+    vertices: tuple[tuple[float, float], ...] = (
+        (0.3, 0.3),
+        (0.6, 0.3),
+        (0.6, 0.6),
+    ),
+) -> None:
+    canvas = win._canvas_widgets.canvas
+    win._switch_canvas_mode(edit=False, create_mode="polygon")
+    qtbot.wait(50)
+    for xy in vertices:
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
 
 def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QCheckBox
+from pytestqt.qtbot import QtBot
+
+from labelme.widgets.label_dialog import LabelDialog
+
+from ..conftest import close_or_pause
+from .conftest import MainWinFactory
+from .conftest import click_canvas_fraction
+from .conftest import draw_triangle
+from .conftest import schedule_on_dialog
+from .conftest import show_window_and_wait_for_imagedata
+
+_RAW_FILE: Final[str] = "raw/2011_000003.jpg"
+_LABEL_FLAGS: Final[dict[str, list[str]]] = {"cat": ["a", "b"]}
+_CLOSE_POLYGON_CLICK: Final[tuple[float, float]] = (0.3, 0.3)
+
+
+def _check_flag(label_dialog: LabelDialog, name: str) -> None:
+    for cb in label_dialog.findChildren(QCheckBox):
+        if cb.text() == name:
+            cb.setChecked(True)
+            return
+    raise AssertionError(f"Flag checkbox {name!r} not found")
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("flag_to_toggle", "expected_flags"),
+    [
+        pytest.param(None, {"a": False, "b": False}, id="no-toggle"),
+        pytest.param("b", {"a": False, "b": True}, id="toggle-b"),
+    ],
+)
+def test_label_flags_applied_to_shape(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    flag_to_toggle: str | None,
+    expected_flags: dict[str, bool],
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / _RAW_FILE),
+        config_overrides={"label_flags": _LABEL_FLAGS},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    label_dialog = win._label_dialog
+    num_shapes_before = len(canvas.shapes)
+
+    draw_triangle(qtbot=qtbot, win=win)
+
+    def _enter_cat() -> None:
+        label_dialog.edit.clear()
+        qtbot.keyClicks(label_dialog.edit, "cat")
+        qtbot.wait(100)
+        if flag_to_toggle is not None:
+            _check_flag(label_dialog=label_dialog, name=flag_to_toggle)
+        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+
+    schedule_on_dialog(label_dialog=label_dialog, action=_enter_cat)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
+
+    qtbot.waitUntil(lambda: len(canvas.shapes) == num_shapes_before + 1, timeout=3000)
+
+    shape = canvas.shapes[-1]
+    assert shape.label == "cat"
+    assert shape.flags == expected_flags
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_flags_survive_save_reload_roundtrip(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / _RAW_FILE),
+        config_overrides={"label_flags": _LABEL_FLAGS, "auto_save": False},
+        output_dir=str(tmp_path),
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    label_dialog = win._label_dialog
+    num_shapes_before = len(canvas.shapes)
+
+    draw_triangle(qtbot=qtbot, win=win)
+
+    def _enter_cat_a_true() -> None:
+        label_dialog.edit.clear()
+        qtbot.keyClicks(label_dialog.edit, "cat")
+        qtbot.wait(100)
+        _check_flag(label_dialog=label_dialog, name="a")
+        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+
+    schedule_on_dialog(label_dialog=label_dialog, action=_enter_cat_a_true)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
+
+    qtbot.waitUntil(lambda: len(canvas.shapes) == num_shapes_before + 1, timeout=3000)
+    assert canvas.shapes[-1].flags == {"a": True, "b": False}
+
+    label_path = str(tmp_path / "2011_000003.json")
+    assert win.save_labels(label_path=label_path)
+
+    with open(label_path) as f:
+        disk_data = json.load(f)
+    cat_shapes = [s for s in disk_data["shapes"] if s["label"] == "cat"]
+    assert len(cat_shapes) == 1
+    assert cat_shapes[0]["flags"] == {"a": True, "b": False}
+
+    win._load_file(image_or_label_path=label_path)
+    qtbot.waitUntil(lambda: any(s.label == "cat" for s in canvas.shapes), timeout=3000)
+
+    reloaded_shape = next(s for s in canvas.shapes if s.label == "cat")
+    assert reloaded_shape.flags == {"a": True, "b": False}
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QMessageBox
+from pytestqt.qtbot import QtBot
+
+from ..conftest import close_or_pause
+from .conftest import MainWinFactory
+from .conftest import click_canvas_fraction
+from .conftest import draw_triangle
+from .conftest import schedule_on_dialog
+from .conftest import show_window_and_wait_for_imagedata
+
+_RAW_FILE: Final[str] = "raw/2011_000003.jpg"
+_CLOSE_POLYGON_CLICK: Final[tuple[float, float]] = (0.3, 0.3)
+
+
+@pytest.mark.gui
+def test_blank_input_keeps_dialog_open(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(file_or_dir=str(data_path / _RAW_FILE))
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    label_dialog = win._label_dialog
+    num_shapes_before = len(canvas.shapes)
+
+    draw_triangle(qtbot=qtbot, win=win)
+
+    dialog_stayed_open: list[bool] = []
+
+    def _try_blank_then_cancel() -> None:
+        label_dialog.edit.clear()
+        qtbot.keyClick(label_dialog, Qt.Key_Return)
+        qtbot.wait(50)
+        if label_dialog.isVisible():
+            dialog_stayed_open.append(True)
+        qtbot.keyClick(label_dialog, Qt.Key_Escape)
+
+    schedule_on_dialog(label_dialog=label_dialog, action=_try_blank_then_cancel)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
+
+    qtbot.waitUntil(lambda: bool(dialog_stayed_open), timeout=3000)
+    assert len(canvas.shapes) == num_shapes_before
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_validate_label_exact_rejects_unknown_label(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / _RAW_FILE),
+        config_overrides={"validate_label": "exact", "labels": ["cat", "dog"]},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    label_dialog = win._label_dialog
+    num_shapes_before = len(canvas.shapes)
+
+    error_shown: list[bool] = []
+
+    def _record_critical(*args: object, **kwargs: object) -> int:
+        error_shown.append(True)
+        return QMessageBox.Ok
+
+    monkeypatch.setattr(QMessageBox, "critical", _record_critical)
+
+    def _enter_unknown_label() -> None:
+        label_dialog.edit.clear()
+        qtbot.keyClicks(label_dialog.edit, "tiger")
+        qtbot.wait(50)
+        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+
+    draw_triangle(qtbot=qtbot, win=win)
+    schedule_on_dialog(label_dialog=label_dialog, action=_enter_unknown_label)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
+
+    qtbot.waitUntil(lambda: bool(error_shown), timeout=3000)
+    assert len(canvas.shapes) == num_shapes_before
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_trailing_whitespace_label_is_stripped(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / _RAW_FILE),
+        config_overrides={"labels": ["cat", "dog"]},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    label_dialog = win._label_dialog
+    num_shapes_before = len(canvas.shapes)
+
+    draw_triangle(qtbot=qtbot, win=win)
+
+    def _enter_trailing_space_label() -> None:
+        label_dialog.edit.clear()
+        qtbot.keyClicks(label_dialog.edit, "cat  ")
+        qtbot.wait(50)
+        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+
+    schedule_on_dialog(label_dialog=label_dialog, action=_enter_trailing_space_label)
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
+
+    qtbot.waitUntil(lambda: len(canvas.shapes) == num_shapes_before + 1, timeout=3000)
+    assert canvas.shapes[-1].label == "cat"
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -5,7 +5,6 @@ from typing import Final
 import pytest
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
@@ -13,7 +12,8 @@ from labelme.app import MainWindow
 from labelme.widgets.label_dialog import LabelDialog
 
 from ..conftest import close_or_pause
-from .conftest import click_canvas_fraction
+from .conftest import draw_triangle
+from .conftest import schedule_on_dialog
 from .conftest import select_shape
 from .conftest import submit_label_dialog
 
@@ -24,26 +24,19 @@ def _schedule_capture_then_cancel(
     label_dialog: LabelDialog,
     captured: list[str],
 ) -> None:
-    def _capture_when_visible() -> None:
-        if not label_dialog.isVisible():
-            QTimer.singleShot(50, _capture_when_visible)
-            return
+    def _action() -> None:
         captured.append(label_dialog.edit.text())
         label_dialog.reject()
 
-    QTimer.singleShot(0, _capture_when_visible)
+    schedule_on_dialog(label_dialog=label_dialog, action=_action)
 
 
 def _draw_triangle(qtbot: QtBot, win: MainWindow) -> None:
-    TRIANGLE_VERTICES: Final[tuple[tuple[float, float], ...]] = (
-        (0.2, 0.2),
-        (0.6, 0.2),
-        (0.6, 0.6),
+    draw_triangle(
+        qtbot=qtbot,
+        win=win,
+        vertices=((0.2, 0.2), (0.6, 0.2), (0.6, 0.6)),
     )
-    canvas = win._canvas_widgets.canvas
-    win._switch_canvas_mode(edit=False, create_mode="polygon")
-    for xy in TRIANGLE_VERTICES:
-        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
 
 
 def _draw_and_commit_polygon(qtbot: QtBot, win: MainWindow, label: str) -> None:


### PR DESCRIPTION
## Summary

Pins user-visible label-dialog behaviour: blank-input rejection, `validate_label=exact` enforcement, trailing-whitespace stripping, and `label_flags` initial values + toggling (including a save/reload roundtrip). Promotes shared `schedule_on_dialog` and `draw_triangle` helpers to `tests/e2e/conftest.py` and migrates existing call sites in `canvas_interaction_test.py` and `last_label_and_restore_test.py`.

## Tests

`tests/e2e/label_dialog_validation_test.py`:
- `test_blank_input_keeps_dialog_open` — pressing Enter on a blank field keeps the dialog open; cancelling adds no shape.
- `test_validate_label_exact_rejects_unknown_label` — with `validate_label=exact` and `labels=[cat, dog]`, entering `tiger` triggers a critical error and adds no shape.
- `test_trailing_whitespace_label_is_stripped` — typing `\"cat  \"` saves the shape with label `\"cat\"`.

`tests/e2e/label_dialog_flags_test.py`:
- `test_label_flags_applied_to_shape[no-toggle]` — with `label_flags={cat: [a, b]}` and no toggle, the saved shape's flags are `{a: False, b: False}`.
- `test_label_flags_applied_to_shape[toggle-b]` — toggling `b` before accepting saves `{a: False, b: True}`.
- `test_flags_survive_save_reload_roundtrip` — flags written to JSON are read back identically through the running app.

## Test plan

- [x] `uv run pytest tests/e2e/label_dialog_validation_test.py tests/e2e/label_dialog_flags_test.py -q` -> 6 passed.
- [x] `make lint` passes.