### PR TITLE
refactor(app): extract ShapeClipboard and inline copy/paste/duplicate slots

### DIFF
--- a/labelme/_shape_clipboard.py
+++ b/labelme/_shape_clipboard.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from PyQt5 import QtCore
+
+from labelme.shape import Shape
+
+
+class ShapeClipboard(QtCore.QObject):
+    availability_changed = QtCore.pyqtSignal(bool)
+
+    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self._buffer: tuple[Shape, ...] = ()
+
+    def store(self, shapes: Iterable[Shape]) -> None:
+        snapshot = tuple(shape.copy() for shape in shapes)
+        had_content = bool(self._buffer)
+        self._buffer = snapshot
+        if had_content != bool(snapshot):
+            self.availability_changed.emit(bool(snapshot))
+
+    def paste(self) -> list[Shape]:
+        return [shape.copy() for shape in self._buffer]

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -39,6 +39,7 @@ from labelme._automation._osam_session import OsamSession
 from labelme._label_file import LabelFile
 from labelme._label_file import LabelFileError
 from labelme._label_file import ShapeDict
+from labelme._shape_clipboard import ShapeClipboard
 from labelme.config import load_config
 from labelme.shape import Shape
 from labelme.widgets import AiAssistedAnnotationWidget
@@ -171,7 +172,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     _text_osam_session: OsamSession | None = None
     _is_changed: bool = False
-    _copied_shapes: list[Shape]
+    _shape_clipboard: ShapeClipboard
     _zoom_mode: _ZoomMode
     _prev_opened_dir: str | None
     _canvas_widgets: _CanvasWidgets
@@ -228,7 +229,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Set point size from config file
         Shape.point_size = self._config["shape"]["point_size"]
 
-        self._copied_shapes = []
+        self._shape_clipboard = ShapeClipboard(self)
 
         self._label_dialog = LabelDialog(
             parent=self,
@@ -247,6 +248,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets = self._setup_canvas()
 
         self._actions = self._setup_actions()
+        self._shape_clipboard.availability_changed.connect(
+            self._actions.paste.setEnabled
+        )
         self._menus = self._setup_menus()
 
         self._ai_annotation = AiAssistedAnnotationWidget(
@@ -401,7 +405,9 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         duplicate = action(
             self.tr("Duplicate Shapes"),
-            self.duplicate_selected_shapes,
+            lambda: self._insert_shapes(
+                [s.copy() for s in self._canvas_widgets.canvas.selected_shapes]
+            ),
             shortcuts["duplicate_shape"],
             icon="phosphor/copy.svg",
             tip=self.tr("Create a duplicate of the selected shapes"),
@@ -409,7 +415,9 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         copy = action(
             self.tr("Copy Shapes"),
-            self.copy_selected_shapes,
+            lambda: self._shape_clipboard.store(
+                self._canvas_widgets.canvas.selected_shapes
+            ),
             shortcuts["copy_shape"],
             "copy_clipboard",
             self.tr("Copy selected shapes to clipboard"),
@@ -417,7 +425,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         paste = action(
             self.tr("Paste Shapes"),
-            self.paste_selected_shapes,
+            lambda: self._insert_shapes(self._shape_clipboard.paste()),
             shortcuts["paste_shape"],
             "paste",
             self.tr("Paste copied shapes"),
@@ -1669,20 +1677,12 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             return False
 
-    def duplicate_selected_shapes(self) -> None:
-        self.copy_selected_shapes()
-        self.paste_selected_shapes()
-
-    def paste_selected_shapes(self) -> None:
-        self._load_shapes(shapes=self._copied_shapes, replace=False)
-        self._canvas_widgets.canvas.select_shapes(self._copied_shapes)
+    def _insert_shapes(self, shapes: list[Shape]) -> None:
+        if not shapes:
+            return
+        self._load_shapes(shapes=shapes, replace=False)
+        self._canvas_widgets.canvas.select_shapes(shapes)
         self.mark_dirty()
-
-    def copy_selected_shapes(self) -> None:
-        self._copied_shapes = [
-            s.copy() for s in self._canvas_widgets.canvas.selected_shapes
-        ]
-        self._actions.paste.setEnabled(len(self._copied_shapes) > 0)
 
     def _label_selection_changed(self) -> None:
         selected_shapes: list[Shape] = []

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -87,8 +87,8 @@ def test_copy_paste_shape(
     original_label = canvas.selected_shapes[0].label
     num_shapes_before = len(canvas.shapes)
 
-    win.copy_selected_shapes()
-    win.paste_selected_shapes()
+    win._actions.copy.trigger()
+    win._actions.paste.trigger()
     qtbot.wait(50)
 
     assert len(canvas.shapes) == num_shapes_before + 1
@@ -118,7 +118,7 @@ def test_duplicate_shape(
 
     num_shapes_before = len(canvas.shapes)
 
-    win.duplicate_selected_shapes()
+    win._actions.duplicate.trigger()
     qtbot.wait(50)
 
     assert len(canvas.shapes) == num_shapes_before + 1

--- a/tests/unit/_shape_clipboard_test.py
+++ b/tests/unit/_shape_clipboard_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from PyQt5 import QtCore
+
+from labelme._shape_clipboard import ShapeClipboard
+from labelme.shape import Shape
+
+
+def _make_shape(label: str, x: float, y: float) -> Shape:
+    shape = Shape(label=label, shape_type="point")
+    shape.add_point(QtCore.QPointF(x, y))
+    return shape
+
+
+def test_paste_returns_independent_copies() -> None:
+    clipboard = ShapeClipboard()
+    clipboard.store([_make_shape("a", 1.0, 2.0)])
+
+    first = clipboard.paste()
+    first[0].label = "mutated"
+    first[0].points[0].setX(999.0)
+
+    second = clipboard.paste()
+    assert second[0].label == "a"
+    assert second[0].points[0].x() == 1.0
+    assert first[0] is not second[0]


### PR DESCRIPTION
## Summary
- Extract a `ShapeClipboard` QObject (`labelme/_shape_clipboard.py`) that owns the clipboard buffer, deep-copies on `store` and `paste`, and emits `availability_changed(bool)` whenever the buffer transitions between empty and non-empty.
- Drive `paste` action enablement off that signal instead of an inline `setEnabled` call.
- Delete the three trivial wrapper methods on `MainWindow` (`copy_selected_shapes`, `paste_selected_shapes`, `duplicate_selected_shapes`); inline their bodies as lambdas at the `action()` call sites.
- Consolidate the shared load + select + mark-dirty trio into one private `_insert_shapes` helper used by both the duplicate and paste lambdas.
- E2E tests now drive the feature through `QAction.trigger()` so the action wiring is exercised.
- Add a unit test for `ShapeClipboard.paste()` that guards against a shallow-copy regression.

## Why
Clipboard state did not belong on `MainWindow` — it was a list field whose only invariant (paste-action enablement) was maintained by an open-coded `setEnabled` call inline in the copy slot. Pulling it into a dedicated QObject lets the buffer manage its own invariants, makes paste availability signal-driven, and removes a class of latent bugs (e.g., pasting twice would re-add the same `Shape` instances rather than fresh copies). The slot wrappers were one-line passthroughs to the canvas plus this state — inlining them removes indirection without losing readability.

## Behavior change: Duplicate no longer touches the clipboard
The previous `duplicate_selected_shapes` was implemented as `copy_selected_shapes(); paste_selected_shapes()`, so invoking Duplicate silently overwrote the clipboard buffer with the duplicated selection. The new duplicate lambda copies the selected shapes directly through `_insert_shapes` and never touches `_shape_clipboard`, so a prior copy is preserved across duplicates.

## Test plan
- [x] `make test` — 171 passed (170 existing + 1 new unit test)
- [x] `make lint` — ruff/ty/taplo/mdformat/yamlfix/typos all clean; translations unchanged from main
- [x] New `tests/unit/_shape_clipboard_test.py::test_paste_returns_independent_copies` — verifies mutating one paste's shape does not leak into the next
- [x] Existing `tests/e2e/shape_editing_test.py` — copy/paste/duplicate exercised through `_actions.X.trigger()`