### PR TITLE
docs: record the Annotation round-trip architecture decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,7 +90,7 @@ _Avoid_: settings (those are the annotation/behavior values), config, layout con
 
 ## Flagged ambiguities
 
-- **`LabelFile` / `LabelData` in code**: legacy identifiers for what the glossary calls an **Annotation File**. A rename to `AnnotationFile` is under consideration but not decided.
+- **`Annotation` / `LabelFile` in code**: the `Annotation` type names the in-memory **Annotation** (the whole bundle); it supersedes the former `LabelData`. `LabelFile` stays as the legacy identifier for the **Annotation File** (the on-disk form). The previously-mooted `LabelFile` → `AnnotationFile` rename remains deferred.
 - **Concept vs file naming is an intentional split**: the user-facing values are **Settings**, but the file that persists them is the **Config File** (`~/.labelmerc`) and the CLI flag stays `--config`. The menu entry reads "Settings…" while keeping Qt's `PreferencesRole`. Do not "unify" the file/flag/role naming to "settings".
 
 ## Example dialogue

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,7 +90,7 @@ _Avoid_: settings (those are the annotation/behavior values), config, layout con
 
 ## Flagged ambiguities
 
-- **`Annotation` / `LabelFile` in code**: the `Annotation` type names the in-memory **Annotation** (the whole bundle); it supersedes the former `LabelData`. `LabelFile` stays as the legacy identifier for the **Annotation File** (the on-disk form). The previously-mooted `LabelFile` → `AnnotationFile` rename remains deferred.
+- **`Annotation` / `LabelFile` in code**: the `Annotation` type names the in-memory **Annotation** (the whole bundle); it supersedes the former `LabelData`. `LabelFile` stays as the legacy identifier for the **Annotation File** (the on-disk form). The previously-mooted `LabelFile` → `AnnotationFile` rename remains deferred. The Qt-free codec functions (`read_label_file` / `write_label_file`) and their module (`_label_file.py`) keep the `label_file` name for now; renaming them to `read_annotation_file` / `write_annotation_file` (in an `_annotation.py` module) is the matching deferred cleanup, best done together with the `LabelFile` → `AnnotationFile` rename so the module is renamed once.
 - **Concept vs file naming is an intentional split**: the user-facing values are **Settings**, but the file that persists them is the **Config File** (`~/.labelmerc`) and the CLI flag stays `--config`. The menu entry reads "Settings…" while keeping Qt's `PreferencesRole`. Do not "unify" the file/flag/role naming to "settings".
 
 ## Example dialogue

--- a/docs/adr/0002-annotation-round-trip.md
+++ b/docs/adr/0002-annotation-round-trip.md
@@ -1,0 +1,43 @@
+# Annotation owns the round-trip; the disk codec stays Qt-free
+
+A single frozen `Annotation` type (evolved from `LabelData`) owns the in-memory
+load/save round-trip and is used by the app on both boundaries, so the field set
+has one owner instead of being re-encoded across `_load_shape_json_obj`,
+`ShapeDict`, `Shape.__init__`, `_shapes_from_dicts`, and `_shape_to_dict`. The
+on-disk codec (`read_label_file` / `write_label_file` in `_label_file.py`) stays
+free of any PyQt5 import and continues to exchange plain-data `ShapeDict`, so the
+persistence layer remains usable without a GUI.
+
+## Considered options
+
+- **Push the live `Shape` into the codec and delete `ShapeDict`** (rejected):
+  `Shape` carries `QtCore.QPointF` points and render state, so making the codec
+  hold it drags PyQt5 into `_label_file.py`. Four headless example scripts
+  (`examples/instance_segmentation/labelme2voc.py`, `labelme2coco.py`,
+  `examples/tutorial/export_json.py`, `draw_json.py`) and the Qt-free
+  `tests/unit/_label_file_test.py` round-trip depend on that module staying
+  GUI-free. `ShapeDict` is retained on purpose as the Qt-free wire format between
+  the codec and `Annotation`.
+- **Make the owner the mutable `LabelFile` lineage** (rejected): `LabelFile` is
+  public (`labelme.LabelFile`), carries deprecated camelCase properties, and has
+  an incoherent `save()` that ignores its own state. Reusing it would entangle
+  this change with a public-API deprecation cycle. A frozen snapshot also fits
+  the model where the Qt widgets remain the source of truth during editing.
+  `LabelFile` is left untouched as a deprecated shim.
+- **Make `Annotation` the live aggregate root** (deferred, not rejected): having
+  `label_list`, `flag_list`, and the canvas read and mutate through `Annotation`
+  would remove the existing `canvas.shapes` / `label_list` sync, but it needs a
+  Qt model/view migration and reroutes roughly seven mutation entry points. The
+  round-trip type defined here is the prerequisite for that move.
+
+## Consequences
+
+- Three shape representations coexist by design: the JSON object, the plain-data
+  `ShapeDict`, and the live `Shape`. This is intentional layering, not
+  duplication, because the field set now has a single owner.
+- The `Shape` \<-> `ShapeDict` converters stay at the app boundary for now. A
+  later step may move them onto `Annotation` as private implementation, but never
+  into the Qt-free codec.
+- A future architecture review should not re-suggest collapsing `ShapeDict` or
+  pushing `Shape` into `_label_file.py`; doing so breaks the headless consumers
+  above.


### PR DESCRIPTION
> **Stack** (merge bottom-up):
> 1. **#2129** — ADR + glossary (this PR)
> 2. #2130 — code implementation, stacked on this branch

---

Records an architecture decision reached in a design session for the "give the
Annotation one owning module" review candidate. Docs only, no code changes; the
implementation is a separate follow-up.

ADR-0002 decides that a single frozen `Annotation` type (evolved from
`LabelData`) owns the in-memory load/save round-trip, while the on-disk codec in
`_label_file.py` stays free of any PyQt5 import and keeps exchanging plain-data
`ShapeDict`. That keeps the headless example scripts (`labelme2voc.py`,
`labelme2coco.py`, `export_json.py`, `draw_json.py`) and the Qt-free
`_label_file_test.py` working, and it records why a future review should not
collapse `ShapeDict` or push `Shape` into the persistence layer.

The `CONTEXT.md` change resolves the matching glossary ambiguity: `Annotation`
names the in-memory whole (superseding `LabelData`); `LabelFile` stays as the
legacy Annotation File identifier.

## Test plan
- [x] ADR and glossary render correctly on GitHub

