### PR TITLE
refactor(canvas): inline _shapes_from_ai_box into its only call site

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -210,21 +210,6 @@ class Canvas(QtWidgets.QWidget):
             shape_type=self._ai_output_format,
         )
 
-    def _shapes_from_ai_box(self, bbox_points: list[QPointF]) -> list[Shape]:
-        bbox_points = _normalize_bbox_points(bbox_points=bbox_points)
-        image: np.ndarray = labelme.utils.img_qt_to_arr(img_qt=self.pixmap.toImage())
-        response: osam.types.GenerateResponse = self._get_osam_session().run(
-            image=imgviz.asrgb(image),  # type: ignore[arg-type]
-            image_id=str(self._pixmap_hash),
-            points=np.array([[p.x(), p.y()] for p in bbox_points]),
-            # point_labels: 2=box corner, 3=opposite box corner (SAM convention)
-            point_labels=np.array([2, 3]),
-        )
-        return _automation.shapes_from_detections(
-            detections=_detections_from_annotations(response.annotations),
-            shape_type=self._ai_output_format,
-        )
-
     def backup_shapes(self) -> None:
         self.shape_backups.append([s.copy() for s in self.shapes])
 
@@ -1356,7 +1341,11 @@ class Canvas(QtWidgets.QWidget):
                 point_labels=self._current.point_labels,
             )
         if self.create_mode == "ai_box_to_shape":
-            return self._shapes_from_ai_box(bbox_points=self._current.points)
+            # point_labels: 2=box corner, 3=opposite box corner (SAM convention)
+            return self._shapes_from_ai_points(
+                points=_normalize_bbox_points(bbox_points=self._current.points),
+                point_labels=[2, 3],
+            )
         raise AssertionError(f"unreachable: {self.create_mode}")
 
     def _reset_after_shape_creation(self) -> None:

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -139,6 +139,10 @@ def test_finalize_with_empty_inference_resets_state_and_notifies(
     monkeypatch.setattr(canvas, "_shapes_from_ai_points", lambda **_: [])
     canvas.create_mode = create_mode
     canvas._current = Shape(shape_type="rectangle")
+    # ai_box_to_shape normalizes the two bbox corners before delegating to the
+    # (monkeypatched) inference call, so the in-progress shape needs 2 points.
+    canvas._current.add_point(QPointF(0, 0))
+    canvas._current.add_point(QPointF(10, 10))
     drawing_polygon_emissions: list[bool] = []
     inference_no_shapes_emissions: list[None] = []
     canvas.drawing_polygon.connect(drawing_polygon_emissions.append)

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -137,7 +137,6 @@ def test_finalize_with_empty_inference_resets_state_and_notifies(
     # in-progress drawing state so the edit-mode button becomes usable again
     # and notify the user that inference produced nothing.
     monkeypatch.setattr(canvas, "_shapes_from_ai_points", lambda **_: [])
-    monkeypatch.setattr(canvas, "_shapes_from_ai_box", lambda **_: [])
     canvas.create_mode = create_mode
     canvas._current = Shape(shape_type="rectangle")
     drawing_polygon_emissions: list[bool] = []


### PR DESCRIPTION
The function differed from `_shapes_from_ai_points` only in normalizing
the two bbox points and hardcoding the SAM box-corner labels `[2, 3]`.
Inlining at the single call site removes the duplicated OSAM session
call body.