### PR TITLE
refactor(canvas): extract _reset_interaction_state; simplify load_pixmap and load_shapes

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1337,25 +1337,24 @@ class Canvas(QtWidgets.QWidget):
         else:
             self._cancel_current_shape()
 
+    def _reset_interaction_state(self) -> None:
+        self.current = None
+        self.hovered_shape = None
+        self.hovered_vertex = None
+        self.hovered_edge = None
+
     def load_pixmap(self, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
+        pixmap_arr = labelme.utils.img_qt_to_arr(img_qt=pixmap.toImage())
         self.pixmap = pixmap
-        self._pixmap_hash = hash(
-            labelme.utils.img_qt_to_arr(img_qt=self.pixmap.toImage()).tobytes()
-        )
+        self._pixmap_hash = hash(pixmap_arr.tobytes())
         if clear_shapes:
             self.shapes = []
         self.update()
 
     def load_shapes(self, shapes: list[Shape], replace: bool = True) -> None:
-        if replace:
-            self.shapes = list(shapes)
-        else:
-            self.shapes.extend(shapes)
+        self.shapes = list(shapes) if replace else self.shapes + list(shapes)
         self.backup_shapes()
-        self.current = None
-        self.hovered_shape = None
-        self.hovered_vertex = None
-        self.hovered_edge = None
+        self._reset_interaction_state()
         self.update()
 
     def set_shape_visible(self, shape: Shape, value: bool) -> None:


### PR DESCRIPTION
## Summary
- Extract `_reset_interaction_state` from `load_shapes` to make the reset of interaction fields (`current`, `hovered_shape`, `hovered_vertex`, `hovered_edge`) reusable and self-naming.
- Simplify `load_pixmap` by hoisting the `img_qt_to_arr` call into a local before the hash, avoiding the `self.pixmap.toImage()` round-trip.
- Collapse the `if/else` in `load_shapes` to a single ternary (`list(shapes) if replace else self.shapes + list(shapes)`).

## Test plan
- [x] \`make lint\`
- [x] \`make test\`