### PR TITLE
refactor(shape): remove unused _points_raw and _shape_type_raw attributes

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -59,8 +59,6 @@ class Shape:
         self.points: list[QtCore.QPointF] = []
         self.point_labels: list[int] = []
         self.shape_type = shape_type
-        self._points_raw: list[QtCore.QPointF] = []
-        self._shape_type_raw = None
         self.fill = False
         self.selected = False
         self.visible = True


### PR DESCRIPTION
## Summary
- Remove `_points_raw` and `_shape_type_raw` from `Shape.__init__`; both had zero references in the codebase.

## Why
Dead state. Cleaner init.

## Test plan
- [x] `make lint`