### PR TITLE
test(app): pin last-label memo and restore-last-shape behaviour

### DIFF
--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Final
+
+import pytest
+from PyQt5.QtCore import QPointF
+from PyQt5.QtCore import Qt
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QMessageBox
+from pytestqt.qtbot import QtBot
+
+from labelme.app import MainWindow
+from labelme.widgets.label_dialog import LabelDialog
+
+from ..conftest import close_or_pause
+from .conftest import click_canvas_fraction
+from .conftest import select_shape
+from .conftest import submit_label_dialog
+
+_SHAPE_TIMEOUT_MS: Final[int] = 5_000
+
+
+def _schedule_capture_then_cancel(
+    label_dialog: LabelDialog,
+    captured: list[str],
+) -> None:
+    def _capture_when_visible() -> None:
+        if not label_dialog.isVisible():
+            QTimer.singleShot(50, _capture_when_visible)
+            return
+        captured.append(label_dialog.edit.text())
+        label_dialog.reject()
+
+    QTimer.singleShot(0, _capture_when_visible)
+
+
+def _draw_triangle(qtbot: QtBot, win: MainWindow) -> None:
+    TRIANGLE_VERTICES: Final[tuple[tuple[float, float], ...]] = (
+        (0.2, 0.2),
+        (0.6, 0.2),
+        (0.6, 0.6),
+    )
+    canvas = win._canvas_widgets.canvas
+    win._switch_canvas_mode(edit=False, create_mode="polygon")
+    for xy in TRIANGLE_VERTICES:
+        click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
+
+
+def _draw_and_commit_polygon(qtbot: QtBot, win: MainWindow, label: str) -> None:
+    canvas = win._canvas_widgets.canvas
+    _draw_triangle(qtbot=qtbot, win=win)
+    # Schedule the dialog handler before pressing Return: the Return key closes
+    # the polygon which opens the dialog, at which point the queued poller fills
+    # it in. Swapping these two lines would deadlock the test.
+    submit_label_dialog(qtbot=qtbot, label_dialog=win._label_dialog, label=label)
+    qtbot.keyPress(canvas, Qt.Key_Return)
+
+    def shape_committed() -> None:
+        assert any(s.label == label for s in canvas.shapes)
+
+    qtbot.waitUntil(shape_committed, timeout=_SHAPE_TIMEOUT_MS)
+
+
+@pytest.mark.gui
+def test_last_label_memo(
+    qtbot: QtBot,
+    raw_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = raw_win._canvas_widgets.canvas
+    label_dialog = raw_win._label_dialog
+
+    _draw_and_commit_polygon(qtbot=qtbot, win=raw_win, label="foo")
+
+    captured: list[str] = []
+    _schedule_capture_then_cancel(label_dialog=label_dialog, captured=captured)
+
+    _draw_triangle(qtbot=qtbot, win=raw_win)
+    qtbot.keyPress(canvas, Qt.Key_Return)
+
+    qtbot.waitUntil(lambda: bool(captured), timeout=_SHAPE_TIMEOUT_MS)
+
+    assert captured[0] == "foo"
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_restore_last_shape_via_undo(
+    qtbot: QtBot,
+    raw_win: MainWindow,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    canvas = raw_win._canvas_widgets.canvas
+
+    _draw_and_commit_polygon(qtbot=qtbot, win=raw_win, label="restore_me")
+    raw_win._switch_canvas_mode(edit=True)
+
+    assert len(canvas.shapes) == 1
+    original_points = [QPointF(p) for p in canvas.shapes[0].points]
+
+    monkeypatch.setattr(
+        QMessageBox,
+        "warning",
+        lambda *args, **kwargs: QMessageBox.Yes,
+    )
+
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
+    raw_win.delete_selected_shapes()
+    qtbot.waitUntil(lambda: len(canvas.shapes) == 0, timeout=_SHAPE_TIMEOUT_MS)
+
+    raw_win.undo_shape_edit()
+    qtbot.waitUntil(lambda: len(canvas.shapes) == 1, timeout=_SHAPE_TIMEOUT_MS)
+
+    restored = canvas.shapes[0]
+    assert restored.label == "restore_me"
+    assert [QPointF(p) for p in restored.points] == original_points
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)


### PR DESCRIPTION
## Summary

- Adds two behavioural tests in \`tests/e2e/last_label_and_restore_test.py\`.

## Tests

- \`test_last_label_memo\` — draws shape A labelled \"foo\", begins shape B (then cancels the dialog), and asserts the dialog pre-filled \"foo\".
- \`test_restore_last_shape_via_undo\` — draw -> delete (auto-confirmed warning dialog) -> \`undo_shape_edit()\` and verifies the restored shape has identical label and coordinates (within 1 px).

## Test plan

- [x] \`uv run pytest tests/e2e/last_label_and_restore_test.py -v -m gui\` -> 2 passed
- [x] \`make lint\` -> all checks pass