### PR TITLE
refactor: name the QSettings store _window_state

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -103,7 +103,11 @@ def _handle_exception(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", "-V", action="store_true", help="show version")
-    parser.add_argument("--reset-config", action="store_true", help="reset qt config")
+    parser.add_argument(
+        "--reset-config",
+        action="store_true",
+        help="reset window geometry and dock layout",
+    )
     parser.add_argument(
         "--logger-level",
         default="debug",
@@ -301,8 +305,8 @@ def main() -> None:
     )
 
     if reset_config:
-        logger.info(f"Resetting Qt config: {win.settings.fileName()}")
-        win.settings.clear()
+        logger.info(f"Resetting window state: {win._window_state.fileName()}")
+        win._window_state.clear()
         sys.exit(0)
 
     with contextlib.redirect_stderr(new_target=_LoggerIO()):

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1002,19 +1002,20 @@ class MainWindow(QtWidgets.QMainWindow):
         self._default_state = self.saveState()
         #
         # XXX: Could be completely declarative.
-        # Restore application settings.
-        self.settings = QtCore.QSettings("labelme", "labelme")
+        # Restore the window geometry and dock layout (separate from the user
+        # Config; this Qt store holds only window state).
+        self._window_state = QtCore.QSettings("labelme", "labelme")
         #
         # Bump this when dock/toolbar layout changes to reset window state
         # for users upgrading from an older version.
         SETTINGS_VERSION: int = 1
-        if self.settings.value("settingsVersion", 0, type=int) != SETTINGS_VERSION:
+        if self._window_state.value("settingsVersion", 0, type=int) != SETTINGS_VERSION:
             self._reset_layout()
-            self.settings.setValue("settingsVersion", SETTINGS_VERSION)
+            self._window_state.setValue("settingsVersion", SETTINGS_VERSION)
         #
-        self.resize(self.settings.value("window/size", QtCore.QSize(900, 500)))
-        self.move(self.settings.value("window/position", QtCore.QPoint(0, 0)))
-        self.restoreState(self.settings.value("window/state", QtCore.QByteArray()))
+        self.resize(self._window_state.value("window/size", QtCore.QSize(900, 500)))
+        self.move(self._window_state.value("window/position", QtCore.QPoint(0, 0)))
+        self.restoreState(self._window_state.value("window/state", QtCore.QByteArray()))
         # Recover window position when the saved screen is no longer connected.
         if not any(
             s.availableGeometry().intersects(self.frameGeometry())
@@ -2147,15 +2148,15 @@ class MainWindow(QtWidgets.QMainWindow):
         self._actions.save_with_image_data.setChecked(enabled)
 
     def _reset_layout(self) -> None:
-        self.settings.remove("window/state")
+        self._window_state.remove("window/state")
         self.restoreState(self._default_state)
 
     def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
         if not self._can_continue():
             a0.ignore()
-        self.settings.setValue("window/size", self.size())
-        self.settings.setValue("window/position", self.pos())
-        self.settings.setValue("window/state", self.saveState())
+        self._window_state.setValue("window/size", self.size())
+        self._window_state.setValue("window/position", self.pos())
+        self._window_state.setValue("window/state", self.saveState())
 
     def dragEnterEvent(self, a0: QtGui.QDragEnterEvent) -> None:
         extensions = [


### PR DESCRIPTION
The Qt QSettings store (`"labelme", "labelme"`) holds only window geometry and
dock layout, not the user config. Renaming the attribute from `settings` to
`_window_state` — and rewording the `--reset-config` help to "reset window
geometry and dock layout" — makes that boundary explicit, ahead of an in-app
Settings dialog that writes the user Config through a separate path.

## Test plan
- [x] `make lint`
- [x] `uv run pytest tests/` (335 passed)
