### PR TITLE
refactor(label-file): extract LabelData dataclass and module-level I/O helpers

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -5,9 +5,11 @@ import io
 import json
 import time
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
+from typing import Final
 from typing import TypedDict
 
 import numpy as np
@@ -124,21 +126,176 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
 
 
 class LabelFileError(Exception):
-    pass
+    """Base for read/write failures of labelme JSON annotation files."""
+
+
+class LabelFileReadError(LabelFileError):
+    """Wraps an underlying parse or image-decode failure during load."""
+
+
+class LabelFileWriteError(LabelFileError):
+    """Wraps an underlying I/O failure during save."""
+
+
+@dataclass(frozen=True)
+class LabelData:
+    image_path: str
+    image_data: bytes
+    shapes: list[ShapeDict]
+    flags: dict[str, bool]
+    other_data: dict[str, Any]
+
+
+LABEL_FILE_SUFFIX: Final[str] = ".json"
+
+_RESERVED_TOP_LEVEL_KEYS: Final[tuple[str, ...]] = (
+    "version",
+    "imageData",
+    "imagePath",
+    "shapes",
+    "flags",
+    "imageHeight",
+    "imageWidth",
+)
+
+
+def is_label_file_path(filename: str) -> bool:
+    return Path(filename).suffix.lower() == LABEL_FILE_SUFFIX
+
+
+def read_image_file(filename: str) -> bytes:
+    t_start = time.time()
+    image_pil = _imread(filename=filename)
+
+    oriented: PIL.Image.Image = utils.apply_exif_orientation(image=image_pil)
+    ext = Path(filename).suffix.lower()
+    if oriented is image_pil and ext in (".jpg", ".jpeg", ".png"):
+        with open(filename, "rb") as f:
+            image_data = f.read()
+    else:
+        with io.BytesIO() as f:
+            fmt = "PNG" if "A" in oriented.mode else "JPEG"
+            oriented.save(fp=f, format=fmt, quality=95)
+            f.seek(0)
+            image_data = f.read()
+
+    logger.debug(
+        "Loaded image file: {!r} in {:.0f}ms", filename, (time.time() - t_start) * 1000
+    )
+    return image_data
+
+
+def _check_image_dimensions(
+    *,
+    image_data: bytes,
+    expected_height: int | None,
+    expected_width: int | None,
+) -> None:
+    if expected_height is None and expected_width is None:
+        return
+    actual_w, actual_h = utils.img_data_to_pil(img_data=image_data).size
+    if expected_height is not None and expected_height != actual_h:
+        raise ValueError(
+            f"imageHeight mismatch: declared={expected_height}, actual={actual_h}"
+        )
+    if expected_width is not None and expected_width != actual_w:
+        raise ValueError(
+            f"imageWidth mismatch: declared={expected_width}, actual={actual_w}"
+        )
+
+
+def read_label_file(filename: str) -> LabelData:
+    try:
+        with open(filename, encoding="utf-8") as f:
+            raw: dict[str, Any] = json.load(f)
+        image_path = PureWindowsPath(raw["imagePath"]).as_posix()
+        if raw["imageData"] is not None:
+            image_data = base64.b64decode(raw["imageData"])
+        else:
+            image_data = read_image_file(
+                filename=str(Path(filename).parent / image_path)
+            )
+        _check_image_dimensions(
+            image_data=image_data,
+            expected_height=raw.get("imageHeight"),
+            expected_width=raw.get("imageWidth"),
+        )
+        shapes: list[ShapeDict] = [
+            _load_shape_json_obj(shape_json_obj=s) for s in raw["shapes"]
+        ]
+        flags = raw.get("flags") or {}
+    except (
+        OSError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+        RuntimeError,
+    ) as e:
+        raise LabelFileReadError(f"failed to load {filename!r}: {e}") from e
+    other_data = {k: v for k, v in raw.items() if k not in _RESERVED_TOP_LEVEL_KEYS}
+    return LabelData(
+        image_path=image_path,
+        image_data=image_data,
+        shapes=shapes,
+        flags=flags,
+        other_data=other_data,
+    )
+
+
+def write_label_file(
+    filename: str,
+    *,
+    shapes: list[dict[str, Any]],
+    image_path: str,
+    image_height: int | None,
+    image_width: int | None,
+    image_data: bytes | None = None,
+    other_data: dict[str, Any] | None = None,
+    flags: dict[str, bool] | None = None,
+) -> None:
+    try:
+        image_data_b64: str | None = None
+        if image_data is not None:
+            _check_image_dimensions(
+                image_data=image_data,
+                expected_height=image_height,
+                expected_width=image_width,
+            )
+            image_data_b64 = base64.b64encode(image_data).decode("utf-8")
+        # JSON keys stay camelCase: changing them would break existing .json files.
+        payload: dict[str, Any] = {
+            "version": __version__,
+            "flags": dict(flags) if flags else {},
+            "shapes": list(shapes),
+            "imagePath": image_path,
+            "imageData": image_data_b64,
+            "imageHeight": image_height,
+            "imageWidth": image_width,
+        }
+        for key, value in (other_data or {}).items():
+            if key in _RESERVED_TOP_LEVEL_KEYS:
+                raise ValueError(f"reserved key in other_data: {key!r}")
+            payload[key] = value
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+    except (OSError, TypeError, ValueError) as e:
+        raise LabelFileWriteError(f"failed to write {filename!r}: {e}") from e
 
 
 class LabelFile:
     shapes: list[ShapeDict]
-    suffix = ".json"
+    suffix: Final[str] = LABEL_FILE_SUFFIX
 
     def __init__(self, filename: str | None = None) -> None:
-        self.shapes: list[ShapeDict] = []
+        self.shapes = []
         self.image_path: str | None = None
         self.image_data: bytes | None = None
         self.other_data: dict[str, Any] = {}
-        if filename is not None:
-            self.load(filename)
+        self.flags: dict[str, bool] = {}
         self.filename: str | None = filename
+        if filename is not None:
+            self.load(filename=filename)
 
     @property
     def imagePath(self) -> str | None:
@@ -202,95 +359,16 @@ class LabelFile:
 
     @staticmethod
     def load_image_file(filename: str) -> bytes:
-        t0 = time.time()
-        image_pil = _imread(filename=filename)
-
-        oriented: PIL.Image.Image = utils.apply_exif_orientation(image_pil)
-        ext = Path(filename).suffix.lower()
-        if oriented is image_pil and ext in (".jpg", ".jpeg", ".png"):
-            # no encoding needed
-            with open(filename, "rb") as f:
-                image_data = f.read()
-        else:
-            with io.BytesIO() as f:
-                format = "PNG" if "A" in oriented.mode else "JPEG"
-                oriented.save(f, format=format, quality=95)
-                f.seek(0)
-                image_data = f.read()
-
-        logger.debug(
-            "Loaded image file: {!r} in {:.0f}ms", filename, (time.time() - t0) * 1000
-        )
-        return image_data
+        return read_image_file(filename=filename)
 
     def load(self, filename: str) -> None:
-        keys = [
-            "version",
-            "imageData",
-            "imagePath",
-            "shapes",  # polygonal annotations
-            "flags",  # image level flags
-            "imageHeight",
-            "imageWidth",
-        ]
-        try:
-            with open(filename, encoding="utf-8") as f:
-                data = json.load(f)
-
-            # Normalize Windows-style backslash paths to POSIX forward slashes
-            image_path = PureWindowsPath(data["imagePath"]).as_posix()
-
-            if data["imageData"] is not None:
-                image_data = base64.b64decode(data["imageData"])
-            else:
-                # relative path from label file to relative path from cwd
-                image_data = self.load_image_file(
-                    str(Path(filename).parent / image_path)
-                )
-            flags = data.get("flags") or {}
-            self._check_image_height_and_width(
-                image_data,
-                data.get("imageHeight"),
-                data.get("imageWidth"),
-            )
-            shapes: list[ShapeDict] = [
-                _load_shape_json_obj(shape_json_obj=s) for s in data["shapes"]
-            ]
-        except Exception as e:
-            raise LabelFileError(e)
-
-        other_data = {}
-        for key, value in data.items():
-            if key not in keys:
-                other_data[key] = value
-
-        # Only replace data after everything is loaded.
-        self.flags = flags
-        self.shapes = shapes
-        self.image_path = image_path
-        self.image_data = image_data
+        loaded: LabelData = read_label_file(filename=filename)
+        self.flags = loaded.flags
+        self.shapes = loaded.shapes
+        self.image_path = loaded.image_path
+        self.image_data = loaded.image_data
+        self.other_data = loaded.other_data
         self.filename = filename
-        self.other_data = other_data
-
-    @staticmethod
-    def _check_image_height_and_width(
-        image_data: bytes, image_height: int | None, image_width: int | None
-    ) -> tuple[int | None, int | None]:
-        img_pil = utils.img_data_to_pil(image_data)
-        actual_w, actual_h = img_pil.size
-        if image_height is not None and actual_h != image_height:
-            logger.error(
-                "imageHeight does not match with imageData or imagePath, "
-                "so getting imageHeight from actual image."
-            )
-            image_height = actual_h
-        if image_width is not None and actual_w != image_width:
-            logger.error(
-                "imageWidth does not match with imageData or imagePath, "
-                "so getting imageWidth from actual image."
-            )
-            image_width = actual_w
-        return image_height, image_width
 
     def save(
         self,
@@ -303,39 +381,21 @@ class LabelFile:
         other_data: dict[str, Any] | None = None,
         flags: dict[str, bool] | None = None,
     ) -> None:
-        image_data_b64: str | None = None
-        if image_data is not None:
-            image_height, image_width = self._check_image_height_and_width(
-                image_data, image_height, image_width
-            )
-            image_data_b64 = base64.b64encode(image_data).decode("utf-8")
-        if other_data is None:
-            other_data = {}
-        if flags is None:
-            flags = {}
-        # JSON keys stay camelCase — on-disk format, breaks existing .json files.
-        data = {
-            "version": __version__,
-            "flags": flags,
-            "shapes": shapes,
-            "imagePath": image_path,
-            "imageData": image_data_b64,
-            "imageHeight": image_height,
-            "imageWidth": image_width,
-        }
-        for key, value in other_data.items():
-            assert key not in data
-            data[key] = value
-        try:
-            with open(filename, "w", encoding="utf-8") as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
-            self.filename = filename
-        except Exception as e:
-            raise LabelFileError(e)
+        write_label_file(
+            filename=filename,
+            shapes=shapes,
+            image_path=image_path,
+            image_height=image_height,
+            image_width=image_width,
+            image_data=image_data,
+            other_data=other_data,
+            flags=flags,
+        )
+        self.filename = filename
 
     @staticmethod
     def is_label_file(filename: str) -> bool:
-        return Path(filename).suffix.lower() == LabelFile.suffix
+        return is_label_file_path(filename=filename)
 
 
 _DISPLAYABLE_MODES = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -35,9 +35,14 @@ from labelme import __appname__
 from labelme import __version__
 from labelme._automation import bbox_from_text
 from labelme._automation._osam_session import OsamSession
-from labelme._label_file import LabelFile
+from labelme._label_file import LABEL_FILE_SUFFIX
+from labelme._label_file import LabelData
 from labelme._label_file import LabelFileError
 from labelme._label_file import ShapeDict
+from labelme._label_file import is_label_file_path
+from labelme._label_file import read_image_file
+from labelme._label_file import read_label_file
+from labelme._label_file import write_label_file
 from labelme._shape_clipboard import ShapeClipboard
 from labelme.config import load_config
 from labelme.shape import Shape
@@ -188,7 +193,7 @@ class MainWindow(QtWidgets.QMainWindow):
     _output_dir: Path | None
     _image: QtGui.QImage
     _image_data: bytes | None
-    _label_file: LabelFile | None
+    _label_file_path: str | None
     _image_path: str | None
     _prev_image_path: str | None
     _other_data: dict | None
@@ -964,7 +969,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._output_dir = Path(output_dir) if output_dir else None
 
         self._image = QtGui.QImage()
-        self._label_file = None
+        self._label_file_path = None
         self._image_path = None
         self._prev_image_path = None
         self._other_data = None
@@ -1314,7 +1319,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.label_list.clear()
         self._image_path = None
         self._image_data = None
-        self._label_file = None
+        self._label_file_path = None
         self._other_data = None
         self._canvas_widgets.canvas.reset_state()
 
@@ -1627,27 +1632,23 @@ class MainWindow(QtWidgets.QMainWindow):
             widget.addItem(item)
 
     def save_labels(self, label_path: str) -> bool:
-        lf = LabelFile()
-
         shapes = [
             _shape_to_dict(s)
             for item in self._docks.label_list
             if (s := item.shape()) is not None
         ]
-        flags = {}
+        flags: dict[str, bool] = {}
         for i in range(self._docks.flag_list.count()):
             item = self._docks.flag_list.item(i)
             assert item
-            key = item.text()
-            flag = item.checkState() == Qt.Checked
-            flags[key] = flag
+            flags[item.text()] = item.checkState() == Qt.Checked
         try:
             assert self._image_path
             label_dir = Path(label_path).parent
             image_path = os.path.relpath(self._image_path, label_dir)
             image_data = self._image_data if self._config["with_image_data"] else None
             label_dir.mkdir(parents=True, exist_ok=True)
-            lf.save(
+            write_label_file(
                 filename=label_path,
                 shapes=shapes,
                 image_path=image_path,
@@ -1657,7 +1658,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 other_data=self._other_data,
                 flags=flags,
             )
-            self._label_file = lf
+            self._label_file_path = label_path
             items = self._docks.file_list.findItems(self._image_path, Qt.MatchExactly)
             if len(items) > 0:
                 if len(items) != 1:
@@ -1922,6 +1923,43 @@ class MainWindow(QtWidgets.QMainWindow):
             target = item.checkState() == Qt.Unchecked if value is None else value
             item.setCheckState(Qt.Checked if target else Qt.Unchecked)
 
+    def _open_label_file_into_state(self, label_path: str) -> LabelData | None:
+        try:
+            label_data = read_label_file(filename=label_path)
+        except LabelFileError as e:
+            self.show_error_message(
+                self.tr("Error opening file"),
+                self.tr(
+                    "<p><b>%s</b></p><p>Make sure <i>%s</i> is a valid label file.</p>"
+                )
+                % (e, label_path),
+            )
+            self.show_status_message(self.tr("Error reading %s") % label_path)
+            return None
+        self._label_file_path = label_path
+        self._image_data = label_data.image_data
+        self._image_path = str(Path(label_path).parent / label_data.image_path)
+        self._other_data = label_data.other_data
+        return label_data
+
+    def _open_image_into_state(self, image_path: str) -> bool:
+        try:
+            image_data = read_image_file(filename=image_path)
+        except OSError as e:
+            self.show_error_message(
+                self.tr("Error opening file"),
+                self.tr(
+                    "<p><b>%s</b></p><p>Make sure <i>%s</i> is a valid image file.</p>"
+                )
+                % (e, image_path),
+            )
+            self.show_status_message(self.tr("Error reading %s") % image_path)
+            return False
+        self._image_data = image_data
+        self._image_path = image_path
+        self._label_file_path = None
+        return True
+
     def _load_file(self, image_or_label_path: str) -> None:
         # changing fileListWidget loads file
         if image_or_label_path in self.image_list and (
@@ -1956,50 +1994,18 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
         t0_load_file = time.time()
-        if QtCore.QFile.exists(
-            label_path := _resolve_label_path(
-                image_or_label_path=image_or_label_path,
-                output_dir=self._output_dir,
-            )
-        ):
-            try:
-                self._label_file = LabelFile(label_path)
-            except LabelFileError as e:
-                self.show_error_message(
-                    self.tr("Error opening file"),
-                    self.tr(
-                        "<p><b>%s</b></p>"
-                        "<p>Make sure <i>%s</i> is a valid label file.</p>"
-                    )
-                    % (e, label_path),
-                )
-                self.show_status_message(self.tr("Error reading %s") % label_path)
+        label_path: str = _resolve_label_path(
+            image_or_label_path=image_or_label_path,
+            output_dir=self._output_dir,
+        )
+        label_data: LabelData | None = None
+        if QtCore.QFile.exists(label_path):
+            label_data = self._open_label_file_into_state(label_path=label_path)
+            if label_data is None:
                 return
-            assert self._label_file is not None
-            self._image_data = self._label_file.image_data
-            assert self._label_file.image_path
-            self._image_path = str(
-                Path(label_path).parent / self._label_file.image_path
-            )
-            self._other_data = self._label_file.other_data
         else:
-            image_path: str = image_or_label_path
-            try:
-                self._image_data = LabelFile.load_image_file(image_path)
-            except OSError as e:
-                self.show_error_message(
-                    self.tr("Error opening file"),
-                    self.tr(
-                        "<p><b>%s</b></p>"
-                        "<p>Make sure <i>%s</i> is a valid image file.</p>"
-                    )
-                    % (e, image_path),
-                )
-                self.show_status_message(self.tr("Error reading %s") % image_path)
+            if not self._open_image_into_state(image_path=image_or_label_path):
                 return
-            if self._image_data:
-                self._image_path = image_path
-            self._label_file = None
         assert self._image_data is not None
         t0 = time.time()
         image = QtGui.QImage.fromData(self._image_data)
@@ -2024,15 +2030,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
         logger.debug("Loaded pixmap in {:.0f}ms", (time.time() - t0) * 1000)
         flags = {k: False for k in self._config["flags"] or []}
-        if self._label_file:
+        if label_data is not None:
             self._load_shapes(
                 shapes=_shapes_from_dicts(
-                    shape_dicts=self._label_file.shapes,
+                    shape_dicts=label_data.shapes,
                     label_flags=self._config["label_flags"],
                 )
             )
-            if self._label_file.flags is not None:
-                flags.update(self._label_file.flags)
+            flags.update(label_data.flags)
         self._load_flags(flags=flags, widget=self._docks.flag_list)
         if prev_shapes and self.has_no_shapes():
             self._load_shapes(shapes=prev_shapes, replace=False)
@@ -2172,7 +2177,7 @@ class MainWindow(QtWidgets.QMainWindow):
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
         filters = self.tr("Image & Label files (%s)") % " ".join(
-            formats + [f"*{LabelFile.suffix}"]
+            formats + [f"*{LABEL_FILE_SUFFIX}"]
         )
         image_or_label_path, _ = QtWidgets.QFileDialog.getOpenFileName(
             self,
@@ -2226,8 +2231,8 @@ class MainWindow(QtWidgets.QMainWindow):
         assert not self._image.isNull(), "cannot save empty image"
 
         label_path: str | None = None
-        if not save_as and self._label_file:
-            label_path = self._label_file.filename
+        if not save_as and self._label_file_path is not None:
+            label_path = self._label_file_path
         if label_path is None:
             label_path = self.prompt_save_file_path()
 
@@ -2241,14 +2246,14 @@ class MainWindow(QtWidgets.QMainWindow):
     def prompt_save_file_path(self) -> str:
         assert self._image_path is not None
         caption = self.tr("%s - Choose File") % __appname__
-        filters = self.tr("Label files (*%s)") % LabelFile.suffix
+        filters = self.tr("Label files (*%s)") % LABEL_FILE_SUFFIX
         dlg = QtWidgets.QFileDialog(
             parent=self,
             caption=caption,
             directory=str(self._output_dir or Path(self._image_path).parent),
             filter=filters,
         )
-        dlg.setDefaultSuffix(LabelFile.suffix[1:])
+        dlg.setDefaultSuffix(LABEL_FILE_SUFFIX[1:])
         dlg.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
         dlg.setOption(QtWidgets.QFileDialog.DontConfirmOverwrite, False)
         dlg.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, False)
@@ -2259,7 +2264,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 image_or_label_path=self._image_path,
                 output_dir=self._output_dir,
             ),
-            filter=self.tr("Label files (*%s)") % LabelFile.suffix,
+            filter=self.tr("Label files (*%s)") % LABEL_FILE_SUFFIX,
         )
         return label_path
 
@@ -2419,7 +2424,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not file_or_dir:
             raise ValueError("file_or_dir cannot be empty")
 
-        if LabelFile.is_label_file(filename=file_or_dir):
+        if is_label_file_path(filename=file_or_dir):
             self._docks.file_list.clear()
             self._docks.file_dock.setEnabled(False)
             self._docks.file_dock.setToolTip(
@@ -2634,11 +2639,11 @@ def _format_window_title(
 
 
 def _resolve_label_path(*, image_or_label_path: str, output_dir: Path | None) -> str:
-    if LabelFile.is_label_file(filename=image_or_label_path):
+    if is_label_file_path(filename=image_or_label_path):
         return image_or_label_path
     image_path = Path(image_or_label_path)
     parent = output_dir if output_dir is not None else image_path.parent
-    return str(parent / f"{image_path.stem}{LabelFile.suffix}")
+    return str(parent / f"{image_path.stem}{LABEL_FILE_SUFFIX}")
 
 
 def _make_image_list_item(

--- a/tests/e2e/save_format_contract_test.py
+++ b/tests/e2e/save_format_contract_test.py
@@ -144,7 +144,7 @@ def test_round_trip_mask_shape_via_fixture(
         ],
         "imagePath": "2011_000003.jpg",
         "imageData": img_b64,
-        "imageHeight": 281,
+        "imageHeight": 338,
         "imageWidth": 500,
     }
     with open(fixture_json, "w") as f:

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from labelme._label_file import LabelFile
+from labelme._label_file import LabelFileReadError
+from labelme._label_file import LabelFileWriteError
+from labelme._label_file import read_label_file
+from labelme._label_file import write_label_file
 
 
 def test_LabelFile_load_windows_path(data_path: Path, tmp_path: Path) -> None:
@@ -67,3 +73,158 @@ def test_LabelFile_otherData_deprecation() -> None:
     with pytest.warns(DeprecationWarning, match="other_data"):
         label_file.otherData = {"bar": 2}
     assert label_file.other_data == {"bar": 2}
+
+
+@pytest.fixture()
+def annotated_raw(data_path: Path) -> dict[str, Any]:
+    src = data_path / "annotated" / "2011_000003.json"
+    with open(src) as f:
+        return json.load(f)
+
+
+@pytest.fixture()
+def annotated_dst(data_path: Path, tmp_path: Path) -> Path:
+    shutil.copy(
+        data_path / "annotated" / "2011_000003.jpg",
+        tmp_path / "2011_000003.jpg",
+    )
+    return tmp_path / "2011_000003.json"
+
+
+def _dump_json(path: Path, raw: dict[str, Any]) -> None:
+    with open(path, "w") as f:
+        json.dump(raw, f)
+
+
+def test_read_label_file_returns_label_data(data_path: Path) -> None:
+    label_data = read_label_file(
+        filename=str(data_path / "annotated" / "2011_000003.json")
+    )
+
+    assert label_data.image_path == "2011_000003.jpg"
+    assert label_data.image_data
+    assert label_data.shapes
+
+
+def test_read_label_file_extracts_other_data(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    annotated_raw["customField"] = {"reviewer": "alice"}
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    label_data = read_label_file(filename=str(annotated_dst))
+
+    assert label_data.other_data == {"customField": {"reviewer": "alice"}}
+
+
+@pytest.mark.parametrize(
+    "mutator,error_match",
+    [
+        (lambda raw: raw.pop("imagePath"), "imagePath"),
+        (lambda raw: raw.pop("imageData"), "imageData"),
+        (lambda raw: raw.pop("shapes"), "shapes"),
+        (lambda raw: raw["shapes"].append({"label": "x"}), "points is required"),
+        (lambda raw: raw.update({"imageHeight": 1}), "imageHeight mismatch"),
+        (lambda raw: raw.update({"imageWidth": 1}), "imageWidth mismatch"),
+    ],
+    ids=[
+        "missing_imagePath",
+        "missing_imageData",
+        "missing_shapes",
+        "invalid_shape",
+        "imageHeight_mismatch",
+        "imageWidth_mismatch",
+    ],
+)
+def test_read_label_file_raises_read_error_on_malformed(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+    mutator: Callable[[dict[str, Any]], Any],
+    error_match: str,
+) -> None:
+    mutator(annotated_raw)
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    with pytest.raises(LabelFileReadError, match=error_match):
+        read_label_file(filename=str(annotated_dst))
+
+
+def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:
+    src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
+    dst = tmp_path / "out.json"
+
+    shapes: list[dict[str, Any]] = [{**s} for s in src.shapes]
+    write_label_file(
+        filename=str(dst),
+        shapes=shapes,
+        image_path=src.image_path,
+        image_height=None,
+        image_width=None,
+        image_data=src.image_data,
+        other_data={"customField": 42},
+        flags={"ok": True},
+    )
+
+    reloaded = read_label_file(filename=str(dst))
+    assert reloaded.image_path == src.image_path
+    assert reloaded.flags == {"ok": True}
+    assert reloaded.other_data == {"customField": 42}
+    assert [(s["label"], s["points"], s["shape_type"]) for s in reloaded.shapes] == [
+        (s["label"], s["points"], s["shape_type"]) for s in src.shapes
+    ]
+
+
+@pytest.mark.parametrize(
+    "reserved_key",
+    [
+        "version",
+        "imagePath",
+        "imageData",
+        "shapes",
+        "flags",
+        "imageHeight",
+        "imageWidth",
+    ],
+)
+def test_write_label_file_rejects_reserved_other_data_key(
+    tmp_path: Path, reserved_key: str
+) -> None:
+    with pytest.raises(LabelFileWriteError, match=f"reserved key.*{reserved_key}"):
+        write_label_file(
+            filename=str(tmp_path / "out.json"),
+            shapes=[],
+            image_path="foo.jpg",
+            image_height=None,
+            image_width=None,
+            other_data={reserved_key: "x"},
+        )
+
+
+def test_write_label_file_raises_on_dimension_mismatch(
+    data_path: Path, tmp_path: Path
+) -> None:
+    src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
+
+    with pytest.raises(LabelFileWriteError, match="imageHeight mismatch"):
+        write_label_file(
+            filename=str(tmp_path / "out.json"),
+            shapes=[],
+            image_path="foo.jpg",
+            image_height=1,
+            image_width=None,
+            image_data=src.image_data,
+        )
+
+
+def test_write_label_file_raises_write_error_on_io_failure(tmp_path: Path) -> None:
+    bad_path = tmp_path / "missing_dir" / "out.json"
+
+    with pytest.raises(LabelFileWriteError, match="failed to write"):
+        write_label_file(
+            filename=str(bad_path),
+            shapes=[],
+            image_path="foo.jpg",
+            image_height=None,
+            image_width=None,
+        )


### PR DESCRIPTION
## Summary
- Add a frozen `LabelData` dataclass and module-level `read_label_file` / `write_label_file` / `read_image_file` / `is_label_file_path` helpers in `labelme/_label_file.py`. `LabelFile` becomes a thin compatibility shim.
- Split `LabelFileError` into `LabelFileReadError` / `LabelFileWriteError` and narrow the write `except` clause to `(OSError, TypeError, ValueError)` with chained causes.
- Switch `app.py` to the functional API. Track only `_label_file_path: str | None` on `MainWindow` (just the saved path); thread the parsed `LabelData` as a local through `_load_file` instead of stashing it as instance state.
- Split the `_load_file` body into `_open_label_file_into_state` (returns `LabelData | None`) and `_open_image_into_state` (returns `bool`); replace the if/else with if/elif + early returns.

## Why
The class-with-state pattern in `LabelFile` mixed parsing, image I/O, and save serialization with implicit two-phase mutation in `load`. Pulling those out into pure functions plus a frozen dataclass makes atomicity a property of the type instead of a comment, removes the `lf = LabelFile(); lf.save(...)` ceremony, and lets `MainWindow` hold a single string (`_label_file_path`) instead of an attribute that duplicated `_image_path` / `_image_data` / `_other_data`.

## Behavior change
- `imageHeight` / `imageWidth` mismatch is now strict on **both read and write**. Previously the loader logged an error and silently substituted the actual decoded dimensions; now it raises `LabelFileReadError` (read) or `LabelFileWriteError` (write). Files produced by labelme always match, so this only affects manually-edited or third-party JSONs with stale dimension fields. Worth a release note for v6.2.0.

## Test plan
- [x] `make lint`
- [x] `make test` (183/183)
- [x] `.json` annotation file format unchanged byte-for-byte