### PR TITLE
refactor(shape): scale mask via QPainter draw-time transform

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -396,13 +396,15 @@ def _paint_mask(*, painter: QtGui.QPainter, shape: Shape) -> None:
     image_to_draw = np.zeros(shape.mask.shape + (4,), dtype=np.uint8)
     image_to_draw[shape.mask] = fill.getRgb()
     qimage = QtGui.QImage.fromData(labelme.utils.img_arr_to_data(image_to_draw))
-    qimage = qimage.scaled(
-        qimage.size() * shape.scale,
-        QtCore.Qt.IgnoreAspectRatio,
-        QtCore.Qt.SmoothTransformation,
-    )
     origin = shape.points[0]
-    painter.drawImage(_scale_point(point=origin, scale=shape.scale), qimage)
+    target_top_left = _scale_point(point=origin, scale=shape.scale)
+    target_rect = QtCore.QRectF(
+        target_top_left.x(),
+        target_top_left.y(),
+        qimage.width() * shape.scale,
+        qimage.height() * shape.scale,
+    )
+    painter.drawImage(target_rect, qimage)
     painter.drawPath(
         _mask_contour_path(mask=shape.mask, origin=origin, scale=shape.scale)
     )


### PR DESCRIPTION
## Summary
- Drop the explicit `QImage.scaled(...)` pre-scale in `_paint_mask` and let `QPainter.drawImage(QRectF, QImage)` scale at draw time.
- Smooth interpolation is preserved via `Qt.SmoothPixmapTransform`, already set on the painter in `Canvas._setup_world_transform`.

## Why
Removing the intermediate scaled `QImage` keeps sub-pixel precision through to the painter and lets Qt route the resampling through its standard render-hint path, simplifying the mask render path.

## Test plan
- [x] `make lint`
- [x] `make test` (201 passed)
- [x] Visual check: zoom in/out on a mask annotation and confirm smooth edges with no positional drift.