### PR TITLE
docs(canvas): clarify sizeHint/minimumSizeHint comment

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1172,8 +1172,8 @@ class Canvas(QtWidgets.QWidget):
         # divide by scale to allow more precision when zoomed in
         return labelme.utils.distance(p1 - p2) < (self.epsilon / self.scale)
 
-    # These two, along with a call to adjustSize are required for the
-    # scroll area.
+    # Required by QScrollArea: it queries these to compute the
+    # scrollable viewport whenever adjustSize() is called.
     def sizeHint(self) -> QtCore.QSize:
         return self.minimumSizeHint()
 


### PR DESCRIPTION
## Summary
- Rephrase the comment above `sizeHint`/`minimumSizeHint` in `labelme/widgets/canvas.py` to name the consumer (`QScrollArea`) and explain when it queries them.

## Why
The previous comment said "These two, along with a call to adjustSize are required for the scroll area" without naming the actual consumer or the query trigger. The new wording is self-contained and reads without needing to know which methods "these two" refers to.

## Test plan
- [x] No behavior change (comment-only edit)
- [x] `make lint`