### PR TITLE
refactor: small cleanups in format_shortcut and update_action_states

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1221,10 +1221,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._actions.delete_file.setEnabled(False)
 
     def update_action_states(self, value: bool = True) -> None:
-        """Enable/Disable widgets which depend on an opened image."""
-        for z in self._actions.zoom:
-            z.setEnabled(value)
-        for action in self._actions.on_load_active:
+        for action in (*self._actions.zoom, *self._actions.on_load_active):
             action.setEnabled(value)
 
     def queue_event(self, function: Callable[[], None]) -> None:

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -110,5 +110,7 @@ def distance_to_line(
 
 
 def format_shortcut(text: str) -> str:
-    mod, key = text.split("+", 1)
-    return f"<b>{mod}</b>+<b>{key}</b>"
+    if "+" not in text:
+        raise ValueError(f"shortcut missing '+': {text!r}")
+    modifier, _, key = text.partition("+")
+    return f"<b>{modifier}</b>+<b>{key}</b>"


### PR DESCRIPTION
## Summary
- `labelme/utils/qt.py`: `format_shortcut` now raises `ValueError` with a descriptive message when the input does not contain `+`, instead of relying on the implicit unpack failure from `str.split`.
- `labelme/app.py`: `update_action_states` iterates over zoom and on-load-active actions in a single loop using tuple unpacking, instead of two sequential loops.

## Why
Minor readability/robustness cleanups in two small utility methods. No behavior change for valid inputs.

## Test plan
- [x] `make lint` passes
- [x] `pytest tests/unit/utils/qt_test.py tests/e2e/zoom_test.py tests/e2e/file_operations_test.py` passes
- [x] Smoke check: `format_shortcut` returns identical output for valid shortcuts and now raises a clearer `ValueError` for inputs without `+`.