### PR TITLE
fix(canvas): keep mask bbox aligned with its bitmap

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -200,6 +200,8 @@ def nearest_vertex_index(
     point: QtCore.QPointF,
     epsilon: float,
 ) -> int | None:
+    if shape.shape_type == "mask":
+        return None
     scaled_point = point * shape.scale
     nearest = _argmin(
         utils.distance(p * shape.scale - scaled_point) for p in shape.points

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
 import pytest
 from PyQt5 import QtCore
 
@@ -42,4 +43,18 @@ def test_rotate_non_oriented_rectangle_raises() -> None:
             shape=shape,
             center=QtCore.QPointF(0.0, 0.0),
             angle=math.pi / 2,
+        )
+
+
+def test_nearest_vertex_index_returns_none_for_mask() -> None:
+    # Mask bbox is anchored to the bitmap; exposing draggable vertices would
+    # desync the rectangle from the mask.
+    shape = Shape(shape_type="mask", mask=np.ones((4, 4), dtype=bool))
+    shape.add_point(QtCore.QPointF(0.0, 0.0))
+    shape.add_point(QtCore.QPointF(3.0, 3.0))
+    shape.close()
+
+    for corner in shape.points:
+        assert (
+            _shape.nearest_vertex_index(shape=shape, point=corner, epsilon=10.0) is None
         )


### PR DESCRIPTION
## Summary
- Return `None` from `_shape.nearest_vertex_index` when `shape.shape_type == "mask"` so the canvas never arms a vertex-drag on a mask bbox corner.
- Add a unit test asserting `nearest_vertex_index` returns `None` at every corner of a mask shape.

## Why
A mask shape stores its bbox in `shape.points` (TL/BR corners) but the mask bitmap is painted from `points[0]` with fixed dimensions. Hovering near a bbox corner armed the vertex-drag path, and `_bounded_move_vertex` moved a single point — shrinking/growing the rectangle without touching the underlying mask, so the green outline drifted off the mask. Guarding at `nearest_vertex_index` covers every caller (currently `Canvas._highlight_hover_shape`). Whole-shape translate still works because `Shape.translate` moves all points together.

## Test plan
- [x] `uv run pytest tests/e2e/canvas_interaction_test.py tests/e2e/shape_editing_test.py tests/unit/_shape_test.py` (32 passed)
- [x] `make lint`