### PR TITLE
ci: support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "imgviz>=2.0.0",


### PR DESCRIPTION
## Summary
- Add `Python :: 3.14` classifier in `pyproject.toml`
- Bump CI matrix in `.github/workflows/test.yml` from `3.13` to `3.14`

## Why
The previous attempt was blocked by `onnxruntime` (via `osam`) lacking Python 3.14 wheels. `onnxruntime>=1.24` now ships 3.14 wheels, so `uv sync --python 3.14` resolves cleanly.

## Test plan
- [x] `uv sync --python 3.14` resolves successfully
- [x] `make test` passes locally on 3.14 (170 passed)
- [x] `make lint` passes
- [x] CI matrix runs green on `3.10` and `3.14` across ubuntu/macos/windows