### PR TITLE
docs(readme): reword Linux distribution packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ you can download the standalone executable from ["Install Labelme as App"](https
 
 It's a one-time payment for lifetime access, and it helps us to maintain this project.
 
-### Option 3: Using a package manager in each Linux distribution
+### Option 3: Linux distribution packages
 
-In some Linux distributions, you can install labelme via their package managers (e.g., apt, pacman). The following systems are currently available:
+On some Linux distributions, labelme is also packaged in the system's native repository and can be installed with the distribution's standard package tooling. The badge below tracks which distributions currently ship labelme and which version each one provides:
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/labelme.svg)](https://repology.org/project/labelme/versions)
 


### PR DESCRIPTION
## Summary
- Reworded the heading and description of the "Option 3" Linux distribution packages section in `README.md`.

## Why
Refresh the wording so the section reads more naturally and centers on the repology badge rather than naming individual package managers.

## Test plan
- [x] `git diff main...HEAD` reviewed (README only; 2 lines changed)
- [x] Render `README.md` on GitHub and confirm the Installation section displays correctly