### PR TITLE
perf(toolbar): align only the just-added button in addAction

### DIFF
--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -52,11 +52,8 @@ class ToolBar(QtWidgets.QToolBar):
         btn.setDefaultAction(action)
         btn.setToolButtonStyle(self.toolButtonStyle())
         self.addWidget(btn)
-
-        # center align
-        for i in range(self.layout().count()):
-            if isinstance(self.layout().itemAt(i).widget(), QtWidgets.QToolButton):
-                self.layout().itemAt(i).setAlignment(QtCore.Qt.AlignCenter)
+        layout = self.layout()
+        layout.itemAt(layout.count() - 1).setAlignment(QtCore.Qt.AlignCenter)
 
     def _equalize_button_widths(self) -> None:
         layout = self.layout()


### PR DESCRIPTION
The center-align fixup in `ToolBar.addAction` walked the entire layout and reapplied `AlignCenter` to every existing `QToolButton` on every call — quadratic over construction. The newly added button is always at the last index, so a single `setAlignment` on `layout.itemAt(count - 1)` is sufficient. Drops the loop, the isinstance guard, and the explanatory comment.