### PR TITLE
refactor: give Annotation ownership of the JSON round-trip

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -125,6 +125,22 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
     return loaded
 
 
+def _dump_shape_to_json_obj(shape: ShapeDict) -> dict[str, Any]:
+    json_obj: dict[str, Any] = dict(shape["other_data"])
+    json_obj.update(
+        label=shape["label"],
+        points=[list(point) for point in shape["points"]],
+        group_id=shape["group_id"],
+        description=shape["description"],
+        shape_type=shape["shape_type"],
+        flags=shape["flags"],
+        mask=None
+        if shape["mask"] is None
+        else utils.img_arr_to_b64(shape["mask"].astype(np.uint8)),
+    )
+    return json_obj
+
+
 class LabelFileError(Exception):
     """Base for read/write failures of labelme JSON annotation files."""
 
@@ -138,7 +154,7 @@ class LabelFileWriteError(LabelFileError):
 
 
 @dataclass(frozen=True)
-class LabelData:
+class Annotation:
     image_path: str
     image_data: bytes
     shapes: list[ShapeDict]
@@ -204,7 +220,7 @@ def _check_image_dimensions(
         )
 
 
-def read_label_file(filename: str) -> LabelData:
+def read_label_file(filename: str) -> Annotation:
     try:
         with open(filename, encoding="utf-8") as f:
             raw: dict[str, Any] = json.load(f)
@@ -234,7 +250,7 @@ def read_label_file(filename: str) -> LabelData:
     ) as e:
         raise LabelFileReadError(f"failed to load {filename!r}: {e}") from e
     other_data = {k: v for k, v in raw.items() if k not in _RESERVED_TOP_LEVEL_KEYS}
-    return LabelData(
+    return Annotation(
         image_path=image_path,
         image_data=image_data,
         shapes=shapes,
@@ -244,6 +260,26 @@ def read_label_file(filename: str) -> LabelData:
 
 
 def write_label_file(
+    filename: str,
+    annotation: Annotation,
+    *,
+    image_height: int | None,
+    image_width: int | None,
+    save_image_data: bool,
+) -> None:
+    _write_label_json_file(
+        filename=filename,
+        shapes=[_dump_shape_to_json_obj(shape) for shape in annotation.shapes],
+        image_path=annotation.image_path,
+        image_height=image_height,
+        image_width=image_width,
+        image_data=annotation.image_data if save_image_data else None,
+        other_data=annotation.other_data,
+        flags=annotation.flags,
+    )
+
+
+def _write_label_json_file(
     filename: str,
     *,
     shapes: list[dict[str, Any]],
@@ -362,7 +398,7 @@ class LabelFile:
         return read_image_file(filename=filename)
 
     def load(self, filename: str) -> None:
-        loaded: LabelData = read_label_file(filename=filename)
+        loaded: Annotation = read_label_file(filename=filename)
         self.flags = loaded.flags
         self.shapes = loaded.shapes
         self.image_path = loaded.image_path
@@ -381,7 +417,7 @@ class LabelFile:
         other_data: dict[str, Any] | None = None,
         flags: dict[str, bool] | None = None,
     ) -> None:
-        write_label_file(
+        _write_label_json_file(
             filename=filename,
             shapes=shapes,
             image_path=image_path,

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -12,7 +12,6 @@ import time
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 from typing import Final
 from typing import Literal
 from typing import NamedTuple
@@ -37,7 +36,7 @@ from labelme import __version__
 from labelme import _automation
 from labelme import _config
 from labelme._label_file import LABEL_FILE_SUFFIX
-from labelme._label_file import LabelData
+from labelme._label_file import Annotation
 from labelme._label_file import LabelFileError
 from labelme._label_file import ShapeDict
 from labelme._label_file import is_label_file_path
@@ -196,11 +195,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     _output_dir: Path | None
     _image: QtGui.QImage
-    _image_data: bytes | None
+    _annotation: Annotation | None
     _label_file_path: str | None
     _image_path: str | None
     _prev_image_path: str | None
-    _other_data: dict | None
     _zoom_values: dict[str, tuple[_ZoomMode, int]]
     _brightness_contrast_values: dict[str, tuple[int | None, int | None]]
     _scroll_values: dict[Qt.Orientation, dict[str, float]]
@@ -987,10 +985,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self._output_dir = Path(output_dir) if output_dir else None
 
         self._image = QtGui.QImage()
+        self._annotation = None
         self._label_file_path = None
         self._image_path = None
         self._prev_image_path = None
-        self._other_data = None
         self._zoom_values = {}
         self._brightness_contrast_values = {}
         self._scroll_values = {
@@ -1364,10 +1362,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def reset_state(self) -> None:
         self._docks.label_list.clear()
+        self._annotation = None
         self._image_path = None
-        self._image_data = None
         self._label_file_path = None
-        self._other_data = None
         self._canvas_widgets.canvas.reset_state()
 
     # Callbacks
@@ -1695,19 +1692,22 @@ class MainWindow(QtWidgets.QMainWindow):
             flags[item.text()] = item.checkState() == Qt.Checked
         try:
             assert self._image_path
+            assert self._annotation is not None
             label_dir = Path(label_path).parent
-            image_path = os.path.relpath(self._image_path, label_dir)
-            image_data = self._image_data if self._config["with_image_data"] else None
             label_dir.mkdir(parents=True, exist_ok=True)
+            annotation = Annotation(
+                image_path=os.path.relpath(self._image_path, label_dir),
+                image_data=self._annotation.image_data,
+                shapes=shapes,
+                flags=flags,
+                other_data=self._annotation.other_data,
+            )
             write_label_file(
                 filename=label_path,
-                shapes=shapes,
-                image_path=image_path,
-                image_data=image_data,
+                annotation=annotation,
                 image_height=self._image.height(),
                 image_width=self._image.width(),
-                other_data=self._other_data,
-                flags=flags,
+                save_image_data=self._config["with_image_data"],
             )
             self._label_file_path = label_path
             items = self._docks.file_list.findItems(self._image_path, Qt.MatchExactly)
@@ -1939,9 +1939,9 @@ class MainWindow(QtWidgets.QMainWindow):
             brightness,
             contrast,
         )
-        assert self._image_data is not None
+        assert self._annotation is not None
         dialog = BrightnessContrastDialog(
-            utils.img_data_to_pil(self._image_data),
+            utils.img_data_to_pil(self._annotation.image_data),
             self._on_brightness_contrast_changed,
             parent=self,
         )
@@ -1971,17 +1971,16 @@ class MainWindow(QtWidgets.QMainWindow):
             target = item.checkState() == Qt.Unchecked if value is None else value
             item.setCheckState(Qt.Checked if target else Qt.Unchecked)
 
-    def _open_label_file_into_state(self, label_path: str) -> LabelData | None:
+    def _open_label_file_into_state(self, label_path: str) -> Annotation | None:
         try:
-            label_data = read_label_file(filename=label_path)
+            annotation = read_label_file(filename=label_path)
         except LabelFileError as e:
             self._show_file_open_error(path=label_path, file_kind="label", exc=e)
             return None
         self._label_file_path = label_path
-        self._image_data = label_data.image_data
-        self._image_path = str(Path(label_path).parent / label_data.image_path)
-        self._other_data = label_data.other_data
-        return label_data
+        self._annotation = annotation
+        self._image_path = str(Path(label_path).parent / annotation.image_path)
+        return annotation
 
     def _open_image_into_state(self, image_path: str) -> bool:
         try:
@@ -1989,7 +1988,13 @@ class MainWindow(QtWidgets.QMainWindow):
         except OSError as e:
             self._show_file_open_error(path=image_path, file_kind="image", exc=e)
             return False
-        self._image_data = image_data
+        self._annotation = Annotation(
+            image_path=os.path.basename(image_path),
+            image_data=image_data,
+            shapes=[],
+            flags={},
+            other_data={},
+        )
         self._image_path = image_path
         self._label_file_path = None
         return True
@@ -2032,17 +2037,17 @@ class MainWindow(QtWidgets.QMainWindow):
             image_or_label_path=image_or_label_path,
             output_dir=self._output_dir,
         )
-        label_data: LabelData | None = None
+        annotation: Annotation | None = None
         if QtCore.QFile.exists(label_path):
-            label_data = self._open_label_file_into_state(label_path=label_path)
-            if label_data is None:
+            annotation = self._open_label_file_into_state(label_path=label_path)
+            if annotation is None:
                 return
         else:
             if not self._open_image_into_state(image_path=image_or_label_path):
                 return
-        assert self._image_data is not None
+        assert self._annotation is not None
         t0 = time.time()
-        image = QtGui.QImage.fromData(self._image_data)
+        image = QtGui.QImage.fromData(self._annotation.image_data)
         logger.debug("Created QImage in {:.0f}ms", (time.time() - t0) * 1000)
 
         if image.isNull():
@@ -2062,14 +2067,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
         logger.debug("Loaded pixmap in {:.0f}ms", (time.time() - t0) * 1000)
         flags = {k: False for k in self._config["flags"] or []}
-        if label_data is not None:
+        if annotation is not None:
             self._load_shapes(
                 shapes=_shapes_from_dicts(
-                    shape_dicts=label_data.shapes,
+                    shape_dicts=annotation.shapes,
                     label_flags=self._config["label_flags"],
                 )
             )
-            flags.update(label_data.flags)
+            flags.update(annotation.flags)
         self._load_flags(flags=flags, widget=self._docks.flag_list)
         if prev_shapes and self.has_no_shapes():
             self._load_shapes(shapes=prev_shapes, replace=False)
@@ -2787,20 +2792,18 @@ def _make_image_list_item(
     return item
 
 
-def _shape_to_dict(shape: Shape) -> dict[str, Any]:
-    data = shape.other_data.copy()
-    data.update(
+def _shape_to_dict(shape: Shape) -> ShapeDict:
+    assert shape.label is not None
+    return ShapeDict(
         label=shape.label,
-        points=[(p.x(), p.y()) for p in shape.points],
-        group_id=shape.group_id,
-        description=shape.description,
+        points=[[p.x(), p.y()] for p in shape.points],
         shape_type=shape.shape_type,
-        flags=shape.flags,
-        mask=None
-        if shape.mask is None
-        else utils.img_arr_to_b64(shape.mask.astype(np.uint8)),
+        flags=shape.flags or {},
+        description=shape.description or "",
+        group_id=shape.group_id,
+        mask=shape.mask,
+        other_data=shape.other_data,
     )
-    return data
 
 
 def _scan_image_files(root_dir: str) -> list[str]:

--- a/tests/e2e/brightness_contrast_test.py
+++ b/tests/e2e/brightness_contrast_test.py
@@ -19,9 +19,9 @@ def test_brightness_contrast_dialog(
     canvas = annotated_win._canvas_widgets.canvas
     original_pixmap = canvas.pixmap.copy()
 
-    assert annotated_win._image_data is not None
+    assert annotated_win._annotation is not None
     dialog = BrightnessContrastDialog(
-        img=labelme.utils.img_data_to_pil(annotated_win._image_data),
+        img=labelme.utils.img_data_to_pil(annotated_win._annotation.image_data),
         callback=annotated_win._on_brightness_contrast_changed,
         parent=annotated_win,
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -274,8 +274,7 @@ def show_window_and_wait_for_imagedata(qtbot: QtBot, win: MainWindow) -> None:
     win.show()
 
     def check_image_data() -> None:
-        assert hasattr(win, "_image_data")
-        assert win._image_data is not None
+        assert win._annotation is not None
 
     qtbot.waitUntil(check_image_data)
 

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -20,14 +20,14 @@ def test_close_file(
     qtbot: QtBot,
     pause: bool,
 ) -> None:
-    assert annotated_win._image_data is not None
+    assert annotated_win._annotation is not None
     assert annotated_win._canvas_widgets.canvas.isEnabled()
 
     annotated_win.close_file()
     qtbot.wait(50)
 
     assert not annotated_win._canvas_widgets.canvas.isEnabled()
-    assert annotated_win._image_data is None
+    assert annotated_win._annotation is None
     assert annotated_win.windowTitle() == "Labelme"
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)

--- a/tests/e2e/save_format_contract_test.py
+++ b/tests/e2e/save_format_contract_test.py
@@ -214,7 +214,7 @@ def test_open_json_with_missing_image_shows_error_and_recovers(
     raw_win._load_file(str(missing_image_json))
 
     raw_win._load_file(str(data_path / _RAW_FILE_NAME))
-    qtbot.waitUntil(lambda: raw_win._image_data is not None, timeout=5_000)
+    qtbot.waitUntil(lambda: raw_win._annotation is not None, timeout=5_000)
 
     close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
 

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -6,11 +6,14 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 
+from labelme._label_file import Annotation
 from labelme._label_file import LabelFile
 from labelme._label_file import LabelFileReadError
 from labelme._label_file import LabelFileWriteError
+from labelme._label_file import ShapeDict
 from labelme._label_file import read_label_file
 from labelme._label_file import write_label_file
 
@@ -143,16 +146,19 @@ def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:
     src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
     dst = tmp_path / "out.json"
 
-    shapes: list[dict[str, Any]] = [{**s} for s in src.shapes]
+    annotation = Annotation(
+        image_path=src.image_path,
+        image_data=src.image_data,
+        shapes=src.shapes,
+        flags={"ok": True},
+        other_data={"customField": 42},
+    )
     write_label_file(
         filename=str(dst),
-        shapes=shapes,
-        image_path=src.image_path,
+        annotation=annotation,
         image_height=None,
         image_width=None,
-        image_data=src.image_data,
-        other_data={"customField": 42},
-        flags={"ok": True},
+        save_image_data=True,
     )
 
     reloaded = read_label_file(filename=str(dst))
@@ -162,6 +168,48 @@ def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:
     assert [(s["label"], s["points"], s["shape_type"]) for s in reloaded.shapes] == [
         (s["label"], s["points"], s["shape_type"]) for s in src.shapes
     ]
+
+
+def test_write_label_file_round_trips_mask_shape(
+    data_path: Path, annotated_dst: Path
+) -> None:
+    src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
+    mask = np.zeros((4, 5), dtype=bool)
+    mask[1:3, 2:4] = True
+    shape = ShapeDict(
+        label="thing",
+        points=[[2.0, 1.0], [3.0, 2.0]],
+        shape_type="mask",
+        flags={"verified": True},
+        description="d",
+        group_id=7,
+        mask=mask,
+        other_data={"score": 0.5},
+    )
+    annotation = Annotation(
+        image_path=src.image_path,
+        image_data=src.image_data,
+        shapes=[shape],
+        flags={},
+        other_data={},
+    )
+    write_label_file(
+        filename=str(annotated_dst),
+        annotation=annotation,
+        image_height=None,
+        image_width=None,
+        save_image_data=True,
+    )
+
+    [reloaded_shape] = read_label_file(filename=str(annotated_dst)).shapes
+    assert reloaded_shape["label"] == "thing"
+    assert reloaded_shape["shape_type"] == "mask"
+    assert reloaded_shape["group_id"] == 7
+    assert reloaded_shape["description"] == "d"
+    assert reloaded_shape["flags"] == {"verified": True}
+    assert reloaded_shape["other_data"] == {"score": 0.5}
+    assert reloaded_shape["mask"] is not None
+    assert np.array_equal(reloaded_shape["mask"], mask)
 
 
 @pytest.mark.parametrize(
@@ -179,14 +227,20 @@ def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:
 def test_write_label_file_rejects_reserved_other_data_key(
     tmp_path: Path, reserved_key: str
 ) -> None:
+    annotation = Annotation(
+        image_path="foo.jpg",
+        image_data=b"",
+        shapes=[],
+        flags={},
+        other_data={reserved_key: "x"},
+    )
     with pytest.raises(LabelFileWriteError, match=f"reserved key.*{reserved_key}"):
         write_label_file(
             filename=str(tmp_path / "out.json"),
-            shapes=[],
-            image_path="foo.jpg",
+            annotation=annotation,
             image_height=None,
             image_width=None,
-            other_data={reserved_key: "x"},
+            save_image_data=False,
         )
 
 
@@ -194,26 +248,39 @@ def test_write_label_file_raises_on_dimension_mismatch(
     data_path: Path, tmp_path: Path
 ) -> None:
     src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
+    annotation = Annotation(
+        image_path="foo.jpg",
+        image_data=src.image_data,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
 
     with pytest.raises(LabelFileWriteError, match="imageHeight mismatch"):
         write_label_file(
             filename=str(tmp_path / "out.json"),
-            shapes=[],
-            image_path="foo.jpg",
+            annotation=annotation,
             image_height=1,
             image_width=None,
-            image_data=src.image_data,
+            save_image_data=True,
         )
 
 
 def test_write_label_file_raises_write_error_on_io_failure(tmp_path: Path) -> None:
     bad_path = tmp_path / "missing_dir" / "out.json"
+    annotation = Annotation(
+        image_path="foo.jpg",
+        image_data=b"",
+        shapes=[],
+        flags={},
+        other_data={},
+    )
 
     with pytest.raises(LabelFileWriteError, match="failed to write"):
         write_label_file(
             filename=str(bad_path),
-            shapes=[],
-            image_path="foo.jpg",
+            annotation=annotation,
             image_height=None,
             image_width=None,
+            save_image_data=False,
         )


### PR DESCRIPTION
> **Stack** (merge bottom-up):
> 1. #2129 — ADR + glossary (merge first)
> 2. **#2130** — code implementation (this PR)
>
> Based on the `docs/annotation-round-trip-adr` branch, so the diff below is only the code delta.

---

## Summary
- Renames the frozen `LabelData` snapshot to `Annotation` and makes it the single owner of the in-memory load/save round-trip, used by the app on both boundaries.
- The app now holds one `self._annotation` (replacing the separate `_image_data` / `_other_data`) and assembles a fresh `Annotation` at save time instead of passing loose arguments to the writer.
- The Qt-free codec now owns `ShapeDict` <-> JSON in **both** directions: adds `_dump_shape_to_json_obj` (inverse of `_load_shape_json_obj`), and `write_label_file` now takes an `Annotation`.
- `_label_file.py` keeps **zero** PyQt5 imports, so the headless example scripts and the Qt-free unit tests keep working.

## Why
This is **A2** of the architecture review's round-trip candidate, designed in ADR-0002 (docs in #2129). It gives the annotation field set a single owner instead of re-encoding it across `_load_shape_json_obj`, `ShapeDict`, `Shape.__init__`, `_shapes_from_dicts`, and `_shape_to_dict`. Per the ADR, `ShapeDict` is retained on purpose as the Qt-free wire format, `Shape` is kept out of the codec, and the deprecated `LabelFile` public API is untouched (its old loose-arg writer is preserved verbatim as `_write_label_json_file`, which `LabelFile.save` still calls).

Scope is the round-trip snapshot only; moving the `Shape` <-> `ShapeDict` converters onto the type (A1) and making `Annotation` a live aggregate root (B) remain deferred.

## Behavior preservation
This is a behavior-preserving refactor. The on-disk JSON is **byte-identical** to `main`, key order included (verified by diffing the new save path against the old `_shape_to_dict` logic).

## Test plan
- [x] Added a mask-shape `Annotation` round-trip test (mask codec, `other_data`, `flags`, `group_id`, `description`): `tests/unit/_label_file_test.py`
- [x] Updated codec tests to the new `write_label_file(annotation, ...)` signature
- [x] `tests/e2e/save_format_contract_test.py` (load -> save -> reload through the real app) passes unchanged in behavior
- [x] Full suite green: 216 unit + 140 e2e
- [x] `make lint` (ruff, ruff-format, ty all-errors, taplo, mdformat, yamlfix, typos)
- [x] Headless smoke test: `Annotation` round-trip with no `QApplication`; `labelme.LabelFile` shim still loads

