### PR TITLE
fix(ai): drop AI detections with empty mask

### DIFF
--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -76,6 +76,8 @@ def _shape_from_detection(
     if shape_type == "mask":
         if detection.bbox is None or detection.mask is None:
             return None
+        if not detection.mask.any():
+            return None
         xmin = int(detection.bbox[0])
         ymin = int(detection.bbox[1])
         xmax = int(detection.bbox[2])

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -148,3 +148,15 @@ def test_shapes_from_detections_oriented_rectangle_square_mask_no_bbox() -> None
     expected = [(0, 0), (10, 0), (10, 10), (0, 10)]
     for i, (x, y) in enumerate(expected):
         assert (shape.points[i].x(), shape.points[i].y()) == pytest.approx((x, y))
+
+
+def test_shapes_from_detections_mask_drops_empty_mask() -> None:
+    # OSAM occasionally returns a bbox whose segmentation mask is all-False;
+    # without this guard the shape would render as bbox-only (no visible mask).
+    shapes = shapes_from_detections(
+        detections=[
+            Detection(bbox=(10, 20, 30, 50), mask=np.zeros((31, 21), dtype=bool))
+        ],
+        shape_type="mask",
+    )
+    assert shapes == []


### PR DESCRIPTION
## Summary

OSAM occasionally returns a bbox whose segmentation mask is all-False. The mask branch of \`_shape_from_detection\` passed these through, producing a shape that rendered as bbox-only (transparent mask overlay). The other mask-consuming branches (polygon, circle, oriented_rectangle) already drop empty masks via their geometry helpers; the mask branch now matches.

## Test plan

- [x] \`make lint\`
- [x] \`make test\`