### PR TITLE
refactor(shape): test highlight with `is None`

### DIFF
--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -440,9 +440,9 @@ def _paint_points(*, painter: QtGui.QPainter, shape: Shape) -> None:
     painter.drawPath(line_path)
     if vrtx_path.length() > 0:
         vertex_fill = (
-            shape.hvertex_fill_color
-            if shape.highlight is not None
-            else shape.vertex_fill_color
+            shape.vertex_fill_color
+            if shape.highlight is None
+            else shape.hvertex_fill_color
         )
         painter.drawPath(vrtx_path)
         painter.fillPath(vrtx_path, vertex_fill)


### PR DESCRIPTION
## Summary
- Replace `if shape.highlight is not None` with `if shape.highlight is None` (branches flipped) in `_paint_points`.

## Why
`shape.highlight` is typed `_VertexHighlight | None`. PEP 8 prefers explicit `is`/`is not` against `None` over truthiness, and this matches the existing check in `_vertex_size_and_type` (`labelme/shape.py:358`). Putting the default (no-highlight) branch first reads as "fall back unless highlighted".

## Test plan
- [x] `uv run ruff check labelme/shape.py`
- [x] Visually verify vertex highlight color still toggles on hover/move