### PR TITLE
refactor(tools): replace asserts with runtime errors in update_translate

### DIFF
--- a/tools/update_translate.py
+++ b/tools/update_translate.py
@@ -58,10 +58,10 @@ def main() -> None:
     )
 
     for ts_path in ts_paths:
-        # Zero out line numbers to reduce unnecessary diffs in .ts file
         ts_content: str = ts_path.read_text()
         new_ts_content: str = re.sub(r'line="\d+"', 'line="0"', ts_content)
-        assert ts_content.strip() != new_ts_content.strip()
+        if ts_content == new_ts_content:
+            raise RuntimeError(f"no line numbers found in {ts_path}")
         ts_path.write_text(new_ts_content)
 
         qm_path: Path = ts_path.with_suffix(".qm")
@@ -70,7 +70,8 @@ def main() -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        assert qm_path.exists()
+        if not qm_path.exists():
+            raise RuntimeError(f"lrelease did not produce {qm_path}")
 
     logger.info("updated {} languages", len(ts_paths))
 


### PR DESCRIPTION
## Summary
- Drop a stale comment above the line-zeroing regex; the regex is self-explanatory in context.
- Replace two `assert` statements in `tools/update_translate.py` with explicit `RuntimeError` raises so the checks remain active under `python -O`.

## Why
`assert` is intended for invariants the developer believes can never fail; here the checks guard real runtime failure modes (no line numbers found in a `.ts` file; `lrelease` failed to emit a `.qm`). They should always run and surface a clear message.

## Test plan
- [x] `make lint` passes (ruff format/check, ty, taplo, mdformat, yamlfix, typos, translate diff)
- [x] `make update_translate` runs cleanly across all 19 languages