### PR TITLE
feat(ai): suppress redundant mask-overlapping detections

### DIFF
--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -1,6 +1,7 @@
 from ._osam_session import OsamSession
 from ._shape_builders import Detection
 from ._shape_builders import shapes_from_detections
+from ._suppression import suppress_detections_greedy
 from ._text_detection import get_bboxes_from_texts
 from ._text_detection import nms_bboxes
 from ._types import AiOutputFormat

--- a/labelme/_automation/_suppression.py
+++ b/labelme/_automation/_suppression.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._shape_builders import Detection
+
+
+# eq=False: numpy arrays don't reduce to a scalar bool, so the auto-generated
+# dataclass __eq__ (which calls bool() on the result) would raise ValueError.
+@dataclass(frozen=True, eq=False)
+class _LocalMask:
+    mask: NDArray[np.bool_]
+    origin_xy: tuple[int, int]
+    area: int
+
+
+def suppress_detections_greedy(
+    *,
+    detections: list[Detection],
+    iou_threshold: float,
+) -> list[Detection]:
+    """Callers must pass detections in priority order (highest first); the first
+    detection in each redundant cluster is kept and later ones are dropped.
+
+    Redundancy combines IoU with intersection-over-smaller (containment), so
+    nested masks (e.g. tree-cluster containing a single tree) deduplicate even
+    when their IoU is low.
+    """
+    if not detections:
+        return []
+
+    # Mixing bbox-only and mask detections would silently let bbox-only peers
+    # (treated as fully-opaque rectangles) suppress overlapping mask detections
+    # via containment. Require homogeneous input until a caller needs otherwise.
+    mask_presence = {d.mask is not None for d in detections if d.bbox is not None}
+    if len(mask_presence) > 1:
+        raise ValueError(
+            "detections must be homogeneous: either all have masks or none do"
+        )
+
+    kept: list[Detection] = []
+    kept_masks_by_label: dict[str | None, list[_LocalMask]] = {}
+    for detection in detections:
+        if detection.bbox is None:
+            kept.append(detection)
+            continue
+        new_local = _make_local_mask(detection=detection)
+        peers = kept_masks_by_label.setdefault(detection.label, [])
+        if any(
+            _is_redundant_pair(
+                new=new_local,
+                peer=peer,
+                iou_threshold=iou_threshold,
+            )
+            for peer in peers
+        ):
+            continue
+        kept.append(detection)
+        peers.append(new_local)
+    return kept
+
+
+def _is_redundant_pair(
+    *,
+    new: _LocalMask,
+    peer: _LocalMask,
+    iou_threshold: float,
+) -> bool:
+    # Containment (intersection-over-smaller) catches nested masks whose IoU
+    # is too low for the IoU check (e.g. tree-cluster swallowing a single tree).
+    CONTAINMENT_THRESHOLD: Final[float] = 0.85
+
+    intersection = _compute_mask_intersection_area(a=new, b=peer)
+    if intersection == 0:
+        return False
+    iou = intersection / (new.area + peer.area - intersection)
+    if iou >= iou_threshold:
+        return True
+    containment = intersection / min(new.area, peer.area)
+    return containment >= CONTAINMENT_THRESHOLD
+
+
+def _make_local_mask(*, detection: Detection) -> _LocalMask:
+    xmin, ymin, xmax, ymax = np.array(detection.bbox).round().astype(int).tolist()
+    if detection.mask is None:
+        h, w = ymax - ymin + 1, xmax - xmin + 1
+        mask = np.ones((h, w), dtype=np.bool_)
+        return _LocalMask(mask=mask, origin_xy=(xmin, ymin), area=h * w)
+    # Mask geometry below assumes mask covers exactly the bbox-derived extent
+    # (matching the OSAM Annotation contract). Reject inconsistent shapes loudly
+    # so a future non-OSAM caller doesn't silently produce wrong IoU values.
+    expected_shape = (ymax - ymin + 1, xmax - xmin + 1)
+    if detection.mask.shape != expected_shape:
+        raise ValueError(
+            f"mask shape {detection.mask.shape} does not match "
+            f"bbox-derived extent {expected_shape}"
+        )
+    return _LocalMask(
+        mask=detection.mask,
+        origin_xy=(xmin, ymin),
+        area=int(np.count_nonzero(detection.mask)),
+    )
+
+
+def _compute_mask_intersection_area(*, a: _LocalMask, b: _LocalMask) -> int:
+    # bbox endpoints are inclusive pixel coords (mask width = xmax - xmin + 1),
+    # so xmin + w is the exclusive x-upper-bound used for clipping.
+    a_xmin, a_ymin = a.origin_xy
+    b_xmin, b_ymin = b.origin_xy
+    a_h, a_w = a.mask.shape
+    b_h, b_w = b.mask.shape
+
+    inter_xmin = max(a_xmin, b_xmin)
+    inter_ymin = max(a_ymin, b_ymin)
+    inter_xmax = min(a_xmin + a_w, b_xmin + b_w)
+    inter_ymax = min(a_ymin + a_h, b_ymin + b_h)
+    if inter_xmax <= inter_xmin or inter_ymax <= inter_ymin:
+        return 0
+
+    sub_a = a.mask[
+        inter_ymin - a_ymin : inter_ymax - a_ymin,
+        inter_xmin - a_xmin : inter_xmax - a_xmin,
+    ]
+    sub_b = b.mask[
+        inter_ymin - b_ymin : inter_ymax - b_ymin,
+        inter_xmin - b_xmin : inter_xmax - b_xmin,
+    ]
+    return int(np.count_nonzero(sub_a & sub_b))

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1339,6 +1339,10 @@ class MainWindow(QtWidgets.QMainWindow):
                     description=json.dumps(dict(score=score.item(), text=text)),
                 )
             )
+        detections = _automation.suppress_detections_greedy(
+            detections=detections,
+            iou_threshold=self._ai_text.get_iou_threshold(),
+        )
         shapes: list[Shape] = _automation.shapes_from_detections(
             detections=detections, shape_type=shape_type
         )

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -205,8 +205,15 @@ class Canvas(QtWidgets.QWidget):
             points=np.array([[p.x(), p.y()] for p in points]),
             point_labels=np.array(point_labels),
         )
-        return _automation.shapes_from_detections(
+        # iou_threshold is hardcoded here because the ai-points/box flow has
+        # no user-facing IoU control (unlike app.py's ai-text flow). 0.5 is
+        # the same default the ai-text widget ships with.
+        detections = _automation.suppress_detections_greedy(
             detections=_detections_from_annotations(response.annotations),
+            iou_threshold=0.5,
+        )
+        return _automation.shapes_from_detections(
+            detections=detections,
             shape_type=self._ai_output_format,
         )
 

--- a/tests/unit/_automation/_suppression_test.py
+++ b/tests/unit/_automation/_suppression_test.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from labelme._automation import Detection
+from labelme._automation._suppression import suppress_detections_greedy
+
+
+@pytest.fixture
+def make_full_detection() -> Callable[..., Detection]:
+    def _make(*, label: str | None = None) -> Detection:
+        return Detection(
+            bbox=(0.0, 0.0, 10.0, 10.0),
+            mask=np.ones((11, 11), dtype=bool),
+            label=label,
+        )
+
+    return _make
+
+
+def test_redundant_drops_duplicate_mask_keeps_first(
+    make_full_detection: Callable[..., Detection],
+) -> None:
+    first = make_full_detection()
+    second = make_full_detection()
+
+    kept = suppress_detections_greedy(detections=[first, second], iou_threshold=0.5)
+
+    assert kept == [first]
+
+
+def test_redundant_keeps_first_when_descriptions_differ() -> None:
+    mask = np.ones((11, 11), dtype=bool)
+    first = Detection(bbox=(0.0, 0.0, 10.0, 10.0), mask=mask, description="first")
+    second = Detection(
+        bbox=(0.0, 0.0, 10.0, 10.0), mask=mask.copy(), description="second"
+    )
+
+    kept = suppress_detections_greedy(detections=[first, second], iou_threshold=0.5)
+
+    assert len(kept) == 1
+    assert kept[0].description == "first"
+
+
+def test_redundant_keeps_only_first_among_three_duplicates(
+    make_full_detection: Callable[..., Detection],
+) -> None:
+    first = make_full_detection()
+    second = make_full_detection()
+    third = make_full_detection()
+
+    kept = suppress_detections_greedy(
+        detections=[first, second, third], iou_threshold=0.5
+    )
+
+    assert kept == [first]
+
+
+def test_redundant_keeps_disjoint_masks() -> None:
+    first = Detection(
+        bbox=(0.0, 0.0, 5.0, 5.0),
+        mask=np.ones((6, 6), dtype=bool),
+    )
+    second = Detection(
+        bbox=(20.0, 20.0, 25.0, 25.0),
+        mask=np.ones((6, 6), dtype=bool),
+    )
+
+    kept = suppress_detections_greedy(detections=[first, second], iou_threshold=0.5)
+
+    assert kept == [first, second]
+
+
+def test_redundant_drops_mask_contained_in_larger_mask() -> None:
+    # Small mask is fully inside the large one — low IoU, high containment.
+    # Tree-cluster vs single-tree scenario.
+    large = Detection(
+        bbox=(0.0, 0.0, 20.0, 20.0),
+        mask=np.ones((21, 21), dtype=bool),
+    )
+    small = Detection(
+        bbox=(5.0, 5.0, 9.0, 9.0),
+        mask=np.ones((5, 5), dtype=bool),
+    )
+
+    kept = suppress_detections_greedy(detections=[large, small], iou_threshold=0.5)
+
+    assert kept == [large]
+
+
+def test_redundant_keeps_partial_overlap_below_containment_threshold() -> None:
+    # big: 10x10 full mask, area 100. small: 5x5 full mask, area 25, shifted
+    # one row past big's lower edge so only a 4x5 strip (20 pixels) overlaps.
+    # IoU = 20/(100+25-20) = 0.19 (below 0.5, IoU check misses).
+    # containment = 20/min(100,25) = 0.8 (below 0.85, containment check misses).
+    big = Detection(
+        bbox=(0.0, 0.0, 9.0, 9.0),
+        mask=np.ones((10, 10), dtype=bool),
+    )
+    small = Detection(
+        bbox=(5.0, 6.0, 9.0, 10.0),
+        mask=np.ones((5, 5), dtype=bool),
+    )
+
+    kept = suppress_detections_greedy(detections=[big, small], iou_threshold=0.5)
+
+    assert kept == [big, small]
+
+
+def test_redundant_keeps_triangles_sharing_bbox() -> None:
+    rows, cols = np.indices((11, 11))
+    lower_left = Detection(
+        bbox=(0.0, 0.0, 10.0, 10.0),
+        mask=rows + cols <= 10,
+    )
+    upper_right = Detection(
+        bbox=(0.0, 0.0, 10.0, 10.0),
+        mask=rows + cols > 10,
+    )
+
+    kept = suppress_detections_greedy(
+        detections=[lower_left, upper_right], iou_threshold=0.5
+    )
+
+    assert kept == [lower_left, upper_right]
+
+
+def test_redundant_does_not_suppress_across_labels(
+    make_full_detection: Callable[..., Detection],
+) -> None:
+    tree = make_full_detection(label="tree")
+    grass = make_full_detection(label="grass")
+
+    kept = suppress_detections_greedy(detections=[tree, grass], iou_threshold=0.5)
+
+    assert kept == [tree, grass]
+
+
+def test_redundant_empty_detections() -> None:
+    assert suppress_detections_greedy(detections=[], iou_threshold=0.5) == []
+
+
+def test_redundant_drops_duplicate_bbox_only_detections() -> None:
+    first = Detection(bbox=(0.0, 0.0, 10.0, 10.0))
+    second = Detection(bbox=(0.0, 0.0, 10.0, 10.0))
+
+    kept = suppress_detections_greedy(detections=[first, second], iou_threshold=0.5)
+
+    assert kept == [first]
+
+
+def test_redundant_passes_through_detections_without_bbox() -> None:
+    no_bbox = Detection(mask=np.ones((11, 11), dtype=bool))
+
+    kept = suppress_detections_greedy(detections=[no_bbox, no_bbox], iou_threshold=0.5)
+
+    assert kept == [no_bbox, no_bbox]
+
+
+def test_redundant_raises_on_mask_shape_mismatch() -> None:
+    bad = Detection(
+        bbox=(0.0, 0.0, 9.0, 9.0),
+        mask=np.ones((11, 11), dtype=bool),
+    )
+
+    with pytest.raises(ValueError, match="mask shape"):
+        suppress_detections_greedy(detections=[bad], iou_threshold=0.5)
+
+
+def test_redundant_rejects_mixed_mask_and_bbox_only() -> None:
+    with_mask = Detection(
+        bbox=(0.0, 0.0, 10.0, 10.0),
+        mask=np.ones((11, 11), dtype=bool),
+    )
+    bbox_only = Detection(bbox=(0.0, 0.0, 10.0, 10.0))
+
+    with pytest.raises(ValueError, match="homogeneous"):
+        suppress_detections_greedy(detections=[with_mask, bbox_only], iou_threshold=0.5)


### PR DESCRIPTION
Greedy per-label mask NMS using both IoU and intersection-over-smaller (containment) thresholds, so the same region returned at multiple nested SAM granularities (e.g. tree-cluster vs single tree) deduplicates to one detection. Plain bbox NMS cannot deduplicate nested masks that share a bbox.

Applied in the AI-box canvas flow, the AI-points canvas flow, and the AI-text app flow.

Stacked on top of #2091.

## Test plan

- [x] `make lint`
- [x] `make test` (253 passed)