### PR TITLE
feat: oriented_rectangle in AI-assisted annotation

### DIFF
--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 import imgviz
 import numpy as np
+import scipy.spatial
 import skimage
 from loguru import logger
 from numpy.typing import NDArray
@@ -27,6 +28,77 @@ def compute_circle_from_mask(mask: NDArray[np.bool_]) -> Circle | None:
         cy=float(ys.mean()),
         radius=float(np.sqrt(mask.sum() / np.pi)),
     )
+
+
+def compute_oriented_rectangle_from_mask(
+    mask: NDArray[np.bool_],
+) -> NDArray[np.float32] | None:
+    if not mask.any():
+        return None
+    ys, xs = np.nonzero(mask)
+    if len(xs) < 3:
+        return None
+    points = np.stack([xs, ys], axis=1).astype(np.float64)
+    try:
+        # Qhull returns 2D hull vertices in CCW order, which the rotating
+        # calipers loop below relies on for the right-handed perpendicular.
+        hull_indices = scipy.spatial.ConvexHull(points=points).vertices
+    except scipy.spatial.QhullError:
+        # All pixels are collinear, so no rectangle can be fit; let callers
+        # fall back to the axis-aligned bbox.
+        return None
+    return _min_area_rect(hull=points[hull_indices]).astype(np.float32)
+
+
+def _min_area_rect(hull: NDArray[np.float64]) -> NDArray[np.float64]:
+    # Rotating calipers: the minimum-area enclosing rectangle must have one
+    # side flush with an edge of the convex hull. Try each hull edge as the
+    # rect orientation and keep the smallest-area candidate.
+    best_area = float("inf")
+    best_corners: NDArray[np.float64] | None = None
+    n = len(hull)
+    for i in range(n):
+        edge = hull[(i + 1) % n] - hull[i]
+        length = float(np.linalg.norm(edge))
+        if length == 0:
+            continue
+        u = edge / length
+        perp = np.array([-u[1], u[0]])
+        u_coords = hull @ u
+        p_coords = hull @ perp
+        u_min, u_max = float(u_coords.min()), float(u_coords.max())
+        p_min, p_max = float(p_coords.min()), float(p_coords.max())
+        u_extent = u_max - u_min
+        p_extent = p_max - p_min
+        area = u_extent * p_extent
+        if area >= best_area:
+            continue
+        best_area = area
+        center = (u_min + u_max) / 2 * u + (p_min + p_max) / 2 * perp
+        if u_extent >= p_extent:
+            long_axis, half_long, half_short = u, u_extent / 2, p_extent / 2
+        else:
+            long_axis, half_long, half_short = perp, p_extent / 2, u_extent / 2
+        # Pin the long axis to the right half-plane (or to the lower
+        # half-plane when it is exactly vertical) so the corner sequence is
+        # platform-independent.
+        if long_axis[0] < 0 or (long_axis[0] == 0 and long_axis[1] < 0):
+            long_axis = -long_axis
+        # Right-handed perpendicular yields a deterministic corner traversal:
+        # p0 → p1 along the long axis, then p1 → p2 along the short axis.
+        short_axis = np.array([-long_axis[1], long_axis[0]])
+        best_corners = np.array(
+            [
+                center - long_axis * half_long - short_axis * half_short,
+                center + long_axis * half_long - short_axis * half_short,
+                center + long_axis * half_long + short_axis * half_short,
+                center - long_axis * half_long + short_axis * half_short,
+            ]
+        )
+    # Callers filter hulls with fewer than three distinct points, so the loop
+    # above always finds at least one positive-length edge.
+    assert best_corners is not None
+    return best_corners
 
 
 def _get_contour_length(contour: NDArray[np.float32]) -> float:

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -10,6 +10,7 @@ from labelme._shape import Shape
 
 from ._geometry import Circle
 from ._geometry import compute_circle_from_mask
+from ._geometry import compute_oriented_rectangle_from_mask
 from ._geometry import compute_polygon_from_mask
 from ._types import AiOutputFormat
 
@@ -99,7 +100,36 @@ def _shape_from_detection(
             label=detection.label,
             description=detection.description,
         )
+    if shape_type == "oriented_rectangle":
+        corners = _oriented_rectangle_for_detection(detection=detection)
+        if corners is None:
+            return None
+        return _build_shape(
+            shape_type="oriented_rectangle",
+            points=[QPointF(float(x), float(y)) for x, y in corners],
+            label=detection.label,
+            description=detection.description,
+        )
     raise ValueError(f"Unsupported shape_type: {shape_type!r}")
+
+
+def _oriented_rectangle_for_detection(
+    detection: Detection,
+) -> NDArray[np.float32] | None:
+    if detection.mask is not None:
+        corners = compute_oriented_rectangle_from_mask(mask=detection.mask)
+        if corners is not None:
+            offset_x, offset_y = (
+                detection.bbox[:2] if detection.bbox is not None else (0.0, 0.0)
+            )
+            return corners + np.array([offset_x, offset_y], dtype=np.float32)
+    if detection.bbox is not None:
+        xmin, ymin, xmax, ymax = detection.bbox
+        return np.array(
+            [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]],
+            dtype=np.float32,
+        )
+    return None
 
 
 def _circle_for_detection(detection: Detection) -> Circle | None:

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -106,8 +106,9 @@ def _circle_for_detection(detection: Detection) -> Circle | None:
     if detection.mask is not None:
         circle = compute_circle_from_mask(mask=detection.mask)
         if circle is not None:
-            offset_x = detection.bbox[0] if detection.bbox is not None else 0.0
-            offset_y = detection.bbox[1] if detection.bbox is not None else 0.0
+            offset_x, offset_y = (
+                detection.bbox[:2] if detection.bbox is not None else (0.0, 0.0)
+            )
             return Circle(
                 cx=circle.cx + offset_x,
                 cy=circle.cy + offset_y,

--- a/labelme/_automation/_types.py
+++ b/labelme/_automation/_types.py
@@ -1,4 +1,6 @@
 from typing import Literal
 from typing import TypeAlias
 
-AiOutputFormat: TypeAlias = Literal["rectangle", "polygon", "mask", "circle"]
+AiOutputFormat: TypeAlias = Literal[
+    "rectangle", "polygon", "mask", "circle", "oriented_rectangle"
+]

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -90,6 +90,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         self._output_format_combo.addItem("Polygon", "polygon")
         self._output_format_combo.addItem("Mask", "mask")
         self._output_format_combo.addItem("Rectangle", "rectangle")
+        self._output_format_combo.addItem("Oriented Rectangle", "oriented_rectangle")
         self._output_format_combo.addItem("Circle", "circle")
         body_layout.addWidget(self._output_format_combo)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "pyqt5-qt5!=5.15.13 ; sys_platform == 'linux'",
   "pyqt5-qt5!=5.15.11,!=5.15.12,!=5.15.13,!=5.15.14,!=5.15.15,!=5.15.16 ; sys_platform == 'win32'",
   "pyyaml>=6.0",
+  "scipy>=1.8",
   "scikit-image>=0.21",
   "tifffile>=2024.1.30",
 ]

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -121,6 +121,15 @@ _AI_MODEL = "efficientsam:10m"
             "mask",
             id="ai_box-mask",
         ),
+        pytest.param(
+            "ai_box_to_shape",
+            [(0.3, 0.3)],
+            (0.7, 0.7),
+            Qt.NoModifier,
+            4,
+            "oriented_rectangle",
+            id="ai_box-oriented_rectangle",
+        ),
     ],
 )
 def test_annotate_shape_types(
@@ -134,7 +143,7 @@ def test_annotate_shape_types(
     finalize_click: tuple[float, float],
     finalize_modifier: Qt.KeyboardModifier,
     expected_num_points: int | None,
-    ai_output_format: Literal["polygon", "mask"] | None,
+    ai_output_format: Literal["polygon", "mask", "oriented_rectangle"] | None,
 ) -> None:
     expected_shape_type = ai_output_format if ai_output_format else create_mode
 

--- a/tests/unit/_automation/_geometry_test.py
+++ b/tests/unit/_automation/_geometry_test.py
@@ -4,8 +4,10 @@ import math
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 from labelme._automation._geometry import compute_circle_from_mask
+from labelme._automation._geometry import compute_oriented_rectangle_from_mask
 
 
 def test_compute_circle_from_mask_returns_none_when_empty() -> None:
@@ -22,3 +24,103 @@ def test_compute_circle_from_mask_centroid_and_area_equivalent_radius() -> None:
     assert circle.cx == pytest.approx(1)
     assert circle.cy == pytest.approx(1)
     assert circle.radius == pytest.approx(math.sqrt(9 / math.pi))
+
+
+def test_compute_oriented_rectangle_from_mask_returns_none_when_empty() -> None:
+    assert (
+        compute_oriented_rectangle_from_mask(mask=np.zeros((10, 10), dtype=bool))
+        is None
+    )
+
+
+def test_compute_oriented_rectangle_from_mask_returns_none_when_single_pixel() -> None:
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[3, 4] = True
+    assert compute_oriented_rectangle_from_mask(mask=mask) is None
+
+
+def test_compute_oriented_rectangle_from_mask_axis_aligned_wider_than_tall() -> None:
+    # 21x11 mask (cols x rows): wider than tall, so the long axis is +x and the
+    # corners trace (xmin, ymin) → (xmax, ymin) → (xmax, ymax) → (xmin, ymax).
+    mask = np.ones((11, 21), dtype=bool)
+
+    corners = compute_oriented_rectangle_from_mask(mask=mask)
+
+    assert corners is not None
+    expected = np.array(
+        [[0, 0], [20, 0], [20, 10], [0, 10]],
+        dtype=np.float32,
+    )
+    assert corners == pytest.approx(expected)
+
+
+def test_compute_oriented_rectangle_from_mask_axis_aligned_taller_than_wide() -> None:
+    # 11x21 mask (cols x rows): taller than wide, so the long axis is +y. The
+    # right-handed perpendicular rotates the corner sequence one quarter turn
+    # relative to the wider-than-tall case while keeping the same convention.
+    mask = np.ones((21, 11), dtype=bool)
+
+    corners = compute_oriented_rectangle_from_mask(mask=mask)
+
+    assert corners is not None
+    expected = np.array(
+        [[10, 0], [10, 20], [0, 20], [0, 0]],
+        dtype=np.float32,
+    )
+    assert corners == pytest.approx(expected)
+
+
+def test_compute_oriented_rectangle_from_mask_recovers_rotation_angle(
+    rotated_rectangle_mask: NDArray[np.bool_],
+    rotated_rectangle_angle: float,
+) -> None:
+    corners = compute_oriented_rectangle_from_mask(mask=rotated_rectangle_mask)
+
+    assert corners is not None
+    edge = corners[1] - corners[0]
+    recovered = math.atan2(float(edge[1]), float(edge[0]))
+    assert recovered == pytest.approx(rotated_rectangle_angle, abs=math.radians(3))
+
+
+def test_compute_oriented_rectangle_from_mask_returns_none_for_collinear_mask() -> None:
+    # All set pixels lie on a single row, so the convex hull collapses to two
+    # points and there is no rectangle to fit. Bail out so callers fall back
+    # to the axis-aligned bbox.
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[5, :] = True
+    assert compute_oriented_rectangle_from_mask(mask=mask) is None
+
+
+def test_compute_oriented_rectangle_from_mask_square_mask_is_axis_aligned() -> None:
+    # A square mask has a well-defined minimum-area rectangle (the bbox
+    # itself), unlike the variance-based PCA approach which is ambiguous
+    # under equal eigenvalues.
+    mask = np.ones((11, 11), dtype=bool)
+
+    corners = compute_oriented_rectangle_from_mask(mask=mask)
+
+    assert corners is not None
+    expected = np.array(
+        [[0, 0], [10, 0], [10, 10], [0, 10]],
+        dtype=np.float32,
+    )
+    assert corners == pytest.approx(expected)
+
+
+def test_compute_oriented_rectangle_from_mask_l_shape_is_axis_aligned() -> None:
+    # An L-shape with axis-aligned arms: the minimum-area enclosing rectangle
+    # is the axis-aligned bbox, regardless of how mass is distributed between
+    # the arms. PCA tilts the principal axis toward the heavier arm, which is
+    # the failure mode this implementation avoids.
+    mask = np.zeros((20, 30), dtype=bool)
+    mask[0:5, 0:30] = True
+    mask[0:20, 0:5] = True
+
+    corners = compute_oriented_rectangle_from_mask(mask=mask)
+
+    assert corners is not None
+    expected = np.array(
+        [[0, 0], [29, 0], [29, 19], [0, 19]],
+        dtype=np.float32,
+    )
+    assert corners == pytest.approx(expected)

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -4,6 +4,7 @@ import math
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 from labelme._automation import Detection
 from labelme._automation import shapes_from_detections
@@ -41,3 +42,89 @@ def test_shapes_from_detections_circle_without_mask_falls_back_to_inscribed() ->
     assert shape.points[0].y() == pytest.approx(10)
     assert shape.points[1].x() == pytest.approx(10)
     assert shape.points[1].y() == pytest.approx(10)
+
+
+def test_shapes_from_detections_oriented_rectangle_with_mask_uses_min_area_rect() -> (
+    None
+):
+    # Wider-than-tall rectangular mask: long axis is +x in mask-local coords,
+    # so corners trace (xmin, ymin) → (xmax, ymin) → (xmax, ymax) → (xmin, ymax).
+    # World corners are mask-local corners offset by the bbox origin.
+    [shape] = shapes_from_detections(
+        detections=[
+            Detection(
+                bbox=(10, 20, 30, 30),
+                mask=np.ones((11, 21), dtype=bool),
+            )
+        ],
+        shape_type="oriented_rectangle",
+    )
+
+    assert shape.shape_type == "oriented_rectangle"
+    expected = [(10, 20), (30, 20), (30, 30), (10, 30)]
+    for i, (x, y) in enumerate(expected):
+        assert (shape.points[i].x(), shape.points[i].y()) == pytest.approx((x, y))
+
+
+def test_shapes_from_detections_oriented_rectangle_without_mask_falls_back() -> None:
+    [shape] = shapes_from_detections(
+        detections=[Detection(bbox=(0, 0, 10, 20))],
+        shape_type="oriented_rectangle",
+    )
+
+    assert shape.shape_type == "oriented_rectangle"
+    expected = [(0, 0), (10, 0), (10, 20), (0, 20)]
+    for i, (x, y) in enumerate(expected):
+        assert (shape.points[i].x(), shape.points[i].y()) == pytest.approx((x, y))
+
+
+def test_shapes_from_detections_oriented_rectangle_with_rotated_mask(
+    rotated_rectangle_mask: NDArray[np.bool_],
+    rotated_rectangle_angle: float,
+) -> None:
+    # The mask is centred at (20, 20); placing it at bbox origin (50, 100)
+    # offsets the world centre to (70, 120).
+    [shape] = shapes_from_detections(
+        detections=[Detection(bbox=(50, 100, 90, 140), mask=rotated_rectangle_mask)],
+        shape_type="oriented_rectangle",
+    )
+
+    assert shape.shape_type == "oriented_rectangle"
+    edge_dx = shape.points[1].x() - shape.points[0].x()
+    edge_dy = shape.points[1].y() - shape.points[0].y()
+    recovered_angle = math.atan2(edge_dy, edge_dx)
+    assert recovered_angle == pytest.approx(
+        rotated_rectangle_angle, abs=math.radians(3)
+    )
+    centre_x = sum(p.x() for p in shape.points) / 4
+    centre_y = sum(p.y() for p in shape.points) / 4
+    assert centre_x == pytest.approx(70.0, abs=0.5)
+    assert centre_y == pytest.approx(120.0, abs=0.5)
+
+
+def test_shapes_from_detections_oriented_rectangle_with_square_mask() -> None:
+    # The minimum-area rectangle of a square mask is the axis-aligned bbox,
+    # so the offset corners trace the bbox itself.
+    [shape] = shapes_from_detections(
+        detections=[Detection(bbox=(0, 0, 10, 10), mask=np.ones((11, 11), dtype=bool))],
+        shape_type="oriented_rectangle",
+    )
+
+    assert shape.shape_type == "oriented_rectangle"
+    expected = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    for i, (x, y) in enumerate(expected):
+        assert (shape.points[i].x(), shape.points[i].y()) == pytest.approx((x, y))
+
+
+def test_shapes_from_detections_oriented_rectangle_square_mask_no_bbox() -> None:
+    # Without a bbox the mask coordinates are emitted as-is; the square mask
+    # still produces a valid axis-aligned rectangle rather than being dropped.
+    [shape] = shapes_from_detections(
+        detections=[Detection(mask=np.ones((11, 11), dtype=bool))],
+        shape_type="oriented_rectangle",
+    )
+
+    assert shape.shape_type == "oriented_rectangle"
+    expected = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    for i, (x, y) in enumerate(expected):
+        assert (shape.points[i].x(), shape.points[i].y()) == pytest.approx((x, y))

--- a/tests/unit/_automation/conftest.py
+++ b/tests/unit/_automation/conftest.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+
+@pytest.fixture(params=[math.pi / 6, -math.pi / 6], ids=["+30deg", "-30deg"])
+def rotated_rectangle_angle(request: pytest.FixtureRequest) -> float:
+    return request.param
+
+
+@pytest.fixture
+def rotated_rectangle_mask(rotated_rectangle_angle: float) -> NDArray[np.bool_]:
+    cos_a = math.cos(rotated_rectangle_angle)
+    sin_a = math.sin(rotated_rectangle_angle)
+    half_long, half_short = 10.0, 2.0
+    ys, xs = np.mgrid[0:40, 0:40]
+    dx = xs - 20.0
+    dy = ys - 20.0
+    local_x = dx * cos_a + dy * sin_a
+    local_y = -dx * sin_a + dy * cos_a
+    return (np.abs(local_x) <= half_long) & (np.abs(local_y) <= half_short)

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-18T01:32:58.666379Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -1141,6 +1141,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "tifffile", version = "2026.4.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1182,6 +1184,7 @@ requires-dist = [
     { name = "pyqt5-qt5", marker = "sys_platform == 'win32'", specifier = "!=5.15.11,!=5.15.12,!=5.15.13,!=5.15.14,!=5.15.15,!=5.15.16" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "scikit-image", specifier = ">=0.21" },
+    { name = "scipy", specifier = ">=1.8" },
     { name = "tifffile", specifier = ">=2024.1.30" },
 ]
 


### PR DESCRIPTION
Adds `oriented_rectangle` as a fourth AI output format alongside polygon / mask / rectangle / circle.

The SAM mask is reduced to its convex hull, then a rotating-calipers pass picks the minimum-area enclosing rectangle (each hull edge tested as a candidate orientation). Sign disambiguation pins the long axis to the right (or lower) half-plane so the corner sequence is deterministic. When no mask is available the handler falls back to the axis-aligned bbox corners, matching the circle-from-bbox fallback.

Stacks on #1980 (the `oriented_rectangle` shape type itself).

## Test plan

- [x] `make lint` clean
- [x] `make test` (243 passed) — new unit tests cover empty / single-pixel / collinear guards, axis-aligned recovery (wider- and taller-than-tall), 30°-rotated long-axis recovery (within ±3°), and L-shape / square edge cases that catch the PCA failure mode; new e2e parameter `ai_box-oriented_rectangle` exercises the full SAM → min-area-rect pipeline
- [x] Manual: pick AI-Box mode, choose Oriented Rectangle output, draw on a tilted object, confirm orientation arrow points along the long side