### PR TITLE
refactor(canvas, app): import _automation as a module

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -34,12 +34,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 from labelme import __appname__
 from labelme import __version__
-from labelme._automation import AiOutputFormat
-from labelme._automation import Detection
-from labelme._automation import OsamSession
-from labelme._automation import get_bboxes_from_texts
-from labelme._automation import nms_bboxes
-from labelme._automation import shapes_from_detections
+from labelme import _automation
 from labelme._label_file import LABEL_FILE_SUFFIX
 from labelme._label_file import LabelData
 from labelme._label_file import LabelFileError
@@ -182,7 +177,7 @@ class MainWindow(QtWidgets.QMainWindow):
     _config_file: Path | None
     _config: dict
 
-    _text_osam_session: OsamSession | None = None
+    _text_osam_session: _automation.OsamSession | None = None
     _is_changed: bool = False
     _shape_clipboard: ShapeClipboard
     _zoom_mode: _ZoomMode
@@ -1290,9 +1285,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self._text_osam_session is None
             or self._text_osam_session.model_name != model_name
         ):
-            self._text_osam_session = OsamSession(model_name=model_name)
+            self._text_osam_session = _automation.OsamSession(model_name=model_name)
 
-        boxes, scores, labels, masks = get_bboxes_from_texts(
+        boxes, scores, labels, masks = _automation.get_bboxes_from_texts(
             session=self._text_osam_session,
             image=utils.img_qt_to_arr(self._image)[:, :, :3],
             image_id=str(hash(self._image_path)),
@@ -1307,7 +1302,7 @@ class MainWindow(QtWidgets.QMainWindow):
             scores = np.r_[scores, [SCORE_FOR_EXISTING_SHAPE]]
             labels = np.r_[labels, [texts.index(shape.label)]]
 
-        boxes, scores, labels, indices = nms_bboxes(
+        boxes, scores, labels, indices = _automation.nms_bboxes(
             boxes=boxes,
             scores=scores,
             labels=labels,
@@ -1328,11 +1323,11 @@ class MainWindow(QtWidgets.QMainWindow):
             masks = [masks[i] for i in indices]
         del indices
 
-        detections: list[Detection] = []
+        detections: list[_automation.Detection] = []
         for box, score, label, mask in zip(boxes, scores, labels, masks):
             text: str = texts[label]
             detections.append(
-                Detection(
+                _automation.Detection(
                     bbox=(
                         float(box[0]),
                         float(box[1]),
@@ -1344,7 +1339,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     description=json.dumps(dict(score=score.item(), text=text)),
                 )
             )
-        shapes: list[Shape] = shapes_from_detections(
+        shapes: list[Shape] = _automation.shapes_from_detections(
             detections=detections, shape_type=shape_type
         )
 
@@ -2616,8 +2611,8 @@ def _shapes_from_dicts(
 
 
 def _resolve_text_annotation_shape_type(
-    *, create_mode: str, ai_output_format: AiOutputFormat
-) -> AiOutputFormat | None:
+    *, create_mode: str, ai_output_format: _automation.AiOutputFormat
+) -> _automation.AiOutputFormat | None:
     if create_mode in _AI_CREATE_MODES:
         return ai_output_format
     if create_mode in get_args(_TextToAnnotationCreateMode):

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -22,11 +22,8 @@ from PyQt5.QtCore import QRectF
 from PyQt5.QtCore import Qt
 
 import labelme.utils
+from labelme import _automation
 from labelme import _shape
-from labelme._automation import AiOutputFormat
-from labelme._automation import Detection
-from labelme._automation import OsamSession
-from labelme._automation import shapes_from_detections
 from labelme._shape import POLYLINE_SHAPE_TYPES
 from labelme._shape import Shape
 
@@ -111,8 +108,8 @@ class Canvas(QtWidgets.QWidget):
     _pan_anchor: QPointF | None
 
     _osam_session_model_name: str = "sam2:latest"
-    _osam_session: OsamSession | None
-    _ai_output_format: AiOutputFormat = "polygon"
+    _osam_session: _automation.OsamSession | None
+    _ai_output_format: _automation.AiOutputFormat = "polygon"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self._epsilon: float = kwargs.pop("epsilon", 10.0)
@@ -185,15 +182,17 @@ class Canvas(QtWidgets.QWidget):
     def set_ai_model_name(self, model_name: str) -> None:
         self._osam_session_model_name = model_name
 
-    def set_ai_output_format(self, output_format: AiOutputFormat) -> None:
+    def set_ai_output_format(self, output_format: _automation.AiOutputFormat) -> None:
         self._ai_output_format = output_format
 
-    def _get_osam_session(self) -> OsamSession:
+    def _get_osam_session(self) -> _automation.OsamSession:
         if (
             self._osam_session is None
             or self._osam_session.model_name != self._osam_session_model_name
         ):
-            self._osam_session = OsamSession(model_name=self._osam_session_model_name)
+            self._osam_session = _automation.OsamSession(
+                model_name=self._osam_session_model_name
+            )
         return self._osam_session
 
     def _shapes_from_ai_points(
@@ -206,7 +205,7 @@ class Canvas(QtWidgets.QWidget):
             points=np.array([[p.x(), p.y()] for p in points]),
             point_labels=np.array(point_labels),
         )
-        return shapes_from_detections(
+        return _automation.shapes_from_detections(
             detections=_detections_from_annotations(response.annotations),
             shape_type=self._ai_output_format,
         )
@@ -221,7 +220,7 @@ class Canvas(QtWidgets.QWidget):
             # point_labels: 2=box corner, 3=opposite box corner (SAM convention)
             point_labels=np.array([2, 3]),
         )
-        return shapes_from_detections(
+        return _automation.shapes_from_detections(
             detections=_detections_from_annotations(response.annotations),
             shape_type=self._ai_output_format,
         )
@@ -1589,7 +1588,7 @@ class Canvas(QtWidgets.QWidget):
 
 def _detections_from_annotations(
     annotations: list[osam.types.Annotation],
-) -> list[Detection]:
+) -> list[_automation.Detection]:
     if not annotations:
         logger.warning("No annotations returned")
         return []
@@ -1598,13 +1597,13 @@ def _detections_from_annotations(
         key=lambda a: a.score if a.score is not None else 0,
         reverse=True,
     )
-    detections: list[Detection] = []
+    detections: list[_automation.Detection] = []
     for annotation in sorted_annotations:
         bbox: tuple[float, float, float, float] | None = None
         if annotation.bounding_box is not None:
             bb = annotation.bounding_box
             bbox = (bb.xmin, bb.ymin, bb.xmax, bb.ymax)
-        detections.append(Detection(bbox=bbox, mask=annotation.mask))
+        detections.append(_automation.Detection(bbox=bbox, mask=annotation.mask))
     return detections
 
 


### PR DESCRIPTION
Replace per-symbol imports (`OsamSession`, `AiOutputFormat`, `Detection`, `get_bboxes_from_texts`, `nms_bboxes`, `shapes_from_detections`) with a single `from labelme import _automation` and prefix references with `_automation.`. Eliminates an 11-line import block across canvas.py and app.py without making call sites any less clear; the module prefix keeps the origin obvious at each use site.

Stacked on top of #2090.