### PR TITLE
refactor(brightness-contrast): collapse enhance guards into loop

### DIFF
--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -72,14 +72,21 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         self.img = img
 
     def apply(self) -> None:
-        brightness = self.slider_brightness.value() / self._base_value
-        contrast = self.slider_contrast.value() / self._base_value
-
         img: PIL.Image.Image = self.img
-        if brightness != 1:
-            img = PIL.ImageEnhance.Brightness(img).enhance(brightness)
-        if contrast != 1:
-            img = PIL.ImageEnhance.Contrast(img).enhance(contrast)
+        enhancers = [
+            (
+                self.slider_brightness.value() / self._base_value,
+                PIL.ImageEnhance.Brightness,
+            ),
+            (
+                self.slider_contrast.value() / self._base_value,
+                PIL.ImageEnhance.Contrast,
+            ),
+        ]
+        for factor, enhancer_cls in enhancers:
+            if factor == 1.0:
+                continue
+            img = enhancer_cls(img).enhance(factor)
 
         fmt: QImage.Format
         if self._alpha is None:


### PR DESCRIPTION
## Summary
- Replace the two parallel `if x != 1: img = PIL.ImageEnhance.X(img).enhance(x)` blocks in `BrightnessContrastDialog.apply` with a single loop over `(factor, enhancer_cls)` pairs.
- Drop the now-unused `brightness` / `contrast` locals; read slider values inline.

## Why
The two enhance calls share the same shape (neutral short-circuit + enhancer application). A list-driven loop expresses that once, mirroring the loop-driven slider construction already in `__init__`.

## Test plan
- [x] `make lint`
- [x] `make test` (201 passed, including `tests/e2e/brightness_contrast_test.py::test_brightness_contrast_dialog`)