### PR TITLE
fix: fall back to image basename when label file's imagePath fails to load

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -220,6 +220,26 @@ def _check_image_dimensions(
         )
 
 
+def _read_image_with_basename_fallback(*, label_dir: Path, image_path: str) -> bytes:
+    # imagePath can be stale when a dataset moves between machines (absolute
+    # path, or a relative path with a now-missing subdirectory). The image often
+    # still sits next to its label file, so retry once with just the basename.
+    primary = label_dir / image_path
+    try:
+        return read_image_file(filename=str(primary))
+    except OSError as primary_error:
+        fallback = label_dir / Path(image_path).name
+        if fallback == primary:
+            raise
+        try:
+            return read_image_file(filename=str(fallback))
+        except OSError as fallback_error:
+            raise OSError(
+                f"failed to load image from {str(primary)!r} "
+                f"or {str(fallback)!r}: {fallback_error}"
+            ) from primary_error
+
+
 def read_label_file(filename: str) -> Annotation:
     try:
         with open(filename, encoding="utf-8") as f:
@@ -228,8 +248,8 @@ def read_label_file(filename: str) -> Annotation:
         if raw["imageData"] is not None:
             image_data = base64.b64decode(raw["imageData"])
         else:
-            image_data = read_image_file(
-                filename=str(Path(filename).parent / image_path)
+            image_data = _read_image_with_basename_fallback(
+                label_dir=Path(filename).parent, image_path=image_path
             )
         _check_image_dimensions(
             image_data=image_data,

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import shutil
 from collections.abc import Callable
@@ -140,6 +141,59 @@ def test_read_label_file_raises_read_error_on_malformed(
 
     with pytest.raises(LabelFileReadError, match=error_match):
         read_label_file(filename=str(annotated_dst))
+
+
+def test_read_label_file_falls_back_to_basename_for_absolute_path(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    annotated_raw["imagePath"] = "/nonexistent/dir/2011_000003.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    label_data = read_label_file(filename=str(annotated_dst))
+
+    assert label_data.image_data
+
+
+def test_read_label_file_falls_back_to_basename_for_stale_relative_path(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    annotated_raw["imagePath"] = "../old/2011_000003.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    label_data = read_label_file(filename=str(annotated_dst))
+
+    assert label_data.image_data
+
+
+def test_read_label_file_raises_when_primary_and_basename_both_missing(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    annotated_raw["imagePath"] = "/nonexistent/dir/missing.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    with pytest.raises(LabelFileReadError) as excinfo:
+        read_label_file(filename=str(annotated_dst))
+
+    message = str(excinfo.value)
+    assert "/nonexistent/dir/missing.jpg" in message
+    assert str(annotated_dst.parent / "missing.jpg") in message
+
+
+def test_read_label_file_with_embedded_image_data_ignores_missing_imagepath(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    image_bytes = (annotated_dst.parent / "2011_000003.jpg").read_bytes()
+    annotated_raw["imageData"] = base64.b64encode(image_bytes).decode()
+    annotated_raw["imagePath"] = "/nonexistent/dir/whatever.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    label_data = read_label_file(filename=str(annotated_dst))
+
+    assert label_data.image_data
 
 
 def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
A label file with no embedded image data resolves its `imagePath` against the label file's directory. When a dataset moves between machines, that path can be stale (an absolute path, or a relative path with a now-missing subdirectory) even though the image still sits next to its `.json`, and the load failed outright.

Fix: when the primary resolution fails, retry once using the label file's directory joined to **only the basename** of `imagePath`. If that also fails, raise the existing `LabelFileReadError`, whose message now names both attempted paths. The happy path, the write/serialization side, and label files with embedded `imageData` are all unchanged.

Re-implements the idea from #1035 by @drjasonharrison against the current module-level reader (the original patch no longer applied after a refactor).

## Test plan
- [x] `tests/unit/_label_file_test.py` — absolute-path fallback, stale-relative fallback, both-fail error names both paths, and embedded-`imageData` left untouched
- [x] existing happy-path read test unchanged
- [x] `make lint`
- [x] `make test` (361 passed)

Closes #2125.
