### PR TITLE
refactor(shape): make Shape.shape_type immutable

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -19,7 +19,7 @@ from PyQt5 import QtGui
 
 from . import utils
 
-_ShapeType: TypeAlias = Literal[
+ShapeType: TypeAlias = Literal[
     "polygon",
     "rectangle",
     "oriented_rectangle",
@@ -31,7 +31,7 @@ _ShapeType: TypeAlias = Literal[
     "mask",
 ]
 
-POLYLINE_SHAPE_TYPES: Final[tuple[_ShapeType, ...]] = ("polygon", "linestrip")
+POLYLINE_SHAPE_TYPES: Final[tuple[ShapeType, ...]] = ("polygon", "linestrip")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -85,7 +85,11 @@ class Shape:
         self.group_id = group_id
         self.points: list[QtCore.QPointF] = []
         self.point_labels: list[int] = []
-        self.shape_type = shape_type
+        if shape_type is None:
+            shape_type = "polygon"
+        if shape_type not in typing.get_args(ShapeType):
+            raise ValueError(f"Unexpected shape_type: {shape_type}")
+        self._shape_type = cast(ShapeType, shape_type)
         self.fill = False
         self.selected = False
         self.visible = True
@@ -102,16 +106,8 @@ class Shape:
             self.line_color = line_color
 
     @property
-    def shape_type(self) -> _ShapeType:
+    def shape_type(self) -> ShapeType:
         return self._shape_type
-
-    @shape_type.setter
-    def shape_type(self, value: str | None) -> None:
-        if value is None:
-            value = "polygon"
-        if value not in typing.get_args(_ShapeType):
-            raise ValueError(f"Unexpected shape_type: {value}")
-        self._shape_type = cast(_ShapeType, value)
 
     def close(self) -> None:
         self._closed = True

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -26,6 +26,7 @@ from labelme import _automation
 from labelme import _shape
 from labelme._shape import POLYLINE_SHAPE_TYPES
 from labelme._shape import Shape
+from labelme._shape import ShapeType
 
 from .download import download_ai_model
 
@@ -417,13 +418,20 @@ class Canvas(QtWidgets.QWidget):
         self.pan_request.emit(QPoint(int(step.x()), int(step.y())))
 
     def _track_drawing_cursor(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
-        LINE_SHAPE_TYPE_OVERRIDES: Final[dict[str, str]] = {
+        CREATE_MODE_TO_LINE_SHAPE_TYPE: Final[dict[_CreateMode, ShapeType]] = {
+            "polygon": "polygon",
+            "rectangle": "rectangle",
+            "oriented_rectangle": "oriented_rectangle",
+            "circle": "circle",
+            "line": "line",
+            "point": "point",
+            "linestrip": "linestrip",
             "ai_points_to_shape": "points",
             "ai_box_to_shape": "rectangle",
         }
-        self._line.shape_type = LINE_SHAPE_TYPE_OVERRIDES.get(
-            self.create_mode, self.create_mode
-        )
+        desired_line_shape_type = CREATE_MODE_TO_LINE_SHAPE_TYPE[self.create_mode]
+        if self._line.shape_type != desired_line_shape_type:
+            self._line = _rebuild_line(self._line, shape_type=desired_line_shape_type)
         self._apply_cursor(CURSOR_DRAW)
         if self._current is None:
             self.update()
@@ -511,7 +519,6 @@ class Canvas(QtWidgets.QWidget):
         elif mode == "circle":
             self._line.points = [current.points[0], pos]
             self._line.point_labels = [1, 1]
-            self._line.shape_type = "circle"
         elif mode == "line":
             self._line.points = [current.points[0], pos]
             self._line.point_labels = [1, 1]
@@ -824,8 +831,6 @@ class Canvas(QtWidgets.QWidget):
             self._finalize()
             return
 
-        if mode == "circle":
-            new_shape.shape_type = "circle"
         self._line.points = [pos, pos]
         self._line.point_labels = (
             [0, 0] if mode == "ai_points_to_shape" and is_shift_pressed else [1, 1]
@@ -1601,6 +1606,13 @@ def _detections_from_annotations(
             bbox = (bb.xmin, bb.ymin, bb.xmax, bb.ymax)
         detections.append(_automation.Detection(bbox=bbox, mask=annotation.mask))
     return detections
+
+
+def _rebuild_line(line: Shape, *, shape_type: ShapeType) -> Shape:
+    new_line = Shape(shape_type=shape_type)
+    new_line.points = list(line.points)
+    new_line.point_labels = list(line.point_labels)
+    return new_line
 
 
 def _normalize_bbox_points(bbox_points: list[QPointF]) -> list[QPointF]:


### PR DESCRIPTION
Pre-factor for #2103.

Removes the `Shape.shape_type` setter. A shape's type is identity, not state; the setter let callers leave a partial shape with a stale type after a mode switch, which is the mode-switch crash #2103 fixes. Validation moves into `__init__` and the property becomes read-only.

Companion canvas changes are the minimum needed to keep `main` building after the setter goes away:

1. `_track_drawing_cursor` reconstructs `_line` via the new `_rebuild_line(...)` when the desired `shape_type` differs, instead of mutating in place.
2. The two surviving `self._line.shape_type = "circle"` and `new_shape.shape_type = "circle"` reassignments in `_press_left_while_drawing` and `_start_new_shape` are no-ops in current `main` (`_line` is already typed by `_track_drawing_cursor`; `new_shape` is already constructed as `Shape(shape_type="circle")` on the line above), so they drop without replacement.

Also promotes the literal alias from `_ShapeType` to public `ShapeType` (added private in #2104) so #2103 can reference it cross-module.

## Test plan

- [x] `uv run pytest tests/unit`: 153 pass
- [x] `make lint`: clean
