### PR TITLE
refactor(canvas): extract AI Assist inference into AiAssistSession

### DIFF
--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -1,3 +1,4 @@
+from ._ai_assist import AiAssistSession
 from ._geometry import shape_to_xyxy_bbox
 from ._osam_session import OsamSession
 from ._shape_builders import Detection

--- a/labelme/_automation/_ai_assist.py
+++ b/labelme/_automation/_ai_assist.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import numpy as np
+import osam
+from loguru import logger
+from numpy.typing import NDArray
+
+from labelme._shape import Shape
+
+from ._osam_session import OsamSession
+from ._shape_builders import Detection
+from ._shape_builders import shapes_from_detections
+from ._suppression import suppress_detections_greedy
+from ._suppression import suppress_detections_overlapping_existing_shapes
+from ._types import AiOutputFormat
+
+
+class AiAssistSession:
+    model_name: str
+    output_format: AiOutputFormat
+    _session: OsamSession | None
+
+    def __init__(
+        self,
+        model_name: str = "sam2:latest",
+        output_format: AiOutputFormat = "polygon",
+    ) -> None:
+        self.model_name = model_name
+        self.output_format = output_format
+        self._session = None
+
+    def _get_session(self) -> OsamSession:
+        if self._session is None or self._session.model_name != self.model_name:
+            self._session = OsamSession(model_name=self.model_name)
+        return self._session
+
+    def propose_shapes(
+        self,
+        *,
+        image: NDArray[np.uint8],
+        image_id: str,
+        points: NDArray[np.floating],
+        point_labels: NDArray[np.intp],
+        existing_shapes: list[Shape],
+    ) -> list[Shape]:
+        response: osam.types.GenerateResponse = self._get_session().run(
+            image=image,
+            image_id=image_id,
+            points=points,
+            point_labels=point_labels,
+        )
+        # iou_threshold is hardcoded because the AI Assist flow has no
+        # user-facing IoU control (unlike the AI Text Prompt flow); 0.5 matches
+        # the AI Text Prompt widget default.
+        detections = suppress_detections_greedy(
+            detections=_detections_from_annotations(response.annotations),
+            iou_threshold=0.5,
+        )
+        detections = suppress_detections_overlapping_existing_shapes(
+            detections=detections,
+            existing_shapes=existing_shapes,
+        )
+        return shapes_from_detections(
+            detections=detections,
+            shape_type=self.output_format,
+        )
+
+
+def _detections_from_annotations(
+    annotations: list[osam.types.Annotation],
+) -> list[Detection]:
+    if not annotations:
+        logger.warning("No annotations returned")
+        return []
+    sorted_annotations = sorted(
+        annotations,
+        key=lambda a: a.score if a.score is not None else 0,
+        reverse=True,
+    )
+    detections: list[Detection] = []
+    for annotation in sorted_annotations:
+        bbox: tuple[float, float, float, float] | None = None
+        if annotation.bounding_box is not None:
+            bb = annotation.bounding_box
+            bbox = (bb.xmin, bb.ymin, bb.xmax, bb.ymax)
+        detections.append(Detection(bbox=bbox, mask=annotation.mask))
+    return detections

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -11,9 +11,7 @@ from typing import Final
 from typing import Literal
 from typing import cast
 
-import imgviz
 import numpy as np
-import osam
 from loguru import logger
 from PyQt5 import QtCore
 from PyQt5 import QtGui
@@ -209,9 +207,7 @@ class Canvas(QtWidgets.QWidget):
     _draft_palette: Palette
     _palette_cache: dict[str, Palette]
 
-    _osam_session_model_name: str = "sam2:latest"
-    _osam_session: _automation.OsamSession | None
-    _ai_output_format: _automation.AiOutputFormat = "polygon"
+    _ai_assist_session: _automation.AiAssistSession
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self._epsilon: float = kwargs.pop("epsilon", 10.0)
@@ -253,7 +249,7 @@ class Canvas(QtWidgets.QWidget):
         self._rotation_initial_angle = 0.0
         self._rotation_original_points = np.empty((0, 2))
         self.scale: float = 1.0
-        self._osam_session = None
+        self._ai_assist_session = _automation.AiAssistSession()
         self._snapping = True
         self._hovered_shape_is_selected: bool = False
         self._painter = QtGui.QPainter()
@@ -391,48 +387,24 @@ class Canvas(QtWidgets.QWidget):
         self.update()
 
     def get_ai_model_name(self) -> str:
-        return self._osam_session_model_name
+        return self._ai_assist_session.model_name
 
     def set_ai_model_name(self, model_name: str) -> None:
-        self._osam_session_model_name = model_name
+        self._ai_assist_session.model_name = model_name
 
     def set_ai_output_format(self, output_format: _automation.AiOutputFormat) -> None:
-        self._ai_output_format = output_format
-
-    def _get_osam_session(self) -> _automation.OsamSession:
-        if (
-            self._osam_session is None
-            or self._osam_session.model_name != self._osam_session_model_name
-        ):
-            self._osam_session = _automation.OsamSession(
-                model_name=self._osam_session_model_name
-            )
-        return self._osam_session
+        self._ai_assist_session.output_format = output_format
 
     def _shapes_from_ai_points(
         self, points: Sequence[QPointF], point_labels: Sequence[int]
     ) -> list[Shape]:
         image: np.ndarray = labelme.utils.img_qt_to_arr(img_qt=self.pixmap.toImage())
-        response: osam.types.GenerateResponse = self._get_osam_session().run(
-            image=imgviz.asrgb(image),  # type: ignore[arg-type]
+        return self._ai_assist_session.propose_shapes(
+            image=image[:, :, :3],
             image_id=str(self._pixmap_hash),
             points=np.array([[p.x(), p.y()] for p in points]),
             point_labels=np.array(point_labels),
-        )
-        # iou_threshold is hardcoded here because the ai-points/box flow has
-        # no user-facing IoU control (unlike app.py's ai-text flow). 0.5 is
-        # the same default the ai-text widget ships with.
-        detections = _automation.suppress_detections_greedy(
-            detections=_detections_from_annotations(response.annotations),
-            iou_threshold=0.5,
-        )
-        detections = _automation.suppress_detections_overlapping_existing_shapes(
-            detections=detections,
             existing_shapes=self.shapes,
-        )
-        return _automation.shapes_from_detections(
-            detections=detections,
-            shape_type=self._ai_output_format,
         )
 
     def backup_shapes(self) -> None:
@@ -1045,7 +1017,7 @@ class Canvas(QtWidgets.QWidget):
     ) -> None:
         mode = self.create_mode
         if mode in ("ai_points_to_shape", "ai_box_to_shape") and not download_ai_model(
-            model_name=self._osam_session_model_name, parent=self
+            model_name=self.get_ai_model_name(), parent=self
         ):
             return
 
@@ -1823,27 +1795,6 @@ class Canvas(QtWidgets.QWidget):
         self._last_hovered_edge = None
         self._hovered_rotation = None
         self.update()
-
-
-def _detections_from_annotations(
-    annotations: list[osam.types.Annotation],
-) -> list[_automation.Detection]:
-    if not annotations:
-        logger.warning("No annotations returned")
-        return []
-    sorted_annotations = sorted(
-        annotations,
-        key=lambda a: a.score if a.score is not None else 0,
-        reverse=True,
-    )
-    detections: list[_automation.Detection] = []
-    for annotation in sorted_annotations:
-        bbox: tuple[float, float, float, float] | None = None
-        if annotation.bounding_box is not None:
-            bb = annotation.bounding_box
-            bbox = (bb.xmin, bb.ymin, bb.xmax, bb.ymax)
-        detections.append(_automation.Detection(bbox=bbox, mask=annotation.mask))
-    return detections
 
 
 def _is_degenerate_draft(draft: _DraftShape) -> bool:

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -295,7 +295,7 @@ def test_ai_model_download(
     monkeypatch.setattr(osam.types._blob.Blob, "path", property(patched_path))
 
     # Reset cached osam session so the fresh model is loaded from temp dir
-    canvas._osam_session = None
+    canvas._ai_assist_session._session = None
 
     canvas_size = canvas.size()
     pos = QPoint(int(canvas_size.width() * 0.5), int(canvas_size.height() * 0.5))

--- a/tests/unit/_automation/_ai_assist_test.py
+++ b/tests/unit/_automation/_ai_assist_test.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import osam
+import pytest
+
+from labelme._automation import _ai_assist
+from labelme._automation._ai_assist import AiAssistSession
+from labelme._shape import Shape
+
+
+@pytest.fixture
+def install_fake_osam_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[osam.types.GenerateResponse], list[str]]:
+    def _install(response: osam.types.GenerateResponse) -> list[str]:
+        created_model_names: list[str] = []
+
+        class _FakeOsamSession:
+            def __init__(self, model_name: str) -> None:
+                self.model_name = model_name
+                created_model_names.append(model_name)
+
+            def run(self, **_: object) -> osam.types.GenerateResponse:
+                return response
+
+        monkeypatch.setattr(_ai_assist, "OsamSession", _FakeOsamSession)
+        return created_model_names
+
+    return _install
+
+
+def _propose(session: AiAssistSession) -> list[Shape]:
+    return session.propose_shapes(
+        image=np.zeros((1, 1, 3), dtype=np.uint8),
+        image_id="img",
+        points=np.zeros((1, 2)),
+        point_labels=np.array([1]),
+        existing_shapes=[],
+    )
+
+
+def test_propose_shapes_sorts_by_score_and_reuses_session(
+    install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
+) -> None:
+    response = osam.types.GenerateResponse(
+        model="stub",
+        annotations=[
+            osam.types.Annotation(
+                score=0.3,
+                bounding_box=osam.types.BoundingBox(
+                    xmin=100, ymin=100, xmax=110, ymax=110
+                ),
+            ),
+            osam.types.Annotation(
+                score=0.9,
+                bounding_box=osam.types.BoundingBox(xmin=0, ymin=0, xmax=10, ymax=10),
+            ),
+        ],
+    )
+    created_model_names = install_fake_osam_session(response)
+    session = AiAssistSession(model_name="a", output_format="rectangle")
+
+    shapes = _propose(session)
+
+    assert [shape.shape_type for shape in shapes] == ["rectangle", "rectangle"]
+    # Detections are sorted by score descending, so the 0.9 box comes first.
+    np.testing.assert_array_equal(shapes[0].points, [[0, 0], [10, 10]])
+
+    _propose(session)
+    assert created_model_names == ["a"]
+
+    session.model_name = "b"
+    _propose(session)
+    assert created_model_names == ["a", "b"]
+
+
+def test_default_model_name_and_output_format() -> None:
+    session = AiAssistSession()
+    assert session.model_name == "sam2:latest"
+    assert session.output_format == "polygon"
+
+    session.model_name = "efficientsam:latest"
+    session.output_format = "mask"
+    assert session.model_name == "efficientsam:latest"
+    assert session.output_format == "mask"


### PR DESCRIPTION
## Summary
- Extract the click-driven Shape proposal cluster (AI Assist) out of the `Canvas` widget into a new Qt-free `AiAssistSession` in the `_automation` package, which already hosts the Model Session layer.
- `AiAssistSession` owns the model name, output format, lazy `OsamSession` lifecycle, the two-stage detection suppression pipeline, and detection-to-Shape conversion behind a single `propose_shapes(...)` method.
- `Canvas` keeps thin delegating wrappers (`get_ai_model_name` / `set_ai_model_name` / `set_ai_output_format`) and a small numpy adapter; it no longer declares AI session state and no longer imports `osam` or `imgviz`.
- Net effect: `canvas.py` sheds an entire subsystem (-57 lines in that file), and the proposal pipeline is now testable without a Qt widget.

## Test plan
- [x] Added `tests/unit/_automation/_ai_assist_test.py` — hermetic `propose_shapes` test (stubbed `OsamSession`) covering score-sorted output, session reuse, and recreation on model-name change.
- [x] `uv run pytest tests/unit` — 220 passed
- [x] `uv run ruff check` + `ruff format --check` clean
