### PR TITLE
refactor(label_dialog): inline text strip and drop PyQt4 trimmed fallback

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -128,22 +128,14 @@ class LabelDialog(QtWidgets.QDialog):
             self.accept()
             return
 
-        if self._get_stripped_text():
+        if self.edit.text().strip():
             self.accept()
-
-    def _get_stripped_text(self) -> str:
-        text = self.edit.text()
-        if hasattr(text, "strip"):
-            return str(text.strip())
-        if hasattr(text, "trimmed"):
-            return str(text.trimmed())
-        return str(text)
 
     def _on_label_double_clicked(self, _: QtWidgets.QListWidgetItem) -> None:
         self._validate()
 
     def _on_editing_finished(self) -> None:
-        self.edit.setText(self._get_stripped_text())
+        self.edit.setText(self.edit.text().strip())
 
     def _on_text_changed(self, label_new: str) -> None:
         # keep state of shared flags


### PR DESCRIPTION
## Summary
- Remove `_get_stripped_text()` helper from `LabelDialog`
- Inline `self.edit.text().strip()` directly in `_validate()` and `_on_editing_finished()`

## Why
`QLineEdit.text()` always returns a plain `str` on PyQt5, so the `hasattr(text, "trimmed")` branch in `_get_stripped_text()` was unreachable PyQt4-era dead code. Inlining the one-call expression is shorter and more direct than routing through a helper.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (170 tests)