### PR TITLE
refactor(canvas): replace assert with ValueError in set_last_label

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1286,7 +1286,8 @@ class Canvas(QtWidgets.QWidget):
                 self.is_moving_shape = False
 
     def set_last_label(self, text: str, flags: dict[str, bool]) -> list[Shape]:
-        assert text
+        if not text:
+            raise ValueError("text must not be empty")
         shapes = []
         for shape in reversed(self.shapes):
             if shape.label is not None:


### PR DESCRIPTION
## Summary
- Replace `assert text` with `if not text: raise ValueError(...)` in `Canvas.set_last_label`.

## Why
`assert` statements are stripped under `python -O`, so they should not be used for runtime validation. The caller in `app.py` already guards with `if text:`, but keeping a defensive check is appropriate — and it should be a real check, not an assertion.

This also surfaced during a relicensing audit: the original `assert text` line was the last surviving fragment from an old GPL-era contributor commit (`da221841`, mpitid). Rewriting it removes any residual derivation while improving correctness.

## Test plan
- [x] `make lint` passes (ruff format, ruff check, ty, taplo, mdformat, yamlfix, typos)
- [x] Verify label dialog flow still works end-to-end in the GUI