### PR TITLE
feat(config): comment-preserving config I/O via ruamel.yaml

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,8 @@ The domain language of labelme, a desktop image-annotation tool. This glossary c
 
 ## Language
 
+### Data model
+
 **Annotation**:
 The complete bundle of labelme data attached to one Image — its image-level Flags, its Shapes, and the per-Shape Flags carried by each Shape. Persisted as one JSON file on disk.
 _Avoid_: using "annotation" for a single Shape.
@@ -60,9 +62,36 @@ _Avoid_: photo, picture, file, frame.
 The predefined set of allowed Label strings configured for an annotation session (via the `--labels` CLI flag, a labels file, or the user config). The Label List is the *permitted vocabulary*; it is not the same as the Labels that actually appear on Shapes.
 _Avoid_: labels (means actual labels in use), label vocabulary (verbose), classes.
 
+### Configuration
+
+**Settings**:
+The user-adjustable annotation and behavior values (auto-save, drawing colors, shortcuts, AI model, and so on). Each Setting is a *value*, not a control: the value is the source of truth (persisted in the Config File) and may be surfaced by more than one **Setting Control** at once, all bound to it and kept in sync.
+_Avoid_: preferences (only the historical menu label), config (that is the file, not the values), options.
+
+**Setting Control**:
+A UI element bound to a Setting that displays and edits its value: a checkable menu/toolbar action, an inline dock control, or a widget in the Settings dialog. Inline controls are reserved for Settings toggled frequently or meaningful only in context; the Settings dialog is the comprehensive home that exposes every Setting. Multiple Setting Controls for one Setting stay in sync through a single apply path.
+_Avoid_: toggle (only one kind), widget, knob.
+
+**Config File**:
+The on-disk YAML where Settings are persisted as sparse Overrides on top of the Default Config. Defaults to `~/.labelmerc`, but can be relocated, e.g. a `labelmerc` file beside the executable in standalone builds, or any path passed to `--config`. The file is called "config"; the values it carries are Settings.
+_Avoid_: settings file, rc file, labelmerc.
+
+**Default Config**:
+The baseline Settings shipped in `labelme/config/default_config.yaml`. Read-only, and the single source of both every default value and the set of allowed keys.
+_Avoid_: defaults file, base config, schema.
+
+**Override**:
+A single Setting in the Config File whose value differs from the Default Config. The Config File holds only Overrides; resetting a Setting to its default removes its Override and keeps the file sparse.
+_Avoid_: customization, change, diff.
+
+**Window State**:
+The window geometry and dock layout persisted via Qt's `QSettings` store (the `self._window_state` attribute in code), separate from Settings and never written to the Config File. Cleared by `--reset-config`.
+_Avoid_: settings (those are the annotation/behavior values), config, layout config.
+
 ## Flagged ambiguities
 
 - **`LabelFile` / `LabelData` in code**: legacy identifiers for what the glossary calls an **Annotation File**. A rename to `AnnotationFile` is under consideration but not decided.
+- **Concept vs file naming is an intentional split**: the user-facing values are **Settings**, but the file that persists them is the **Config File** (`~/.labelmerc`) and the CLI flag stays `--config`. The menu entry reads "Settings…" while keeping Qt's `PreferencesRole`. Do not "unify" the file/flag/role naming to "settings".
 
 ## Example dialogue
 

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -11,14 +11,14 @@ import warnings
 from pathlib import Path
 from typing import AnyStr
 
-import yaml
 from loguru import logger
 from PyQt5 import QtCore
 from PyQt5 import QtWidgets
 
 from labelme import __appname__
 from labelme import __version__
-from labelme._config import get_user_config_file
+from labelme import _config
+from labelme import _yaml
 from labelme.app import MainWindow
 from labelme.utils import new_icon
 
@@ -115,7 +115,7 @@ def main() -> None:
         "--output",
         help="output directory for saving annotation JSON files",
     )
-    default_config_file = get_user_config_file()
+    default_config_file = _config.get_user_config_file()
     parser.add_argument(
         "--config",
         dest="config",
@@ -245,9 +245,9 @@ def main() -> None:
     if hasattr(args, "label_flags"):
         if Path(args.label_flags).is_file():
             with open(args.label_flags, encoding="utf-8") as f:
-                args.label_flags = yaml.safe_load(f)
+                args.label_flags = _yaml.safe_load(f)
         else:
-            args.label_flags = yaml.safe_load(args.label_flags)
+            args.label_flags = _yaml.safe_load(args.label_flags)
 
     config_from_args = args.__dict__
     config_from_args.pop("version")
@@ -258,7 +258,7 @@ def main() -> None:
     config_overrides: dict
     config_file: Path | None
     config_str: str = config_from_args.pop("config")
-    if isinstance(config_loaded := yaml.safe_load(config_str), dict):
+    if isinstance(config_loaded := _yaml.safe_load(config_str), dict):
         config_overrides = config_loaded
         config_file = None
     else:

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -6,8 +6,10 @@ from collections.abc import Sized
 from pathlib import Path
 from typing import cast
 
-import yaml
 from loguru import logger
+
+from labelme import _yaml
+from labelme._config._writer import set_override
 
 here = Path(__file__).resolve().parent
 
@@ -101,18 +103,7 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
     user_config_path = Path("~/.labelmerc").expanduser()
     if not user_config_path.exists() and create_if_missing:
         try:
-            with open(user_config_path, "w") as f:
-                f.write(
-                    "# Labelme config file.\n"
-                    "# Only add settings you want to override.\n"
-                    "# For all available options and defaults, see:\n"
-                    "#   https://github.com/wkentaro/labelme/blob/main/labelme/_config/default_config.yaml\n"
-                    "#\n"
-                    "# Example:\n"
-                    "# with_image_data: true\n"
-                    "# auto_save: false\n"
-                    "# labels: [cat, dog]\n"
-                )
+            user_config_path.touch()
         except Exception:
             logger.warning("Failed to save config: {!r}", str(user_config_path))
     return str(user_config_path)
@@ -121,11 +112,11 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
 def load_config(config_file: Path | None, config_overrides: dict) -> dict:
     config: dict
     with open(here / "default_config.yaml") as f:
-        config = yaml.safe_load(f)
+        config = _yaml.safe_load(f)
 
     if config_file is not None:
         with open(config_file) as f:
-            config_from_yaml = yaml.safe_load(f)
+            config_from_yaml = _yaml.safe_load(f)
         if isinstance(config_from_yaml, dict):
             _migrate_config_from_file(config_from_yaml=config_from_yaml)
             _update_dict(config, config_from_yaml, validate_item=_validate_config_item)

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Sequence
+from io import StringIO
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.comments import CommentedSeq
+
+from labelme import _yaml
+
+here = Path(__file__).resolve().parent
+
+
+def _default_value(key_path: Sequence[str]) -> object:
+    node: object = _yaml.safe_load((here / "default_config.yaml").read_text())
+    for key in key_path:
+        if not isinstance(node, dict) or key not in node:
+            raise ValueError(f"Unknown config key: {'.'.join(key_path)}")
+        node = node[key]
+    return node
+
+
+def _assign(doc: CommentedMap, key_path: Sequence[str], value: object) -> None:
+    node = doc
+    for key in key_path[:-1]:
+        if key in node and not isinstance(node[key], dict):
+            raise ValueError(
+                f"Config key {'.'.join(key_path)!r} conflicts with a "
+                f"non-mapping value at {key!r}"
+            )
+        if key not in node:
+            node[key] = CommentedMap()
+        node = node[key]
+    if isinstance(value, list):
+        # emit lists inline ([1, 2, 3]) to match default_config.yaml's style
+        value = CommentedSeq(value)
+        value.fa.set_flow_style()
+    node[key_path[-1]] = value
+
+
+def _prune(doc: CommentedMap, key_path: Sequence[str]) -> None:
+    head, *rest = key_path
+    if head not in doc:
+        return
+    if not rest:
+        del doc[head]
+        return
+    if not isinstance(doc[head], dict):
+        return
+    _prune(doc=doc[head], key_path=rest)
+    if len(doc[head]) == 0:
+        del doc[head]
+
+
+def _atomic_write(config_file: Path, content: str) -> None:
+    fd, tmp = tempfile.mkstemp(
+        dir=config_file.parent, prefix=f"{config_file.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, config_file)
+    except BaseException:
+        os.unlink(tmp)
+        raise
+
+
+def set_override(config_file: Path, key_path: Sequence[str], value: object) -> None:
+    if not key_path:
+        raise ValueError("key_path must not be empty")
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    doc = yaml.load(config_file.read_text()) if config_file.exists() else None
+    if not isinstance(doc, CommentedMap):
+        doc = CommentedMap()
+
+    if value == _default_value(key_path=key_path):
+        _prune(doc=doc, key_path=key_path)
+    else:
+        _assign(doc=doc, key_path=key_path, value=value)
+
+    content = ""
+    if doc:
+        buffer = StringIO()
+        yaml.dump(doc, buffer)
+        content = buffer.getvalue()
+    _atomic_write(config_file=config_file, content=content)

--- a/labelme/_yaml.py
+++ b/labelme/_yaml.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import IO
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+def safe_load(stream: str | IO[str]) -> Any:  # noqa: ANN401
+    # A fresh instance per call, not a shared one: ruamel's load() appends to
+    # YAML().doc_infos and never clears it, so a long-lived instance leaks.
+    return YAML(typ="safe").load(stream)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import QMessageBox
 from labelme import __appname__
 from labelme import __version__
 from labelme import _automation
-from labelme._config import load_config
+from labelme import _config
 from labelme._label_file import LABEL_FILE_SUFFIX
 from labelme._label_file import LabelData
 from labelme._label_file import LabelFileError
@@ -1166,7 +1166,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self, config_file: Path | None, config_overrides: dict | None
     ) -> tuple[Path | None, dict]:
         try:
-            config = load_config(
+            config = _config.load_config(
                 config_file=config_file, config_overrides=config_overrides or {}
             )
         except ValueError as e:
@@ -1187,7 +1187,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             config_file = None
             config_overrides = {}
-            config = load_config(
+            config = _config.load_config(
                 config_file=config_file, config_overrides=config_overrides
             )
         return config_file, config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ dependencies = [
   "pyqt5>=5.14.0",
   "pyqt5-qt5!=5.15.13 ; sys_platform == 'linux'",
   "pyqt5-qt5!=5.15.11,!=5.15.12,!=5.15.13,!=5.15.14,!=5.15.15,!=5.15.16 ; sys_platform == 'win32'",
-  "pyyaml>=6.0",
   "scipy>=1.8",
   "scikit-image>=0.21",
   "tifffile>=2024.1.30",
+  "ruamel-yaml>=0.18",
 ]
 dynamic = ["readme", "version"]
 
@@ -69,7 +69,6 @@ dev = [
   "twine>=6.1.0",
   "ty>=0.0.31",
   "types-pillow>=10.2.0.20240822",
-  "types-pyyaml>=6.0.12.20241230",
   "typos>=1.45.0",
   "yamlfix>=1.19.1",
   "mdformat-gfm>=1.0.0",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Callable
 from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-import yaml
 from PyQt5 import QtGui
 from PyQt5.QtCore import QPoint
 from PyQt5.QtCore import QPointF
@@ -103,7 +103,7 @@ def main_win(
                 if "labels" in config_overrides:
                     argv.extend(["--labels", ",".join(config_overrides["labels"])])
         elif config_overrides:
-            argv.extend(["--config", yaml.dump(config_overrides)])
+            argv.extend(["--config", json.dumps(config_overrides)])
 
         if output_dir is not None:
             argv.extend(["--output", str(output_dir)])

--- a/tests/unit/_config/writer_test.py
+++ b/tests/unit/_config/writer_test.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from labelme import _config
+from labelme import _yaml
+
+
+def _parse(config_file: Path) -> dict | None:
+    return _yaml.safe_load(config_file.read_text())
+
+
+def test_creates_file_when_missing(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
+
+    assert _parse(config_file) == {"auto_save": False}
+
+
+def test_preserves_comment_on_untouched_key(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("# my custom note\nauto_save: false\n")
+
+    _config.set_override(
+        config_file=config_file, key_path=["with_image_data"], value=True
+    )
+
+    content = config_file.read_text()
+    assert "# my custom note" in content
+    assert _parse(config_file) == {"auto_save": False, "with_image_data": True}
+
+
+def test_prunes_key_when_value_equals_default(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("auto_save: false\nwith_image_data: true\n")
+
+    # auto_save default is true, so setting it back to true removes the override
+    _config.set_override(config_file=config_file, key_path=["auto_save"], value=True)
+
+    assert _parse(config_file) == {"with_image_data": True}
+
+
+def test_writes_nested_key(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(
+        config_file=config_file, key_path=["shape", "point_size"], value=12
+    )
+
+    content = config_file.read_text()
+    assert "shape:" in content
+    assert _parse(config_file) == {"shape": {"point_size": 12}}
+
+
+def test_prunes_nested_key_and_empty_parent(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("shape:\n  point_size: 12\n")
+
+    # point_size default is 8; reverting empties shape, which should be pruned too
+    _config.set_override(
+        config_file=config_file, key_path=["shape", "point_size"], value=8
+    )
+
+    assert _parse(config_file) is None
+
+
+def test_keeps_sibling_when_pruning_nested_key(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("shape:\n  point_size: 12\n  line_color: [1, 2, 3, 4]\n")
+
+    _config.set_override(
+        config_file=config_file, key_path=["shape", "point_size"], value=8
+    )
+
+    assert _parse(config_file) == {"shape": {"line_color": [1, 2, 3, 4]}}
+
+
+def test_toggle_then_revert_is_idempotent(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(
+        config_file=config_file, key_path=["shape", "point_size"], value=12
+    )
+    _config.set_override(
+        config_file=config_file, key_path=["shape", "point_size"], value=8
+    )
+
+    assert _parse(config_file) is None
+
+
+def test_writes_list_in_flow_style(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(
+        config_file=config_file,
+        key_path=["default_shape_color"],
+        value=[255, 0, 0],
+    )
+
+    assert "default_shape_color: [255, 0, 0]" in config_file.read_text()
+
+
+def test_label_named_like_a_boolean_survives_round_trip(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(
+        config_file=config_file, key_path=["labels"], value=["yes", "no"]
+    )
+
+    config = _config.load_config(config_file=config_file, config_overrides={})
+    assert config["labels"] == ["yes", "no"]
+
+
+def test_empty_key_path_raises(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    with pytest.raises(ValueError, match="key_path must not be empty"):
+        _config.set_override(config_file=config_file, key_path=[], value=1)
+
+
+def test_unknown_key_raises(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    with pytest.raises(ValueError, match="Unknown config key"):
+        _config.set_override(config_file=config_file, key_path=["nope"], value=1)
+
+
+def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("shape: 42\n")
+
+    with pytest.raises(ValueError, match="non-mapping"):
+        _config.set_override(
+            config_file=config_file, key_path=["shape", "point_size"], value=12
+        )
+
+
+def test_overwrites_when_top_level_is_not_a_mapping(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("- one\n- two\n")
+
+    _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
+
+    assert _parse(config_file) == {"auto_save": False}
+
+
+def test_empties_file_when_last_override_pruned(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("auto_save: false\n")
+
+    # reverting the only override to its default leaves nothing to persist
+    _config.set_override(config_file=config_file, key_path=["auto_save"], value=True)
+
+    assert config_file.read_text() == ""
+
+
+def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
+    _config.set_override(
+        config_file=config_file, key_path=["shape", "point_size"], value=12
+    )
+
+    config = _config.load_config(config_file=config_file, config_overrides={})
+
+    assert config["auto_save"] is False
+    assert config["shape"]["point_size"] == 12
+    # an untouched key keeps its default
+    assert config["with_image_data"] is False
+
+
+def test_write_failure_leaves_no_temp_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("labelme._config._writer.os.replace", _fail)
+
+    with pytest.raises(OSError, match="disk full"):
+        _config.set_override(
+            config_file=config_file, key_path=["auto_save"], value=False
+        )
+
+    assert not config_file.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -3,22 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
 
-from labelme._config import _migrate_config_from_file
-from labelme._config import get_user_config_file
-from labelme._config import load_config
+from labelme import _config
 
 
-def test_get_user_config_file_creates_sparse(
+def test_get_user_config_file_creates_empty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    config_file = get_user_config_file()
-    content = Path(config_file).read_text()
-    assert content.startswith("# Labelme config file")
-    parsed = yaml.safe_load(content)
-    assert parsed is None
+    config_file = _config.get_user_config_file()
+    assert Path(config_file).read_text() == ""
 
 
 def test_get_user_config_file_does_not_overwrite(
@@ -27,7 +21,7 @@ def test_get_user_config_file_does_not_overwrite(
     monkeypatch.setenv("HOME", str(tmp_path))
     config_path = tmp_path / ".labelmerc"
     config_path.write_text("auto_save: true\n")
-    config_file = get_user_config_file()
+    config_file = _config.get_user_config_file()
     content = Path(config_file).read_text()
     assert content == "auto_save: true\n"
 
@@ -36,7 +30,7 @@ def test_get_user_config_file_skip_creation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    config_file = get_user_config_file(create_if_missing=False)
+    config_file = _config.get_user_config_file(create_if_missing=False)
     assert not Path(config_file).exists()
 
 
@@ -44,7 +38,7 @@ def test_get_user_config_file_skip_creation(
 def test_migrate_store_data_to_with_image_data(tmp_path: Path, old_value: bool) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(f"store_data: {str(old_value).lower()}\n")
-    config = load_config(config_file=config_file, config_overrides={})
+    config = _config.load_config(config_file=config_file, config_overrides={})
     assert config["with_image_data"] is old_value
     assert "store_data" not in config
 
@@ -61,7 +55,7 @@ def test_migrate_store_data_to_with_image_data(tmp_path: Path, old_value: bool) 
 )
 def test_migrate_ai_model_name(input_name: str, expected_name: str) -> None:
     config: dict = {"ai": {"default": input_name}}
-    _migrate_config_from_file(config)
+    _config._migrate_config_from_file(config)
     assert config["ai"]["default"] == expected_name
 
 
@@ -84,19 +78,19 @@ _POLYGON_TO_SHAPE_RENAMES = {
 )
 def test_migrate_polygon_shortcut_to_shape(old_key: str, new_key: str) -> None:
     config = {"shortcuts": {old_key: "Ctrl+X"}}
-    _migrate_config_from_file(config)
+    _config._migrate_config_from_file(config)
     assert old_key not in config["shortcuts"]
     assert config["shortcuts"][new_key] == "Ctrl+X"
 
 
 def test_migrate_polygon_shortcuts_no_shortcuts_key() -> None:
     config = {}
-    _migrate_config_from_file(config)
+    _config._migrate_config_from_file(config)
     assert "shortcuts" not in config
 
 
 def test_migrate_polygon_shortcut_skips_when_new_key_exists() -> None:
     config = {"shortcuts": {"edit_polygon": "Ctrl+X", "edit_shape": "Ctrl+Y"}}
-    _migrate_config_from_file(config)
+    _config._migrate_config_from_file(config)
     assert config["shortcuts"]["edit_shape"] == "Ctrl+Y"
     assert "edit_polygon" in config["shortcuts"]

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ dependencies = [
     { name = "pyqt5" },
     { name = "pyqt5-qt5", version = "5.15.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
     { name = "pyqt5-qt5", version = "5.15.18", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "pyyaml" },
+    { name = "ruamel-yaml" },
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1162,7 +1162,6 @@ dev = [
     { name = "twine" },
     { name = "ty" },
     { name = "types-pillow" },
-    { name = "types-pyyaml" },
     { name = "typos" },
     { name = "yamlfix" },
 ]
@@ -1179,7 +1178,7 @@ requires-dist = [
     { name = "pyqt5", specifier = ">=5.14.0" },
     { name = "pyqt5-qt5", marker = "sys_platform == 'linux'", specifier = "!=5.15.13" },
     { name = "pyqt5-qt5", marker = "sys_platform == 'win32'", specifier = "!=5.15.11,!=5.15.12,!=5.15.13,!=5.15.14,!=5.15.15,!=5.15.16" },
-    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "scikit-image", specifier = ">=0.21" },
     { name = "scipy", specifier = ">=1.8" },
     { name = "tifffile", specifier = ">=2024.1.30" },
@@ -1201,7 +1200,6 @@ dev = [
     { name = "twine", specifier = ">=6.1.0" },
     { name = "ty", specifier = ">=0.0.31" },
     { name = "types-pillow", specifier = ">=10.2.0.20240822" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
     { name = "typos", specifier = ">=1.45.0" },
     { name = "yamlfix", specifier = ">=1.19.1" },
 ]
@@ -2302,70 +2300,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
-    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
 name = "readme-renderer"
 version = "44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3021,15 +2955,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/4a/4495264dddaa600d65d68bcedb64dcccf9d9da61adff51f7d2ffd8e4c9ce/types-Pillow-10.2.0.20240822.tar.gz", hash = "sha256:559fb52a2ef991c326e4a0d20accb3bb63a7ba8d40eb493e0ecb0310ba52f0d3", size = 35389, upload-time = "2024-08-22T02:32:48.15Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/23/e81a5354859831fcf54d488d33b80ba6133ea84f874a9c0ec40a4881e133/types_Pillow-10.2.0.20240822-py3-none-any.whl", hash = "sha256:d9dab025aba07aeb12fd50a6799d4eac52a9603488eca09d7662543983f16c5d", size = 54354, upload-time = "2024-08-22T02:32:46.664Z" },
-]
-
-[[package]]
-name = "types-pyyaml"
-version = "6.0.12.20260408"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part 1 of 3 of the in-app Settings stack (config I/O, then the dialog, then reopen/language). This PR is the foundation that lets the upcoming dialog persist preferences to `~/.labelmerc` without rewriting the file or discarding user comments.

## Summary
- Replace PyYAML with ruamel.yaml and drop the PyYAML dependency. YAML parsing now goes through a small `labelme._yaml.safe_load` wrapper (`YAML(typ="safe")`, a fresh instance per call).
- Add `set_override(config_file, key_path, value)`: a comment-preserving sparse writer that persists one key through a ruamel round-trip, prunes it back out when it equals the default, and writes atomically (tempfile + `os.replace`).
- Create an empty user config file when missing; leave an existing file's comments and structure intact.
- Add a `CONTEXT.md` glossary defining Settings, Config File, Default Config, Override, and Window State.

## Compatibility note
ruamel parses as YAML 1.2 (PyYAML used 1.1), so an existing `~/.labelmerc` that spells a boolean as `auto_save: no` now reads as the string `"no"` rather than `false`. The shipped config and docs have always used `true`/`false`, so this should affect few users; in exchange, labels named `yes`/`no`/`on`/`off` are no longer coerced to booleans.

## Test plan
- [x] tests added: `tests/unit/_config/writer_test.py` (round-trip comment preservation, prune-on-default + empty-parent pruning, atomic write, inline-list style, reload via `load_config`)
- [x] `make lint`
- [x] `uv run pytest tests/` (335 passed)
