### PR TITLE
refactor(label-file): typed error translation, pure parser, write helper

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import io
 import json
 import time
 import warnings
+from collections.abc import Iterator
 from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
@@ -127,6 +129,24 @@ class LabelFileError(Exception):
     pass
 
 
+@contextlib.contextmanager
+def _translate_label_file_errors(filename: str, action: str) -> Iterator[None]:
+    try:
+        yield
+    except OSError as exc:
+        raise LabelFileError(
+            f"Failed to {action} label file {filename!r}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise LabelFileError(
+            f"Malformed JSON in label file {filename!r}: {exc}"
+        ) from exc
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LabelFileError(
+            f"Invalid label file content in {filename!r}: {exc}"
+        ) from exc
+
+
 class LabelFile:
     shapes: list[ShapeDict]
     suffix = ".json"
@@ -233,7 +253,7 @@ class LabelFile:
             "imageHeight",
             "imageWidth",
         ]
-        try:
+        with _translate_label_file_errors(filename, action="load"):
             with open(filename, encoding="utf-8") as f:
                 data = json.load(f)
 
@@ -256,15 +276,8 @@ class LabelFile:
             shapes: list[ShapeDict] = [
                 _load_shape_json_obj(shape_json_obj=s) for s in data["shapes"]
             ]
-        except Exception as e:
-            raise LabelFileError(e)
+            other_data = {k: v for k, v in data.items() if k not in keys}
 
-        other_data = {}
-        for key, value in data.items():
-            if key not in keys:
-                other_data[key] = value
-
-        # Only replace data after everything is loaded.
         self.flags = flags
         self.shapes = shapes
         self.image_path = image_path
@@ -326,12 +339,10 @@ class LabelFile:
         for key, value in other_data.items():
             assert key not in data
             data[key] = value
-        try:
+        with _translate_label_file_errors(filename, action="save"):
             with open(filename, "w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
             self.filename = filename
-        except Exception as e:
-            raise LabelFileError(e)
 
     @staticmethod
     def is_label_file(filename: str) -> bool:
@@ -355,7 +366,10 @@ def _imread(filename: str) -> PIL.Image.Image:
 
 
 def _imread_tiff(filename: str) -> PIL.Image.Image:
-    img_arr: NDArray = tifffile.imread(filename)
+    try:
+        img_arr: NDArray = tifffile.imread(filename)
+    except tifffile.TiffFileError as exc:
+        raise OSError(f"Failed to read TIFF image {filename!r}: {exc}") from exc
 
     if img_arr.ndim == 2:
         img_arr_normalized = _normalize_to_uint8(img_arr)

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -207,16 +207,22 @@ def _parse_label_json(
 
 class LabelFile:
     shapes: list[ShapeDict]
+    flags: dict[str, bool]
+    image_path: str | None
+    image_data: bytes | None
+    other_data: dict[str, Any]
+    filename: str | None
     suffix = ".json"
 
     def __init__(self, filename: str | None = None) -> None:
-        self.shapes: list[ShapeDict] = []
-        self.image_path: str | None = None
-        self.image_data: bytes | None = None
-        self.other_data: dict[str, Any] = {}
+        self.shapes = []
+        self.flags = {}
+        self.image_path = None
+        self.image_data = None
+        self.other_data = {}
         if filename is not None:
             self.load(filename)
-        self.filename: str | None = filename
+        self.filename = filename
 
     @property
     def imagePath(self) -> str | None:
@@ -335,6 +341,12 @@ class LabelFile:
             image_width = actual_w
         return image_height, image_width
 
+    @classmethod
+    def from_filename(cls, filename: str) -> LabelFile:
+        instance = cls()
+        instance.filename = filename
+        return instance
+
     def save(
         self,
         filename: str,
@@ -346,37 +358,61 @@ class LabelFile:
         other_data: dict[str, Any] | None = None,
         flags: dict[str, bool] | None = None,
     ) -> None:
+        write_label_file(
+            filename=filename,
+            shapes=shapes,
+            image_path=image_path,
+            image_height=image_height,
+            image_width=image_width,
+            image_data=image_data,
+            other_data=other_data,
+            flags=flags,
+        )
+        self.filename = filename
+
+    @staticmethod
+    def is_label_file(filename: str) -> bool:
+        return Path(filename).suffix.lower() == LabelFile.suffix
+
+
+def write_label_file(
+    *,
+    filename: str,
+    shapes: list[dict[str, Any]],
+    image_path: str,
+    image_height: int | None,
+    image_width: int | None,
+    image_data: bytes | None = None,
+    other_data: dict[str, Any] | None = None,
+    flags: dict[str, bool] | None = None,
+) -> None:
+    with _translate_label_file_errors(filename, action="save"):
         image_data_b64: str | None = None
         if image_data is not None:
-            image_height, image_width = self._check_image_height_and_width(
+            image_height, image_width = LabelFile._check_image_height_and_width(
                 image_data, image_height, image_width
             )
             image_data_b64 = base64.b64encode(image_data).decode("utf-8")
-        if other_data is None:
-            other_data = {}
-        if flags is None:
-            flags = {}
-        # JSON keys stay camelCase — on-disk format, breaks existing .json files.
-        data = {
+        payload: dict[str, Any] = {
             "version": __version__,
-            "flags": flags,
+            "flags": flags or {},
             "shapes": shapes,
             "imagePath": image_path,
             "imageData": image_data_b64,
             "imageHeight": image_height,
             "imageWidth": image_width,
         }
-        for key, value in other_data.items():
-            assert key not in data
-            data[key] = value
-        with _translate_label_file_errors(filename, action="save"):
-            with open(filename, "w", encoding="utf-8") as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
-            self.filename = filename
-
-    @staticmethod
-    def is_label_file(filename: str) -> bool:
-        return Path(filename).suffix.lower() == LabelFile.suffix
+        if other_data:
+            for extra_key, extra_value in other_data.items():
+                if extra_key in payload:
+                    raise ValueError(
+                        f"other_data may not override reserved key {extra_key!r}"
+                    )
+                payload[extra_key] = extra_value
+        Path(filename).write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
 
 
 _DISPLAYABLE_MODES = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import dataclasses
 import io
 import json
 import time
 import warnings
+from collections.abc import Callable
 from collections.abc import Iterator
 from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
+from typing import Final
 from typing import TypedDict
 
 import numpy as np
@@ -147,6 +150,61 @@ def _translate_label_file_errors(filename: str, action: str) -> Iterator[None]:
         ) from exc
 
 
+_RESERVED_LABEL_JSON_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "version",
+        "imageData",
+        "imagePath",
+        "shapes",
+        "flags",
+        "imageHeight",
+        "imageWidth",
+    }
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _ParsedLabel:
+    flags: dict[str, bool]
+    shapes: list[ShapeDict]
+    image_path: str
+    image_data: bytes
+    other_data: dict[str, Any]
+
+
+def _parse_label_json(
+    filename: str,
+    image_loader: Callable[[str], bytes],
+    check_dimensions: Callable[[bytes, int | None, int | None], object],
+) -> _ParsedLabel:
+    raw_path: Path = Path(filename)
+    payload: dict[str, Any] = json.loads(raw_path.read_text(encoding="utf-8"))
+
+    posix_image_path: str = PureWindowsPath(payload["imagePath"]).as_posix()
+    encoded_image: str | None = payload["imageData"]
+    image_bytes: bytes = (
+        base64.b64decode(encoded_image)
+        if encoded_image is not None
+        else image_loader(str(raw_path.parent / posix_image_path))
+    )
+
+    check_dimensions(
+        image_bytes,
+        payload.get("imageHeight"),
+        payload.get("imageWidth"),
+    )
+
+    return _ParsedLabel(
+        flags=payload.get("flags") or {},
+        shapes=[_load_shape_json_obj(shape_json_obj=s) for s in payload["shapes"]],
+        image_path=posix_image_path,
+        image_data=image_bytes,
+        other_data={
+            k: v for k, v in payload.items() if k not in _RESERVED_LABEL_JSON_KEYS
+        },
+    )
+
+
 class LabelFile:
     shapes: list[ShapeDict]
     suffix = ".json"
@@ -244,46 +302,18 @@ class LabelFile:
         return image_data
 
     def load(self, filename: str) -> None:
-        keys = [
-            "version",
-            "imageData",
-            "imagePath",
-            "shapes",  # polygonal annotations
-            "flags",  # image level flags
-            "imageHeight",
-            "imageWidth",
-        ]
         with _translate_label_file_errors(filename, action="load"):
-            with open(filename, encoding="utf-8") as f:
-                data = json.load(f)
-
-            # Normalize Windows-style backslash paths to POSIX forward slashes
-            image_path = PureWindowsPath(data["imagePath"]).as_posix()
-
-            if data["imageData"] is not None:
-                image_data = base64.b64decode(data["imageData"])
-            else:
-                # relative path from label file to relative path from cwd
-                image_data = self.load_image_file(
-                    str(Path(filename).parent / image_path)
-                )
-            flags = data.get("flags") or {}
-            self._check_image_height_and_width(
-                image_data,
-                data.get("imageHeight"),
-                data.get("imageWidth"),
+            parsed = _parse_label_json(
+                filename,
+                image_loader=self.load_image_file,
+                check_dimensions=self._check_image_height_and_width,
             )
-            shapes: list[ShapeDict] = [
-                _load_shape_json_obj(shape_json_obj=s) for s in data["shapes"]
-            ]
-            other_data = {k: v for k, v in data.items() if k not in keys}
+        self._adopt_parsed(parsed, filename=filename)
 
-        self.flags = flags
-        self.shapes = shapes
-        self.image_path = image_path
-        self.image_data = image_data
+    def _adopt_parsed(self, parsed: _ParsedLabel, filename: str) -> None:
+        for field in dataclasses.fields(parsed):
+            setattr(self, field.name, getattr(parsed, field.name))
         self.filename = filename
-        self.other_data = other_data
 
     @staticmethod
     def _check_image_height_and_width(

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -38,6 +38,7 @@ from labelme._automation._osam_session import OsamSession
 from labelme._label_file import LabelFile
 from labelme._label_file import LabelFileError
 from labelme._label_file import ShapeDict
+from labelme._label_file import write_label_file
 from labelme._shape_clipboard import ShapeClipboard
 from labelme.config import load_config
 from labelme.shape import Shape
@@ -1627,42 +1628,43 @@ class MainWindow(QtWidgets.QMainWindow):
             widget.addItem(item)
 
     def save_labels(self, label_path: str) -> bool:
-        lf = LabelFile()
-
-        shapes = [
+        shape_dicts: list[dict[str, Any]] = [
             _shape_to_dict(s)
             for item in self._docks.label_list
             if (s := item.shape()) is not None
         ]
-        flags = {}
+        flag_states: dict[str, bool] = {}
         for i in range(self._docks.flag_list.count()):
             item = self._docks.flag_list.item(i)
             assert item
-            key = item.text()
-            flag = item.checkState() == Qt.Checked
-            flags[key] = flag
+            flag_states[item.text()] = item.checkState() == Qt.Checked
+
         try:
             assert self._image_path
-            label_dir = Path(label_path).parent
-            image_path = os.path.relpath(self._image_path, label_dir)
-            image_data = self._image_data if self._config["with_image_data"] else None
+            label_dir: Path = Path(label_path).parent
+            relative_image_path: str = os.path.relpath(self._image_path, label_dir)
+            embedded_image_data: bytes | None = (
+                self._image_data if self._config["with_image_data"] else None
+            )
             label_dir.mkdir(parents=True, exist_ok=True)
-            lf.save(
+            write_label_file(
                 filename=label_path,
-                shapes=shapes,
-                image_path=image_path,
-                image_data=image_data,
+                shapes=shape_dicts,
+                image_path=relative_image_path,
+                image_data=embedded_image_data,
                 image_height=self._image.height(),
                 image_width=self._image.width(),
                 other_data=self._other_data,
-                flags=flags,
+                flags=flag_states,
             )
-            self._label_file = lf
-            items = self._docks.file_list.findItems(self._image_path, Qt.MatchExactly)
-            if len(items) > 0:
-                if len(items) != 1:
+            self._label_file = LabelFile.from_filename(label_path)
+            matching_items = self._docks.file_list.findItems(
+                self._image_path, Qt.MatchExactly
+            )
+            if len(matching_items) > 0:
+                if len(matching_items) != 1:
                     raise RuntimeError("There are duplicate files.")
-                items[0].setCheckState(Qt.Checked)
+                matching_items[0].setCheckState(Qt.Checked)
             return True
         except LabelFileError as e:
             self.show_error_message(


### PR DESCRIPTION
First of a 2-PR stack tidying \`labelme/_label_file.py\` and the matching caller in \`labelme/app.py\`. Three commits:

- **\`ecce709b\`** — replace blanket \`try/except Exception → raise LabelFileError(e)\` in \`LabelFile.load\`/\`save\` with a \`_translate_label_file_errors\` context manager that catches specific exception types and chains via \`from exc\`. Also convert \`tifffile.TiffFileError\` to \`OSError\` at the \`_imread_tiff\` boundary so malformed TIFFs surface as \`LabelFileError\` dialogs instead of crashing the Qt loop.
- **\`c166635f\`** — factor JSON parsing out of \`LabelFile.load\` into a pure \`_parse_label_json\` returning a frozen \`_ParsedLabel\` dataclass.
- **\`7ed7c854\`** — introduce \`write_label_file\` free function and \`LabelFile.from_filename\` classmethod; \`MainWindow.save_labels\` uses them. \`other_data\` reserved-key conflicts now surface as \`LabelFileError\` (was uncaught \`AssertionError\`).

Public API and on-disk JSON schema unchanged. \`make lint\` clean, 183/183 tests pass locally.

## Stack
- This PR (1/2): \`refactor/label-file-relicensing\` → \`main\`
- Next PR (2/2): #2038