### PR TITLE
refactor(shape): track visibility as a Shape attribute

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -60,6 +60,7 @@ class Shape:
         self._shape_type_raw = None
         self.fill = False
         self.selected = False
+        self.visible = True
         self.flags = flags
         self.description = description
         self.other_data: dict[str, Any] = {}

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -122,7 +122,6 @@ class Canvas(QtWidgets.QWidget):
         self.offsets = QPointF(), QPointF()
         self.scale: float = 1.0
         self._osam_session = None
-        self.visible: dict = {}
         self._hide_background: bool = False
         self.hide_background: bool = False
         self.snapping = True
@@ -249,7 +248,7 @@ class Canvas(QtWidgets.QWidget):
         self._update_status()
 
     def is_shape_visible(self, shape: Shape) -> bool:
-        return self.visible.get(shape, True)
+        return shape.visible
 
     def drawing(self) -> bool:
         return self.mode == CanvasMode.CREATE
@@ -1360,7 +1359,9 @@ class Canvas(QtWidgets.QWidget):
         self.update()
 
     def set_shape_visible(self, shape: Shape, value: bool) -> None:
-        self.visible[shape] = value
+        if shape.visible == value:
+            return
+        shape.visible = value
         self.update()
 
     def _apply_cursor(self, cursor: QtCore.Qt.CursorShape) -> None:

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -98,7 +98,9 @@ class LabelListWidgetItem(QtGui.QStandardItem):
         self.set_shape(shape)
 
         self.setCheckable(True)
-        self.setCheckState(Qt.Checked)
+        self.setCheckState(
+            Qt.Checked if shape is None or shape.visible else Qt.Unchecked
+        )
         self.setEditable(False)
         self.setTextAlignment(Qt.AlignBottom)
 

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -7,6 +7,7 @@ from PyQt5 import QtGui
 from PyQt5.QtCore import QPointF
 from pytestqt.qtbot import QtBot
 
+from labelme.shape import Shape
 from labelme.widgets.canvas import Canvas
 from labelme.widgets.canvas import _compute_intersection_edges_image
 from labelme.widgets.canvas import _normalize_bbox_points
@@ -121,3 +122,20 @@ def test_normalize_bbox_points(p1: QPointF, p2: QPointF) -> None:
 def test_normalize_bbox_points_rejects_wrong_length() -> None:
     with pytest.raises(ValueError, match="Expected 2 points"):
         _normalize_bbox_points(bbox_points=[QPointF(0, 0)])
+
+
+@pytest.mark.gui
+def test_shape_visibility_survives_backup_and_restore(canvas: Canvas) -> None:
+    shape = Shape(label="a", shape_type="rectangle")
+    shape.add_point(QPointF(0, 0))
+    shape.add_point(QPointF(10, 10))
+    shape.close()
+    canvas.load_shapes([shape])
+
+    canvas.set_shape_visible(canvas.shapes[0], False)
+    canvas.backup_shapes()
+    canvas.load_shapes([shape.copy()])
+    assert canvas.is_shape_visible(canvas.shapes[0]) is False
+
+    canvas.restore_last_shape()
+    assert canvas.is_shape_visible(canvas.shapes[0]) is False


### PR DESCRIPTION
## Summary
Pure refactor extracted from #2028 to make review easier.

Moves shape visibility from `Canvas.visible: dict[Shape, bool]` (keyed by Shape object identity) onto `Shape.visible`, so visibility travels with the shape through `Shape.copy()` (deep-copy) and lives on the object that owns the state.

## Why
`Canvas.visible` was keyed by Shape object identity, but `backup_shapes()` deep-copies shapes onto the undo stack. After an undo, the restored shapes were new objects whose identity was no longer in the dict, so lookups always fell through to the default `True` and visibility silently reset.

## Behavior change
Because `Shape.visible` is now part of the deep-copied state, **undo and other paths that round-trip a Shape through `copy()` now preserve visibility** instead of silently resetting to `True`. This is the latent bug described above and is the only user-visible difference; no other behavior changes. The user-facing entry point (toggle wiring) and multi-select propagation are stacked in the follow-up PR.

A regression test (`test_shape_visibility_survives_backup_and_restore`) locks in the new behavior: it would have failed against the old dict-based implementation because the restored deep-copy was never a key in `Canvas.visible`.

## Test plan
- [x] `make test` (incl. new regression test)
- [x] `make lint`

Stacked PR: feature on top of this is #2028 (re-targeted to this branch).