### PR TITLE
test(app): pin drag-and-drop file behaviour

### DIFF
--- a/tests/e2e/drag_and_drop_test.py
+++ b/tests/e2e/drag_and_drop_test.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PyQt5.QtCore import QMimeData
+from PyQt5.QtCore import QPoint
+from PyQt5.QtCore import QPointF
+from PyQt5.QtCore import Qt
+from PyQt5.QtCore import QUrl
+from PyQt5.QtGui import QDragEnterEvent
+from PyQt5.QtGui import QDropEvent
+from PyQt5.QtWidgets import QApplication
+from pytestqt.qtbot import QtBot
+
+from labelme.app import MainWindow
+
+from ..conftest import close_or_pause
+from .conftest import MainWinFactory
+
+
+def _make_drop_mime(paths: list[Path]) -> QMimeData:
+    mime = QMimeData()
+    mime.setUrls([QUrl.fromLocalFile(str(p)) for p in paths])
+    return mime
+
+
+def _drag_enter_accepted(win: MainWindow, mime: QMimeData) -> bool:
+    event = QDragEnterEvent(
+        QPoint(0, 0),
+        Qt.CopyAction,
+        mime,
+        Qt.LeftButton,
+        Qt.NoModifier,
+    )
+    QApplication.sendEvent(win, event)
+    return event.isAccepted()
+
+
+def _send_drop(win: MainWindow, mime: QMimeData) -> None:
+    event = QDropEvent(
+        QPointF(0, 0),
+        Qt.CopyAction,
+        mime,
+        Qt.LeftButton,
+        Qt.NoModifier,
+    )
+    QApplication.sendEvent(win, event)
+
+
+@pytest.mark.gui
+def test_drop_image_files_loads_them(
+    qtbot: QtBot,
+    main_win: MainWinFactory,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win()
+    win.show()
+    qtbot.waitUntil(win.isVisible)
+
+    first_image = data_path / "raw/2011_000003.jpg"
+    second_image = data_path / "raw/2011_000006.jpg"
+
+    mime = _make_drop_mime(paths=[first_image, second_image])
+    assert _drag_enter_accepted(win=win, mime=mime)
+    _send_drop(win=win, mime=mime)
+
+    def check_image_list_populated() -> None:
+        assert len(win.image_list) == 2
+        assert str(first_image) in win.image_list
+        assert str(second_image) in win.image_list
+
+    qtbot.waitUntil(check_image_list_populated)
+    assert first_image.name in win.windowTitle()
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_drag_enter_rejects_non_image_and_keeps_state(
+    qtbot: QtBot,
+    raw_win: MainWindow,
+    data_path: Path,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    original_title = raw_win.windowTitle()
+    original_image_list = list(raw_win.image_list)
+
+    non_image_file = tmp_path / "notes.txt"
+    non_image_file.write_text("not an image")
+    directory = data_path / "raw"
+
+    for path in [directory, non_image_file]:
+        mime = _make_drop_mime(paths=[path])
+        assert not _drag_enter_accepted(win=raw_win, mime=mime)
+
+    assert raw_win.windowTitle() == original_title
+    assert list(raw_win.image_list) == original_image_list
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)


### PR DESCRIPTION
## Summary

- Pins user-visible drag-and-drop behaviour: dropping image URLs onto \`MainWindow\` loads them into \`image_list\` and reflects the first image's filename in \`windowTitle()\`.
- \`dragEnterEvent\` rejects directories and non-image files; rejected drops leave \`image_list\` and \`windowTitle()\` unchanged.

## Tests

- \`tests/e2e/drag_and_drop_test.py::test_drop_image_files_loads_them\` — drops two image URLs; both appear in \`image_list\` and the first image's name shows in the window title.
- \`tests/e2e/drag_and_drop_test.py::test_drag_enter_rejects_non_image_and_keeps_state\` — directory URL and a plain \`.txt\` URL are both rejected at the drag-enter stage; \`image_list\` and \`windowTitle()\` are preserved.

## Notes

- Directory drops are rejected, not accepted: the \`dragEnterEvent\` only accepts URLs whose paths end with a recognised image extension.
- Drive mechanism: synthesised \`QDragEnterEvent\` + \`QDropEvent\` posted via \`QApplication.sendEvent\`; assertions only on \`image_list\`, \`windowTitle()\`, and \`event.isAccepted()\`.

## Test plan

- [x] \`make test\` passes locally (2 tests).
- [x] \`make lint\` passes.