### PR TITLE
fix(config): pin UTF-8 encoding on config file read/write

### DIFF
--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -111,11 +111,11 @@ def get_user_config_file(create_if_missing: bool = True) -> str:
 
 def load_config(config_file: Path | None, config_overrides: dict) -> dict:
     config: dict
-    with open(here / "default_config.yaml") as f:
+    with open(here / "default_config.yaml", encoding="utf-8") as f:
         config = _yaml.safe_load(f)
 
     if config_file is not None:
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             config_from_yaml = _yaml.safe_load(f)
         if isinstance(config_from_yaml, dict):
             _migrate_config_from_file(config_from_yaml=config_from_yaml)

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -15,7 +15,9 @@ from labelme import _yaml
 
 here = Path(__file__).resolve().parent
 
-_DEFAULT_CONFIG: Final = _yaml.safe_load((here / "default_config.yaml").read_text())
+_DEFAULT_CONFIG: Final = _yaml.safe_load(
+    (here / "default_config.yaml").read_text(encoding="utf-8")
+)
 
 
 def _default_value(key_path: Sequence[str]) -> object:
@@ -64,7 +66,7 @@ def _atomic_write(config_file: Path, content: str) -> None:
         dir=config_file.parent, prefix=f"{config_file.name}.", suffix=".tmp"
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
         os.replace(tmp, config_file)
     except BaseException:
@@ -79,7 +81,11 @@ def set_override(config_file: Path, key_path: Sequence[str], value: object) -> N
     yaml = YAML()
     yaml.preserve_quotes = True
     yaml.indent(mapping=2, sequence=4, offset=2)
-    doc = yaml.load(config_file.read_text()) if config_file.exists() else None
+    doc = (
+        yaml.load(config_file.read_text(encoding="utf-8"))
+        if config_file.exists()
+        else None
+    )
     if not isinstance(doc, CommentedMap):
         doc = CommentedMap()
 

--- a/tests/unit/_config/_writer_test.py
+++ b/tests/unit/_config/_writer_test.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -9,7 +13,7 @@ from labelme import _yaml
 
 
 def _parse(config_file: Path) -> dict | None:
-    return _yaml.safe_load(config_file.read_text())
+    return _yaml.safe_load(config_file.read_text(encoding="utf-8"))
 
 
 def test_creates_file_when_missing(tmp_path: Path) -> None:
@@ -22,20 +26,22 @@ def test_creates_file_when_missing(tmp_path: Path) -> None:
 
 def test_preserves_comment_on_untouched_key(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("# my custom note\nauto_save: false\n")
+    config_file.write_text("# my custom note\nauto_save: false\n", encoding="utf-8")
 
     _config.set_override(
         config_file=config_file, key_path=["with_image_data"], value=True
     )
 
-    content = config_file.read_text()
+    content = config_file.read_text(encoding="utf-8")
     assert "# my custom note" in content
     assert _parse(config_file) == {"auto_save": False, "with_image_data": True}
 
 
 def test_prunes_key_when_value_equals_default(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("auto_save: false\nwith_image_data: true\n")
+    config_file.write_text(
+        "auto_save: false\nwith_image_data: true\n", encoding="utf-8"
+    )
 
     # auto_save default is true, so setting it back to true removes the override
     _config.set_override(config_file=config_file, key_path=["auto_save"], value=True)
@@ -50,14 +56,14 @@ def test_writes_nested_key(tmp_path: Path) -> None:
         config_file=config_file, key_path=["shape", "point_size"], value=12
     )
 
-    content = config_file.read_text()
+    content = config_file.read_text(encoding="utf-8")
     assert "shape:" in content
     assert _parse(config_file) == {"shape": {"point_size": 12}}
 
 
 def test_prunes_nested_key_and_empty_parent(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("shape:\n  point_size: 12\n")
+    config_file.write_text("shape:\n  point_size: 12\n", encoding="utf-8")
 
     # point_size default is 8; reverting empties shape, which should be pruned too
     _config.set_override(
@@ -69,7 +75,9 @@ def test_prunes_nested_key_and_empty_parent(tmp_path: Path) -> None:
 
 def test_keeps_sibling_when_pruning_nested_key(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("shape:\n  point_size: 12\n  line_color: [1, 2, 3, 4]\n")
+    config_file.write_text(
+        "shape:\n  point_size: 12\n  line_color: [1, 2, 3, 4]\n", encoding="utf-8"
+    )
 
     _config.set_override(
         config_file=config_file, key_path=["shape", "point_size"], value=8
@@ -100,7 +108,7 @@ def test_writes_list_in_flow_style(tmp_path: Path) -> None:
         value=[255, 0, 0],
     )
 
-    assert "default_shape_color: [255, 0, 0]" in config_file.read_text()
+    assert "default_shape_color: [255, 0, 0]" in config_file.read_text(encoding="utf-8")
 
 
 def test_label_named_like_a_boolean_survives_round_trip(tmp_path: Path) -> None:
@@ -130,7 +138,7 @@ def test_unknown_key_raises(tmp_path: Path) -> None:
 
 def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("shape: 42\n")
+    config_file.write_text("shape: 42\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="non-mapping"):
         _config.set_override(
@@ -140,7 +148,7 @@ def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
 
 def test_overwrites_when_top_level_is_not_a_mapping(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("- one\n- two\n")
+    config_file.write_text("- one\n- two\n", encoding="utf-8")
 
     _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
 
@@ -149,12 +157,12 @@ def test_overwrites_when_top_level_is_not_a_mapping(tmp_path: Path) -> None:
 
 def test_empties_file_when_last_override_pruned(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
-    config_file.write_text("auto_save: false\n")
+    config_file.write_text("auto_save: false\n", encoding="utf-8")
 
     # reverting the only override to its default leaves nothing to persist
     _config.set_override(config_file=config_file, key_path=["auto_save"], value=True)
 
-    assert config_file.read_text() == ""
+    assert config_file.read_text(encoding="utf-8") == ""
 
 
 def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
@@ -171,6 +179,61 @@ def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
     assert config["shape"]["point_size"] == 12
     # an untouched key keeps its default
     assert config["with_image_data"] is False
+
+
+def test_non_ascii_label_round_trips(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+
+    _config.set_override(
+        config_file=config_file, key_path=["labels"], value=["ラベル", "café"]
+    )
+
+    config = _config.load_config(config_file=config_file, config_overrides={})
+    assert config["labels"] == ["ラベル", "café"]
+
+
+def test_non_ascii_label_round_trips_under_non_utf8_locale(tmp_path: Path) -> None:
+    # The default text encoding is fixed at interpreter startup, so the only way
+    # to exercise a non-UTF-8 locale is to relaunch Python. The script goes to a
+    # file rather than `python -c`: source files are decoded as UTF-8 regardless
+    # of locale, so the non-ASCII label survives parsing and only the config I/O
+    # is stressed; passing it via `-c` would instead fail at argv decoding.
+    config_file = tmp_path / ".labelmerc"
+    script = textwrap.dedent(
+        f"""
+        from pathlib import Path
+
+        from labelme import _config
+
+        config_file = Path({str(config_file)!r})
+        _config.set_override(
+            config_file=config_file, key_path=["labels"], value=["ラベル"]
+        )
+        config = _config.load_config(config_file=config_file, config_overrides={{}})
+        assert config["labels"] == ["ラベル"], config["labels"]
+        """
+    )
+    script_file = tmp_path / "roundtrip.py"
+    script_file.write_text(script, encoding="utf-8")
+
+    # LANG=C with utf8 mode off makes the platform default text encoding ASCII,
+    # so unpinned reads/writes would raise on the non-ASCII label.
+    env = {
+        **os.environ,
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+    }
+    result = subprocess.run(
+        [sys.executable, "-X", "utf8=0", str(script_file)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_write_failure_leaves_no_temp_file(


### PR DESCRIPTION
Config file I/O relied on the platform default text encoding, so a non-ASCII label (CJK, accented) written via the Settings dialog could raise `UnicodeEncodeError` or corrupt the file on non-UTF-8 locales (notably Windows cp1252/cp932). YAML is UTF-8 by spec, so this pins `encoding="utf-8"` on every config read and write rather than working around the symptom.

Sites fixed:
- `labelme/_config/_writer.py`: `default_config.yaml` `read_text`, the user-config `read_text`, and the atomic `os.fdopen(fd, "w")` write.
- `labelme/_config/__init__.py` (`load_config`): the bare `open(...)` for `default_config.yaml` and the user config.

## Test plan
- [x] `test_non_ascii_label_round_trips` — writes then reloads a config with Japanese and accented labels, asserts unchanged
- [x] `test_non_ascii_label_round_trips_under_non_utf8_locale` — runs the round trip in a subprocess with `LANG=C` / utf8 mode off (ASCII default encoding); fails against the unpinned code with `UnicodeEncodeError`, passes with the fix
- [x] `make lint`
- [x] `make test` (358 passed)

Closes #2122
