### PR TITLE
refactor(canvas): drop unused helpers and inline thin wrappers

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -247,9 +247,6 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self._update_status()
 
-    def is_shape_visible(self, shape: Shape) -> bool:
-        return shape.visible
-
     def drawing(self) -> bool:
         return self.mode == CanvasMode.CREATE
 
@@ -516,11 +513,7 @@ class Canvas(QtWidgets.QWidget):
     def _highlight_hover_shape(self, pos: QPointF, status_messages: list[str]) -> None:
         ordered_shapes: list[Shape] = (
             [self.hovered_shape] if self.hovered_shape else []
-        ) + [
-            s
-            for s in reversed(self.shapes)
-            if self.is_shape_visible(s) and s != self.hovered_shape
-        ]
+        ) + [s for s in reversed(self.shapes) if s.visible and s != self.hovered_shape]
 
         for shape in ordered_shapes:
             index: int | None = shape.nearest_vertex(pos, self.epsilon)
@@ -901,7 +894,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _find_shape_at_point(self, point: QPointF) -> Shape | None:
         for shape in reversed(self.shapes):
-            if self.is_shape_visible(shape) and shape.contains_point(point):
+            if shape.visible and shape.contains_point(point):
                 return shape
         return None
 
@@ -1060,7 +1053,7 @@ class Canvas(QtWidgets.QWidget):
         for shape in self.shapes:
             if not _is_shape_paintable(
                 shape=shape,
-                visible=self.is_shape_visible(shape),
+                visible=shape.visible,
                 hide_background=self._hide_background,
             ):
                 continue

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -247,9 +247,6 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self._update_status()
 
-    def drawing(self) -> bool:
-        return self.mode == CanvasMode.CREATE
-
     def editing(self) -> bool:
         return self.mode == CanvasMode.EDIT
 
@@ -301,7 +298,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _update_status(self, extra_messages: list[str] | None = None) -> None:
         messages: list[str] = []
-        if self.drawing():
+        if self.mode == CanvasMode.CREATE:
             messages.append(self.tr("Creating %r") % self.create_mode)
             messages.append(self._get_create_mode_message())
             if self.current:
@@ -316,7 +313,7 @@ class Canvas(QtWidgets.QWidget):
         self.status_updated.emit(" • ".join(messages))
 
     def _get_create_mode_message(self) -> str:
-        assert self.drawing()
+        assert self.mode == CanvasMode.CREATE
         is_new: bool = self.current is None
         if self.create_mode == "ai_points_to_shape":
             return self.tr(
@@ -365,7 +362,7 @@ class Canvas(QtWidgets.QWidget):
         if self._pan_anchor is not None:
             self._advance_pan(event=event)
             return
-        if self.drawing():
+        if self.mode == CanvasMode.CREATE:
             self._track_drawing_cursor(pos=pos, event=event)
             return
         buttons = event.buttons()
@@ -605,7 +602,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _press_left(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         is_shift_pressed = bool(event.modifiers() & Qt.ShiftModifier)
-        if self.drawing():
+        if self.mode == CanvasMode.CREATE:
             self._press_left_while_drawing(
                 pos=pos, event=event, is_shift_pressed=is_shift_pressed
             )
@@ -840,7 +837,7 @@ class Canvas(QtWidgets.QWidget):
         self._hide_background = self.hide_background if enable else False
 
     def can_close_shape(self) -> bool:
-        if not self.drawing():
+        if self.mode != CanvasMode.CREATE:
             return False
         if not self.current:
             return False
@@ -1041,7 +1038,7 @@ class Canvas(QtWidgets.QWidget):
         painter.drawLine(cx, 0, cx, max_y)
 
     def _should_draw_crosshair(self, cursor: QPointF | None) -> bool:
-        if not self.drawing():
+        if self.mode != CanvasMode.CREATE:
             return False
         if not self._crosshair[self._create_mode]:
             return False
@@ -1233,7 +1230,7 @@ class Canvas(QtWidgets.QWidget):
     def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:
         modifiers = a0.modifiers()
         key = a0.key()
-        if self.drawing():
+        if self.mode == CanvasMode.CREATE:
             if key == Qt.Key_Escape and self.current:
                 self._cancel_current_shape()
             elif key in (Qt.Key_Return, Qt.Key_Space) and self.can_close_shape():
@@ -1255,7 +1252,7 @@ class Canvas(QtWidgets.QWidget):
 
     def keyReleaseEvent(self, a0: QtGui.QKeyEvent) -> None:
         modifiers = a0.modifiers()
-        if self.drawing():
+        if self.mode == CanvasMode.CREATE:
             if int(modifiers) == 0:
                 self.snapping = True
         elif self.editing():

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -247,9 +247,6 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self._update_status()
 
-    def editing(self) -> bool:
-        return self.mode == CanvasMode.EDIT
-
     def set_editing(self, value: bool = True) -> None:
         self.mode = CanvasMode.EDIT if value else CanvasMode.CREATE
         if self.mode == CanvasMode.EDIT:
@@ -306,7 +303,7 @@ class Canvas(QtWidgets.QWidget):
             if self.can_close_shape():
                 messages.append(self.tr("Enter or Space to finalize"))
         else:
-            assert self.editing()
+            assert self.mode == CanvasMode.EDIT
             messages.append(self.tr("Editing shapes"))
         if extra_messages:
             messages.extend(extra_messages)
@@ -594,7 +591,7 @@ class Canvas(QtWidgets.QWidget):
         if button == Qt.LeftButton:
             self._press_left(pos=pos, event=event)
             return
-        if button == Qt.RightButton and self.editing():
+        if button == Qt.RightButton and self.mode == CanvasMode.EDIT:
             self._press_right(pos=pos, event=event)
             return
         if button == Qt.MiddleButton and self._is_image_overflowing_viewport():
@@ -607,7 +604,7 @@ class Canvas(QtWidgets.QWidget):
                 pos=pos, event=event, is_shift_pressed=is_shift_pressed
             )
             return
-        if self.editing():
+        if self.mode == CanvasMode.EDIT:
             self._press_left_while_editing(pos=pos, event=event)
 
     def _press_left_while_drawing(
@@ -748,7 +745,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
 
     def _release_left(self) -> None:
-        if not self.editing():
+        if self.mode != CanvasMode.EDIT:
             return
         if self.hovered_shape is None:
             return
@@ -1237,7 +1234,7 @@ class Canvas(QtWidgets.QWidget):
                 self.finalise()
             elif modifiers == Qt.AltModifier:
                 self.snapping = False
-        elif self.editing():
+        elif self.mode == CanvasMode.EDIT:
             if key == Qt.Key_Up:
                 self.move_by_keyboard(QPointF(0.0, -MOVE_SPEED))
             elif key == Qt.Key_Down:
@@ -1255,7 +1252,7 @@ class Canvas(QtWidgets.QWidget):
         if self.mode == CanvasMode.CREATE:
             if int(modifiers) == 0:
                 self.snapping = True
-        elif self.editing():
+        elif self.mode == CanvasMode.EDIT:
             if (
                 self.is_moving_shape
                 and self.selected_shapes

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -138,9 +138,6 @@ class Canvas(QtWidgets.QWidget):
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.WheelFocus)
 
-    def fill_drawing(self) -> bool:
-        return self._fill_drawing
-
     def set_fill_drawing(self, value: bool) -> None:
         self._fill_drawing = value
 
@@ -1085,8 +1082,8 @@ class Canvas(QtWidgets.QWidget):
         preview = self._build_preview_shape()
         if preview is None:
             return
-        preview.fill = self.fill_drawing()
-        preview.selected = self.fill_drawing()
+        preview.fill = self._fill_drawing
+        preview.selected = self._fill_drawing
         preview.paint(painter)
 
     def _build_preview_shape(self) -> Shape | None:
@@ -1100,7 +1097,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _build_polygon_preview(self, current: Shape) -> Shape:
         preview: Shape = current.copy()
-        if not self.fill_drawing():
+        if not self._fill_drawing:
             return preview
         if len(preview.points) < 2:
             return preview

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -22,7 +22,7 @@ def test_toggle_all_shapes(
 
     assert len(canvas.shapes) == 5
     for shape in canvas.shapes:
-        assert canvas.is_shape_visible(shape)
+        assert shape.visible
 
     annotated_win.toggle_shape_visibility(False)
     qtbot.wait(50)
@@ -30,7 +30,7 @@ def test_toggle_all_shapes(
     for item in label_list:
         assert item.checkState() == Qt.Unchecked
     for shape in canvas.shapes:
-        assert not canvas.is_shape_visible(shape)
+        assert not shape.visible
 
     annotated_win.toggle_shape_visibility(True)
     qtbot.wait(50)
@@ -38,7 +38,7 @@ def test_toggle_all_shapes(
     for item in label_list:
         assert item.checkState() == Qt.Checked
     for shape in canvas.shapes:
-        assert canvas.is_shape_visible(shape)
+        assert shape.visible
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
 
@@ -57,15 +57,15 @@ def test_toggle_individual_shape(
     first_item = label_list[0]
     first_shape = first_item.shape()
     assert first_shape is not None
-    assert canvas.is_shape_visible(first_shape)
+    assert first_shape.visible
 
     first_item.setCheckState(Qt.Unchecked)
     qtbot.wait(50)
-    assert not canvas.is_shape_visible(first_shape)
+    assert not first_shape.visible
 
     first_item.setCheckState(Qt.Checked)
     qtbot.wait(50)
-    assert canvas.is_shape_visible(first_shape)
+    assert first_shape.visible
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
 
@@ -84,7 +84,7 @@ def test_visibility_preserved_when_undoing_unrelated_edit(
     hidden_index = 1
     label_list[hidden_index].setCheckState(Qt.Unchecked)
     qtbot.wait(50)
-    assert not canvas.is_shape_visible(canvas.shapes[hidden_index])
+    assert not canvas.shapes[hidden_index].visible
 
     canvas.shapes[0].points[0] += QPointF(5.0, 5.0)
     canvas.backup_shapes()
@@ -95,7 +95,7 @@ def test_visibility_preserved_when_undoing_unrelated_edit(
     assert len(canvas.shapes) == 5
     for i, shape in enumerate(canvas.shapes):
         expected_visible = i != hidden_index
-        assert canvas.is_shape_visible(shape) is expected_visible
+        assert shape.visible is expected_visible
         expected_state = Qt.Checked if expected_visible else Qt.Unchecked
         assert label_list[i].checkState() == expected_state
 
@@ -116,7 +116,7 @@ def test_undo_recovers_accidental_hide(
 
     label_list[hidden_index].setCheckState(Qt.Unchecked)
     qtbot.wait(50)
-    assert not canvas.is_shape_visible(canvas.shapes[hidden_index])
+    assert not canvas.shapes[hidden_index].visible
     assert annotated_win._actions.undo.isEnabled()
 
     annotated_win._actions.undo.trigger()
@@ -124,7 +124,7 @@ def test_undo_recovers_accidental_hide(
 
     assert len(canvas.shapes) == 5
     for i, shape in enumerate(canvas.shapes):
-        assert canvas.is_shape_visible(shape)
+        assert shape.visible
         assert label_list[i].checkState() == Qt.Checked
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
@@ -155,17 +155,17 @@ def test_multi_select_toggle_propagates(
 
     for i in range(len(canvas.shapes)):
         if i in selected_indices:
-            assert not canvas.is_shape_visible(canvas.shapes[i])
+            assert not canvas.shapes[i].visible
             assert label_list[i].checkState() == Qt.Unchecked
         else:
-            assert canvas.is_shape_visible(canvas.shapes[i])
+            assert canvas.shapes[i].visible
             assert label_list[i].checkState() == Qt.Checked
 
     annotated_win._actions.undo.trigger()
     qtbot.wait(50)
 
     for i in range(len(canvas.shapes)):
-        assert canvas.is_shape_visible(canvas.shapes[i])
+        assert canvas.shapes[i].visible
         assert label_list[i].checkState() == Qt.Checked
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
@@ -199,7 +199,7 @@ def test_multi_select_preserves_selection_after_checkbox_click(
     }
     for i in selected_indices:
         assert label_list[i].checkState() == Qt.Unchecked
-        assert not canvas.is_shape_visible(canvas.shapes[i])
+        assert not canvas.shapes[i].visible
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
 

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -135,7 +135,7 @@ def test_shape_visibility_survives_backup_and_restore(canvas: Canvas) -> None:
     canvas.set_shape_visible(canvas.shapes[0], False)
     canvas.backup_shapes()
     canvas.load_shapes([shape.copy()])
-    assert canvas.is_shape_visible(canvas.shapes[0]) is False
+    assert canvas.shapes[0].visible is False
 
     canvas.restore_last_shape()
-    assert canvas.is_shape_visible(canvas.shapes[0]) is False
+    assert canvas.shapes[0].visible is False


### PR DESCRIPTION
Tightens the Canvas API by dropping methods that were either unused outside `canvas.py` or thin one-line wrappers around an attribute / mode comparison.

Per commit:
- inline `Canvas.fill_drawing()` getter; `_fill_drawing` is read directly internally
- drop `Canvas.is_shape_visible(shape)`; callers read `shape.visible` directly
- inline `Canvas.drawing()`; callers compare `self.mode == CanvasMode.CREATE`
- inline `Canvas.editing()`; callers compare `self.mode == CanvasMode.EDIT`

No external callers (verified across `labelme/app.py` and tests). Public setter `set_fill_drawing` is unchanged.

## Test plan
- [x] `make lint`
- [x] `make test` (207 passed)