### PR TITLE
refactor(shape,canvas): rework translate and drag-bound clamp

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 from typing import Final
 from typing import NamedTuple
+from typing import Protocol
 
 import numpy as np
 import numpy.typing as npt
@@ -189,17 +190,16 @@ class Shape:
             point_size=self.point_size,
         )
 
-    def to_path(self) -> QtGui.QPainterPath:
-        return _make_shape_path(shape_type=self.shape_type, points=self.points)
-
-    def bounding_rect(self) -> QtCore.QRectF:
-        return self.to_path().boundingRect()
-
-    def move_by(self, offset: QtCore.QPointF) -> None:
-        self.points = [p + offset for p in self.points]
+    def bounds(self) -> QtCore.QRectF:
+        path = _make_shape_path(shape_type=self.shape_type, points=self.points)
+        return path.boundingRect()
 
     def move_vertex(self, i: int, pos: QtCore.QPointF) -> None:
         self.points[i] = pos
+
+    def translate(self, offset: QtCore.QPointF) -> None:
+        for i, point in enumerate(self.points):
+            self.points[i] = point + offset
 
     def highlight_vertex(self, i: int, action: int) -> None:
         self.highlight = _Highlight(index=i, mode=action)
@@ -230,24 +230,47 @@ def _scale_point(*, point: QtCore.QPointF, scale: float) -> QtCore.QPointF:
     return QtCore.QPointF(point.x() * scale, point.y() * scale)
 
 
+def _build_rectangle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if len(points) == 2:
+        out.addRect(QtCore.QRectF(points[0], points[1]))
+    return out
+
+
+def _build_circle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if len(points) == 2:
+        radius = labelme.utils.distance(points[0] - points[1])
+        out.addEllipse(points[0], radius, radius)
+    return out
+
+
+def _build_polyline_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if not points:
+        return out
+    out.moveTo(points[0])
+    for vertex in points[1:]:
+        out.lineTo(vertex)
+    return out
+
+
+class _PathBuilder(Protocol):
+    def __call__(self, *, points: list[QtCore.QPointF]) -> QtGui.QPainterPath: ...
+
+
+_PATH_BUILDERS: Final[dict[str, _PathBuilder]] = {
+    "rectangle": _build_rectangle_path,
+    "mask": _build_rectangle_path,
+    "circle": _build_circle_path,
+}
+
+
 def _make_shape_path(
     *, shape_type: str, points: list[QtCore.QPointF]
 ) -> QtGui.QPainterPath:
-    if shape_type in ["rectangle", "mask"]:
-        path = QtGui.QPainterPath()
-        if len(points) == 2:
-            path.addRect(QtCore.QRectF(points[0], points[1]))
-        return path
-    if shape_type == "circle":
-        path = QtGui.QPainterPath()
-        if len(points) == 2:
-            radius = labelme.utils.distance(points[0] - points[1])
-            path.addEllipse(points[0], radius, radius)
-        return path
-    path = QtGui.QPainterPath(points[0])
-    for vertex in points[1:]:
-        path.lineTo(vertex)
-    return path
+    builder = _PATH_BUILDERS.get(shape_type, _build_polyline_path)
+    return builder(points=points)
 
 
 def _argmin(values: Iterable[float]) -> tuple[int, float] | None:
@@ -320,20 +343,20 @@ def _mask_contour_path(
     origin: QtCore.QPointF,
     scale: float,
 ) -> QtGui.QPainterPath:
-    path = QtGui.QPainterPath()
     contours = skimage.measure.find_contours(np.pad(mask, pad_width=1))
+    output = QtGui.QPainterPath()
     for contour in contours:
         contour = contour + [origin.y(), origin.x()]
-        path.moveTo(
+        output.moveTo(
             _scale_point(
                 point=QtCore.QPointF(contour[0, 1], contour[0, 0]), scale=scale
             )
         )
         for point in contour[1:]:
-            path.lineTo(
+            output.lineTo(
                 _scale_point(point=QtCore.QPointF(point[1], point[0]), scale=scale)
             )
-    return path
+    return output
 
 
 def _vertex_size_and_type(

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -77,7 +77,7 @@ class Canvas(QtWidgets.QWidget):
 
     prev_point: QPointF
     prev_move_point: QPointF
-    offsets: tuple[QPointF, QPointF]
+    _drag_anchor: tuple[QPointF, QtCore.QRectF]
 
     _pan_anchor: QPointF | None
 
@@ -119,7 +119,10 @@ class Canvas(QtWidgets.QWidget):
         self.line = Shape()
         self.prev_point = QPointF()
         self.prev_move_point = QPointF()
-        self.offsets = QPointF(), QPointF()
+        self._drag_anchor: tuple[QPointF, QtCore.QRectF] = (
+            QPointF(),
+            QtCore.QRectF(),
+        )
         self.scale: float = 1.0
         self._osam_session = None
         self._hide_background: bool = False
@@ -477,7 +480,7 @@ class Canvas(QtWidgets.QWidget):
     def _continue_right_button_drag(self, pos: QPointF) -> None:
         if self.selected_shapes_copy:
             self._apply_cursor(CURSOR_MOVE)
-            self.bounded_move_shapes(shapes=self.selected_shapes_copy, pos=pos)
+            self._drag_shapes(shapes=self.selected_shapes_copy, cursor=pos)
             self.update()
         elif self.selected_shapes:
             self.selected_shapes_copy = [s.copy() for s in self.selected_shapes]
@@ -509,7 +512,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _drag_selected_shapes(self, pos: QPointF) -> None:
         self._apply_cursor(CURSOR_MOVE)
-        self.bounded_move_shapes(shapes=self.selected_shapes, pos=pos)
+        self._drag_shapes(shapes=self.selected_shapes, cursor=pos)
         self.update()
         self.is_moving_shape = True
 
@@ -898,7 +901,7 @@ class Canvas(QtWidgets.QWidget):
             )
             self.selection_changed.emit(new_selection)
             self.hovered_shape_is_selected = False
-        self.calculate_offsets(point)
+        self._record_drag_anchor(click=point)
 
     def _find_shape_at_point(self, point: QPointF) -> Shape | None:
         for shape in reversed(self.shapes):
@@ -906,21 +909,14 @@ class Canvas(QtWidgets.QWidget):
                 return shape
         return None
 
-    def calculate_offsets(self, point: QPointF) -> None:
+    def _record_drag_anchor(self, click: QPointF) -> None:
         if not self.selected_shapes:
-            self.offsets = QPointF(0.0, 0.0), QPointF(0.0, 0.0)
+            self._drag_anchor = (QPointF(), QtCore.QRectF())
             return
-
-        rects = [s.bounding_rect() for s in self.selected_shapes]
-        left = min(r.left() for r in rects)
-        top = min(r.top() for r in rects)
-        right = max(r.right() for r in rects)
-        bottom = max(r.bottom() for r in rects)
-
-        self.offsets = (
-            QPointF(left - point.x(), top - point.y()),
-            QPointF(right - point.x(), bottom - point.y()),
-        )
+        bounds = self.selected_shapes[0].bounds()
+        for s in self.selected_shapes[1:]:
+            bounds = bounds.united(s.bounds())
+        self._drag_anchor = (bounds.topLeft() - click, bounds)
 
     def bounded_move_vertex(
         self, shape: Shape, vertex_index: int, pos: QPointF, is_shift_pressed: bool
@@ -945,28 +941,28 @@ class Canvas(QtWidgets.QWidget):
 
         shape.move_vertex(i=vertex_index, pos=pos)
 
-    def bounded_move_shapes(self, shapes: list[Shape], pos: QPointF) -> bool:
-        if self.is_out_of_pixmap(pos):
+    def _drag_shapes(self, shapes: list[Shape], cursor: QPointF) -> bool:
+        if self.is_out_of_pixmap(cursor):
             return False
 
-        tl = pos + self.offsets[0]
-        if self.is_out_of_pixmap(tl):
-            pos -= QPointF(min(0, tl.x()), min(0, tl.y()))
+        rel_tl, bounds = self._drag_anchor
+        pw = float(self.pixmap.width())
+        ph = float(self.pixmap.height())
 
-        br = pos + self.offsets[1]
-        if self.is_out_of_pixmap(br):
-            pos += QPointF(
-                min(0, self.pixmap.width() - br.x()),
-                min(0, self.pixmap.height() - br.y()),
-            )
+        target = cursor + rel_tl
+        target.setX(max(0.0, target.x()))
+        target.setY(max(0.0, target.y()))
+        target.setX(min(target.x(), pw - bounds.width()))
+        target.setY(min(target.y(), ph - bounds.height()))
 
-        dp = pos - self.prev_point
-        if dp.isNull():
+        new_cursor = target - rel_tl
+        delta = new_cursor - self.prev_point
+        if delta.isNull():
             return False
 
         for shape in shapes:
-            shape.move_by(dp)
-        self.prev_point = pos
+            shape.translate(offset=delta)
+        self.prev_point = new_cursor
         return True
 
     def deselect_shape(self) -> bool:
@@ -1241,9 +1237,7 @@ class Canvas(QtWidgets.QWidget):
     def move_by_keyboard(self, offset: QPointF) -> None:
         if not self.selected_shapes:
             return
-        self.bounded_move_shapes(
-            shapes=self.selected_shapes, pos=self.prev_point + offset
-        )
+        self._drag_shapes(shapes=self.selected_shapes, cursor=self.prev_point + offset)
         self.update()
         self.is_moving_shape = True
 

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -47,14 +47,14 @@ def test_auto_save_on_shape_move(
 
     canvas = _auto_save_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
-    original_center = QPointF(canvas.selected_shapes[0].bounding_rect().center())
+    original_center = QPointF(canvas.selected_shapes[0].bounds().center())
 
     qtbot.keyPress(canvas, Qt.Key_Right)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, Qt.Key_Right)
     qtbot.wait(50)
 
-    new_center = canvas.selected_shapes[0].bounding_rect().center()
+    new_center = canvas.selected_shapes[0].bounds().center()
     assert abs((new_center.x() - original_center.x()) - 5.0) < 1.0
 
     assert label_file.exists()

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -101,7 +101,7 @@ def test_move_shape_by_drag(
     shape = canvas.shapes[_SHAPE_INDEX]
     original_points = [QPointF(p) for p in shape.points]
 
-    center = shape.bounding_rect().center()
+    center = shape.bounds().center()
     offset = QPointF(15, 10)
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     _hover_and_drag(
@@ -166,14 +166,14 @@ def test_move_shape_by_arrow_key(
     canvas = annotated_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     shape = canvas.selected_shapes[0]
-    original_center = QPointF(shape.bounding_rect().center())
+    original_center = QPointF(shape.bounds().center())
 
     qtbot.keyPress(canvas, key)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, key)
     qtbot.wait(50)
 
-    new_center = shape.bounding_rect().center()
+    new_center = shape.bounds().center()
     assert abs((new_center.x() - original_center.x()) - expected_dx) < 1.0
     assert abs((new_center.y() - original_center.y()) - expected_dy) < 1.0
 
@@ -496,7 +496,7 @@ def test_select_nonpolygon_shape(
     raw_win._switch_canvas_mode(edit=True)
     qtbot.wait(50)
 
-    click_pos = shape.bounding_rect().center() + QPointF(*select_offset)
+    click_pos = shape.bounds().center() + QPointF(*select_offset)
     click_widget = image_to_widget_pos(canvas=canvas, image_pos=click_pos)
     qtbot.mouseMove(canvas, pos=click_widget)
     qtbot.wait(50)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -240,7 +240,7 @@ def draw_and_commit_polygon(
 
 
 def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
-    shape_center = canvas.shapes[shape_index].bounding_rect().center()
+    shape_center = canvas.shapes[shape_index].bounds().center()
     pos = image_to_widget_pos(canvas=canvas, image_pos=shape_center)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)


### PR DESCRIPTION
## Summary
- Replace the `if/elif` chain in `_make_shape_path` with a `_PATH_BUILDERS` dispatch table (one builder per shape kind).
- Drop `Shape.to_path` wrapper; call `_make_shape_path` directly from `Shape.bounds`.
- Rename `Shape.move_by` to `Shape.translate` and use an `enumerate`-based in-place loop.
- Rename `Shape.bounding_rect` to `Shape.bounds` (matches the `QRectF` return type, no abbreviation).
- Replace `Canvas.calculate_offsets` / `Canvas.bounded_move_shapes` with `_record_drag_anchor` / `_drag_shapes`. The drag anchor is now `(rel_top_left, bounds: QRectF)`, and clamping is expressed as direct `max`/`min` on the bbox top-left rather than two corner offsets with `min(0, ...)`.

## Why
The previous shape API mixed naming styles (`bounding_rect`, `to_path`, `move_by`) and the drag-bound clamp encoded its constraint via a two-corner-offset trick that took mental decoding. The dispatch table makes it trivial to add new shape types, and the clamp now reads as "keep the bounds top-left inside the pixmap rectangle".

## Test plan
- [x] `make lint`
- [x] `make test` (201 passed)
- [x] Manual smoke: drag a shape near the pixmap edge in the GUI; bounded movement still works