### PR TITLE
feat(label-list): propagate hide/show across multi-selection

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1690,15 +1690,37 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._canvas_widgets.canvas.update()
 
     def _on_label_item_changed(self, item: LabelListWidgetItem) -> None:
-        shape = item.shape()
-        assert shape is not None
-        new_visible = item.checkState() == Qt.Checked
-        if shape.visible == new_visible:
+        is_visible_new = item.checkState() == Qt.Checked
+
+        selected_group = (
+            self._docks.label_list.selection_at_press()
+            or self._docks.label_list.selected_items()
+        )
+        items_to_toggle = (
+            selected_group
+            if item in selected_group and len(selected_group) > 1
+            else [item]
+        )
+        items_to_change = [
+            it
+            for it in items_to_toggle
+            if (sh := it.shape()) is not None and sh.visible != is_visible_new
+        ]
+        if not items_to_change:
             return
-        canvas = self._canvas_widgets.canvas
-        canvas.set_shape_visible(shape, new_visible)
-        canvas.backup_shapes()
-        self._actions.undo.setEnabled(canvas.can_restore_shape)
+
+        new_check_state = Qt.Checked if is_visible_new else Qt.Unchecked
+        with QtCore.QSignalBlocker(self._docks.label_list._model):
+            for item_to_toggle in items_to_change:
+                shape_to_toggle = item_to_toggle.shape()
+                assert shape_to_toggle is not None
+                item_to_toggle.setCheckState(new_check_state)
+                self._canvas_widgets.canvas.set_shape_visible(
+                    shape=shape_to_toggle, value=is_visible_new
+                )
+
+        self._canvas_widgets.canvas.backup_shapes()
+        self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
 
     def _on_label_order_changed(self) -> None:
         self.mark_dirty()

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
+from typing import NamedTuple
 from typing import cast
 
 if TYPE_CHECKING:
@@ -157,6 +158,11 @@ class _ItemModel(QtGui.QStandardItemModel):
         return super().dropMimeData(data, action, row, column, parent)
 
 
+class _ItemSnapshot(NamedTuple):
+    item: LabelListWidgetItem
+    check_state: Qt.CheckState
+
+
 class LabelListWidget(QtWidgets.QListView):
     item_double_clicked = QtCore.pyqtSignal(LabelListWidgetItem)
     item_selection_changed = QtCore.pyqtSignal(list, list)
@@ -177,6 +183,41 @@ class LabelListWidget(QtWidgets.QListView):
 
         self.doubleClicked.connect(self._on_item_double_clicked)
         self.selectionModel().selectionChanged.connect(self._on_item_selection_changed)
+
+        self._press_snapshot: tuple[_ItemSnapshot, ...] = ()
+
+    def mousePressEvent(self, e: QtGui.QMouseEvent) -> None:
+        self._press_snapshot = tuple(
+            _ItemSnapshot(item=item, check_state=item.checkState())
+            for item in self.selected_items()
+        )
+        super().mousePressEvent(e)
+
+    def mouseReleaseEvent(self, e: QtGui.QMouseEvent) -> None:
+        super().mouseReleaseEvent(e)
+
+        # Restore the multi-selection only when a checkbox toggle collapsed it.
+        # A plain row click should narrow the selection to one row.
+        check_state_changed = any(
+            snap.item.checkState() != snap.check_state for snap in self._press_snapshot
+        )
+        items_at_press = tuple(snap.item for snap in self._press_snapshot)
+        if (
+            check_state_changed
+            and len(items_at_press) > 1
+            and set(self.selected_items()) != set(items_at_press)
+        ):
+            self.selectionModel().clearSelection()
+            for item in items_at_press:
+                self.selectionModel().select(
+                    self._model.indexFromItem(item),
+                    QtCore.QItemSelectionModel.Select,
+                )
+
+        self._press_snapshot = ()
+
+    def selection_at_press(self) -> tuple[LabelListWidgetItem, ...]:
+        return tuple(snap.item for snap in self._press_snapshot)
 
     def __len__(self) -> int:
         return self._model.rowCount()

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from PyQt5.QtCore import QPoint
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import Qt
 from pytestqt.qtbot import QtBot
@@ -125,5 +126,106 @@ def test_undo_recovers_accidental_hide(
     for i, shape in enumerate(canvas.shapes):
         assert canvas.is_shape_visible(shape)
         assert label_list[i].checkState() == Qt.Checked
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_multi_select_toggle_propagates(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+    selected_indices = (0, 1, 3)
+
+    label_list.clearSelection()
+    for i in selected_indices:
+        label_list.select_item(label_list[i])
+    qtbot.wait(50)
+    assert {item for item in label_list.selected_items()} == {
+        label_list[i] for i in selected_indices
+    }
+
+    label_list[selected_indices[1]].setCheckState(Qt.Unchecked)
+    qtbot.wait(50)
+
+    for i in range(len(canvas.shapes)):
+        if i in selected_indices:
+            assert not canvas.is_shape_visible(canvas.shapes[i])
+            assert label_list[i].checkState() == Qt.Unchecked
+        else:
+            assert canvas.is_shape_visible(canvas.shapes[i])
+            assert label_list[i].checkState() == Qt.Checked
+
+    annotated_win._actions.undo.trigger()
+    qtbot.wait(50)
+
+    for i in range(len(canvas.shapes)):
+        assert canvas.is_shape_visible(canvas.shapes[i])
+        assert label_list[i].checkState() == Qt.Checked
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_multi_select_preserves_selection_after_checkbox_click(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    label_list = annotated_win._docks.label_list
+
+    assert len(canvas.shapes) == 5
+    selected_indices = (0, 1, 3)
+
+    label_list.clearSelection()
+    for i in selected_indices:
+        label_list.select_item(label_list[i])
+    qtbot.wait(50)
+
+    target_index = label_list._model.indexFromItem(label_list[selected_indices[1]])
+    rect = label_list.visualRect(target_index)
+    checkbox_pos = QPoint(rect.left() + 5, rect.center().y())
+    qtbot.mouseClick(label_list.viewport(), Qt.LeftButton, pos=checkbox_pos)
+    qtbot.wait(50)
+
+    assert {item for item in label_list.selected_items()} == {
+        label_list[i] for i in selected_indices
+    }
+    for i in selected_indices:
+        assert label_list[i].checkState() == Qt.Unchecked
+        assert not canvas.is_shape_visible(canvas.shapes[i])
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_multi_select_collapses_on_row_body_click(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    label_list = annotated_win._docks.label_list
+
+    selected_indices = (0, 1, 3)
+    clicked_index = 2
+
+    label_list.clearSelection()
+    for i in selected_indices:
+        label_list.select_item(label_list[i])
+    qtbot.wait(50)
+
+    target_index = label_list._model.indexFromItem(label_list[clicked_index])
+    rect = label_list.visualRect(target_index)
+    row_body_pos = QPoint(rect.center().x(), rect.center().y())
+    qtbot.mouseClick(label_list.viewport(), Qt.LeftButton, pos=row_body_pos)
+    qtbot.wait(50)
+
+    assert {item for item in label_list.selected_items()} == {label_list[clicked_index]}
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)


### PR DESCRIPTION
## Summary
- Stacked on top of #2034.
- When several rows in the label list are selected, toggling one row's visibility checkbox now propagates the same state to every selected row, captured as a single undoable step.
- Adds a `mousePressEvent`/`mouseReleaseEvent` pair on `LabelListWidget` so multi-selection survives a checkbox click (Qt would otherwise collapse it to the clicked row).
- Adds e2e tests for both the propagation and the selection-preservation behavior.

## Test plan
- [x] `uv run pytest tests/e2e/visibility_test.py`
- [x] `make lint`