### PR TITLE
refactor(shape): encapsulate vertex highlight styling

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 from collections.abc import Iterable
 from typing import Any
 from typing import Final
-from typing import NamedTuple
+from typing import Literal
 from typing import Protocol
 
 import numpy as np
@@ -22,15 +23,27 @@ _P_ROUND: Final[int] = 1
 POLYLINE_SHAPE_TYPES: Final[tuple[str, ...]] = ("polygon", "linestrip")
 
 
-class _Highlight(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class _VertexHighlight:
     index: int
-    mode: int
+    mode: Literal["move", "near"]
+
+    @property
+    def size_factor(self) -> float:
+        return {
+            "move": 1.5,
+            "near": 4.0,
+        }[self.mode]
+
+    @property
+    def point_type(self) -> int:
+        return {
+            "move": _P_SQUARE,
+            "near": _P_ROUND,
+        }[self.mode]
 
 
 class Shape:
-    MOVE_VERTEX: Final[int] = 0
-    NEAR_VERTEX: Final[int] = 1
-
     PEN_WIDTH: Final[int] = 2
 
     line_color: QtGui.QColor = QtGui.QColor(0, 255, 0, 128)
@@ -67,7 +80,7 @@ class Shape:
         self.other_data: dict[str, Any] = {}
         self.mask = mask
         self._closed = False
-        self.highlight: _Highlight | None = None
+        self.highlight: _VertexHighlight | None = None
 
         if line_color is not None:
             # Per-instance line color override (used for the pending line).
@@ -183,8 +196,8 @@ class Shape:
         for i, point in enumerate(self.points):
             self.points[i] = point + offset
 
-    def highlight_vertex(self, i: int, action: int) -> None:
-        self.highlight = _Highlight(index=i, mode=action)
+    def highlight_vertex(self, index: int, mode: Literal["move", "near"]) -> None:
+        self.highlight = _VertexHighlight(index=index, mode=mode)
 
     def clear_highlight(self) -> None:
         self.highlight = None
@@ -200,12 +213,6 @@ class Shape:
 
     def __setitem__(self, key: int, value: QtCore.QPointF) -> None:
         self.points[key] = value
-
-
-_HIGHLIGHT_STYLES: Final[dict[int, tuple[float, int]]] = {
-    Shape.NEAR_VERTEX: (4.0, _P_ROUND),
-    Shape.MOVE_VERTEX: (1.5, _P_SQUARE),
-}
 
 
 def _scale_point(*, point: QtCore.QPointF, scale: float) -> QtCore.QPointF:
@@ -345,12 +352,11 @@ def _vertex_size_and_type(
     *,
     base_size: int,
     base_type: int,
-    highlight: _Highlight | None,
+    highlight: _VertexHighlight | None,
     vertex_index: int,
 ) -> tuple[float, int]:
     if highlight is not None and highlight.index == vertex_index:
-        size_factor, point_type = _HIGHLIGHT_STYLES[highlight.mode]
-        return base_size * size_factor, point_type
+        return base_size * highlight.size_factor, highlight.point_type
     return base_size, base_type
 
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -411,7 +411,7 @@ class Canvas(QtWidgets.QWidget):
         if not self._cursor_should_snap_to_polygon_origin(pos=pos):
             return pos
         self._apply_cursor(CURSOR_POINT)
-        current.highlight_vertex(i=0, action=Shape.NEAR_VERTEX)
+        current.highlight_vertex(index=0, mode="near")
         return current[0]
 
     def _cursor_should_snap_to_polygon_origin(self, pos: QPointF) -> bool:
@@ -515,7 +515,7 @@ class Canvas(QtWidgets.QWidget):
                 self._set_highlight(
                     hovered_shape=shape, hovered_edge=None, hovered_vertex=index
                 )
-                shape.highlight_vertex(i=index, action=shape.MOVE_VERTEX)
+                shape.highlight_vertex(index=index, mode="move")
                 self._apply_cursor(CURSOR_POINT)
                 status_messages.append(self.tr("Click & drag to move point"))
                 if shape.can_remove_point():
@@ -564,7 +564,7 @@ class Canvas(QtWidgets.QWidget):
         if shape is None or index is None or point is None:
             return
         shape.insert_point(index, point)
-        shape.highlight_vertex(i=index, action=shape.MOVE_VERTEX)
+        shape.highlight_vertex(index=index, mode="move")
         self.hovered_shape = shape
         self._hovered_vertex = index
         self._hovered_edge = None
@@ -861,9 +861,7 @@ class Canvas(QtWidgets.QWidget):
     ) -> None:
         if self._hovered_vertex is not None:
             assert self.hovered_shape is not None
-            self.hovered_shape.highlight_vertex(
-                i=self._hovered_vertex, action=self.hovered_shape.MOVE_VERTEX
-            )
+            self.hovered_shape.highlight_vertex(index=self._hovered_vertex, mode="move")
             if self.deselect_shape():
                 self.update()
             return


### PR DESCRIPTION
## Summary
- Replace `_Highlight` NamedTuple with frozen `_VertexHighlight` dataclass
- Move size/point-type derivation onto the highlight object via `size_factor` / `point_type` properties
- Type `mode` as `Literal["move", "near"]` instead of int constants on `Shape`
- Drop `Shape.MOVE_VERTEX`, `Shape.NEAR_VERTEX`, and the module-level `_HIGHLIGHT_STYLES` dict
- Rename `highlight_vertex(i, action)` to `highlight_vertex(index, mode)` and update all callers

## Why
Encapsulates highlight styling next to the data it describes, removes the int-keyed indirection, and makes call sites self-documenting (`mode="move"` vs `action=0`).

## Test plan
- [x] `make lint`
- [x] `make test` (207 passing)