### PR TITLE
refactor(app): clarify mark_dirty undo-enable comment

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1209,7 +1209,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def mark_dirty(self) -> None:
-        # Even if we autosave the file, we keep the ability to undo
+        # Autosave does not clear the undo stack; keep the undo action available.
         self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
 
         if self._actions.save_auto.isChecked():


### PR DESCRIPTION
## Summary
- Reword the `mark_dirty` comment to spell out that autosave does not clear the undo stack.

## Why
The previous wording was terse and read as a hedge rather than the actual design constraint. Make it explicit so the deliberate position of `setEnabled` outside the autosave branch isn't refactored away by accident.

## Test plan
- [x] `make lint`