### PR TITLE
fix(canvas): normalize AI-BOX bbox points before sending to model

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -194,8 +194,7 @@ class Canvas(QtWidgets.QWidget):
         )
 
     def _shapes_from_bbox_ai(self, bbox_points: list[QPointF]) -> list[Shape]:
-        if len(bbox_points) != 2:
-            raise ValueError(f"Expected 2 points for bbox AI, got {len(bbox_points)}")
+        bbox_points = _normalize_bbox_points(bbox_points=bbox_points)
         image: np.ndarray = labelme.utils.img_qt_to_arr(img_qt=self.pixmap.toImage())
         response: osam.types.GenerateResponse = self._get_osam_session().run(
             image=imgviz.asrgb(image),  # type: ignore[arg-type]
@@ -1466,6 +1465,18 @@ def _shapes_from_ai_response(
         if shape is not None:
             shapes.append(shape)
     return shapes
+
+
+def _normalize_bbox_points(bbox_points: list[QPointF]) -> list[QPointF]:
+    if len(bbox_points) != 2:
+        raise ValueError(f"Expected 2 points for bbox, got {len(bbox_points)}")
+
+    p1, p2 = bbox_points
+    xmin = min(p1.x(), p2.x())
+    ymin = min(p1.y(), p2.y())
+    xmax = max(p1.x(), p2.x())
+    ymax = max(p1.y(), p2.y())
+    return [QPointF(xmin, ymin), QPointF(xmax, ymax)]
 
 
 def _snap_cursor_pos_for_square(pos: QPointF, opposite_vertex: QPointF) -> QPointF:

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -9,6 +9,7 @@ from pytestqt.qtbot import QtBot
 
 from labelme.widgets.canvas import Canvas
 from labelme.widgets.canvas import _compute_intersection_edges_image
+from labelme.widgets.canvas import _normalize_bbox_points
 
 _WIDTH: Final = 100
 _HEIGHT: Final = 50
@@ -99,3 +100,24 @@ def test_intersectionPoint(
         _compute_intersection_edges_image(p1, p2, image_size=canvas.pixmap.size())
         == pt_intersection
     )
+
+
+@pytest.mark.parametrize(
+    ("p1", "p2"),
+    [
+        (QPointF(10, 20), QPointF(30, 40)),  # top-left -> bottom-right
+        (QPointF(30, 40), QPointF(10, 20)),  # bottom-right -> top-left
+        (QPointF(30, 20), QPointF(10, 40)),  # top-right -> bottom-left
+        (QPointF(10, 40), QPointF(30, 20)),  # bottom-left -> top-right
+    ],
+)
+def test_normalize_bbox_points(p1: QPointF, p2: QPointF) -> None:
+    assert _normalize_bbox_points(bbox_points=[p1, p2]) == [
+        QPointF(10, 20),
+        QPointF(30, 40),
+    ]
+
+
+def test_normalize_bbox_points_rejects_wrong_length() -> None:
+    with pytest.raises(ValueError, match="Expected 2 points"):
+        _normalize_bbox_points(bbox_points=[QPointF(0, 0)])


### PR DESCRIPTION
## Summary
- Add `_normalize_bbox_points` helper that reorders the two clicked corners to `(xmin, ymin), (xmax, ymax)`.
- Call it from `Canvas._shapes_from_bbox_ai` so the AI receives a canonical bbox regardless of click order.
- Add unit coverage for all four opposite-corner click orders plus a length-validation case.

## Why
The canvas already displays the rectangle correctly for any two opposite corners, but the AI bbox prompt was passing the raw clicked points directly to the model. This made the segmentation ROI differ from the displayed rectangle when the user drew the box from a non-top-left corner (e.g. top-right → bottom-left).

Replaces #2026, which mixed this fix with reverts of unrelated refactors that had landed on `main` after the PR branch was created. This PR is rebased on current `main` and contains only the bbox-normalization change + tests.

## Test plan
- [x] `uv run pytest tests/unit/widgets/canvas_test.py` — 23 passed
- [x] `make lint` — clean (ruff, ty, taplo, mdformat, yamlfix, typos, translation diff)
- [ ] Manual: draw an AI-BOX from each of the 4 corner orders and confirm the segmentation matches the displayed rectangle