### PR TITLE
fix(canvas): ramp grab-pan overscroll continuously past viewport

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1386,12 +1386,11 @@ class Canvas(QtWidgets.QWidget):
         viewport = self._scroll_viewport()
         if viewport is None:
             return QtCore.QSize(scaled_w, scaled_h)
-        # Overscroll only along axes where the image actually overflows the
-        # viewport. Half a viewport of slack (split evenly around the centered
-        # image) lets each edge be panned a quarter-viewport past the viewport
-        # boundary, derived from the viewport rather than a fixed multiplier.
-        slack_w = viewport.width() // 2 if scaled_w > viewport.width() else 0
-        slack_h = viewport.height() // 2 if scaled_h > viewport.height() else 0
+        # Ramp overscroll with the overflow, capped at V/2 so each image
+        # edge can be panned V/4 inside the viewport. A step from 0 to V/2
+        # at the threshold would snap the centered image sideways by V/4.
+        slack_w = max(0, min(viewport.width() // 2, scaled_w - viewport.width()))
+        slack_h = max(0, min(viewport.height() // 2, scaled_h - viewport.height()))
         return QtCore.QSize(scaled_w + slack_w, scaled_h + slack_h)
 
     def sizeHint(self) -> QtCore.QSize:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -1386,11 +1386,8 @@ class Canvas(QtWidgets.QWidget):
         viewport = self._scroll_viewport()
         if viewport is None:
             return QtCore.QSize(scaled_w, scaled_h)
-        # Ramp overscroll with the overflow, capped at V/2 so each image
-        # edge can be panned V/4 inside the viewport. A step from 0 to V/2
-        # at the threshold would snap the centered image sideways by V/4.
-        slack_w = max(0, min(viewport.width() // 2, scaled_w - viewport.width()))
-        slack_h = max(0, min(viewport.height() // 2, scaled_h - viewport.height()))
+        slack_w = _compute_overscroll_slack(scaled=scaled_w, viewport=viewport.width())
+        slack_h = _compute_overscroll_slack(scaled=scaled_h, viewport=viewport.height())
         return QtCore.QSize(scaled_w + slack_w, scaled_h + slack_h)
 
     def sizeHint(self) -> QtCore.QSize:
@@ -1625,6 +1622,18 @@ def _snap_cursor_pos_for_square(pos: QPointF, opposite_vertex: QPointF) -> QPoin
         np.sign(pos_from_opposite.x()) * square_size,
         np.sign(pos_from_opposite.y()) * square_size,
     )
+
+
+def _compute_overscroll_slack(*, scaled: int, viewport: int) -> int:
+    # Floor (viewport // 8) keeps middle-drag pan responsive at slight
+    # overflow; without it, scroll range equals the overflow and a
+    # 2-px-overflowing image feels locked under the cursor. The floor
+    # reintroduces a viewport/16 image shift at the threshold, 4x smaller
+    # than the original viewport/4 jump. Cap (viewport // 2) lets each
+    # image edge be panned to the viewport center but no further.
+    if scaled <= viewport:
+        return 0
+    return max(viewport // 8, min(viewport // 2, scaled - viewport))
 
 
 def _compute_intersection_edges_image(

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -5,6 +5,7 @@ from typing import Final
 
 import pytest
 from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import QSize
 from pytestqt.qtbot import QtBot
@@ -290,3 +291,55 @@ def test_project_oriented_rectangle_corners_with_cursor_off_locked_edge() -> Non
     )
     assert (perp.x(), perp.y()) == pytest.approx((0.0, 4.0))
     assert (para.x(), para.y()) == pytest.approx((15.0, 0.0))
+
+
+_VIEWPORT_SIZE: Final[QSize] = QSize(400, 300)
+
+
+@pytest.fixture()
+def scrolled_canvas(qtbot: QtBot) -> Canvas:
+    scroll_area = QtWidgets.QScrollArea()
+    scroll_area.viewport().setFixedSize(_VIEWPORT_SIZE)
+    canvas = Canvas()
+    canvas.pixmap = QtGui.QPixmap(_WIDTH, _HEIGHT)
+    scroll_area.setWidget(canvas)
+    qtbot.addWidget(scroll_area)
+    # Keep a Python reference on the canvas so the scroll area survives the
+    # fixture's local scope; otherwise GC drops it and its C++ child canvas
+    # is destroyed before the test body runs.
+    canvas._test_scroll_area_keepalive = scroll_area  # ty: ignore[unresolved-attribute]
+    return canvas
+
+
+@pytest.mark.gui
+def test_compute_canvas_size_is_continuous_through_overflow_threshold(
+    scrolled_canvas: Canvas,
+) -> None:
+    # Pre-fix the slack jumped from 0 to V/2 the instant scaled_w crossed the
+    # viewport width, shifting the centered image by V/4 in one zoom step.
+    # Adjacent scales straddling the threshold should now differ only by
+    # rounding noise (pre-fix the gap was ~V/2, here ~2).
+    viewport_w: Final[int] = _VIEWPORT_SIZE.width()
+    pixmap_w: Final[int] = scrolled_canvas.pixmap.width()
+
+    scrolled_canvas.scale = (viewport_w - 1) / pixmap_w
+    just_below = scrolled_canvas._compute_canvas_size().width()
+    scrolled_canvas.scale = (viewport_w + 1) / pixmap_w
+    just_above = scrolled_canvas._compute_canvas_size().width()
+
+    assert just_above - just_below <= 3
+
+
+@pytest.mark.gui
+def test_compute_canvas_size_caps_overscroll_at_half_viewport(
+    scrolled_canvas: Canvas,
+) -> None:
+    # Slack saturates at V/2 so each image edge can be panned to the viewport
+    # center but no further. Sampling at the exact saturation point (1.5V)
+    # locks both the cap value and the scale at which it engages.
+    viewport_w: Final[int] = _VIEWPORT_SIZE.width()
+    pixmap_w: Final[int] = scrolled_canvas.pixmap.width()
+
+    scrolled_canvas.scale = 1.5 * viewport_w / pixmap_w
+    scaled_w = int(pixmap_w * scrolled_canvas.scale)
+    assert scrolled_canvas._compute_canvas_size().width() == scaled_w + viewport_w // 2

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -5,7 +5,6 @@ from typing import Final
 
 import pytest
 from PyQt5 import QtGui
-from PyQt5 import QtWidgets
 from PyQt5.QtCore import QPointF
 from PyQt5.QtCore import QSize
 from pytestqt.qtbot import QtBot
@@ -13,6 +12,7 @@ from pytestqt.qtbot import QtBot
 from labelme._shape import Shape
 from labelme.widgets.canvas import Canvas
 from labelme.widgets.canvas import _compute_intersection_edges_image
+from labelme.widgets.canvas import _compute_overscroll_slack
 from labelme.widgets.canvas import _normalize_bbox_points
 from labelme.widgets.canvas import _opposite_corner_in_parallelogram
 from labelme.widgets.canvas import _project_oriented_rectangle_corners
@@ -293,53 +293,17 @@ def test_project_oriented_rectangle_corners_with_cursor_off_locked_edge() -> Non
     assert (para.x(), para.y()) == pytest.approx((15.0, 0.0))
 
 
-_VIEWPORT_SIZE: Final[QSize] = QSize(400, 300)
-
-
-@pytest.fixture()
-def scrolled_canvas(qtbot: QtBot) -> Canvas:
-    scroll_area = QtWidgets.QScrollArea()
-    scroll_area.viewport().setFixedSize(_VIEWPORT_SIZE)
-    canvas = Canvas()
-    canvas.pixmap = QtGui.QPixmap(_WIDTH, _HEIGHT)
-    scroll_area.setWidget(canvas)
-    qtbot.addWidget(scroll_area)
-    # Keep a Python reference on the canvas so the scroll area survives the
-    # fixture's local scope; otherwise GC drops it and its C++ child canvas
-    # is destroyed before the test body runs.
-    canvas._test_scroll_area_keepalive = scroll_area  # ty: ignore[unresolved-attribute]
-    return canvas
-
-
-@pytest.mark.gui
-def test_compute_canvas_size_is_continuous_through_overflow_threshold(
-    scrolled_canvas: Canvas,
-) -> None:
-    # Pre-fix the slack jumped from 0 to V/2 the instant scaled_w crossed the
-    # viewport width, shifting the centered image by V/4 in one zoom step.
-    # Adjacent scales straddling the threshold should now differ only by
-    # rounding noise (pre-fix the gap was ~V/2, here ~2).
-    viewport_w: Final[int] = _VIEWPORT_SIZE.width()
-    pixmap_w: Final[int] = scrolled_canvas.pixmap.width()
-
-    scrolled_canvas.scale = (viewport_w - 1) / pixmap_w
-    just_below = scrolled_canvas._compute_canvas_size().width()
-    scrolled_canvas.scale = (viewport_w + 1) / pixmap_w
-    just_above = scrolled_canvas._compute_canvas_size().width()
-
-    assert just_above - just_below <= 3
-
-
-@pytest.mark.gui
-def test_compute_canvas_size_caps_overscroll_at_half_viewport(
-    scrolled_canvas: Canvas,
-) -> None:
-    # Slack saturates at V/2 so each image edge can be panned to the viewport
-    # center but no further. Sampling at the exact saturation point (1.5V)
-    # locks both the cap value and the scale at which it engages.
-    viewport_w: Final[int] = _VIEWPORT_SIZE.width()
-    pixmap_w: Final[int] = scrolled_canvas.pixmap.width()
-
-    scrolled_canvas.scale = 1.5 * viewport_w / pixmap_w
-    scaled_w = int(pixmap_w * scrolled_canvas.scale)
-    assert scrolled_canvas._compute_canvas_size().width() == scaled_w + viewport_w // 2
+@pytest.mark.parametrize(
+    ("scaled", "viewport", "expected"),
+    [
+        pytest.param(399, 400, 0, id="image_fits_below_threshold"),
+        pytest.param(400, 400, 0, id="image_exactly_fills_viewport"),
+        pytest.param(401, 400, 50, id="slight_overflow_floored_to_viewport_eighth"),
+        pytest.param(450, 400, 50, id="overflow_at_floor_boundary"),
+        pytest.param(500, 400, 100, id="ramp_grows_with_overflow_past_floor"),
+        pytest.param(600, 400, 200, id="overflow_at_cap_boundary"),
+        pytest.param(1000, 400, 200, id="large_overflow_capped_at_viewport_half"),
+    ],
+)
+def test_compute_overscroll_slack(scaled: int, viewport: int, expected: int) -> None:
+    assert _compute_overscroll_slack(scaled=scaled, viewport=viewport) == expected


### PR DESCRIPTION
The slack added to the canvas size for grab-pan padding was a step function: `0` while the image fit the viewport, then `viewport.width() // 2` the instant `scaled_w` crossed the viewport width. Because the image is centered in the canvas, its widget-coord offset jumped by `V/4` at that exact zoom step, visible as the image suddenly snapping sideways during zoom.

The fix ramps the slack linearly with the overflow, capped at `V/2`, and floored at `V/8`. The cap preserves the existing guarantee that any edge can ultimately be panned to the viewport center. The floor keeps middle-drag pan responsive at slight overflow: without it, the scroll range equals the overflow, so a 2-px-overflowing image feels locked under the cursor.

The floor still leaves a discontinuity at the threshold, but a much smaller one: the image shift at the crossover drops from `V/4` to `V/16` (4x smaller than before).

## Test plan

- [x] new parametrized unit test covers the threshold, the floor region, the linear ramp, and the cap saturation
- [x] existing `tests/e2e/middle_drag_scroll_test.py` still passes (depends on overscroll being present)
- [x] `make lint`