### PR TITLE
refactor: move paint to labelme/_shape.py and drop Shape.paint()

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -9,8 +9,6 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 
 from . import utils
-from .shape import _P_ROUND
-from .shape import _P_SQUARE
 from .shape import Shape
 
 
@@ -210,9 +208,9 @@ def _build_shape_point_path(
     pos = shape.points[vertex_index] * shape.scale
 
     half = size / 2.0
-    if point_type == _P_SQUARE:
+    if point_type == "square":
         path.addRect(pos.x() - half, pos.y() - half, size, size)
-    elif point_type == _P_ROUND:
+    elif point_type == "round":
         path.addEllipse(pos, half, half)
     else:
         raise ValueError(f"Unsupported vertex shape: {point_type}")

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+import numpy as np
+import numpy.typing as npt
+import skimage.measure
 from PyQt5 import QtCore
 from PyQt5 import QtGui
 
 from . import utils
+from .shape import _P_ROUND
+from .shape import _P_SQUARE
 from .shape import Shape
 
 
@@ -102,3 +107,157 @@ def _build_path(*, shape: Shape) -> QtGui.QPainterPath:
         "circle": _build_path_circle,
     }.get(shape.shape_type, _build_path_polyline)
     return build_path_fn(points=shape.points)
+
+
+def paint(*, shape: Shape, painter: QtGui.QPainter) -> None:
+    if shape.mask is None and not shape.points:
+        return
+
+    color = shape.select_line_color if shape.selected else shape.line_color
+    pen = QtGui.QPen(color)
+    pen.setWidth(shape.PEN_WIDTH)
+    painter.setPen(pen)
+
+    if shape.shape_type == "mask" and shape.mask is not None:
+        _paint_shape_mask(painter=painter, shape=shape)
+
+    if shape.points:
+        _paint_shape_points(painter=painter, shape=shape)
+
+
+def _paint_shape_mask(*, painter: QtGui.QPainter, shape: Shape) -> None:
+    assert shape.mask is not None
+    fill = shape.select_fill_color if shape.selected else shape.fill_color
+    image_to_draw = np.zeros(shape.mask.shape + (4,), dtype=np.uint8)
+    image_to_draw[shape.mask] = fill.getRgb()
+    qimage = QtGui.QImage.fromData(utils.img_arr_to_data(image_to_draw))
+    origin = shape.points[0]
+    target_top_left = origin * shape.scale
+    target_rect = QtCore.QRectF(
+        target_top_left.x(),
+        target_top_left.y(),
+        qimage.width() * shape.scale,
+        qimage.height() * shape.scale,
+    )
+    painter.drawImage(target_rect, qimage)
+
+    path = QtGui.QPainterPath()
+    _build_shape_mask_contour_path(
+        path=path, mask=shape.mask, origin=origin, scale=shape.scale
+    )
+    painter.drawPath(path)
+
+
+def _paint_shape_points(*, painter: QtGui.QPainter, shape: Shape) -> None:
+    path_line = QtGui.QPainterPath()
+    path_vertices = QtGui.QPainterPath()
+    path_negative_vertices = QtGui.QPainterPath()
+
+    _build_shape_points_paths(
+        shape=shape,
+        path_line=path_line,
+        path_vertices=path_vertices,
+        path_negative_vertices=path_negative_vertices,
+    )
+
+    painter.drawPath(path_line)
+    if path_vertices.length() > 0:
+        vertex_fill = (
+            shape.vertex_fill_color
+            if shape.highlight is None
+            else shape.hvertex_fill_color
+        )
+        painter.drawPath(path_vertices)
+        painter.fillPath(path_vertices, vertex_fill)
+    if shape.fill and shape.shape_type not in ["line", "linestrip", "points", "mask"]:
+        fill = shape.select_fill_color if shape.selected else shape.fill_color
+        painter.fillPath(path_line, fill)
+
+    neg_color = QtGui.QColor(255, 0, 0, 255)
+    neg_pen = QtGui.QPen(neg_color)
+    neg_pen.setWidth(shape.PEN_WIDTH)
+    painter.setPen(neg_pen)
+    painter.drawPath(path_negative_vertices)
+    painter.fillPath(path_negative_vertices, neg_color)
+
+
+def _build_shape_mask_contour_path(
+    *,
+    path: QtGui.QPainterPath,
+    mask: npt.NDArray[np.bool_],
+    origin: QtCore.QPointF,
+    scale: float,
+) -> None:
+    contours = skimage.measure.find_contours(np.pad(mask, pad_width=1))
+    for contour in contours:
+        contour = contour + [origin.y(), origin.x()]
+        path.moveTo(QtCore.QPointF(contour[0, 1], contour[0, 0]) * scale)
+        for point in contour[1:]:
+            path.lineTo(QtCore.QPointF(point[1], point[0]) * scale)
+
+
+def _build_shape_point_path(
+    *, path: QtGui.QPainterPath, shape: Shape, vertex_index: int
+) -> None:
+    highlight = shape.highlight
+    if highlight is not None and highlight.index == vertex_index:
+        size = shape.point_size * highlight.size_factor
+        point_type = highlight.point_type
+    else:
+        size = shape.point_size
+        point_type = shape.point_type
+
+    pos = shape.points[vertex_index] * shape.scale
+
+    half = size / 2.0
+    if point_type == _P_SQUARE:
+        path.addRect(pos.x() - half, pos.y() - half, size, size)
+    elif point_type == _P_ROUND:
+        path.addEllipse(pos, half, half)
+    else:
+        raise ValueError(f"Unsupported vertex shape: {point_type}")
+
+
+def _build_shape_points_paths(
+    *,
+    shape: Shape,
+    path_line: QtGui.QPainterPath,
+    path_vertices: QtGui.QPainterPath,
+    path_negative_vertices: QtGui.QPainterPath,
+) -> None:
+    if shape.shape_type in ["rectangle", "mask"]:
+        assert len(shape.points) in [1, 2]
+        if len(shape.points) == 2:
+            path_line.addRect(
+                QtCore.QRectF(
+                    shape.points[0] * shape.scale,
+                    shape.points[1] * shape.scale,
+                )
+            )
+        if shape.shape_type == "rectangle":
+            for i in range(len(shape.points)):
+                _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
+    elif shape.shape_type == "circle":
+        assert len(shape.points) in [1, 2]
+        if len(shape.points) == 2:
+            radius = utils.distance((shape.points[0] - shape.points[1]) * shape.scale)
+            path_line.addEllipse(shape.points[0] * shape.scale, radius, radius)
+        for i in range(len(shape.points)):
+            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
+    elif shape.shape_type == "linestrip":
+        path_line.moveTo(shape.points[0] * shape.scale)
+        for i, p in enumerate(shape.points):
+            path_line.lineTo(p * shape.scale)
+            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
+    elif shape.shape_type == "points":
+        assert len(shape.points) == len(shape.point_labels)
+        for i, point_label in enumerate(shape.point_labels):
+            path = path_vertices if point_label == 1 else path_negative_vertices
+            _build_shape_point_path(path=path, shape=shape, vertex_index=i)
+    else:
+        path_line.moveTo(shape.points[0] * shape.scale)
+        for i, p in enumerate(shape.points):
+            path_line.lineTo(p * shape.scale)
+            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
+        if shape.is_closed():
+            path_line.lineTo(shape.points[0] * shape.scale)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -8,12 +8,9 @@ from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
-import skimage.measure
 from loguru import logger
 from PyQt5 import QtCore
 from PyQt5 import QtGui
-
-import labelme.utils
 
 _P_SQUARE: Final[int] = 0
 _P_ROUND: Final[int] = 1
@@ -161,9 +158,6 @@ class Shape:
     def open(self) -> None:
         self._closed = False
 
-    def paint(self, painter: QtGui.QPainter) -> None:
-        _paint_shape(painter=painter, shape=self)
-
     def move_vertex(self, i: int, pos: QtCore.QPointF) -> None:
         self.points[i] = pos
 
@@ -188,159 +182,3 @@ class Shape:
 
     def __setitem__(self, key: int, value: QtCore.QPointF) -> None:
         self.points[key] = value
-
-
-def _build_shape_mask_contour_path(
-    *,
-    path: QtGui.QPainterPath,
-    mask: npt.NDArray[np.bool_],
-    origin: QtCore.QPointF,
-    scale: float,
-) -> None:
-    contours = skimage.measure.find_contours(np.pad(mask, pad_width=1))
-    for contour in contours:
-        contour = contour + [origin.y(), origin.x()]
-        path.moveTo(QtCore.QPointF(contour[0, 1], contour[0, 0]) * scale)
-        for point in contour[1:]:
-            path.lineTo(QtCore.QPointF(point[1], point[0]) * scale)
-
-
-def _build_shape_point_path(
-    *, path: QtGui.QPainterPath, shape: Shape, vertex_index: int
-) -> None:
-    highlight = shape.highlight
-    if highlight is not None and highlight.index == vertex_index:
-        size = shape.point_size * highlight.size_factor
-        point_type = highlight.point_type
-    else:
-        size = shape.point_size
-        point_type = shape.point_type
-
-    pos = shape.points[vertex_index] * shape.scale
-
-    half = size / 2.0
-    if point_type == _P_SQUARE:
-        path.addRect(pos.x() - half, pos.y() - half, size, size)
-    elif point_type == _P_ROUND:
-        path.addEllipse(pos, half, half)
-    else:
-        raise ValueError(f"Unsupported vertex shape: {point_type}")
-
-
-def _paint_shape(*, painter: QtGui.QPainter, shape: Shape) -> None:
-    if shape.mask is None and not shape.points:
-        return
-
-    color = shape.select_line_color if shape.selected else shape.line_color
-    pen = QtGui.QPen(color)
-    pen.setWidth(shape.PEN_WIDTH)
-    painter.setPen(pen)
-
-    if shape.shape_type == "mask" and shape.mask is not None:
-        _paint_shape_mask(painter=painter, shape=shape)
-
-    if shape.points:
-        _paint_shape_points(painter=painter, shape=shape)
-
-
-def _paint_shape_mask(*, painter: QtGui.QPainter, shape: Shape) -> None:
-    assert shape.mask is not None
-    fill = shape.select_fill_color if shape.selected else shape.fill_color
-    image_to_draw = np.zeros(shape.mask.shape + (4,), dtype=np.uint8)
-    image_to_draw[shape.mask] = fill.getRgb()
-    qimage = QtGui.QImage.fromData(labelme.utils.img_arr_to_data(image_to_draw))
-    origin = shape.points[0]
-    target_top_left = origin * shape.scale
-    target_rect = QtCore.QRectF(
-        target_top_left.x(),
-        target_top_left.y(),
-        qimage.width() * shape.scale,
-        qimage.height() * shape.scale,
-    )
-    painter.drawImage(target_rect, qimage)
-
-    path = QtGui.QPainterPath()
-    _build_shape_mask_contour_path(
-        path=path, mask=shape.mask, origin=origin, scale=shape.scale
-    )
-    painter.drawPath(path)
-
-
-def _paint_shape_points(*, painter: QtGui.QPainter, shape: Shape) -> None:
-    path_line = QtGui.QPainterPath()
-    path_vertices = QtGui.QPainterPath()
-    path_negative_vertices = QtGui.QPainterPath()
-
-    _build_shape_points_paths(
-        shape=shape,
-        path_line=path_line,
-        path_vertices=path_vertices,
-        path_negative_vertices=path_negative_vertices,
-    )
-
-    painter.drawPath(path_line)
-    if path_vertices.length() > 0:
-        vertex_fill = (
-            shape.vertex_fill_color
-            if shape.highlight is None
-            else shape.hvertex_fill_color
-        )
-        painter.drawPath(path_vertices)
-        painter.fillPath(path_vertices, vertex_fill)
-    if shape.fill and shape.shape_type not in ["line", "linestrip", "points", "mask"]:
-        fill = shape.select_fill_color if shape.selected else shape.fill_color
-        painter.fillPath(path_line, fill)
-
-    neg_color = QtGui.QColor(255, 0, 0, 255)
-    neg_pen = QtGui.QPen(neg_color)
-    neg_pen.setWidth(shape.PEN_WIDTH)
-    painter.setPen(neg_pen)
-    painter.drawPath(path_negative_vertices)
-    painter.fillPath(path_negative_vertices, neg_color)
-
-
-def _build_shape_points_paths(
-    *,
-    shape: Shape,
-    path_line: QtGui.QPainterPath,
-    path_vertices: QtGui.QPainterPath,
-    path_negative_vertices: QtGui.QPainterPath,
-) -> None:
-    if shape.shape_type in ["rectangle", "mask"]:
-        assert len(shape.points) in [1, 2]
-        if len(shape.points) == 2:
-            path_line.addRect(
-                QtCore.QRectF(
-                    shape.points[0] * shape.scale,
-                    shape.points[1] * shape.scale,
-                )
-            )
-        if shape.shape_type == "rectangle":
-            for i in range(len(shape.points)):
-                _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
-    elif shape.shape_type == "circle":
-        assert len(shape.points) in [1, 2]
-        if len(shape.points) == 2:
-            radius = labelme.utils.distance(
-                (shape.points[0] - shape.points[1]) * shape.scale
-            )
-            path_line.addEllipse(shape.points[0] * shape.scale, radius, radius)
-        for i in range(len(shape.points)):
-            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
-    elif shape.shape_type == "linestrip":
-        path_line.moveTo(shape.points[0] * shape.scale)
-        for i, p in enumerate(shape.points):
-            path_line.lineTo(p * shape.scale)
-            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
-    elif shape.shape_type == "points":
-        assert len(shape.points) == len(shape.point_labels)
-        for i, point_label in enumerate(shape.point_labels):
-            path = path_vertices if point_label == 1 else path_negative_vertices
-            _build_shape_point_path(path=path, shape=shape, vertex_index=i)
-    else:
-        path_line.moveTo(shape.points[0] * shape.scale)
-        for i, p in enumerate(shape.points):
-            path_line.lineTo(p * shape.scale)
-            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
-        if shape.is_closed():
-            path_line.lineTo(shape.points[0] * shape.scale)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -190,24 +190,23 @@ class Shape:
         self.points[key] = value
 
 
-def _mask_contour_path(
+def _build_shape_mask_contour_path(
     *,
+    path: QtGui.QPainterPath,
     mask: npt.NDArray[np.bool_],
     origin: QtCore.QPointF,
     scale: float,
-) -> QtGui.QPainterPath:
+) -> None:
     contours = skimage.measure.find_contours(np.pad(mask, pad_width=1))
-    output = QtGui.QPainterPath()
     for contour in contours:
         contour = contour + [origin.y(), origin.x()]
-        output.moveTo(QtCore.QPointF(contour[0, 1], contour[0, 0]) * scale)
+        path.moveTo(QtCore.QPointF(contour[0, 1], contour[0, 0]) * scale)
         for point in contour[1:]:
-            output.lineTo(QtCore.QPointF(point[1], point[0]) * scale)
-    return output
+            path.lineTo(QtCore.QPointF(point[1], point[0]) * scale)
 
 
-def _add_shape_vertex(
-    path: QtGui.QPainterPath, *, shape: Shape, vertex_index: int
+def _build_shape_point_path(
+    *, path: QtGui.QPainterPath, shape: Shape, vertex_index: int
 ) -> None:
     highlight = shape.highlight
     if highlight is not None and highlight.index == vertex_index:
@@ -259,9 +258,12 @@ def _paint_shape_mask(*, painter: QtGui.QPainter, shape: Shape) -> None:
         qimage.height() * shape.scale,
     )
     painter.drawImage(target_rect, qimage)
-    painter.drawPath(
-        _mask_contour_path(mask=shape.mask, origin=origin, scale=shape.scale)
+
+    path = QtGui.QPainterPath()
+    _build_shape_mask_contour_path(
+        path=path, mask=shape.mask, origin=origin, scale=shape.scale
     )
+    painter.drawPath(path)
 
 
 def _paint_shape_points(*, painter: QtGui.QPainter, shape: Shape) -> None:
@@ -269,7 +271,7 @@ def _paint_shape_points(*, painter: QtGui.QPainter, shape: Shape) -> None:
     path_vertices = QtGui.QPainterPath()
     path_negative_vertices = QtGui.QPainterPath()
 
-    _build_shape_paths(
+    _build_shape_points_paths(
         shape=shape,
         path_line=path_line,
         path_vertices=path_vertices,
@@ -297,7 +299,7 @@ def _paint_shape_points(*, painter: QtGui.QPainter, shape: Shape) -> None:
     painter.fillPath(path_negative_vertices, neg_color)
 
 
-def _build_shape_paths(
+def _build_shape_points_paths(
     *,
     shape: Shape,
     path_line: QtGui.QPainterPath,
@@ -315,7 +317,7 @@ def _build_shape_paths(
             )
         if shape.shape_type == "rectangle":
             for i in range(len(shape.points)):
-                _add_shape_vertex(path_vertices, shape=shape, vertex_index=i)
+                _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
     elif shape.shape_type == "circle":
         assert len(shape.points) in [1, 2]
         if len(shape.points) == 2:
@@ -324,21 +326,21 @@ def _build_shape_paths(
             )
             path_line.addEllipse(shape.points[0] * shape.scale, radius, radius)
         for i in range(len(shape.points)):
-            _add_shape_vertex(path_vertices, shape=shape, vertex_index=i)
+            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
     elif shape.shape_type == "linestrip":
         path_line.moveTo(shape.points[0] * shape.scale)
         for i, p in enumerate(shape.points):
             path_line.lineTo(p * shape.scale)
-            _add_shape_vertex(path_vertices, shape=shape, vertex_index=i)
+            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
     elif shape.shape_type == "points":
         assert len(shape.points) == len(shape.point_labels)
         for i, point_label in enumerate(shape.point_labels):
-            target = path_vertices if point_label == 1 else path_negative_vertices
-            _add_shape_vertex(target, shape=shape, vertex_index=i)
+            path = path_vertices if point_label == 1 else path_negative_vertices
+            _build_shape_point_path(path=path, shape=shape, vertex_index=i)
     else:
         path_line.moveTo(shape.points[0] * shape.scale)
         for i, p in enumerate(shape.points):
             path_line.lineTo(p * shape.scale)
-            _add_shape_vertex(path_vertices, shape=shape, vertex_index=i)
+            _build_shape_point_path(path=path_vertices, shape=shape, vertex_index=i)
         if shape.is_closed():
             path_line.lineTo(shape.points[0] * shape.scale)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import typing
 from typing import Any
 from typing import Final
 from typing import Literal
@@ -11,9 +12,6 @@ import numpy.typing as npt
 from loguru import logger
 from PyQt5 import QtCore
 from PyQt5 import QtGui
-
-_P_SQUARE: Final[int] = 0
-_P_ROUND: Final[int] = 1
 
 POLYLINE_SHAPE_TYPES: Final[tuple[str, ...]] = ("polygon", "linestrip")
 
@@ -31,11 +29,14 @@ class _VertexHighlight:
         }[self.mode]
 
     @property
-    def point_type(self) -> int:
-        return {
-            "move": _P_SQUARE,
-            "near": _P_ROUND,
-        }[self.mode]
+    def point_type(self) -> Literal["square", "round"]:
+        match self.mode:
+            case "move":
+                return "square"
+            case "near":
+                return "round"
+            case _:
+                typing.assert_never(self.mode)
 
 
 class Shape:
@@ -48,7 +49,7 @@ class Shape:
     select_fill_color: QtGui.QColor = QtGui.QColor(0, 255, 0, 64)
     hvertex_fill_color: QtGui.QColor = QtGui.QColor(255, 255, 255, 255)
 
-    point_type: int = _P_ROUND
+    point_type: Literal["square", "round"] = "round"
     point_size: int = 8
     scale: float = 1.0
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1057,18 +1057,18 @@ class Canvas(QtWidgets.QWidget):
             ):
                 continue
             shape.fill = _is_shape_filled(shape=shape, hovered_shape=self.hovered_shape)
-            shape.paint(painter)
+            _shape.paint(shape=shape, painter=painter)
 
     def _draw_active_shape_layer(self, painter: QtGui.QPainter) -> None:
         if self._current is None:
             return
-        self._current.paint(painter)
+        _shape.paint(shape=self._current, painter=painter)
         assert len(self._line.points) == len(self._line.point_labels)
-        self._line.paint(painter)
+        _shape.paint(shape=self._line, painter=painter)
 
     def _draw_drag_copy_layer(self, painter: QtGui.QPainter) -> None:
         for copy_shape in self._selected_shapes_copy:
-            copy_shape.paint(painter)
+            _shape.paint(shape=copy_shape, painter=painter)
 
     def _draw_preview_overlay_layer(self, painter: QtGui.QPainter) -> None:
         preview = self._build_preview_shape()
@@ -1076,7 +1076,7 @@ class Canvas(QtWidgets.QWidget):
             return
         preview.fill = self._fill_drawing
         preview.selected = self._fill_drawing
-        preview.paint(painter)
+        _shape.paint(shape=preview, painter=painter)
 
     def _build_preview_shape(self) -> Shape | None:
         if self._current is None:


### PR DESCRIPTION
## Summary
Final piece of the `Shape` slimming. Painters move out, `Shape` no longer owns drawing.

- Rename remaining painter-side helpers in `shape.py` to `_build_shape_*_path(s)` for symmetry with `_shape.py:_build_path_*`.
- Move `_paint_shape*` and `_build_shape_*` into `_shape.py`; expose `_shape.paint(shape, painter)`.
- Drop the `Shape.paint()` method; canvas call sites now invoke `_shape.paint(shape=..., painter=...)`.
- Replace the integer constants `_P_SQUARE` / `_P_ROUND` with `Literal[\"square\", \"round\"]` for `Shape.point_type` and `_VertexHighlight.point_type`.

Stacked on #2074.

## Test plan
- [x] `make lint`
- [x] `make test` (207 passed)