### PR TITLE
refactor(qt): rewrite distance_to_line with parametric clamp

### DIFF
--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -93,20 +93,23 @@ def distance_to_line(
     point: QtCore.QPointF,
     line: tuple[QtCore.QPointF, QtCore.QPointF],
 ) -> np.floating[Any]:
-    p1, p2 = line
-    p1 = np.array([p1.x(), p1.y()])
-    p2 = np.array([p2.x(), p2.y()])
-    p3 = np.array([point.x(), point.y()])
-    if np.dot((p3 - p1), (p2 - p1)) < 0:
-        return np.linalg.norm(p3 - p1)
-    if np.dot((p3 - p2), (p1 - p2)) < 0:
-        return np.linalg.norm(p3 - p2)
-    d = p2 - p1
-    if np.linalg.norm(d) == 0:
-        return np.linalg.norm(p3 - p1)
-    v = p1 - p3
-    cross = d[0] * v[1] - d[1] * v[0]
-    return abs(cross) / np.linalg.norm(d)
+    start, end = line
+    sx, sy = start.x(), start.y()
+    ex, ey = end.x(), end.y()
+    px, py = point.x(), point.y()
+
+    edge_x = ex - sx
+    edge_y = ey - sy
+    length_sq = edge_x * edge_x + edge_y * edge_y
+    if length_sq == 0:
+        return np.hypot(px - sx, py - sy)
+
+    t = ((px - sx) * edge_x + (py - sy) * edge_y) / length_sq
+    t = min(1.0, max(0.0, t))
+
+    nearest_x = sx + t * edge_x
+    nearest_y = sy + t * edge_y
+    return np.hypot(px - nearest_x, py - nearest_y)
 
 
 def format_shortcut(text: str) -> str:


### PR DESCRIPTION
## Summary
- Replace `distance_to_line` body with a parametric clamp-`t` formulation: project the point onto the segment via the dot product divided by squared length, clamp to `[0, 1]`, and return `np.hypot` to the projected point.
- Unifies the prior dual-branch (two dot-product early-returns) plus cross-product fallback into a single, simpler expression with the same semantics.

## Why
Simplify the implementation. The previous version split the computation across two early-return endpoint guards plus a cross-product fallback for the line-distance case; the parametric form expresses the same point-to-segment distance in one path with fewer branches.

## Test plan
- [x] `uv run pytest tests/unit/utils/qt_test.py` (5 assertions: on-segment, perpendicular, endpoint, beyond-start, beyond-end) — all pass.
- [x] `uv run ruff format --check labelme/utils/qt.py` — clean.
- [x] `uv run ruff check labelme/utils/qt.py` — clean.