### PR TITLE
refactor(zoom-widget): extract configuration helpers and use Final constants

### DIFF
--- a/labelme/widgets/zoom_widget.py
+++ b/labelme/widgets/zoom_widget.py
@@ -1,23 +1,27 @@
 from __future__ import annotations
 
+from typing import Final
+
 from PyQt5 import QtCore
-from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
 
 class ZoomWidget(QtWidgets.QSpinBox):
-    def __init__(self, value: int = 100) -> None:
-        super().__init__()
-        self.setRange(1, 1000)
-        self.setSuffix(" %")
-        self.setValue(value)
-        self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
-        self.setAlignment(QtCore.Qt.AlignCenter)
-        self.setToolTip("Zoom Level")
-        self.setStatusTip(self.toolTip())
+    PERCENT_MAX: Final = 1000
+    PERCENT_SUFFIX: Final = " %"
 
-    def minimumSizeHint(self) -> QtCore.QSize:
-        base = super().minimumSizeHint()
-        font_metrics = QtGui.QFontMetrics(self.font())
-        digits_width = font_metrics.horizontalAdvance(str(self.maximum()))
-        return QtCore.QSize(digits_width, base.height())
+    def __init__(self) -> None:
+        super().__init__()
+        self.setRange(1, self.PERCENT_MAX)
+        self.setValue(100)
+        self.setSuffix(self.PERCENT_SUFFIX)
+        self.setAlignment(QtCore.Qt.AlignCenter)
+        self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+        tooltip = "Zoom Level"
+        self.setToolTip(tooltip)
+        self.setStatusTip(tooltip)
+        self._apply_minimum_width()
+
+    def _apply_minimum_width(self) -> None:
+        sample = f"{self.PERCENT_MAX}{self.PERCENT_SUFFIX}"
+        self.setMinimumWidth(self.fontMetrics().horizontalAdvance(sample))


### PR DESCRIPTION
## Summary
- Lift the shared values to class-level `Final` constants (`PERCENT_MAX`, `PERCENT_SUFFIX`).
- Extract `_apply_minimum_width()` from `__init__`.
- Replace the `minimumSizeHint()` override with a one-shot `setMinimumWidth()` computed from the `"1000 %"` sample string (the previous override only measured `"1000"` and ignored the suffix).
- Drop the unused `value` constructor parameter; the widget always initializes at 100, matching the only call site (`labelme/app.py`).
- Deduplicate `setToolTip` / `setStatusTip` via a local `tooltip`.

## Why
Improves readability of the widget initialization and incidentally corrects the minimum-width computation, which previously did not account for the `" %"` suffix shown in the spinbox.

## Test plan
- [x] `make lint` passes (`ruff format --check`, `ruff check`, `ty check`, taplo, mdformat, yamlfix, typos).
- [x] `make test` passes (171/171), including the e2e zoom suite (`tests/e2e/zoom_test.py`).
- [x] Manual: open the app, exercise zoom in / zoom out / fit window / fit width / manual percentage entry — confirm the toolbar zoom percentage display and behavior is unchanged.