### PR TITLE
refactor(shape): express nearest-within-epsilon search via min(..., key=...)

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Iterable
 from typing import Any
 from typing import Final
 from typing import NamedTuple
@@ -249,6 +250,10 @@ def _make_shape_path(
     return path
 
 
+def _argmin(values: Iterable[float]) -> tuple[int, float] | None:
+    return min(enumerate(values), key=lambda item: item[1], default=None)
+
+
 def _nearest_vertex_index(
     *,
     point: QtCore.QPointF,
@@ -256,15 +261,14 @@ def _nearest_vertex_index(
     scale: float,
     epsilon: float,
 ) -> int | None:
-    min_distance = float("inf")
-    min_i = None
-    scaled = _scale_point(point=point, scale=scale)
-    for i, p in enumerate(points):
-        dist = labelme.utils.distance(_scale_point(point=p, scale=scale) - scaled)
-        if dist <= epsilon and dist < min_distance:
-            min_distance = dist
-            min_i = i
-    return min_i
+    scaled_point = _scale_point(point=point, scale=scale)
+    nearest = _argmin(
+        labelme.utils.distance(_scale_point(point=p, scale=scale) - scaled_point)
+        for p in points
+    )
+    if nearest is None or nearest[1] > epsilon:
+        return None
+    return nearest[0]
 
 
 def _nearest_edge_index(
@@ -274,17 +278,17 @@ def _nearest_edge_index(
     scale: float,
     epsilon: float,
 ) -> int | None:
-    min_distance = float("inf")
-    post_i = None
-    scaled = _scale_point(point=point, scale=scale)
-    for i in range(len(points)):
-        start = _scale_point(point=points[i - 1], scale=scale)
-        end = _scale_point(point=points[i], scale=scale)
-        dist = labelme.utils.distance_to_line(scaled, (start, end))
-        if dist <= epsilon and dist < min_distance:
-            min_distance = dist
-            post_i = i
-    return post_i
+    scaled_point = _scale_point(point=point, scale=scale)
+    scaled_points = [_scale_point(point=p, scale=scale) for p in points]
+    nearest = _argmin(
+        labelme.utils.distance_to_line(
+            scaled_point, (scaled_points[i - 1], scaled_points[i])
+        )
+        for i in range(len(points))
+    )
+    if nearest is None or nearest[1] > epsilon:
+        return None
+    return nearest[0]
 
 
 def _shape_contains_point(

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from math import sqrt
 from pathlib import Path
-from typing import Any
 from typing import Final
 
 import numpy as np
@@ -92,7 +91,7 @@ def distance(p: QtCore.QPointF) -> float:
 def distance_to_line(
     point: QtCore.QPointF,
     line: tuple[QtCore.QPointF, QtCore.QPointF],
-) -> np.floating[Any]:
+) -> float:
     start, end = line
     sx, sy = start.x(), start.y()
     ex, ey = end.x(), end.y()
@@ -102,14 +101,14 @@ def distance_to_line(
     edge_y = ey - sy
     length_sq = edge_x * edge_x + edge_y * edge_y
     if length_sq == 0:
-        return np.hypot(px - sx, py - sy)
+        return float(np.hypot(px - sx, py - sy))
 
     t = ((px - sx) * edge_x + (py - sy) * edge_y) / length_sq
     t = min(1.0, max(0.0, t))
 
     nearest_x = sx + t * edge_x
     nearest_y = sy + t * edge_y
-    return np.hypot(px - nearest_x, py - nearest_y)
+    return float(np.hypot(px - nearest_x, py - nearest_y))
 
 
 def format_shortcut(text: str) -> str:


### PR DESCRIPTION
## Summary
- Rewrite `_nearest_vertex_index` and `_nearest_edge_index` to use a build-then-filter-then-`min(..., key=...)` pipeline.
- Drop the running-min loop with `min_distance` / `min_i` sentinels.

## Why
The two helpers expressed an argmin-with-threshold via an imperative running-min loop. Using `min(..., key=...)` over a filtered list of `(index, distance)` pairs is more declarative and matches the rest of the codebase.

## Test plan
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos, translations)
- [x] `make test` (201 passed)