### PR TITLE
ci: adopt canonical "type:" labels in repo automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 description: Create a bug report
-labels: bug
+labels: 'type: bug'
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -8,7 +8,8 @@ jobs:
   notify:
     if: |
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'feature')
+      (startsWith(github.event.pull_request.title, 'feat: ') ||
+       startsWith(github.event.pull_request.title, 'feat('))
     runs-on: ubuntu-latest
     steps:
       - name: Send to Discord


### PR DESCRIPTION
Adopts the new canonical `type:` label vocabulary in the two places `.github`
automation still referenced labels:

- **Bug report template** now applies `type: bug` (previously `bug`, which was
  not even a defined label in the repo, so new reports landed unlabeled).
- **discord-notify** now fires on the conventional-commit PR title (`feat: ` or
  `feat(scope): `) instead of the `feature` label. Nothing auto-applies
  `feature`, so the label trigger rarely fired; keying off the title makes the
  notification reliable and drops the workflow's last dependency on that legacy
  label (so it can later be retired).

## Test plan
- [ ] A new bug report created from the template lands with `type: bug`
- [ ] Merging a `feat: ` / `feat(scope): ` PR to `main` posts the Discord notification
