### PR TITLE
feat(visibility): undoable hide/show with multi-select propagation

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1692,9 +1692,38 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_label_item_changed(self, item: LabelListWidgetItem) -> None:
         shape = item.shape()
         assert shape is not None
-        self._canvas_widgets.canvas.set_shape_visible(
-            shape, item.checkState() == Qt.Checked
-        )
+        new_visible = item.checkState() == Qt.Checked
+
+        label_list = self._docks.label_list
+        prior = label_list.selection_at_press()
+        current = label_list.selected_items()
+        if item in prior and len(prior) > 1:
+            targets = prior
+        elif item in current and len(current) > 1:
+            targets = current
+        else:
+            targets = [item]
+
+        canvas = self._canvas_widgets.canvas
+        any_changed = False
+        target_state = Qt.Checked if new_visible else Qt.Unchecked
+        label_list.item_changed.disconnect(self._on_label_item_changed)
+        try:
+            for target in targets:
+                target_shape = target.shape()
+                assert target_shape is not None
+                if target_shape.visible == new_visible:
+                    continue
+                if target.checkState() != target_state:
+                    target.setCheckState(target_state)
+                canvas.set_shape_visible(target_shape, new_visible)
+                any_changed = True
+        finally:
+            label_list.item_changed.connect(self._on_label_item_changed)
+
+        if any_changed:
+            canvas.backup_shapes()
+        self._actions.undo.setEnabled(canvas.can_restore_shape)
 
     def _on_label_order_changed(self) -> None:
         self.mark_dirty()

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -178,6 +178,51 @@ class LabelListWidget(QtWidgets.QListView):
         self.doubleClicked.connect(self._on_item_double_clicked)
         self.selectionModel().selectionChanged.connect(self._on_item_selection_changed)
 
+        self._selection_at_press: list[LabelListWidgetItem] = []
+        self._press_item: LabelListWidgetItem | None = None
+        self._press_check_state: Qt.CheckState | None = None
+
+    def mousePressEvent(self, e: QtGui.QMouseEvent) -> None:
+        self._selection_at_press = self.selected_items()
+        index = self.indexAt(e.pos())
+        item_at_pos = (
+            cast(LabelListWidgetItem, self._model.itemFromIndex(index))
+            if index.isValid()
+            else None
+        )
+        self._press_item = item_at_pos
+        self._press_check_state = (
+            item_at_pos.checkState() if item_at_pos is not None else None
+        )
+        super().mousePressEvent(e)
+
+    def mouseReleaseEvent(self, e: QtGui.QMouseEvent) -> None:
+        super().mouseReleaseEvent(e)
+        try:
+            press_item = self._press_item
+            prior_check = self._press_check_state
+            if (
+                press_item is not None
+                and prior_check is not None
+                and press_item.checkState() != prior_check
+                and press_item in self._selection_at_press
+                and len(self._selection_at_press) > 1
+            ):
+                sel_model = self.selectionModel()
+                sel_model.clearSelection()
+                for it in self._selection_at_press:
+                    sel_model.select(
+                        self._model.indexFromItem(it),
+                        QtCore.QItemSelectionModel.Select,
+                    )
+        finally:
+            self._press_item = None
+            self._press_check_state = None
+            self._selection_at_press = []
+
+    def selection_at_press(self) -> list[LabelListWidgetItem]:
+        return list(self._selection_at_press)
+
     def __len__(self) -> int:
         return self._model.rowCount()
 

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+from PyQt5.QtCore import QPoint
+from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
@@ -64,5 +66,139 @@ def test_toggle_individual_shape(
     first_item.setCheckState(Qt.Checked)
     qtbot.wait(50)
     assert canvas.is_shape_visible(first_shape)
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_visibility_preserved_when_undoing_unrelated_edit(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+
+    hidden_index = 1
+    label_list[hidden_index].setCheckState(Qt.Unchecked)
+    qtbot.wait(50)
+    assert not canvas.is_shape_visible(canvas.shapes[hidden_index])
+
+    canvas.shapes[0].points[0] += QPointF(5.0, 5.0)
+    canvas.backup_shapes()
+
+    annotated_win.undo_shape_edit()
+    qtbot.wait(50)
+
+    assert len(canvas.shapes) == 5
+    for i, shape in enumerate(canvas.shapes):
+        expected_visible = i != hidden_index
+        assert canvas.is_shape_visible(shape) is expected_visible
+        expected_state = Qt.Checked if expected_visible else Qt.Unchecked
+        assert label_list[i].checkState() == expected_state
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_undo_recovers_accidental_hide(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+    hidden_index = 1
+
+    label_list[hidden_index].setCheckState(Qt.Unchecked)
+    qtbot.wait(50)
+    assert not canvas.is_shape_visible(canvas.shapes[hidden_index])
+    assert annotated_win._actions.undo.isEnabled()
+
+    annotated_win._actions.undo.trigger()
+    qtbot.wait(50)
+
+    assert len(canvas.shapes) == 5
+    for i, shape in enumerate(canvas.shapes):
+        assert canvas.is_shape_visible(shape)
+        assert label_list[i].checkState() == Qt.Checked
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_multi_select_toggle_propagates(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+    selected_indices = (0, 1, 3)
+
+    label_list.clearSelection()
+    for i in selected_indices:
+        label_list.select_item(label_list[i])
+    qtbot.wait(50)
+    assert {item for item in label_list.selected_items()} == {
+        label_list[i] for i in selected_indices
+    }
+
+    label_list[selected_indices[1]].setCheckState(Qt.Unchecked)
+    qtbot.wait(50)
+
+    for i in range(len(canvas.shapes)):
+        if i in selected_indices:
+            assert not canvas.is_shape_visible(canvas.shapes[i])
+            assert label_list[i].checkState() == Qt.Unchecked
+        else:
+            assert canvas.is_shape_visible(canvas.shapes[i])
+            assert label_list[i].checkState() == Qt.Checked
+
+    annotated_win._actions.undo.trigger()
+    qtbot.wait(50)
+
+    for i in range(len(canvas.shapes)):
+        assert canvas.is_shape_visible(canvas.shapes[i])
+        assert label_list[i].checkState() == Qt.Checked
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_multi_select_preserves_selection_after_checkbox_click(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+    selected_indices = (0, 1, 3)
+
+    label_list.clearSelection()
+    for i in selected_indices:
+        label_list.select_item(label_list[i])
+    qtbot.wait(50)
+
+    target_index = label_list._model.indexFromItem(label_list[selected_indices[1]])
+    rect = label_list.visualRect(target_index)
+    checkbox_pos = QPoint(rect.left() + 5, rect.center().y())
+    qtbot.mouseClick(label_list.viewport(), Qt.LeftButton, pos=checkbox_pos)
+    qtbot.wait(50)
+
+    assert {item for item in label_list.selected_items()} == {
+        label_list[i] for i in selected_indices
+    }
+    for i in selected_indices:
+        assert label_list[i].checkState() == Qt.Unchecked
+        assert not canvas.is_shape_visible(canvas.shapes[i])
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)


### PR DESCRIPTION
## Summary
**Stacked on top of #2033** (pure refactor — please review/merge that one first).

This PR adds the user-facing behavior:
- Each label-list checkbox toggle records an undo step, so Ctrl+Z recovers an accidental hide and visibility is no longer reset by undo.
- When the changed item is part of a multi-selection, the new check state propagates to all selected items as a single undo step.
- Multi-selection is preserved across the click so the same group can be toggled repeatedly without re-selecting.
- Refresh the Undo action's enabled state on toggle (visibility changes don't go through `mark_dirty`).

## Why
Reported bug: hitting undo reset every shape's hidden/shown status. Root cause is fixed in #2033 (the `Canvas.visible` dict was keyed by Shape object identity while `backup_shapes()` deep-copies shapes, so post-undo lookups always fell through to the default `True`). With that data-location fix in place, this PR answers the design question — should hide/show be undoable at all? — with yes (Photoshop/Figma-style), so users can recover from an accidental click. Multi-select toggle is a common follow-up workflow.

## Test plan
- [x] `make test` — 175 passed (4 new e2e tests for the new behaviors)
- [x] `make lint` — clean
- New tests:
  - `test_visibility_preserved_when_undoing_unrelated_edit` — hide → edit → undo edit → shape stays hidden
  - `test_undo_recovers_accidental_hide` — hide → undo → shape visible again, asserts Undo action enabled
  - `test_multi_select_toggle_propagates` — multi-select → toggle one → all flip; one undo reverts the bulk action
  - `test_multi_select_preserves_selection_after_checkbox_click` — simulated mouse click on a checkbox does not collapse the multi-selection
- [ ] Manual: in the GUI, hide a few shapes and verify Ctrl+Z reveals them one-by-one
- [ ] Manual: select multiple labels, click one checkbox, verify the rest follow and selection stays intact