### PR TITLE
fix: keep color indicator after editing label group_id

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import enum
 import functools
-import html
 import math
 import os
 import platform
@@ -1481,14 +1480,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             self._update_shape_color(shape)
             assert shape.label is not None
-            if shape.group_id is None:
-                r, g, b = shape.fill_color.getRgb()[:3]
-                item.setText(
-                    f"{html.escape(shape.label)} "
-                    f'<font color="#{r:02x}{g:02x}{b:02x}">●</font>'
-                )
-            else:
-                item.setText(f"{shape.label} ({shape.group_id})")
+            item.setText(format_shape_label(shape))
             self.mark_dirty()
             if self._docks.unique_label_list.find_label_item(shape.label) is None:
                 self._docks.unique_label_list.add_label_item(

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -54,6 +54,7 @@ from labelme.widgets import ToolBar
 from labelme.widgets import UniqueLabelQListWidget
 from labelme.widgets import ZoomWidget
 from labelme.widgets import download_ai_model
+from labelme.widgets import format_shape_label
 
 from . import utils
 
@@ -1535,11 +1536,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def add_label(self, shape: Shape) -> None:
         assert shape.label is not None
-        if shape.group_id is None:
-            text = shape.label
-        else:
-            text = f"{shape.label} ({shape.group_id})"
-        label_list_item = LabelListWidgetItem(text, shape)
+        label_list_item = LabelListWidgetItem(shape=shape)
         self._docks.label_list.add_item(label_list_item)
         if self._docks.unique_label_list.find_label_item(shape.label) is None:
             self._docks.unique_label_list.add_label_item(
@@ -1554,10 +1551,7 @@ class MainWindow(QtWidgets.QMainWindow):
             action.setEnabled(True)
 
         self._update_shape_color(shape)
-        r, g, b = shape.fill_color.getRgb()[:3]
-        label_list_item.setText(
-            f'{html.escape(text)} <font color="#{r:02x}{g:02x}{b:02x}">●</font>'
-        )
+        label_list_item.setText(format_shape_label(shape))
 
     def _update_shape_color(self, shape: Shape) -> None:
         assert shape.label is not None

--- a/labelme/widgets/__init__.py
+++ b/labelme/widgets/__init__.py
@@ -8,6 +8,7 @@ from .label_dialog import LabelDialog
 from .label_dialog import LabelQLineEdit
 from .label_list_widget import LabelListWidget
 from .label_list_widget import LabelListWidgetItem
+from .label_list_widget import format_shape_label
 from .tool_bar import ToolBar
 from .unique_label_qlist_widget import UniqueLabelQListWidget
 from .zoom_widget import ZoomWidget

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 from typing import cast
@@ -13,6 +14,20 @@ from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPalette
 from PyQt5.QtWidgets import QStyle
+
+
+def format_label_with_color_dot(text: str, color: tuple[int, int, int]) -> str:
+    r, g, b = color
+    return f'{html.escape(text)} <font color="#{r:02x}{g:02x}{b:02x}">●</font>'
+
+
+def format_shape_label(shape: Shape) -> str:
+    assert shape.label is not None
+    if shape.group_id is None:
+        text = shape.label
+    else:
+        text = f"{shape.label} ({shape.group_id})"
+    return format_label_with_color_dot(text=text, color=shape.fill_color.getRgb()[:3])
 
 
 class HTMLDelegate(QtWidgets.QStyledItemDelegate):

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import html
-
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt
 
 from .label_list_widget import HTMLDelegate
+from .label_list_widget import format_label_with_color_dot
 
 
 class _EscapableQListWidget(QtWidgets.QListWidget):
@@ -39,8 +38,5 @@ class UniqueLabelQListWidget(_EscapableQListWidget):
 
         item = QtWidgets.QListWidgetItem()
         item.setData(Qt.UserRole, label)  # for find_label_item
-        item.setText(
-            f"{html.escape(label)} "
-            f"<font color='#{color[0]:02x}{color[1]:02x}{color[2]:02x}'>●</font>"
-        )
+        item.setText(format_label_with_color_dot(text=label, color=color))
         self.addItem(item)


### PR DESCRIPTION
## Summary
- Fix Annotation List rows losing the color dot after editing a label with a `group_id`. `_edit_label` rebuilt the row text as `"label (gid)"` and skipped the `<font color=...>●</font>` HTML, so the indicator vanished.
- Refactor: extract `format_label_with_color_dot()` and `format_shape_label()` helpers in `widgets/label_list_widget.py`. Three duplicated copies of the HTML construction (in `app.py` ×2 and `unique_label_qlist_widget.py`) collapse into the helpers.

## Why
Reported by user: some rows in the Annotation List had no colored dot. Reproduced by editing a label and assigning a `group_id` (e.g. `person (0)`) — the dot disappeared from that row only.

## Test plan
- [x] `make lint` passes (ruff, ty, mdformat, yamlfix, typos)
- [x] `make test` passes (171 tests)
- [x] Manually verify: create an annotation, edit it, assign a `group_id`, confirm the colored dot still renders next to the entry in the Annotation List.