### PR TITLE
fix(canvas): preserve oriented_rectangle on label dialog cancel

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1504,7 +1504,6 @@ class Canvas(QtWidgets.QWidget):
             self._line.points = [self._current.points[-1], self._current.points[0]]
         elif self.create_mode in (
             "rectangle",
-            "oriented_rectangle",
             "line",
             "circle",
             "ai_box_to_shape",
@@ -1512,6 +1511,8 @@ class Canvas(QtWidgets.QWidget):
             self._current.points = self._current.points[0:1]
         elif self.create_mode == "point":
             self._current = None
+        else:
+            assert self.create_mode == "oriented_rectangle"
         self.drawing_polygon.emit(True)
 
     def undo_last_point(self) -> None:


### PR DESCRIPTION
## Summary
- Stop truncating `oriented_rectangle` points to the first point in `Canvas.finalise`-adjacent flow when the label dialog is cancelled.
- Keep the existing reset path for `rectangle`, `line`, `circle`, and `ai_box_to_shape`; add an `assert` to make the remaining `oriented_rectangle` branch explicit.

## Why
Cancelling the label dialog after drawing an oriented rectangle was discarding the rotation/extent points, leaving only the first point. Oriented rectangles need their full point set preserved so the user can resume or finalise the shape.

## Test plan
- [x] Draw an oriented rectangle, cancel the label dialog, and confirm the shape geometry is preserved.
- [x] Draw a regular rectangle / line / circle, cancel the label dialog, and confirm the existing reset behaviour still applies.
- [x] `make lint` and `make test`.