### PR TITLE
fix: stop loguru file handler leaking FDs across tests

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -48,10 +48,7 @@ class _LoggerIO(io.StringIO):
 
 
 def _setup_loguru(logger_level: str) -> None:
-    try:
-        logger.remove(handler_id=0)
-    except ValueError:
-        pass
+    logger.remove()
 
     if sys.stderr:
         logger.add(sys.stderr, level=logger_level)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -47,6 +47,15 @@ def _isolated_qtsettings(
     yield
 
 
+@pytest.fixture(autouse=True)
+def _stub_setup_loguru(monkeypatch: pytest.MonkeyPatch) -> None:
+    # main() configures loguru with a file handler using enqueue=True, which
+    # spawns a multiprocessing.Queue (semaphores → file descriptors). Calling
+    # main() per test leaks FDs faster than GC reclaims them and exhausts the
+    # worker's ulimit. Tests don't need file logging, so stub it out.
+    monkeypatch.setattr("labelme.__main__._setup_loguru", lambda logger_level: None)
+
+
 MainWinFactory = Callable[..., MainWindow]
 
 


### PR DESCRIPTION
## Summary
- Simplify `_setup_loguru` to call `logger.remove()` instead of `try: logger.remove(handler_id=0)`.
- Add an autouse fixture in `tests/e2e/conftest.py` that stubs `_setup_loguru` as a no-op for e2e tests.

## Why
`main()` registers a file handler with `enqueue=True`, which spawns a `multiprocessing.Queue` backed by semaphores (file descriptors). E2E tests invoke `main()` per test, and the multiprocessing primitives release lazily via GC, so xdist workers exhausted the macOS FD limit and tests crashed with `OSError: [Errno 24] Too many open files` (both directly and as collateral in unit tests sharing the worker process).

The old `try/except` only removed handler 0 on the first call and silently no-op'd thereafter; the new `logger.remove()` is robust to repeated calls but the multiprocessing leak still required a test-side stub.

## Test plan
- [x] `make test` — 247 passed