### PR TITLE
refactor(shape): extract POLYLINE_SHAPE_TYPES constant

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -19,6 +19,8 @@ import labelme.utils
 _P_SQUARE: Final[int] = 0
 _P_ROUND: Final[int] = 1
 
+POLYLINE_SHAPE_TYPES: Final[tuple[str, ...]] = ("polygon", "linestrip")
+
 
 class _Highlight(NamedTuple):
     index: int
@@ -125,7 +127,7 @@ class Shape:
         self.point_labels.append(label)
 
     def can_add_point(self) -> bool:
-        return self.shape_type in ["polygon", "linestrip"]
+        return self.shape_type in POLYLINE_SHAPE_TYPES
 
     def pop_point(self) -> QtCore.QPointF | None:
         if not self.points:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -22,6 +22,7 @@ from PyQt5.QtCore import Qt
 import labelme.utils
 from labelme._automation import OsamSession
 from labelme._automation import polygon_from_mask
+from labelme.shape import POLYLINE_SHAPE_TYPES
 from labelme.shape import Shape
 
 from .download import download_ai_model
@@ -445,7 +446,7 @@ class Canvas(QtWidgets.QWidget):
         current = self.current
         assert current is not None
         mode = self.create_mode
-        if mode in ("polygon", "linestrip"):
+        if mode in POLYLINE_SHAPE_TYPES:
             self.line.points = [current[-1], pos]
             self.line.point_labels = [1, 1]
         elif mode == "ai_points_to_shape":
@@ -1307,7 +1308,7 @@ class Canvas(QtWidgets.QWidget):
         self.current = self.shapes.pop()
         self.current.open()
         self.current.unrefine()
-        if self.create_mode in ("polygon", "linestrip"):
+        if self.create_mode in POLYLINE_SHAPE_TYPES:
             self.line.points = [self.current[-1], self.current[0]]
         elif self.create_mode in ("rectangle", "line", "circle", "ai_box_to_shape"):
             self.current.points = self.current.points[0:1]


### PR DESCRIPTION
## Summary
Extract the inline list `["polygon", "linestrip"]` into a module-level `POLYLINE_SHAPE_TYPES: Final[tuple[str, ...]]` constant in `labelme/shape.py`, and reuse it in `Shape.can_add_point` and in `canvas.py` (`_update_drawing_line`, `undo_last_line`).

Names the geometric concept (shape types built from a polyline vertex sequence) and gives a single point of update if more such shape types are added later.

No behavior change.

## Test plan
- [x] `make lint` clean
- [x] `make test` (201 passed)