### PR TITLE
feat(ai): add rectangle and circle output formats for AI-assisted annotation

### DIFF
--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -3,3 +3,4 @@ from ._shape_builders import Detection
 from ._shape_builders import shapes_from_detections
 from ._text_detection import get_bboxes_from_texts
 from ._text_detection import nms_bboxes
+from ._types import AiOutputFormat

--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -1,8 +1,32 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
 import imgviz
 import numpy as np
 import skimage
 from loguru import logger
 from numpy.typing import NDArray
+
+
+class Circle(NamedTuple):
+    cx: float
+    cy: float
+    radius: float
+
+
+def compute_circle_from_mask(mask: NDArray[np.bool_]) -> Circle | None:
+    if not mask.any():
+        return None
+    ys, xs = np.nonzero(mask)
+    # Area-equivalent radius: matches the mask's pixel area, not its extent.
+    # For elongated or sparse masks the resulting circle may be smaller than
+    # the tightest enclosing one.
+    return Circle(
+        cx=float(xs.mean()),
+        cy=float(ys.mean()),
+        radius=float(np.sqrt(mask.sum() / np.pi)),
+    )
 
 
 def _get_contour_length(contour: NDArray[np.float32]) -> float:

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
 
 import numpy as np
 from numpy.typing import NDArray
@@ -9,7 +8,10 @@ from PyQt5.QtCore import QPointF
 
 from labelme.shape import Shape
 
+from ._geometry import Circle
+from ._geometry import compute_circle_from_mask
 from ._geometry import compute_polygon_from_mask
+from ._types import AiOutputFormat
 
 
 @dataclass
@@ -21,7 +23,7 @@ class Detection:
 
 
 def _build_shape(
-    shape_type: Literal["rectangle", "polygon", "mask"],
+    shape_type: AiOutputFormat,
     points: list[QPointF],
     *,
     mask: NDArray[np.bool_] | None = None,
@@ -42,7 +44,7 @@ def _build_shape(
 
 def _shape_from_detection(
     detection: Detection,
-    shape_type: Literal["rectangle", "polygon", "mask"],
+    shape_type: AiOutputFormat,
 ) -> Shape | None:
     if shape_type == "rectangle":
         if detection.bbox is None:
@@ -84,12 +86,45 @@ def _shape_from_detection(
             label=detection.label,
             description=detection.description,
         )
+    if shape_type == "circle":
+        circle = _circle_for_detection(detection=detection)
+        if circle is None:
+            return None
+        return _build_shape(
+            shape_type="circle",
+            points=[
+                QPointF(circle.cx, circle.cy),
+                QPointF(circle.cx + circle.radius, circle.cy),
+            ],
+            label=detection.label,
+            description=detection.description,
+        )
     raise ValueError(f"Unsupported shape_type: {shape_type!r}")
+
+
+def _circle_for_detection(detection: Detection) -> Circle | None:
+    if detection.mask is not None:
+        circle = compute_circle_from_mask(mask=detection.mask)
+        if circle is not None:
+            offset_x = detection.bbox[0] if detection.bbox is not None else 0.0
+            offset_y = detection.bbox[1] if detection.bbox is not None else 0.0
+            return Circle(
+                cx=circle.cx + offset_x,
+                cy=circle.cy + offset_y,
+                radius=circle.radius,
+            )
+    if detection.bbox is not None:
+        # Inscribed in bbox when no usable mask is available.
+        xmin, ymin, xmax, ymax = detection.bbox
+        radius = min(xmax - xmin, ymax - ymin) / 2
+        if radius > 0:
+            return Circle(cx=(xmin + xmax) / 2, cy=(ymin + ymax) / 2, radius=radius)
+    return None
 
 
 def shapes_from_detections(
     detections: list[Detection],
-    shape_type: Literal["rectangle", "polygon", "mask"],
+    shape_type: AiOutputFormat,
 ) -> list[Shape]:
     shapes: list[Shape] = []
     for detection in detections:

--- a/labelme/_automation/_types.py
+++ b/labelme/_automation/_types.py
@@ -1,0 +1,4 @@
+from typing import Literal
+from typing import TypeAlias
+
+AiOutputFormat: TypeAlias = Literal["rectangle", "polygon", "mask", "circle"]

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -34,6 +34,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 from labelme import __appname__
 from labelme import __version__
+from labelme._automation import AiOutputFormat
 from labelme._automation import Detection
 from labelme._automation import OsamSession
 from labelme._automation import get_bboxes_from_texts
@@ -2593,8 +2594,8 @@ def _shapes_from_dicts(
 
 
 def _resolve_text_annotation_shape_type(
-    *, create_mode: str, ai_output_format: Literal["rectangle", "polygon", "mask"]
-) -> Literal["rectangle", "polygon", "mask"] | None:
+    *, create_mode: str, ai_output_format: AiOutputFormat
+) -> AiOutputFormat | None:
     if create_mode in _AI_CREATE_MODES:
         return ai_output_format
     if create_mode in get_args(_TextToAnnotationCreateMode):
@@ -2603,10 +2604,24 @@ def _resolve_text_annotation_shape_type(
 
 
 def _shape_to_xyxy_bbox(shape: Shape) -> NDArray[np.float32]:
-    points = np.array([[p.x(), p.y()] for p in shape.points])
-    xmin, ymin = points.min(axis=0)
-    xmax, ymax = points.max(axis=0)
-    return np.array([xmin, ymin, xmax, ymax], dtype=np.float32)
+    if shape.shape_type == "circle":
+        center, edge = shape.points
+        radius = math.sqrt((edge.x() - center.x()) ** 2 + (edge.y() - center.y()) ** 2)
+        return np.array(
+            [
+                center.x() - radius,
+                center.y() - radius,
+                center.x() + radius,
+                center.y() + radius,
+            ],
+            dtype=np.float32,
+        )
+    if shape.shape_type in ("rectangle", "polygon", "mask"):
+        points = np.array([[p.x(), p.y()] for p in shape.points])
+        xmin, ymin = points.min(axis=0)
+        xmax, ymax = points.max(axis=0)
+        return np.array([xmin, ymin, xmax, ymax], dtype=np.float32)
+    raise ValueError(f"Unsupported shape_type: {shape.shape_type!r}")
 
 
 def _rgb_from_colormap_id(*, label_id: int) -> tuple[int, int, int]:

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import typing
 from collections.abc import Callable
-from typing import Literal
 
 from loguru import logger
 from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt
+
+from labelme._automation import AiOutputFormat
 
 from ._info_button import InfoButton
 
@@ -36,7 +37,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         self,
         default_model: str,
         on_model_changed: Callable[[str], None],
-        on_output_format_changed: Callable[[Literal["polygon", "mask"]], None],
+        on_output_format_changed: Callable[[AiOutputFormat], None],
         parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
@@ -47,14 +48,14 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         )
 
     @property
-    def output_format(self) -> Literal["polygon", "mask"]:
+    def output_format(self) -> AiOutputFormat:
         return self._output_format_combo.currentData()
 
     def _init_ui(
         self,
         default_model: str,
         on_model_changed: Callable[[str], None],
-        on_output_format_changed: Callable[[Literal["polygon", "mask"]], None],
+        on_output_format_changed: Callable[[AiOutputFormat], None],
     ) -> None:
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(4, 4, 4, 4)
@@ -88,6 +89,8 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         self._output_format_combo = QtWidgets.QComboBox()
         self._output_format_combo.addItem("Polygon", "polygon")
         self._output_format_combo.addItem("Mask", "mask")
+        self._output_format_combo.addItem("Rectangle", "rectangle")
+        self._output_format_combo.addItem("Circle", "circle")
         body_layout.addWidget(self._output_format_combo)
 
         layout.addWidget(body)

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -5,7 +5,6 @@ import enum
 from collections.abc import Callable
 from typing import Any
 from typing import Final
-from typing import Literal
 
 import imgviz
 import numpy as np
@@ -20,6 +19,7 @@ from PyQt5.QtCore import QRectF
 from PyQt5.QtCore import Qt
 
 import labelme.utils
+from labelme._automation import AiOutputFormat
 from labelme._automation import Detection
 from labelme._automation import OsamSession
 from labelme._automation import shapes_from_detections
@@ -86,7 +86,7 @@ class Canvas(QtWidgets.QWidget):
 
     _osam_session_model_name: str = "sam2:latest"
     _osam_session: OsamSession | None
-    _ai_output_format: Literal["polygon", "mask"] = "polygon"
+    _ai_output_format: AiOutputFormat = "polygon"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self.epsilon: float = kwargs.pop("epsilon", 10.0)
@@ -169,7 +169,7 @@ class Canvas(QtWidgets.QWidget):
     def set_ai_model_name(self, model_name: str) -> None:
         self._osam_session_model_name = model_name
 
-    def set_ai_output_format(self, output_format: Literal["polygon", "mask"]) -> None:
+    def set_ai_output_format(self, output_format: AiOutputFormat) -> None:
         self._ai_output_format = output_format
 
     def _get_osam_session(self) -> OsamSession:

--- a/tests/unit/_automation/_geometry_test.py
+++ b/tests/unit/_automation/_geometry_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from labelme._automation._geometry import compute_circle_from_mask
+
+
+def test_compute_circle_from_mask_returns_none_when_empty() -> None:
+    assert compute_circle_from_mask(mask=np.zeros((10, 10), dtype=bool)) is None
+
+
+def test_compute_circle_from_mask_centroid_and_area_equivalent_radius() -> None:
+    mask = np.zeros((11, 11), dtype=bool)
+    mask[0:3, 0:3] = True
+
+    circle = compute_circle_from_mask(mask=mask)
+
+    assert circle is not None
+    assert circle.cx == pytest.approx(1)
+    assert circle.cy == pytest.approx(1)
+    assert circle.radius == pytest.approx(math.sqrt(9 / math.pi))

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from labelme._automation import Detection
+from labelme._automation import shapes_from_detections
+
+
+def test_shapes_from_detections_circle_with_mask_uses_centroid_and_area() -> None:
+    [shape] = shapes_from_detections(
+        detections=[
+            Detection(
+                bbox=(10, 20, 30, 50),
+                mask=np.ones((31, 21), dtype=bool),
+            )
+        ],
+        shape_type="circle",
+    )
+
+    assert shape.shape_type == "circle"
+    expected_cx = 10 + 10
+    expected_cy = 20 + 15
+    expected_radius = math.sqrt(21 * 31 / math.pi)
+    assert shape.points[0].x() == pytest.approx(expected_cx)
+    assert shape.points[0].y() == pytest.approx(expected_cy)
+    assert shape.points[1].x() == pytest.approx(expected_cx + expected_radius)
+    assert shape.points[1].y() == pytest.approx(expected_cy)
+
+
+def test_shapes_from_detections_circle_without_mask_falls_back_to_inscribed() -> None:
+    [shape] = shapes_from_detections(
+        detections=[Detection(bbox=(0, 0, 10, 20))],
+        shape_type="circle",
+    )
+
+    assert shape.shape_type == "circle"
+    assert shape.points[0].x() == pytest.approx(5)
+    assert shape.points[0].y() == pytest.approx(10)
+    assert shape.points[1].x() == pytest.approx(10)
+    assert shape.points[1].y() == pytest.approx(10)

--- a/tests/unit/app_test.py
+++ b/tests/unit/app_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+from PyQt5 import QtCore
+
+from labelme.app import _shape_to_xyxy_bbox
+from labelme.shape import Shape
+
+
+def test_shape_to_xyxy_bbox_circle() -> None:
+    shape = Shape(shape_type="circle")
+    shape.add_point(QtCore.QPointF(50, 40))
+    shape.add_point(QtCore.QPointF(53, 44))
+
+    bbox = _shape_to_xyxy_bbox(shape)
+
+    radius = math.sqrt((53 - 50) ** 2 + (44 - 40) ** 2)
+    assert bbox.tolist() == pytest.approx(
+        [50 - radius, 40 - radius, 50 + radius, 40 + radius]
+    )
+
+
+def test_shape_to_xyxy_bbox_raises_on_unsupported_shape_type() -> None:
+    shape = Shape(shape_type="point")
+    shape.add_point(QtCore.QPointF(1, 2))
+
+    with pytest.raises(ValueError, match="Unsupported shape_type"):
+        _shape_to_xyxy_bbox(shape)


### PR DESCRIPTION
## Summary
- Add Rectangle and Circle entries to the AI-Assisted Annotation output format dropdown
- Rectangle: built directly from `annotation.bounding_box` corners
- Circle: centroid from mask + area-equivalent radius (`sqrt(area/pi)`), mirroring how polygon already approximates the mask

## Why
SAM emits a mask + bounding box; previously we only converted those to polygon or mask. The same data trivially supports rectangle (corners) and circle (centroid + area).

## Test plan
- [x] `make lint`
- [x] `make test` (203 passed)
- [x] Unit tests added for rectangle and circle branches of `_shape_from_annotation`
- [x] Manual: AI-Box mode with each new output format