### PR TITLE
fix(canvas): make line and two-point linestrip selectable by click

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -309,8 +309,10 @@ def _rotate_point_around_origin(
     return rotation @ point
 
 
-def contains_point(*, shape: Shape, point: QtCore.QPointF) -> bool:
-    if shape.shape_type in ("line", "linestrip", "points"):
+def is_hit_by_point(*, shape: Shape, point: QtCore.QPointF, epsilon: float) -> bool:
+    if shape.shape_type in ("line", "linestrip"):
+        return nearest_edge_index(shape=shape, point=point, epsilon=epsilon) is not None
+    if shape.shape_type == "points":
         return False
     if shape.shape_type == "point":
         if not shape.points:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -715,7 +715,9 @@ class Canvas(QtWidgets.QWidget):
             return
 
         for shape in ordered_shapes:
-            if not _shape.contains_point(shape=shape, point=pos):
+            if not _shape.is_hit_by_point(
+                shape=shape, point=pos, epsilon=self._epsilon
+            ):
                 continue
             self._set_highlight(
                 hovered_shape=shape,
@@ -1088,7 +1090,9 @@ class Canvas(QtWidgets.QWidget):
 
     def _find_shape_at_point(self, point: QPointF) -> Shape | None:
         for shape in reversed(self.shapes):
-            if shape.visible and _shape.contains_point(shape=shape, point=point):
+            if shape.visible and _shape.is_hit_by_point(
+                shape=shape, point=point, epsilon=self._epsilon
+            ):
                 return shape
         return None
 

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -473,10 +473,46 @@ def test_undo_shape_creation(
 
 @pytest.mark.gui
 @pytest.mark.parametrize(
-    ("create_mode", "setup_click", "finalize_click", "select_offset"),
+    (
+        "create_mode",
+        "setup_click",
+        "finalize_click",
+        "finalize_modifier",
+        "select_offset",
+    ),
     [
-        pytest.param("rectangle", (0.2, 0.2), (0.8, 0.8), (0.0, 0.0), id="rectangle"),
-        pytest.param("circle", (0.5, 0.5), (0.75, 0.5), (0.0, -20.0), id="circle"),
+        pytest.param(
+            "rectangle",
+            (0.2, 0.2),
+            (0.8, 0.8),
+            Qt.NoModifier,
+            (0.0, 0.0),
+            id="rectangle",
+        ),
+        pytest.param(
+            "circle",
+            (0.5, 0.5),
+            (0.75, 0.5),
+            Qt.NoModifier,
+            (0.0, -20.0),
+            id="circle",
+        ),
+        pytest.param(
+            "line",
+            (0.2, 0.5),
+            (0.8, 0.5),
+            Qt.NoModifier,
+            (0.0, 0.0),
+            id="line",
+        ),
+        pytest.param(
+            "linestrip",
+            (0.2, 0.5),
+            (0.8, 0.5),
+            Qt.ControlModifier,
+            (0.0, 0.0),
+            id="two-point-linestrip",
+        ),
     ],
 )
 def test_select_nonpolygon_shape(
@@ -487,6 +523,7 @@ def test_select_nonpolygon_shape(
     create_mode: str,
     setup_click: tuple[float, float],
     finalize_click: tuple[float, float],
+    finalize_modifier: Qt.KeyboardModifier,
     select_offset: tuple[float, float],
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -497,7 +534,9 @@ def test_select_nonpolygon_shape(
 
     label = f"test_{create_mode}"
     submit_label_dialog(qtbot=qtbot, label_dialog=raw_win._label_dialog, label=label)
-    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=finalize_click)
+    click_canvas_fraction(
+        qtbot=qtbot, canvas=canvas, xy=finalize_click, modifier=finalize_modifier
+    )
 
     shape = _wait_for_shape(qtbot=qtbot, canvas=canvas, label=label)
     assert shape.shape_type == create_mode
@@ -690,7 +729,7 @@ def test_select_mask_shape_by_click(
 ) -> None:
     # Mask cells are indexed pixel-for-pixel from points[0]; clicking inside
     # the True region must land on a True cell to exercise the mask branch
-    # of `_shape.contains_point`.
+    # of `_shape.is_hit_by_point`.
     mask_arr = np.zeros((40, 40), dtype=np.uint8)
     mask_arr[10:30, 10:30] = 1
     mask_b64 = utils.img_arr_to_b64(mask_arr)


### PR DESCRIPTION
## Summary

- `line` and 2-point `linestrip` shapes had no interior, so the old `_shape.contains_point` always returned `False` and `_find_shape_at_point` never picked them up — clicking on them did nothing, making it hard to select or delete them.
- Rename `_shape.contains_point` → `_shape.is_hit_by_point` (now takes `epsilon`) and route `line` / `linestrip` through `nearest_edge_index`, so clicks within `epsilon` of an edge select the shape. Polygon, point, circle, and mask branches are unchanged; `points` (plural) stays unselectable.

Re-addresses the gap left after #1502 (the `point` case was already handled there; `line` and 2-point `linestrip` still needed work).

## Test plan

- [x] `uv run pytest tests/e2e/canvas_interaction_test.py` — 25 passed, including new `test_select_nonpolygon_shape[line]` and `[two-point-linestrip]` cases
- [x] `uv run ruff check` + `uv run ruff format --check` on changed files
- [x] `uv run ty check labelme/_shape.py labelme/widgets/canvas.py`
