### PR TITLE
refactor(label-dialog): rewrite _current_flags as dict comprehension

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -86,7 +86,6 @@ class LabelDialog(QtWidgets.QDialog):
         self.label_list.setFixedHeight(150)
         self.edit.set_list_widget(self.label_list)
         layout.addWidget(self.label_list)
-        # label_flags
         if flags is None:
             flags = {}
         self._flags = flags
@@ -171,12 +170,11 @@ class LabelDialog(QtWidgets.QDialog):
             item.show()
 
     def _current_flags(self) -> dict[str, bool]:
-        flags = {}
-        for i in range(self._flags_layout.count()):
-            item = self._flags_layout.itemAt(i).widget()
-            item = cast(QtWidgets.QCheckBox, item)
-            flags[item.text()] = item.isChecked()
-        return flags
+        return {
+            cb.text(): cb.isChecked()
+            for i in range(self._flags_layout.count())
+            if (cb := cast(QtWidgets.QCheckBox, self._flags_layout.itemAt(i).widget()))
+        }
 
     def _current_group_id(self) -> int | None:
         group_id = self.edit_group_id.text()


### PR DESCRIPTION
## Summary
- Rewrite `LabelDialog._current_flags` from a mutable-accumulator loop into a single `dict` comprehension.
- Drop a stale `# label_flags` section comment above the flag initialization.

## Why
The comprehension expresses the intent (build a `{checkbox text: checked}` map from the flags layout) more directly than the loop form. The deleted comment added no information beyond what the surrounding code already conveys.

## Test plan
- [x] `make lint` passes (ruff format/check, ty, taplo, mdformat, yamlfix, typos, translation diff).
- [x] `make test` passes (171/171), including `test_LabelDialog_popup` which asserts the empty-layout return is `{}`.