### PR TITLE
feat: show enabled shape flags in annotation list

### DIFF
--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -22,10 +22,12 @@ def format_label_with_color_dot(text: str, color: tuple[int, int, int]) -> str:
 
 def format_shape_label(shape: Shape) -> str:
     assert shape.label is not None
-    if shape.group_id is None:
-        text = shape.label
-    else:
-        text = f"{shape.label} ({shape.group_id})"
+    text = shape.label
+    if shape.group_id is not None:
+        text += f" ({shape.group_id})"
+    enabled_flags = [key for key, value in (shape.flags or {}).items() if value]
+    if enabled_flags:
+        text += f" [{', '.join(enabled_flags)}]"
     return format_label_with_color_dot(text=text, color=shape.fill_color.getRgb()[:3])
 
 

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -98,6 +98,48 @@ def test_label_flags_applied_to_shape(
 
 
 @pytest.mark.gui
+def test_enabled_flags_shown_in_label_list(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / _RAW_FILE),
+        config_overrides={"label_flags": _LABEL_FLAGS},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    label_dialog = win._label_dialog
+    label_list = win._docks.label_list
+    num_shapes_before = len(canvas.shapes)
+
+    _draw_triangle(qtbot=qtbot, win=win)
+
+    schedule_on_dialog(
+        label_dialog=label_dialog,
+        action=partial(
+            _enter_label,
+            qtbot=qtbot,
+            label_dialog=label_dialog,
+            name="cat",
+            flags=["b"],
+        ),
+    )
+    click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
+
+    qtbot.waitUntil(lambda: len(canvas.shapes) == num_shapes_before + 1, timeout=3000)
+
+    item = next(
+        it for it in label_list if (s := it.shape()) is not None and s.label == "cat"
+    )
+    assert "[b]" in item.text()
+    assert "[a" not in item.text()
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
 def test_flags_survive_save_reload_roundtrip(
     main_win: MainWinFactory,
     qtbot: QtBot,

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -34,6 +34,20 @@ def _check_flag(label_dialog: LabelDialog, name: str) -> None:
     raise AssertionError(f"Flag checkbox {name!r} not found")
 
 
+def _enter_label(
+    qtbot: QtBot,
+    label_dialog: LabelDialog,
+    name: str,
+    flags: list[str],
+) -> None:
+    label_dialog.edit.clear()
+    qtbot.keyClicks(label_dialog.edit, name)
+    qtbot.wait(100)
+    for flag in flags:
+        _check_flag(label_dialog=label_dialog, name=flag)
+    qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+
+
 @pytest.mark.gui
 @pytest.mark.parametrize(
     ("flag_to_toggle", "expected_flags"),
@@ -61,15 +75,17 @@ def test_label_flags_applied_to_shape(
 
     _draw_triangle(qtbot=qtbot, win=win)
 
-    def _enter_cat() -> None:
-        label_dialog.edit.clear()
-        qtbot.keyClicks(label_dialog.edit, "cat")
-        qtbot.wait(100)
-        if flag_to_toggle is not None:
-            _check_flag(label_dialog=label_dialog, name=flag_to_toggle)
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
-
-    schedule_on_dialog(label_dialog=label_dialog, action=_enter_cat)
+    flags = [] if flag_to_toggle is None else [flag_to_toggle]
+    schedule_on_dialog(
+        label_dialog=label_dialog,
+        action=partial(
+            _enter_label,
+            qtbot=qtbot,
+            label_dialog=label_dialog,
+            name="cat",
+            flags=flags,
+        ),
+    )
     click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
 
     qtbot.waitUntil(lambda: len(canvas.shapes) == num_shapes_before + 1, timeout=3000)
@@ -101,14 +117,16 @@ def test_flags_survive_save_reload_roundtrip(
 
     _draw_triangle(qtbot=qtbot, win=win)
 
-    def _enter_cat_a_true() -> None:
-        label_dialog.edit.clear()
-        qtbot.keyClicks(label_dialog.edit, "cat")
-        qtbot.wait(100)
-        _check_flag(label_dialog=label_dialog, name="a")
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
-
-    schedule_on_dialog(label_dialog=label_dialog, action=_enter_cat_a_true)
+    schedule_on_dialog(
+        label_dialog=label_dialog,
+        action=partial(
+            _enter_label,
+            qtbot=qtbot,
+            label_dialog=label_dialog,
+            name="cat",
+            flags=["a"],
+        ),
+    )
     click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
 
     qtbot.waitUntil(lambda: len(canvas.shapes) == num_shapes_before + 1, timeout=3000)


### PR DESCRIPTION
Shape flags were invisible in the annotation list: the only way to tell whether a
shape carried a flag like `occluded` or `truncated` was to open the label dialog
for each shape one at a time. This shows the enabled flags inline next to the
label, the same way `group_id` already appears, so the whole list can be scanned
at a glance.

Enabled flags are appended in square brackets after the `group_id`, in their
stored order; flags set to false are omitted:

```
car
car (5)
car [occluded]
car (5) [occluded, truncated]
```

## Test plan
- [x] e2e test added: `tests/e2e/label_dialog_flags_test.py::test_enabled_flags_shown_in_label_list`
- [x] `uv run python -m pytest tests/e2e/label_dialog_flags_test.py` — 4 passed
- [x] `uv run ruff check` / `ruff format --check` clean
