### PR TITLE
refactor(shape): dispatch table and tidier API

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 from typing import Final
 from typing import NamedTuple
+from typing import Protocol
 
 import numpy as np
 import numpy.typing as npt
@@ -189,17 +190,16 @@ class Shape:
             point_size=self.point_size,
         )
 
-    def to_path(self) -> QtGui.QPainterPath:
-        return _make_shape_path(shape_type=self.shape_type, points=self.points)
-
-    def bounding_rect(self) -> QtCore.QRectF:
-        return self.to_path().boundingRect()
-
-    def move_by(self, offset: QtCore.QPointF) -> None:
-        self.points = [p + offset for p in self.points]
+    def bounds(self) -> QtCore.QRectF:
+        path = _make_shape_path(shape_type=self.shape_type, points=self.points)
+        return path.boundingRect()
 
     def move_vertex(self, i: int, pos: QtCore.QPointF) -> None:
         self.points[i] = pos
+
+    def translate(self, offset: QtCore.QPointF) -> None:
+        for i, point in enumerate(self.points):
+            self.points[i] = point + offset
 
     def highlight_vertex(self, i: int, action: int) -> None:
         self.highlight = _Highlight(index=i, mode=action)
@@ -230,24 +230,47 @@ def _scale_point(*, point: QtCore.QPointF, scale: float) -> QtCore.QPointF:
     return QtCore.QPointF(point.x() * scale, point.y() * scale)
 
 
+def _build_rectangle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if len(points) == 2:
+        out.addRect(QtCore.QRectF(points[0], points[1]))
+    return out
+
+
+def _build_circle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if len(points) == 2:
+        radius = labelme.utils.distance(points[0] - points[1])
+        out.addEllipse(points[0], radius, radius)
+    return out
+
+
+def _build_polyline_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if not points:
+        return out
+    out.moveTo(points[0])
+    for vertex in points[1:]:
+        out.lineTo(vertex)
+    return out
+
+
+class _PathBuilder(Protocol):
+    def __call__(self, *, points: list[QtCore.QPointF]) -> QtGui.QPainterPath: ...
+
+
+_PATH_BUILDERS: Final[dict[str, _PathBuilder]] = {
+    "rectangle": _build_rectangle_path,
+    "mask": _build_rectangle_path,
+    "circle": _build_circle_path,
+}
+
+
 def _make_shape_path(
     *, shape_type: str, points: list[QtCore.QPointF]
 ) -> QtGui.QPainterPath:
-    if shape_type in ["rectangle", "mask"]:
-        path = QtGui.QPainterPath()
-        if len(points) == 2:
-            path.addRect(QtCore.QRectF(points[0], points[1]))
-        return path
-    if shape_type == "circle":
-        path = QtGui.QPainterPath()
-        if len(points) == 2:
-            radius = labelme.utils.distance(points[0] - points[1])
-            path.addEllipse(points[0], radius, radius)
-        return path
-    path = QtGui.QPainterPath(points[0])
-    for vertex in points[1:]:
-        path.lineTo(vertex)
-    return path
+    builder = _PATH_BUILDERS.get(shape_type, _build_polyline_path)
+    return builder(points=points)
 
 
 def _argmin(values: Iterable[float]) -> tuple[int, float] | None:
@@ -320,20 +343,20 @@ def _mask_contour_path(
     origin: QtCore.QPointF,
     scale: float,
 ) -> QtGui.QPainterPath:
-    path = QtGui.QPainterPath()
     contours = skimage.measure.find_contours(np.pad(mask, pad_width=1))
+    output = QtGui.QPainterPath()
     for contour in contours:
         contour = contour + [origin.y(), origin.x()]
-        path.moveTo(
+        output.moveTo(
             _scale_point(
                 point=QtCore.QPointF(contour[0, 1], contour[0, 0]), scale=scale
             )
         )
         for point in contour[1:]:
-            path.lineTo(
+            output.lineTo(
                 _scale_point(point=QtCore.QPointF(point[1], point[0]), scale=scale)
             )
-    return path
+    return output
 
 
 def _vertex_size_and_type(

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -911,7 +911,7 @@ class Canvas(QtWidgets.QWidget):
             self.offsets = QPointF(0.0, 0.0), QPointF(0.0, 0.0)
             return
 
-        rects = [s.bounding_rect() for s in self.selected_shapes]
+        rects = [s.bounds() for s in self.selected_shapes]
         left = min(r.left() for r in rects)
         top = min(r.top() for r in rects)
         right = max(r.right() for r in rects)
@@ -965,7 +965,7 @@ class Canvas(QtWidgets.QWidget):
             return False
 
         for shape in shapes:
-            shape.move_by(dp)
+            shape.translate(offset=dp)
         self.prev_point = pos
         return True
 

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -47,14 +47,14 @@ def test_auto_save_on_shape_move(
 
     canvas = _auto_save_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
-    original_center = QPointF(canvas.selected_shapes[0].bounding_rect().center())
+    original_center = QPointF(canvas.selected_shapes[0].bounds().center())
 
     qtbot.keyPress(canvas, Qt.Key_Right)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, Qt.Key_Right)
     qtbot.wait(50)
 
-    new_center = canvas.selected_shapes[0].bounding_rect().center()
+    new_center = canvas.selected_shapes[0].bounds().center()
     assert abs((new_center.x() - original_center.x()) - 5.0) < 1.0
 
     assert label_file.exists()

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -101,7 +101,7 @@ def test_move_shape_by_drag(
     shape = canvas.shapes[_SHAPE_INDEX]
     original_points = [QPointF(p) for p in shape.points]
 
-    center = shape.bounding_rect().center()
+    center = shape.bounds().center()
     offset = QPointF(15, 10)
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     _hover_and_drag(
@@ -166,14 +166,14 @@ def test_move_shape_by_arrow_key(
     canvas = annotated_win._canvas_widgets.canvas
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     shape = canvas.selected_shapes[0]
-    original_center = QPointF(shape.bounding_rect().center())
+    original_center = QPointF(shape.bounds().center())
 
     qtbot.keyPress(canvas, key)
     qtbot.wait(50)
     qtbot.keyRelease(canvas, key)
     qtbot.wait(50)
 
-    new_center = shape.bounding_rect().center()
+    new_center = shape.bounds().center()
     assert abs((new_center.x() - original_center.x()) - expected_dx) < 1.0
     assert abs((new_center.y() - original_center.y()) - expected_dy) < 1.0
 
@@ -496,7 +496,7 @@ def test_select_nonpolygon_shape(
     raw_win._switch_canvas_mode(edit=True)
     qtbot.wait(50)
 
-    click_pos = shape.bounding_rect().center() + QPointF(*select_offset)
+    click_pos = shape.bounds().center() + QPointF(*select_offset)
     click_widget = image_to_widget_pos(canvas=canvas, image_pos=click_pos)
     qtbot.mouseMove(canvas, pos=click_widget)
     qtbot.wait(50)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -240,7 +240,7 @@ def draw_and_commit_polygon(
 
 
 def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
-    shape_center = canvas.shapes[shape_index].bounding_rect().center()
+    shape_center = canvas.shapes[shape_index].bounds().center()
     pos = image_to_widget_pos(canvas=canvas, image_pos=shape_center)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)


### PR DESCRIPTION
## Summary
- Replace the `if/elif` chain in `_make_shape_path` with a `_PATH_BUILDERS` dispatch table; one builder per shape kind (`rectangle`/`mask`, `circle`, polyline).
- Rename `Shape.bounding_rect` to `Shape.bounds` (matches the `QRectF` return type).
- Rename `Shape.move_by(offset)` to `Shape.translate(offset)` and use an `enumerate`-based in-place loop.
- Drop the one-line `Shape.to_path()` wrapper; `bounds()` calls `_make_shape_path` directly.
- Update `canvas.py` and three e2e tests for the renamed methods.

## Why
Mixed-style API (`bounding_rect`, `to_path`, `move_by`) is unified, and the shape-path builder is now trivially extensible (add a new entry to `_PATH_BUILDERS` instead of editing a conditional ladder).

## Test plan
- [x] make lint
- [x] make test (201 passed)