### PR TITLE
fix(canvas): repaint after adding/removing polygon points

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -752,6 +752,7 @@ class Canvas(QtWidgets.QWidget):
         self._hovered_vertex = index
         self._hovered_edge = None
         self._is_moving_shape = True
+        self.update()
 
     def remove_selected_point(self) -> None:
         shape = self._last_hovered_shape
@@ -763,6 +764,7 @@ class Canvas(QtWidgets.QWidget):
         self.hovered_shape = shape
         self._last_hovered_vertex = None
         self._is_moving_shape = True  # Save changes
+        self.update()
 
     def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
         pos: QPointF = self._transform_point_widget_to_image(a0.localPos())

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -90,6 +90,21 @@ def _click_to_remove_point(
     qtbot.wait(50)
 
 
+def _spy_on_update(
+    monkeypatch: pytest.MonkeyPatch,
+    canvas: Canvas,
+) -> list[int]:
+    counter = [0]
+    original = canvas.update
+
+    def _counting_update(*args: object, **kwargs: object) -> None:
+        counter[0] += 1
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(canvas, "update", _counting_update)
+    return counter
+
+
 def _save_and_check(
     win: MainWindow,
     tmp_path: Path,
@@ -301,6 +316,63 @@ def test_remove_point_from_shape(
     assert len(shape.points) == original_num_points - 1
 
     _save_and_check(win=annotated_win, tmp_path=tmp_path)
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_add_point_to_edge_repaints_canvas(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    # Regression test for https://github.com/wkentaro/labelme/issues/890:
+    # adding a point must repaint the canvas immediately (e.g. when invoked via
+    # its shortcut), instead of waiting for the next mouse-move event.
+    canvas = annotated_win._canvas_widgets.canvas
+    shape = canvas.shapes[_SHAPE_INDEX]
+    num_points_before = len(shape.points)
+
+    p0, p1 = shape.points[0], shape.points[1]
+    qtbot.mouseMove(
+        canvas, pos=image_to_widget_pos(canvas=canvas, image_pos=(p0 + p1) / 2)
+    )
+    qtbot.wait(100)
+
+    update_calls = _spy_on_update(monkeypatch=monkeypatch, canvas=canvas)
+    canvas.add_point_to_edge()
+
+    assert len(shape.points) == num_points_before + 1
+    assert update_calls[0] > 0
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_remove_selected_point_repaints_canvas(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    # Regression test for https://github.com/wkentaro/labelme/issues/890:
+    # removing a point must repaint the canvas immediately (e.g. when invoked
+    # via its shortcut), instead of waiting for the next mouse-move event.
+    canvas = annotated_win._canvas_widgets.canvas
+    shape = canvas.shapes[_SHAPE_INDEX]
+    num_points_before = len(shape.points)
+
+    qtbot.mouseMove(
+        canvas, pos=image_to_widget_pos(canvas=canvas, image_pos=shape.points[0])
+    )
+    qtbot.wait(100)
+
+    update_calls = _spy_on_update(monkeypatch=monkeypatch, canvas=canvas)
+    canvas.remove_selected_point()
+
+    assert len(shape.points) == num_points_before - 1
+    assert update_calls[0] > 0
+
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
 
 


### PR DESCRIPTION
## Summary

`Canvas.add_point_to_edge` and `Canvas.remove_selected_point` mutated the shape (inserting/removing a vertex) but never called `self.update()`. When these are invoked via their keyboard shortcuts, the canvas did not repaint until the next mouse-move event, so the polygon appeared stale.

This adds `self.update()` at the end of both methods, matching the repaint idiom used throughout the canvas. The fix mirrors the resolution suggested in the issue (the methods have since been renamed to snake_case during the canvas refactor).

## Changes

- `labelme/widgets/canvas.py`: call `self.update()` at the end of `add_point_to_edge` and `remove_selected_point`.
- `tests/e2e/canvas_interaction_test.py`: add two regression tests spying on `canvas.update` to assert an immediate repaint after each operation. Both tests fail on the unpatched code and pass with the fix.

## Testing

- `make lint` — clean
- `make test` — 357 passed, 1 skipped

Fixes #890

https://claude.ai/code/session_01SSF8nwKeVc5ypScmknmRNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSF8nwKeVc5ypScmknmRNj)_