### PR TITLE
feat(ai): default to sam3 and enable it in AI-Points mode

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -84,7 +84,6 @@ _AI_CREATE_MODES: tuple[str, ...] = (
     "ai_points_to_shape",
     "ai_box_to_shape",
 )
-_AI_MODELS_WITHOUT_POINT_SUPPORT: tuple[str, ...] = ("sam3:latest",)
 
 
 class _StatusBarWidgets(NamedTuple):
@@ -1389,19 +1388,6 @@ class MainWindow(QtWidgets.QMainWindow):
     def _switch_canvas_mode(
         self, edit: bool = True, create_mode: str | None = None
     ) -> None:
-        if create_mode == "ai_points_to_shape":
-            model_name = self._canvas_widgets.canvas.get_ai_model_name()
-            if model_name in _AI_MODELS_WITHOUT_POINT_SUPPORT:
-                QtWidgets.QMessageBox.warning(
-                    self,
-                    self.tr("AI-Points Unavailable"),
-                    self.tr(
-                        "%s does not support point prompts.\n"
-                        "Please select a different model or use AI-Box mode."
-                    )
-                    % model_name,
-                )
-                return
         self._canvas_widgets.canvas.set_editing(edit)
         if create_mode is not None:
             self._canvas_widgets.canvas.create_mode = create_mode
@@ -1422,10 +1408,6 @@ class MainWindow(QtWidgets.QMainWindow):
             in (*get_args(_TextToAnnotationCreateMode), *_AI_CREATE_MODES)
         )
         self._ai_annotation.setEnabled(not edit and create_mode in _AI_CREATE_MODES)
-        if create_mode == "ai_points_to_shape":
-            self._ai_annotation.set_disabled_models(_AI_MODELS_WITHOUT_POINT_SUPPORT)
-        else:
-            self._ai_annotation.set_disabled_models(())
 
     def _highlight_ai_buttons(self, highlight: bool) -> None:
         HIGHLIGHT_COLOR: Final = "#FFFFCC"

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -27,7 +27,7 @@ shape:
   hvertex_fill_color: [255, 255, 255, 255]
   point_size: 8
 ai:
-  default: Sam2 (balanced)
+  default: Sam3
 # main
 flag_dock:
   show: true

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import typing
 from collections.abc import Callable
 
 from loguru import logger
 from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
 
 from labelme._automation import AiOutputFormat
 
@@ -116,17 +114,6 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         self._output_format_combo.setCurrentIndex(0)
 
         self.setMaximumWidth(200)
-
-    def set_disabled_models(self, disabled_models: tuple[str, ...]) -> None:
-        model = typing.cast(QtGui.QStandardItemModel, self._model_combo.model())
-        for i in range(self._model_combo.count()):
-            model_id = self._model_combo.itemData(i)
-            item = model.item(i)
-            assert item is not None
-            if model_id in disabled_models:
-                item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
-            else:
-                item.setFlags(item.flags() | Qt.ItemIsEnabled)
 
     def setEnabled(self, a0: bool) -> None:
         self._body.setEnabled(a0)

--- a/labelme/widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/widgets/_ai_text_to_annotation_widget.py
@@ -14,7 +14,7 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
         ("sam3:latest", "SAM3 (smart)"),
         ("yoloworld:latest", "YOLO-World (fast)"),
     ]
-    _default_model_name: str = "yoloworld:latest"
+    _default_model_name: str = "sam3:latest"
     _default_score_threshold: float = 0.1
     _default_iou_threshold: float = 0.5
 


### PR DESCRIPTION
Switches both AI widgets to default to `sam3:latest` and removes the gate that previously blocked `sam3:latest` from AI-Points mode.

- `default_config.yaml`: `ai.default` → `Sam3` (was `Sam2 (balanced)`).
- `_ai_text_to_annotation_widget.py`: `_default_model_name` → `sam3:latest` (was `yoloworld:latest`).
- `app.py`: drop `_AI_MODELS_WITHOUT_POINT_SUPPORT`, the AI-Points warning dialog, and the combo-disable wiring. sam3 now supports point prompts upstream, so the guard is stale.
- `_ai_assisted_annotation_widget.py`: drop the now-unused `set_disabled_models` method and orphaned imports.

## Test plan
- [ ] Launch labelme, enter AI-Points mode, confirm the model dropdown defaults to "Sam3" and the mode switch succeeds without warning
- [ ] Drop a point prompt and confirm a shape is produced
- [ ] In AI Text-to-Annotation, confirm the model dropdown defaults to "SAM3 (smart)"