### PR TITLE
refactor(shape): make Shape.add_point auto-close opt-in

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -97,8 +97,10 @@ class Shape:
     def close(self) -> None:
         self._closed = True
 
-    def add_point(self, point: QtCore.QPointF, label: int = 1) -> None:
-        if self.points and self.points[0] == point:
+    def add_point(
+        self, point: QtCore.QPointF, label: int = 1, *, autoclose: bool = False
+    ) -> None:
+        if autoclose and self.points and self.points[0] == point:
             self.close()
             return
         self.points.append(point)

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -640,7 +640,7 @@ class Canvas(QtWidgets.QWidget):
         mode = self.create_mode
         modifiers = event.modifiers()
         if mode == "polygon":
-            current.add_point(self.line[1])
+            current.add_point(self.line[1], autoclose=True)
             self.line[0] = current[-1]
             if current.is_closed():
                 self.finalise()
@@ -1111,7 +1111,7 @@ class Canvas(QtWidgets.QWidget):
                 " so forcing to be opaque."
             )
             preview.fill_color.setAlpha(64)
-        preview.add_point(point=self.line[1])
+        preview.add_point(point=self.line[1], autoclose=True)
         return preview
 
     def _build_ai_points_preview(self, current: Shape) -> Shape:


### PR DESCRIPTION
## Summary

Auto-closing a shape on a duplicate first-point click is polygon-specific behavior. Today it lives unconditionally inside `Shape.add_point`, even though `linestrip` and `ai_points_to_shape` both use Ctrl+Click to finalize and never act on `is_closed()` after `add_point` — so the auto-close was dead code on those paths.

This PR adds an explicit `autoclose: bool = False` keyword-only parameter and gates the close-on-duplicate logic behind it. The two polygon callers (`_extend_current_shape` and the fill-drawing `_build_polygon_preview`) opt in with `autoclose=True`; everything else falls through to plain append.

## Why

- Removes coupling between `add_point` and the implicit "first call site that cares is polygon" behavior.
- Makes the closing behavior visible at the call site instead of hidden in `add_point`.
- Eliminates dead-code auto-close on linestrip / ai_points_to_shape paths.
- Sets up cleaner future extensions (e.g. shapes whose creation flow legitimately reuses `points[0]` as a placeholder).

## No behavior change

- Polygon: same — both polygon callers pass `autoclose=True`.
- Linestrip / ai_points_to_shape: previously the auto-close set `_closed = True` silently, but the canvas never checked `is_closed()` after these `add_point` calls. Effectively dead code; now removed.
- `app.py` shape deserialization (`shape.add_point(...)` then explicit `shape.close()`): unaffected since saved polygons don't repeat the first vertex.

## Test plan

- [x] \`make lint\` clean
- [x] \`make test\` (102 unit tests pass)
- [x] Manually drew + closed polygons (click first vertex), verified close still works
- [x] Manually drew linestrip and ai_points_to_shape, verified Ctrl+Click finalize