### PR TITLE
docs: set up agent skills config and seed project glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked as GitHub issues on `wkentaro/labelme` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles map 1:1 to label strings of the same name (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/` at the repo root (created lazily by `/grill-with-docs`). See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,89 @@
+# labelme
+
+The domain language of labelme, a desktop image-annotation tool. This glossary covers the user-facing data model — what an annotated Image consists of and how its parts relate.
+
+## Language
+
+**Annotation**:
+The complete bundle of labelme data attached to one Image — its image-level Flags, its Shapes, and the per-Shape Flags carried by each Shape. Persisted as one JSON file on disk.
+_Avoid_: using "annotation" for a single Shape.
+
+**Shape**:
+One drawn region on an Image with a class Label. Concrete kinds are distinguished by `shape_type` (polygon, rectangle, circle, line, point, linestrip, mask). A Shape is one constituent of an Annotation, never the whole.
+_Avoid_: annotation (for a single region), region, marker, primitive.
+
+**Flag**:
+A boolean tag attached to the Image as a whole, used for image-level classification or cleaning (e.g. `cat`, `dog`, `blurry`). Lives at the top of the Annotation alongside Shapes.
+_Avoid_: tag, attribute, image label.
+
+**Shape Flag**:
+A boolean attribute attached to one Shape (e.g. `occluded`, `truncated`). Same data shape as a Flag but a different concept — it qualifies a single Shape, not the Image.
+_Avoid_: flag (unqualified), attribute, modifier.
+
+**Label**:
+The class string on a Shape (e.g. `"cat"`, `"car"`). One Shape has exactly one Label. Labels are not Annotations — they are a property of one Shape.
+_Avoid_: class, category, tag, name; also avoid "label" to mean the Annotation File.
+
+**Annotation File**:
+The on-disk persisted form of one Annotation, stored as JSON. There is one Annotation File per Image. Identified in code as `LabelFile` / `LabelData` for historical reasons — that legacy name is not promoted as glossary vocabulary.
+_Avoid_: label file, JSON file (when more precision is helpful), annotation json.
+
+**Group**:
+A set of Shapes sharing a common `group_id`, marking them as belonging together. The reason for grouping is application-defined — instance segmentation uses it for the visible parts of one occluded object, but the concept is general and not tied to any one use case.
+_Avoid_: instance (it is only one application of grouping), cluster.
+
+**AI Assist**:
+Interactive, click-driven Shape proposal: the user places positive / negative points on the Image and a vision model (SAM, EfficientSAM) returns a proposed Shape. One user action produces one candidate Shape.
+_Avoid_: AI annotation (too vague — covers AI Text Prompt too), auto-annotation, automation.
+
+**AI Text Prompt**:
+Bulk, text-driven Shape proposal: the user types a class name and an open-vocabulary detector (YOLO-world, SAM3) returns Shapes for every matching instance in the Image. One user action produces many candidate Shapes.
+_Avoid_: AI annotation (too vague), text-to-annotation (verbose), auto-detect.
+
+**Model Session**:
+A loaded ML model that backs AI Assist or AI Text Prompt. One Model Session serves many proposals across the lifetime of the app. The legacy code directory `_automation/` hosts this layer.
+_Avoid_: automation (legacy code-only term), backend, engine.
+
+**Mask Shape**:
+A Shape whose `shape_type` is `mask` — hybrid representation combining a rectangular bounding box (2 points) with a Mask (the raster pixels) that fills the bbox. The only `shape_type` that carries dense pixel data.
+_Avoid_: raster shape, pixel polygon; do not say "mask" when you mean the whole Shape.
+
+**Mask**:
+The boolean pixel array inside a Mask Shape — one bit per pixel of the Mask Shape's bbox indicating whether the pixel belongs to the annotated region. Serialized as a base64-encoded PNG inside the Annotation File.
+_Avoid_: bitmap, raster, segmentation map (when you mean just this Shape's pixels).
+
+**Image**:
+An input image file (PNG, JPEG, TIFF, etc.) that is the subject of an Annotation. Identified by its path on disk. The in-memory pixel array used while annotating is an implementation concern and not part of this term.
+_Avoid_: photo, picture, file, frame.
+
+**Label List**:
+The predefined set of allowed Label strings configured for an annotation session (via the `--labels` CLI flag, a labels file, or the user config). The Label List is the *permitted vocabulary*; it is not the same as the Labels that actually appear on Shapes.
+_Avoid_: labels (means actual labels in use), label vocabulary (verbose), classes.
+
+## Flagged ambiguities
+
+- **`LabelFile` / `LabelData` in code**: legacy identifiers for what the glossary calls an **Annotation File**. A rename to `AnnotationFile` is under consideration but not decided.
+
+## Example dialogue
+
+A new contributor (N) asks a maintainer (M) about a bug report.
+
+> **N:** A user filed a bug saying their annotations get wiped when they reopen an image. What's actually being wiped?
+>
+> **M:** Probably the Annotation, not just one Shape. The Annotation includes the Image's Flags, every Shape on it, and the Shape Flags on each Shape. If the Annotation File didn't load, all of that is gone from view.
+>
+> **N:** Is the Annotation File on disk corrupted, or is the load failing?
+>
+> **M:** Check the file first. If it parses, the Annotation is fine; the UI just isn't picking it up. If it doesn't parse, the Annotation File itself is the problem.
+>
+> **N:** They also said their AI shapes disappear. They use AI Text Prompt — type "person", get a bunch of Shapes.
+>
+> **M:** Right. Those are still ordinary Shapes once the Model Session returns them; AI Text Prompt only produces them. After that they're stored in the Annotation File like any other Shape.
+>
+> **N:** They mentioned one Shape is a Mask Shape — does that change anything?
+>
+> **M:** Only the storage. A Mask Shape has a bbox plus an embedded Mask — the boolean pixel array, base64-encoded inside the Annotation File. If the file got truncated, the Mask is the most likely thing to be malformed.
+>
+> **N:** Last thing — they want Shapes from one occluded car to share a `group_id`. Is that an Instance?
+>
+> **M:** It's a Group. Instance segmentation is one application of grouping, but in our domain we just say Group. The Shapes share a `group_id` — that's all the data model knows about it.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo uses a **single-context** layout: one `CONTEXT.md` and one `docs/adr/` directory at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the project's glossary and domain language.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md          ← glossary, created lazily by /grill-with-docs
+├── docs/
+│   └── adr/            ← architectural decisions, created lazily
+│       ├── 0001-...md
+│       └── 0002-...md
+└── labelme/            ← source
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-NNNN (short title) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `wkentaro/labelme`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+These labels do not yet exist on `wkentaro/labelme` — the triage skill will create them on first use via `gh label create`. Existing category labels (`issue:bug`, `feature`, `docs`, `refactor`, `test`, `ui`, `perf`, `i18n`, `dependencies`, `python:uv`, `others`) live in a separate namespace and are unaffected.
+
+Edit the right-hand column to remap any role to an existing label.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
   "types-pyyaml>=6.0.12.20241230",
   "typos>=1.45.0",
   "yamlfix>=1.19.1",
+  "mdformat-gfm>=1.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1151,6 +1151,7 @@ dev = [
     { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
+    { name = "mdformat-gfm" },
     { name = "pyqt5-stubs" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1189,6 +1190,7 @@ dev = [
     { name = "ipython" },
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },
+    { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "pyqt5-stubs", specifier = ">=5.15.6.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -1369,6 +1371,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/94/ccb15e0535f35c21b2b533cafb232f11ac0e7046dd122029b7ec0513c82e/mdformat_frontmatter-2.0.10.tar.gz", hash = "sha256:decefcb4beb66cf111f17e8c0d82e60b208104c7922ec09564d05365db551bd8", size = 3958, upload-time = "2026-01-19T23:42:23.672Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/40/e61f8ed549bed3159a9677eadb89849ccca6de30eb90bf61e1b6026df96d/mdformat_frontmatter-2.0.10-py3-none-any.whl", hash = "sha256:c99f7c52de0403e39f48b6a1c2bb79a4c8ce69304a799ff0e403e3957aa3669b", size = 4636, upload-time = "2026-01-19T23:42:22.341Z" },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` (with a `CLAUDE.md` symlink so Claude Code reads the same file) declaring where agent skills find the issue tracker, triage labels, and domain docs.
- Configures GitHub Issues as the tracker, canonical 1:1 triage labels, and a single-context domain doc layout under `docs/agents/`.
- Seeds `CONTEXT.md` with 13 glossary terms covering the data model (Annotation, Shape, Flag, Shape Flag, Label, Annotation File, Group, Mask Shape, Mask, Image), the AI-assisted features (AI Assist, AI Text Prompt, Model Session), and the Label List. Includes an example dialogue and a flagged ambiguity about the legacy `LabelFile` / `LabelData` names that may later be renamed to `AnnotationFile`.

## Test plan
- [x] Verified canonical triage label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) do not collide with the repo's existing labels via `gh label list`.
