### PR TITLE
fix: keep image on canvas when deleting label file

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2341,7 +2341,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if item:
             item.setCheckState(Qt.Unchecked)
 
-        self.reset_state()
+        # Only the label file was deleted, not the image: clear the annotations
+        # but keep the image on the canvas.
+        self._docks.label_list.clear()
+        self._canvas_widgets.canvas.load_shapes(shapes=[], replace=True)
+        self.mark_clean()
 
     @property
     def _is_settings_editable(self) -> bool:

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -68,3 +68,40 @@ def test_delete_label_file(
     assert item.checkState() == Qt.Unchecked
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_delete_label_file_keeps_image(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / "annotated"),
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    assert not canvas.pixmap.isNull()
+    assert canvas.shapes
+    assert len(win._docks.label_list) > 0
+
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+    )
+    win.delete_file()
+    qtbot.wait(50)
+
+    # The annotations are cleared, but the image stays on the canvas.
+    assert not canvas.pixmap.isNull()
+    assert canvas.isEnabled()
+    assert canvas.shapes == []
+    assert len(win._docks.label_list) == 0
+    assert win._image_path is not None
+    assert win._annotation is not None
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)


### PR DESCRIPTION
**Delete File** deletes only the current label `.json`, but the canvas went blank afterwards because `delete_file()` called `reset_state()`, which also clears the image state and resets the canvas pixmap. Since the image itself is not deleted, it should stay on screen.

Fix: after unlinking the label file, clear only the shapes and label list and keep the loaded image (and its `_image_path` / `_annotation`, so a later re-annotation can still be saved).

## Test plan
- [x] `tests/e2e/file_operations_test.py::test_delete_label_file_keeps_image` — after delete, canvas pixmap is non-null and enabled, shapes/label list are empty, image state is retained
- [x] `make lint`
- [x] `make test` (358 passed)

Closes #2126.
