### PR TITLE
refactor: extract path-construction helpers to labelme/_shape.py

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Final
+from typing import Protocol
 
 from PyQt5 import QtCore
+from PyQt5 import QtGui
 
 from . import utils
 from .shape import Shape
-from .shape import _make_shape_path
 
 
 def _argmin(values: Iterable[float]) -> tuple[int, float] | None:
@@ -71,3 +73,46 @@ def contains_point(*, shape: Shape, point: QtCore.QPointF) -> bool:
 def bounds(*, shape: Shape) -> QtCore.QRectF:
     path = _make_shape_path(shape_type=shape.shape_type, points=shape.points)
     return path.boundingRect()
+
+
+def _build_rectangle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if len(points) == 2:
+        out.addRect(QtCore.QRectF(points[0], points[1]))
+    return out
+
+
+def _build_circle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if len(points) == 2:
+        radius = utils.distance(points[0] - points[1])
+        out.addEllipse(points[0], radius, radius)
+    return out
+
+
+def _build_polyline_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+    out = QtGui.QPainterPath()
+    if not points:
+        return out
+    out.moveTo(points[0])
+    for vertex in points[1:]:
+        out.lineTo(vertex)
+    return out
+
+
+class _PathBuilder(Protocol):
+    def __call__(self, *, points: list[QtCore.QPointF]) -> QtGui.QPainterPath: ...
+
+
+_PATH_BUILDERS: Final[dict[str, _PathBuilder]] = {
+    "rectangle": _build_rectangle_path,
+    "mask": _build_rectangle_path,
+    "circle": _build_circle_path,
+}
+
+
+def _make_shape_path(
+    *, shape_type: str, points: list[QtCore.QPointF]
+) -> QtGui.QPainterPath:
+    builder = _PATH_BUILDERS.get(shape_type, _build_polyline_path)
+    return builder(points=points)

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Final
-from typing import Protocol
 
 from PyQt5 import QtCore
 from PyQt5 import QtGui
@@ -65,24 +63,21 @@ def contains_point(*, shape: Shape, point: QtCore.QPointF) -> bool:
         ):
             return False
         return bool(shape.mask[raw_y, raw_x])
-    return _make_shape_path(shape_type=shape.shape_type, points=shape.points).contains(
-        point
-    )
+    return _build_path(shape=shape).contains(point)
 
 
 def bounds(*, shape: Shape) -> QtCore.QRectF:
-    path = _make_shape_path(shape_type=shape.shape_type, points=shape.points)
-    return path.boundingRect()
+    return _build_path(shape=shape).boundingRect()
 
 
-def _build_rectangle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+def _build_path_rectangle(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
     out = QtGui.QPainterPath()
     if len(points) == 2:
         out.addRect(QtCore.QRectF(points[0], points[1]))
     return out
 
 
-def _build_circle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+def _build_path_circle(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
     out = QtGui.QPainterPath()
     if len(points) == 2:
         radius = utils.distance(points[0] - points[1])
@@ -90,7 +85,7 @@ def _build_circle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
     return out
 
 
-def _build_polyline_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
+def _build_path_polyline(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
     out = QtGui.QPainterPath()
     if not points:
         return out
@@ -100,19 +95,10 @@ def _build_polyline_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
     return out
 
 
-class _PathBuilder(Protocol):
-    def __call__(self, *, points: list[QtCore.QPointF]) -> QtGui.QPainterPath: ...
-
-
-_PATH_BUILDERS: Final[dict[str, _PathBuilder]] = {
-    "rectangle": _build_rectangle_path,
-    "mask": _build_rectangle_path,
-    "circle": _build_circle_path,
-}
-
-
-def _make_shape_path(
-    *, shape_type: str, points: list[QtCore.QPointF]
-) -> QtGui.QPainterPath:
-    builder = _PATH_BUILDERS.get(shape_type, _build_polyline_path)
-    return builder(points=points)
+def _build_path(*, shape: Shape) -> QtGui.QPainterPath:
+    build_path_fn = {
+        "rectangle": _build_path_rectangle,
+        "mask": _build_path_rectangle,
+        "circle": _build_path_circle,
+    }.get(shape.shape_type, _build_path_polyline)
+    return build_path_fn(points=shape.points)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -5,7 +5,6 @@ import dataclasses
 from typing import Any
 from typing import Final
 from typing import Literal
-from typing import Protocol
 
 import numpy as np
 import numpy.typing as npt
@@ -189,49 +188,6 @@ class Shape:
 
     def __setitem__(self, key: int, value: QtCore.QPointF) -> None:
         self.points[key] = value
-
-
-def _build_rectangle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
-    out = QtGui.QPainterPath()
-    if len(points) == 2:
-        out.addRect(QtCore.QRectF(points[0], points[1]))
-    return out
-
-
-def _build_circle_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
-    out = QtGui.QPainterPath()
-    if len(points) == 2:
-        radius = labelme.utils.distance(points[0] - points[1])
-        out.addEllipse(points[0], radius, radius)
-    return out
-
-
-def _build_polyline_path(*, points: list[QtCore.QPointF]) -> QtGui.QPainterPath:
-    out = QtGui.QPainterPath()
-    if not points:
-        return out
-    out.moveTo(points[0])
-    for vertex in points[1:]:
-        out.lineTo(vertex)
-    return out
-
-
-class _PathBuilder(Protocol):
-    def __call__(self, *, points: list[QtCore.QPointF]) -> QtGui.QPainterPath: ...
-
-
-_PATH_BUILDERS: Final[dict[str, _PathBuilder]] = {
-    "rectangle": _build_rectangle_path,
-    "mask": _build_rectangle_path,
-    "circle": _build_circle_path,
-}
-
-
-def _make_shape_path(
-    *, shape_type: str, points: list[QtCore.QPointF]
-) -> QtGui.QPainterPath:
-    builder = _PATH_BUILDERS.get(shape_type, _build_polyline_path)
-    return builder(points=points)
 
 
 def _mask_contour_path(


### PR DESCRIPTION
## Summary
Move the per-shape-type painter-path builders (`_make_shape_path` and friends) into `_shape.py` so the cross-module private import disappears, then regroup the helpers under a `_build_path_*` prefix and inline the single-use dispatcher.

- Move `_make_shape_path`, `_build_*_path`, `_PathBuilder` Protocol, `_PATH_BUILDERS` from `shape.py` into `_shape.py`.
- Rename the family to `_build_path_rectangle` / `_build_path_circle` / `_build_path_polyline` and replace the module-level dispatch table with a function that takes `shape` directly.

Stacked on #2073.

## Test plan
- [x] `make lint`
- [x] `make test` (207 passed)