### PR TITLE
refactor(canvas): simplify can_restore_shape and undo-related comments

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -62,7 +62,7 @@ canvas:
   # None: do nothing
   # close: close polygon
   double_click: close
-  # The max number of edits we can undo
+  # max undo depth (number of edits kept on the backup stack)
   num_backups: 10
   # show crosshair
   crosshair:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -91,7 +91,7 @@ class Canvas(QtWidgets.QWidget):
             raise ValueError(
                 f"Unexpected value for double_click event: {self.double_click}"
             )
-        self.num_backups = kwargs.pop("num_backups", 10)
+        self.num_backups: int = kwargs.pop("num_backups", 10)
         self._crosshair = kwargs.pop(
             "crosshair",
             {
@@ -213,23 +213,19 @@ class Canvas(QtWidgets.QWidget):
 
     @property
     def can_restore_shape(self) -> bool:
-        # We save the state AFTER each edit (not before) so for an
-        # edit to be undoable, we expect the CURRENT and the PREVIOUS state
-        # to be in the undo stack.
-        if len(self.shape_backups) < 2:
-            return False
-        return True
+        # The latest entry on the backup stack mirrors the current state, so
+        # at least one prior entry must exist for an undo to be meaningful.
+        return len(self.shape_backups) >= 2
 
     def restore_last_shape(self) -> None:
-        # This does _part_ of the job of restoring shapes.
-        # The complete process is also done in app.py::undo_shape_edit
-        # and app.py::load_shapes and our own Canvas::load_shapes function.
+        # Undo coordinates with app.py::undo_shape_edit, app.py::load_shapes,
+        # and Canvas::load_shapes; this method only adjusts the backup stack.
         if not self.can_restore_shape:
             return
-        self.shape_backups.pop()  # latest
+        self.shape_backups.pop()  # discard current state
 
-        # The application will eventually call Canvas.load_shapes which will
-        # push this right back onto the stack.
+        # load_shapes (called downstream by the application) will re-push
+        # this entry as the new current state.
         self.shapes = self.shape_backups.pop()
         for shape in self.shapes:
             shape.selected = False


### PR DESCRIPTION
## Summary
- Collapse `can_restore_shape` from a `if x < 2: return False / return True` block into a direct `return len(self.shape_backups) >= 2`.
- Tighten the comments around `can_restore_shape` and `restore_last_shape` so the prose explains why the invariant matters and how the method coordinates with `app.py`'s undo path, instead of restating what each line does.
- Add an `int` annotation to `self.num_backups` in `Canvas.__init__` for consistency with the other annotated kwargs (`epsilon: float`).
- Refresh the `num_backups` comment in `default_config.yaml` to describe the field as the max undo depth.

## Why
Reduce noise in a hot path of the canvas widget: the comments duplicated what the code already said, and the predicate was written in a verbose two-step form. Behavior is preserved end-to-end.

## Test plan
- [x] `uv run pytest tests/unit` — 72 passed.
- [x] `make format` — clean.
- [x] Manual: trigger an undo (Ctrl+Z) on a canvas with multiple edits and confirm the previous state is restored exactly as before.