### PR TITLE
feat(app): make hide/show shape undoable

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1692,9 +1692,13 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_label_item_changed(self, item: LabelListWidgetItem) -> None:
         shape = item.shape()
         assert shape is not None
-        self._canvas_widgets.canvas.set_shape_visible(
-            shape, item.checkState() == Qt.Checked
-        )
+        new_visible = item.checkState() == Qt.Checked
+        if shape.visible == new_visible:
+            return
+        canvas = self._canvas_widgets.canvas
+        canvas.set_shape_visible(shape, new_visible)
+        canvas.backup_shapes()
+        self._actions.undo.setEnabled(canvas.can_restore_shape)
 
     def _on_label_order_changed(self) -> None:
         self.mark_dirty()

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
@@ -64,5 +65,65 @@ def test_toggle_individual_shape(
     first_item.setCheckState(Qt.Checked)
     qtbot.wait(50)
     assert canvas.is_shape_visible(first_shape)
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_visibility_preserved_when_undoing_unrelated_edit(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+
+    hidden_index = 1
+    label_list[hidden_index].setCheckState(Qt.Unchecked)
+    qtbot.wait(50)
+    assert not canvas.is_shape_visible(canvas.shapes[hidden_index])
+
+    canvas.shapes[0].points[0] += QPointF(5.0, 5.0)
+    canvas.backup_shapes()
+
+    annotated_win.undo_shape_edit()
+    qtbot.wait(50)
+
+    assert len(canvas.shapes) == 5
+    for i, shape in enumerate(canvas.shapes):
+        expected_visible = i != hidden_index
+        assert canvas.is_shape_visible(shape) is expected_visible
+        expected_state = Qt.Checked if expected_visible else Qt.Unchecked
+        assert label_list[i].checkState() == expected_state
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_undo_recovers_accidental_hide(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+    hidden_index = 1
+
+    label_list[hidden_index].setCheckState(Qt.Unchecked)
+    qtbot.wait(50)
+    assert not canvas.is_shape_visible(canvas.shapes[hidden_index])
+    assert annotated_win._actions.undo.isEnabled()
+
+    annotated_win._actions.undo.trigger()
+    qtbot.wait(50)
+
+    assert len(canvas.shapes) == 5
+    for i, shape in enumerate(canvas.shapes):
+        assert canvas.is_shape_visible(shape)
+        assert label_list[i].checkState() == Qt.Checked
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)


### PR DESCRIPTION
## Summary
- Toggling a shape's visibility checkbox now calls `canvas.backup_shapes()` so the change is captured in the undo stack.
- The undo action is enabled immediately after a hide/show toggle.
- Adds e2e tests covering visibility persistence across an unrelated edit's undo, and undo recovering an accidental hide.

## Test plan
- [x] `uv run pytest tests/e2e/visibility_test.py`
- [x] `make lint`