### PR TITLE
chore: improve labelme maintenance path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,12 +67,19 @@ def assert_labelfile_sanity(filename: str) -> None:
         data = json.load(f)
 
     assert "imagePath" in data
+    assert isinstance(data["imagePath"], str)
+    assert "imageHeight" in data
+    assert isinstance(data["imageHeight"], int)
+    assert "imageWidth" in data
+    assert isinstance(data["imageWidth"], int)
+
     image_data = data.get("imageData", None)
     if image_data is None:
         img_file = label_path.parent / data["imagePath"]
         assert img_file.exists()
         img = imgviz.io.imread(img_file)
     else:
+        assert isinstance(image_data, str)
         img = labelme.utils.img_b64_to_arr(image_data)
 
     height, width = img.shape[:2]
@@ -80,10 +87,15 @@ def assert_labelfile_sanity(filename: str) -> None:
     assert width == data["imageWidth"]
 
     assert "shapes" in data
+    assert isinstance(data["shapes"], list)
     for shape in data["shapes"]:
         assert "label" in shape
+        assert isinstance(shape["label"], str)
         assert "points" in shape
+        assert isinstance(shape["points"], list)
         for x, y in shape["points"]:
+            assert isinstance(x, (int, float))
+            assert isinstance(y, (int, float))
             assert 0 <= x <= width
             assert 0 <= y <= height
 


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/conftest.py, tests/e2e/conftest.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.