### PR TITLE
fix(test): make click_canvas_fraction interpret xy in image space

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -137,11 +137,12 @@ def click_canvas_fraction(
     xy: tuple[float, float],
     modifier: Qt.KeyboardModifier = Qt.NoModifier,
 ) -> None:
-    canvas_size = canvas.size()
-    pos = QPoint(
-        int(canvas_size.width() * xy[0]),
-        int(canvas_size.height() * xy[1]),
-    )
+    # Fractions are interpreted in image-pixel space so callers stay valid
+    # regardless of window/canvas size or letterboxing.
+    pixmap = canvas.pixmap
+    assert pixmap is not None
+    image_pos = QPointF(pixmap.width() * xy[0], pixmap.height() * xy[1])
+    pos = image_to_widget_pos(canvas=canvas, image_pos=image_pos)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)
     qtbot.mouseClick(canvas, Qt.LeftButton, modifier=modifier, pos=pos)


### PR DESCRIPTION
## Summary
- The Canvas widget letterboxes the image at smaller window sizes, so fractions of `canvas.size()` could land in the empty padding rather than on the image.
- `click_canvas_fraction` now multiplies the fraction by the pixmap's image dimensions and maps through `image_to_widget_pos`, making fractional clicks geometry-independent.

## Test plan
- [x] `uv run pytest tests/e2e/` — all e2e tests pass