### PR TITLE
refactor(config): rename display_label_popup → prompt_label_on_create

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1742,7 +1742,7 @@ class MainWindow(QtWidgets.QMainWindow):
         flags = {}
         group_id = None
         description = ""
-        if self._config["display_label_popup"] or not text:
+        if not text or self._config["prompt_label_on_create"]:
             previous_text = self._label_dialog.edit.text()
             text, flags, group_id, description = self._label_dialog.popup(text)
             if not text:

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -61,6 +61,14 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         logger.info("Migrating old config: store_data -> with_image_data")
         config_from_yaml["with_image_data"] = config_from_yaml.pop("store_data")
 
+    if "display_label_popup" in config_from_yaml:
+        logger.info(
+            "Migrating old config: display_label_popup -> prompt_label_on_create"
+        )
+        config_from_yaml["prompt_label_on_create"] = config_from_yaml.pop(
+            "display_label_popup"
+        )
+
     if config_from_yaml.get("shortcuts", {}).pop("add_point_to_edge", None):
         logger.info("Migrating old config: removing shortcuts.add_point_to_edge")
 

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -1,6 +1,6 @@
 ---
 auto_save: true
-display_label_popup: true
+prompt_label_on_create: true
 with_image_data: false
 keep_prev: false
 keep_prev_scale: false


### PR DESCRIPTION
## Summary
Rename the \`display_label_popup\` config key to \`prompt_label_on_create\`.

The new name reads better at the call site (\"prompt for a label when a shape is created\") and matches the surrounding boolean-config naming convention. Predicate operands at the use site are also reordered to put the \"first shape always gets a label\" rule first.

A migration shim is added in \`_migrate_config_from_file\` so existing \`~/.labelmerc\` files continue to work without user action.

## Test plan
- [x] \`make lint\` clean
- [x] \`make test\` (201 passed)
- [ ] Smoke-test: existing \`~/.labelmerc\` with the old key still works (migration logs the rename and the new key takes effect)