### PR TITLE
Migrate from PyQt5 to PySide6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@v1
         if: matrix.os == 'ubuntu-latest'
         with:
-          packages: xvfb libqt5widgets5
+          packages: xvfb libegl1 libxkbcommon0 libxcb-cursor0 libgl1
           version: 1.0
       - name: Test
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 setup:  # Setup the development environment
 	$(call exec,uv sync)
 
-lint: update_translate  # Lint code
+lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
 	$(call exec,uv run ty check --no-progress)

--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -9,7 +9,7 @@ __appname__ = "Labelme"
 # e.g., 1.0.0a0, 1.0.0a1, 1.0.0b0, 1.0.0rc0, 1.0.0, 1.0.0.post0
 __version__ = importlib.metadata.version("labelme")
 
-# XXX: has to be imported before PyQt5 to load dlls in order on Windows
+# XXX: has to be imported before PySide6 to load dlls in order on Windows
 # https://github.com/wkentaro/labelme/issues/1564
 import onnxruntime
 

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import AnyStr
 
 from loguru import logger
-from PyQt5 import QtCore
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtWidgets
 
 from labelme import __appname__
 from labelme import __version__
@@ -330,7 +330,7 @@ def main() -> None:
     with contextlib.redirect_stderr(new_target=_LoggerIO()):
         win.show()
         win.raise_()
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
 
 
 # this main block is required to generate executable by pyinstaller

--- a/labelme/_config/_schema.py
+++ b/labelme/_config/_schema.py
@@ -5,7 +5,7 @@ from typing import Final
 from typing import Literal
 from typing import get_args
 
-from PyQt5.QtCore import QT_TRANSLATE_NOOP
+from PySide6.QtCore import QT_TRANSLATE_NOOP
 
 Section = Literal["General", "Labels"]
 Kind = Literal["bool", "enum", "str_list", "language"]

--- a/labelme/_config/_schema.py
+++ b/labelme/_config/_schema.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Final
 from typing import Literal
+from typing import cast
 from typing import get_args
 
 from PySide6.QtCore import QT_TRANSLATE_NOOP
@@ -40,26 +41,30 @@ SETTINGS: Final[tuple[Setting, ...]] = (
     Setting(
         key_path=("display_label_popup",),
         section="General",
-        label=QT_TRANSLATE_NOOP("SettingsDialog", "Show label popup on new shape"),
+        label=cast(
+            str, QT_TRANSLATE_NOOP("SettingsDialog", "Show label popup on new shape")
+        ),
         kind="bool",
     ),
     Setting(
         key_path=("language",),
         section="General",
-        label=QT_TRANSLATE_NOOP("SettingsDialog", "Language"),
+        label=cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Language")),
         kind="language",
-        note=QT_TRANSLATE_NOOP("SettingsDialog", "Takes effect after restart."),
+        note=cast(
+            str, QT_TRANSLATE_NOOP("SettingsDialog", "Takes effect after restart.")
+        ),
     ),
     Setting(
         key_path=("labels",),
         section="Labels",
-        label=QT_TRANSLATE_NOOP("SettingsDialog", "Predefined labels"),
+        label=cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Predefined labels")),
         kind="str_list",
     ),
     Setting(
         key_path=("validate_label",),
         section="Labels",
-        label=QT_TRANSLATE_NOOP("SettingsDialog", "Label validation"),
+        label=cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Label validation")),
         kind="enum",
         choices=(None, "exact"),
     ),

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -98,7 +98,7 @@ def nearest_vertex_index(
     scale: float,
     epsilon: float,
 ) -> int | None:
-    if shape.shape_type == "mask" or len(shape.points) == 0:
+    if shape.shape_type in ("mask", "point") or len(shape.points) == 0:
         return None
     distances = np.linalg.norm((shape.points - point) * scale, axis=1)
     nearest = int(np.argmin(distances))

--- a/labelme/_shape_clipboard.py
+++ b/labelme/_shape_clipboard.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from PyQt5 import QtCore
+from PySide6 import QtCore
 
 from labelme._shape import Shape
 
 
 class ShapeClipboard(QtCore.QObject):
-    availability_changed = QtCore.pyqtSignal(bool)
+    availability_changed = QtCore.Signal(bool)
 
     def __init__(self, parent: QtCore.QObject | None = None) -> None:
         super().__init__(parent)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -640,7 +640,7 @@ class MainWindow(QtWidgets.QMainWindow):
         zoom_widget_action = QtWidgets.QWidgetAction(self)
         zoom_box_layout = QtWidgets.QVBoxLayout()
         zoom_label = QtWidgets.QLabel(self.tr("Zoom"))
-        zoom_label.setAlignment(Qt.AlignCenter)
+        zoom_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         zoom_box_layout.addWidget(zoom_label)
         zoom_box_layout.addWidget(self._canvas_widgets.zoom_widget)
         zoom_widget_action.setDefaultWidget(QtWidgets.QWidget())
@@ -805,7 +805,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
             enabled=settings_editable,
         )
-        open_config.setMenuRole(QtGui.QAction.PreferencesRole)
+        open_config.setMenuRole(QtGui.QAction.MenuRole.PreferencesRole)
         help_ = action(
             self.tr("&Tutorial"),
             self.tutorial,
@@ -819,7 +819,9 @@ class MainWindow(QtWidgets.QMainWindow):
         help_menu = self.menu(self.tr("&Help"))
         label_menu = QtWidgets.QMenu()
         utils.add_actions(label_menu, (self._actions.edit, self._actions.delete))
-        self._docks.label_list.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._docks.label_list.setContextMenuPolicy(
+            Qt.ContextMenuPolicy.CustomContextMenu
+        )
         self._docks.label_list.customContextMenuRequested.connect(
             self.show_label_list_menu
         )
@@ -901,7 +903,7 @@ class MainWindow(QtWidgets.QMainWindow):
         ai_prompt_action.setDefaultWidget(self._ai_text)
 
         self.addToolBar(
-            Qt.TopToolBarArea,
+            Qt.ToolBarArea.TopToolBarArea,
             ToolBar(
                 title="Tools",
                 actions=[
@@ -929,7 +931,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
         )
         self.addToolBar(
-            Qt.LeftToolBarArea,
+            Qt.ToolBarArea.LeftToolBarArea,
             ToolBar(
                 title="CreateShapeTools",
                 actions=[
@@ -941,8 +943,8 @@ class MainWindow(QtWidgets.QMainWindow):
                     None,
                     *[a for mode, a in self._actions.draw if mode.startswith("ai_")],
                 ],
-                orientation=Qt.Vertical,
-                button_style=Qt.ToolButtonTextUnderIcon,
+                orientation=Qt.Orientation.Vertical,
+                button_style=Qt.ToolButtonStyle.ToolButtonTextUnderIcon,
                 font_base=self.font(),
             ),
         )
@@ -966,8 +968,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._zoom_values = {}
         self._brightness_contrast_values = {}
         self._scroll_values = {
-            Qt.Horizontal: {},
-            Qt.Vertical: {},
+            Qt.Orientation.Horizontal: {},
+            Qt.Orientation.Vertical: {},
         }
 
         if self._config["file_search"]:
@@ -987,9 +989,24 @@ class MainWindow(QtWidgets.QMainWindow):
             self._reset_layout()
             self._window_state.setValue("settingsVersion", SETTINGS_VERSION)
         #
-        self.resize(self._window_state.value("window/size", QtCore.QSize(900, 500)))
-        self.move(self._window_state.value("window/position", QtCore.QPoint(0, 0)))
-        self.restoreState(self._window_state.value("window/state", QtCore.QByteArray()))
+        self.resize(
+            cast(
+                QtCore.QSize,
+                self._window_state.value("window/size", QtCore.QSize(900, 500)),
+            )
+        )
+        self.move(
+            cast(
+                QtCore.QPoint,
+                self._window_state.value("window/position", QtCore.QPoint(0, 0)),
+            )
+        )
+        self.restoreState(
+            cast(
+                QtCore.QByteArray,
+                self._window_state.value("window/state", QtCore.QByteArray()),
+            )
+        )
         # Recover window position when the saved screen is no longer connected.
         if not any(
             s.availableGeometry().intersects(self.frameGeometry())
@@ -1043,8 +1060,8 @@ class MainWindow(QtWidgets.QMainWindow):
         scroll_area.setWidget(canvas)
         scroll_area.setWidgetResizable(True)
         scroll_bars = {
-            Qt.Vertical: scroll_area.verticalScrollBar(),
-            Qt.Horizontal: scroll_area.horizontalScrollBar(),
+            Qt.Orientation.Vertical: scroll_area.verticalScrollBar(),
+            Qt.Orientation.Horizontal: scroll_area.horizontalScrollBar(),
         }
         canvas.scroll_request.connect(self._on_scroll_request)
         canvas.pan_request.connect(self._on_pan_request)
@@ -1129,17 +1146,25 @@ class MainWindow(QtWidgets.QMainWindow):
             ("shape_dock", shape),
             ("file_dock", file),
         ]:
-            features = QtWidgets.QDockWidget.DockWidgetFeatures()
+            features = QtWidgets.QDockWidget.DockWidgetFeature()
             if self._config[config_key]["closable"]:
-                features = features | QtWidgets.QDockWidget.DockWidgetClosable
+                features = (
+                    features
+                    | QtWidgets.QDockWidget.DockWidgetFeature.DockWidgetClosable
+                )
             if self._config[config_key]["floatable"]:
-                features = features | QtWidgets.QDockWidget.DockWidgetFloatable
+                features = (
+                    features
+                    | QtWidgets.QDockWidget.DockWidgetFeature.DockWidgetFloatable
+                )
             if self._config[config_key]["movable"]:
-                features = features | QtWidgets.QDockWidget.DockWidgetMovable
+                features = (
+                    features | QtWidgets.QDockWidget.DockWidgetFeature.DockWidgetMovable
+                )
             dock_widget.setFeatures(features)
             if self._config[config_key]["show"] is False:
                 dock_widget.setVisible(False)
-            self.addDockWidget(Qt.RightDockWidgetArea, dock_widget)
+            self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock_widget)
 
         return _DockWidgets(
             flag_dock=flag,
@@ -1162,7 +1187,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         except ValueError as e:
             msg_box = QMessageBox(self)
-            msg_box.setIcon(QMessageBox.Warning)
+            msg_box.setIcon(QMessageBox.Icon.Warning)
             msg_box.setWindowTitle(self.tr("Configuration Errors"))
             msg_box.setText(
                 self.tr(
@@ -1172,7 +1197,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 )
             )
             msg_box.setInformativeText(str(e))
-            msg_box.setStandardButtons(QMessageBox.Ignore)
+            msg_box.setStandardButtons(QMessageBox.StandardButton.Ignore)
             msg_box.setModal(False)
             msg_box.show()
 
@@ -1440,7 +1465,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return True
         unique_label_list = self._docks.unique_label_list
         existing_labels = [
-            unique_label_list.item(i).data(Qt.UserRole)  # ty: ignore[unresolved-attribute]
+            unique_label_list.item(i).data(Qt.ItemDataRole.UserRole)
             for i in range(unique_label_list.count())
         ]
         return _is_valid_label(
@@ -1660,8 +1685,10 @@ class MainWindow(QtWidgets.QMainWindow):
         flag: bool
         for key, flag in flags.items():
             item: QtWidgets.QListWidgetItem = QtWidgets.QListWidgetItem(key)
-            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-            item.setCheckState(Qt.Checked if flag else Qt.Unchecked)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(
+                Qt.CheckState.Checked if flag else Qt.CheckState.Unchecked
+            )
             widget.addItem(item)
 
     def save_labels(self, label_path: str) -> bool:
@@ -1674,7 +1701,7 @@ class MainWindow(QtWidgets.QMainWindow):
         for i in range(self._docks.flag_list.count()):
             item = self._docks.flag_list.item(i)
             assert item
-            flags[item.text()] = item.checkState() == Qt.Checked
+            flags[item.text()] = item.checkState() == Qt.CheckState.Checked
         try:
             assert self._image_path
             assert self._annotation is not None
@@ -1695,11 +1722,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 save_image_data=self._config["with_image_data"],
             )
             self._label_file_path = label_path
-            items = self._docks.file_list.findItems(self._image_path, Qt.MatchExactly)
+            items = self._docks.file_list.findItems(
+                self._image_path, Qt.MatchFlag.MatchExactly
+            )
             if len(items) > 0:
                 if len(items) != 1:
                     raise RuntimeError("There are duplicate files.")
-                items[0].setCheckState(Qt.Checked)
+                items[0].setCheckState(Qt.CheckState.Checked)
             return True
         except LabelFileError as e:
             self.show_error_message(
@@ -1727,7 +1756,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._canvas_widgets.canvas.update()
 
     def _on_label_item_changed(self, item: LabelListWidgetItem) -> None:
-        is_visible_new = item.checkState() == Qt.Checked
+        is_visible_new = item.checkState() == Qt.CheckState.Checked
 
         selected_group = (
             self._docks.label_list.selection_at_press()
@@ -1746,7 +1775,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if not items_to_change:
             return
 
-        new_check_state = Qt.Checked if is_visible_new else Qt.Unchecked
+        new_check_state = (
+            Qt.CheckState.Checked if is_visible_new else Qt.CheckState.Unchecked
+        )
         with QtCore.QSignalBlocker(self._docks.label_list._model):
             for item_to_toggle in items_to_change:
                 shape_to_toggle = item_to_toggle.shape()
@@ -1772,7 +1803,7 @@ class MainWindow(QtWidgets.QMainWindow):
         items = self._docks.unique_label_list.selectedItems()
         text = None
         if items:
-            text = items[0].data(Qt.UserRole)
+            text = items[0].data(Qt.ItemDataRole.UserRole)
         flags = {}
         group_id = None
         description = ""
@@ -1820,10 +1851,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_pan_request(self, step: QtCore.QPoint) -> None:
         # Pan moves the viewport opposite to the cursor delta so the image
         # tracks the grabbed point one-for-one in widget pixels.
-        h_bar = self._canvas_widgets.scroll_bars[Qt.Horizontal]
-        v_bar = self._canvas_widgets.scroll_bars[Qt.Vertical]
-        self.set_scroll_value(Qt.Horizontal, h_bar.value() - step.x())
-        self.set_scroll_value(Qt.Vertical, v_bar.value() - step.y())
+        h_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Horizontal]
+        v_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
+        self.set_scroll_value(Qt.Orientation.Horizontal, h_bar.value() - step.x())
+        self.set_scroll_value(Qt.Orientation.Vertical, v_bar.value() - step.y())
 
     def set_scroll_value(self, orientation: Qt.Orientation, value: float) -> None:
         self._canvas_widgets.scroll_bars[orientation].setValue(int(value))
@@ -1852,12 +1883,13 @@ class MainWindow(QtWidgets.QMainWindow):
         x_shift: float = pos.x() * canvas_scale_factor - pos.x()
         y_shift: float = pos.y() * canvas_scale_factor - pos.y()
         self.set_scroll_value(
-            Qt.Horizontal,
-            self._canvas_widgets.scroll_bars[Qt.Horizontal].value() + x_shift,
+            Qt.Orientation.Horizontal,
+            self._canvas_widgets.scroll_bars[Qt.Orientation.Horizontal].value()
+            + x_shift,
         )
         self.set_scroll_value(
-            Qt.Vertical,
-            self._canvas_widgets.scroll_bars[Qt.Vertical].value() + y_shift,
+            Qt.Orientation.Vertical,
+            self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical].value() + y_shift,
         )
 
     def _set_zoom_to_original(self) -> None:
@@ -1953,8 +1985,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def toggle_shape_visibility(self, value: bool | None) -> None:
         for item in self._docks.label_list:
-            target = item.checkState() == Qt.Unchecked if value is None else value
-            item.setCheckState(Qt.Checked if target else Qt.Unchecked)
+            target = (
+                item.checkState() == Qt.CheckState.Unchecked if value is None else value
+            )
+            item.setCheckState(
+                Qt.CheckState.Checked if target else Qt.CheckState.Unchecked
+            )
 
     def _open_label_file_into_state(self, label_path: str) -> Annotation | None:
         try:
@@ -2000,7 +2036,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._canvas_widgets.canvas.shapes
             if self._config["keep_prev"]
             or QtWidgets.QApplication.keyboardModifiers()
-            == (Qt.ControlModifier | Qt.ShiftModifier)
+            == (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier)
             else []
         )
         self._prev_image_path = self._image_path
@@ -2037,7 +2073,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if image.isNull():
             formats = ", ".join(
-                f"*.{fmt.data().decode()}"
+                f"*.{fmt.toStdString()}"
                 for fmt in QtGui.QImageReader.supportedImageFormats()
             )
             extra = self.tr("Allowed formats: {formats}").format(formats=formats)
@@ -2152,7 +2188,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def dragEnterEvent(self, a0: QtGui.QDragEnterEvent) -> None:
         extensions = [
-            f".{fmt.data().decode().lower()}"
+            f".{fmt.toStdString().lower()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
         if a0.mimeData().hasUrls():
@@ -2195,7 +2231,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self._can_continue():
             return
         formats = [
-            f"*.{fmt.data().decode()}"
+            f"*.{fmt.toStdString()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         ]
         filters = self.tr("Image & Label files (%s)") % " ".join(
@@ -2223,8 +2259,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self,
             self.tr("%s - Save/Load Annotations in Directory") % __appname__,
             default_output_dir,
-            QtWidgets.QFileDialog.ShowDirsOnly
-            | QtWidgets.QFileDialog.DontResolveSymlinks,
+            QtWidgets.QFileDialog.Option.ShowDirsOnly
+            | QtWidgets.QFileDialog.Option.DontResolveSymlinks,
         )
         output_dir = str(output_dir)
 
@@ -2276,13 +2312,13 @@ class MainWindow(QtWidgets.QMainWindow):
             filter=filters,
         )
         dlg.setDefaultSuffix(LABEL_FILE_SUFFIX[1:])
-        dlg.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-        dlg.setOption(QtWidgets.QFileDialog.DontConfirmOverwrite, False)
-        dlg.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, False)
+        dlg.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptSave)
+        dlg.setOption(QtWidgets.QFileDialog.Option.DontConfirmOverwrite, False)
+        dlg.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog, False)
         label_path, _ = dlg.getSaveFileName(
             parent=self,
             caption=self.tr("Choose File"),
-            directory=_resolve_label_path(
+            dir=_resolve_label_path(
                 image_or_label_path=self._image_path,
                 output_dir=self._output_dir,
             ),
@@ -2312,9 +2348,10 @@ class MainWindow(QtWidgets.QMainWindow):
             self,
             self.tr("Attention"),
             msg,
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.No,
         )
-        if answer != QtWidgets.QMessageBox.Yes:
+        if answer != QtWidgets.QMessageBox.StandardButton.Yes:
             return
 
         annotation_path = Path(self.current_label_file_path())
@@ -2326,7 +2363,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         item = self._docks.file_list.currentItem()
         if item:
-            item.setCheckState(Qt.Unchecked)
+            item.setCheckState(Qt.CheckState.Unchecked)
 
         # Only the label file was deleted, not the image: clear the annotations
         # but keep the image on the canvas.
@@ -2448,15 +2485,15 @@ class MainWindow(QtWidgets.QMainWindow):
             self,
             self.tr("Save annotations?"),
             prompt_text,
-            QtWidgets.QMessageBox.Save
-            | QtWidgets.QMessageBox.Discard
-            | QtWidgets.QMessageBox.Cancel,
-            QtWidgets.QMessageBox.Save,
+            QtWidgets.QMessageBox.StandardButton.Save
+            | QtWidgets.QMessageBox.StandardButton.Discard
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Save,
         )
-        if user_choice == QtWidgets.QMessageBox.Save:
+        if user_choice == QtWidgets.QMessageBox.StandardButton.Save:
             self._save_label_file()
             return True
-        return user_choice == QtWidgets.QMessageBox.Discard
+        return user_choice == QtWidgets.QMessageBox.StandardButton.Discard
 
     def show_error_message(self, title: str, message: str) -> int:
         return QtWidgets.QMessageBox.critical(
@@ -2506,7 +2543,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.mark_dirty()
 
     def delete_selected_shapes(self) -> None:
-        yes, no = QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No
+        yes, no = (
+            QtWidgets.QMessageBox.StandardButton.Yes,
+            QtWidgets.QMessageBox.StandardButton.No,
+        )
         msg = self.tr(
             "Permanently delete {} shapes? This action cannot be undone."
         ).format(len(self._canvas_widgets.canvas.selected_shapes))
@@ -2570,8 +2610,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self,
                 self.tr("%s - Open Directory") % __appname__,
                 default_open_dir_path,
-                QtWidgets.QFileDialog.ShowDirsOnly
-                | QtWidgets.QFileDialog.DontResolveSymlinks,
+                QtWidgets.QFileDialog.Option.ShowDirsOnly
+                | QtWidgets.QFileDialog.Option.DontResolveSymlinks,
             )
         )
         if dir_path:
@@ -2588,7 +2628,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def import_dropped_image_files(self, image_files: list[str]) -> None:
         extensions = tuple(
-            f".{fmt.data().decode().lower()}"
+            f".{fmt.toStdString().lower()}"
             for fmt in QtGui.QImageReader.supportedImageFormats()
         )
         already_loaded = set(self.image_list)
@@ -2634,15 +2674,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 pass
         for image_path in image_paths:
             item = QtWidgets.QListWidgetItem(image_path)
-            item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             if QtCore.QFile.exists(
                 _resolve_label_path(
                     image_or_label_path=image_path, output_dir=self._output_dir
                 )
             ):
-                item.setCheckState(Qt.Checked)
+                item.setCheckState(Qt.CheckState.Checked)
             else:
-                item.setCheckState(Qt.Unchecked)
+                item.setCheckState(Qt.CheckState.Unchecked)
             self._docks.file_list.addItem(item)
 
     def _update_status_stats(self, mouse_pos: QtCore.QPointF) -> None:
@@ -2752,12 +2792,12 @@ def _make_image_list_item(
     *, image_path: str, output_dir: Path | None
 ) -> QtWidgets.QListWidgetItem:
     item = QtWidgets.QListWidgetItem(image_path)
-    item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+    item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
     label_path = _resolve_label_path(
         image_or_label_path=image_path, output_dir=output_dir
     )
     has_label = QtCore.QFile.exists(label_path)
-    item.setCheckState(Qt.Checked if has_label else Qt.Unchecked)
+    item.setCheckState(Qt.CheckState.Checked if has_label else Qt.CheckState.Unchecked)
     return item
 
 
@@ -2777,7 +2817,7 @@ def _shape_to_dict(shape: Shape) -> ShapeDict:
 
 def _scan_image_files(root_dir: str) -> list[str]:
     extensions: list[str] = [
-        f".{fmt.data().decode().lower()}"
+        f".{fmt.toStdString().lower()}"
         for fmt in QtGui.QImageReader.supportedImageFormats()
     ]
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1426,7 +1426,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         for mode, action in self._actions.draw:
             if mode in _AI_CREATE_MODES:
-                for widget in action.associatedWidgets():
+                for widget in action.associatedObjects():
                     if isinstance(widget, QtWidgets.QToolButton):
                         widget.setStyleSheet(style)
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -24,11 +24,11 @@ import numpy as np
 import osam
 from loguru import logger
 from numpy.typing import NDArray
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMessageBox
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 
 from labelme import __appname__
 from labelme import __version__
@@ -62,14 +62,6 @@ from labelme.widgets import download_ai_model
 from labelme.widgets import format_shape_label
 
 from . import utils
-
-# handle high-dpi scaling issue
-# https://leomoon.com/journal/python/high-dpi-scaling-in-pyqt5
-if hasattr(QtCore.Qt, "AA_EnableHighDpiScaling"):
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
-if hasattr(QtCore.Qt, "AA_UseHighDpiPixmaps"):
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
-
 
 LABEL_COLORMAP: NDArray[np.uint8] = imgviz.label_colormap()
 
@@ -112,58 +104,58 @@ class _DockWidgets(NamedTuple):
 
 
 class _Actions(NamedTuple):
-    about: QtWidgets.QAction
-    save: QtWidgets.QAction
-    save_as: QtWidgets.QAction
-    save_auto: QtWidgets.QAction
-    save_with_image_data: QtWidgets.QAction
-    change_output_dir: QtWidgets.QAction
-    open: QtWidgets.QAction
-    close: QtWidgets.QAction
-    delete_file: QtWidgets.QAction
-    toggle_keep_prev_mode: QtWidgets.QAction
-    toggle_keep_prev_brightness_contrast: QtWidgets.QAction
-    delete: QtWidgets.QAction
-    edit: QtWidgets.QAction
-    duplicate: QtWidgets.QAction
-    copy: QtWidgets.QAction
-    paste: QtWidgets.QAction
-    undo_last_point: QtWidgets.QAction
-    undo: QtWidgets.QAction
-    add_point_to_edge: QtWidgets.QAction
-    remove_point: QtWidgets.QAction
-    create_mode: QtWidgets.QAction
-    edit_mode: QtWidgets.QAction
-    create_rectangle_mode: QtWidgets.QAction
-    create_oriented_rectangle_mode: QtWidgets.QAction
-    create_circle_mode: QtWidgets.QAction
-    create_line_mode: QtWidgets.QAction
-    create_point_mode: QtWidgets.QAction
-    create_line_strip_mode: QtWidgets.QAction
-    create_ai_points_to_shape_mode: QtWidgets.QAction
-    create_ai_box_to_shape_mode: QtWidgets.QAction
-    open_next_img: QtWidgets.QAction
-    open_prev_img: QtWidgets.QAction
-    keep_prev_zoom: QtWidgets.QAction
-    fit_window: QtWidgets.QAction
-    fit_width: QtWidgets.QAction
-    brightness_contrast: QtWidgets.QAction
-    zoom_in: QtWidgets.QAction
-    zoom_out: QtWidgets.QAction
-    zoom_org: QtWidgets.QAction
-    reset_layout: QtWidgets.QAction
-    fill_drawing: QtWidgets.QAction
-    hide_all: QtWidgets.QAction
-    show_all: QtWidgets.QAction
-    toggle_all: QtWidgets.QAction
-    open_dir: QtWidgets.QAction
+    about: QtGui.QAction
+    save: QtGui.QAction
+    save_as: QtGui.QAction
+    save_auto: QtGui.QAction
+    save_with_image_data: QtGui.QAction
+    change_output_dir: QtGui.QAction
+    open: QtGui.QAction
+    close: QtGui.QAction
+    delete_file: QtGui.QAction
+    toggle_keep_prev_mode: QtGui.QAction
+    toggle_keep_prev_brightness_contrast: QtGui.QAction
+    delete: QtGui.QAction
+    edit: QtGui.QAction
+    duplicate: QtGui.QAction
+    copy: QtGui.QAction
+    paste: QtGui.QAction
+    undo_last_point: QtGui.QAction
+    undo: QtGui.QAction
+    add_point_to_edge: QtGui.QAction
+    remove_point: QtGui.QAction
+    create_mode: QtGui.QAction
+    edit_mode: QtGui.QAction
+    create_rectangle_mode: QtGui.QAction
+    create_oriented_rectangle_mode: QtGui.QAction
+    create_circle_mode: QtGui.QAction
+    create_line_mode: QtGui.QAction
+    create_point_mode: QtGui.QAction
+    create_line_strip_mode: QtGui.QAction
+    create_ai_points_to_shape_mode: QtGui.QAction
+    create_ai_box_to_shape_mode: QtGui.QAction
+    open_next_img: QtGui.QAction
+    open_prev_img: QtGui.QAction
+    keep_prev_zoom: QtGui.QAction
+    fit_window: QtGui.QAction
+    fit_width: QtGui.QAction
+    brightness_contrast: QtGui.QAction
+    zoom_in: QtGui.QAction
+    zoom_out: QtGui.QAction
+    zoom_org: QtGui.QAction
+    reset_layout: QtGui.QAction
+    fill_drawing: QtGui.QAction
+    hide_all: QtGui.QAction
+    show_all: QtGui.QAction
+    toggle_all: QtGui.QAction
+    open_dir: QtGui.QAction
     zoom_widget_action: QtWidgets.QWidgetAction
-    draw: list[tuple[str, QtWidgets.QAction]]
-    zoom: tuple[ZoomWidget | QtWidgets.QAction, ...]
-    on_load_active: tuple[QtWidgets.QAction, ...]
-    on_shapes_present: tuple[QtWidgets.QAction, ...]
-    context_menu: tuple[QtWidgets.QAction, ...]
-    edit_menu: tuple[QtWidgets.QAction | None, ...]
+    draw: list[tuple[str, QtGui.QAction]]
+    zoom: tuple[ZoomWidget | QtGui.QAction, ...]
+    on_load_active: tuple[QtGui.QAction, ...]
+    on_shapes_present: tuple[QtGui.QAction, ...]
+    context_menu: tuple[QtGui.QAction, ...]
+    edit_menu: tuple[QtGui.QAction | None, ...]
 
 
 class _Menus(NamedTuple):
@@ -669,7 +661,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.zoom_widget.setEnabled(False)
 
         self._zoom_mode = _ZoomMode.FIT_WINDOW
-        fit_window.setChecked(Qt.Checked)
+        fit_window.setChecked(True)
 
         self._canvas_widgets.canvas.vertex_selected.connect(remove_point.setEnabled)
         self._canvas_widgets.canvas.edge_selected.connect(add_point_to_edge.setEnabled)
@@ -813,7 +805,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
             enabled=settings_editable,
         )
-        open_config.setMenuRole(QtWidgets.QAction.PreferencesRole)
+        open_config.setMenuRole(QtGui.QAction.PreferencesRole)
         help_ = action(
             self.tr("&Tutorial"),
             self.tutorial,
@@ -1194,7 +1186,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def menu(
         self,
         title: str,
-        actions: tuple[QtWidgets.QAction | QtWidgets.QMenu | None, ...] | None = None,
+        actions: tuple[QtGui.QAction | QtWidgets.QMenu | None, ...] | None = None,
     ) -> QtWidgets.QMenu:
         menu = self.menuBar().addMenu(title)
         if actions:
@@ -1439,7 +1431,7 @@ class MainWindow(QtWidgets.QMainWindow):
                         widget.setStyleSheet(style)
 
     def show_label_list_menu(self, point: QtCore.QPoint) -> None:
-        # PyQt5 stubs type QMenu.exec() argument too narrowly
+        # PySide6 type QMenu.exec() argument too narrowly
         self._menus.label_list.exec(self._docks.label_list.mapToGlobal(point))  # ty: ignore[invalid-argument-type]
 
     def validate_label(self, label: str) -> bool:
@@ -1448,7 +1440,6 @@ class MainWindow(QtWidgets.QMainWindow):
             return True
         unique_label_list = self._docks.unique_label_list
         existing_labels = [
-            # PyQt5 stubs: item() typed as Optional and .data() unrecognized
             unique_label_list.item(i).data(Qt.UserRole)  # ty: ignore[unresolved-attribute]
             for i in range(unique_label_list.count())
         ]
@@ -1948,7 +1939,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if is_initial_load:
             dialog.apply()
         else:
-            dialog.exec_()
+            dialog.exec()
             brightness = dialog.slider_brightness.value()
             contrast = dialog.slider_contrast.value()
 

--- a/labelme/utils/image.py
+++ b/labelme/utils/image.py
@@ -11,7 +11,7 @@ import PIL.ExifTags
 import PIL.Image
 import PIL.ImageOps
 from numpy.typing import NDArray
-from PyQt5 import QtGui
+from PySide6 import QtGui
 
 
 def img_data_to_pil(img_data: bytes) -> PIL.Image.Image:
@@ -55,7 +55,7 @@ def img_data_to_png_data(img_data: bytes) -> bytes:
 
 def img_qt_to_arr(img_qt: QtGui.QImage) -> NDArray[np.uint8]:
     w, h, d = img_qt.size().width(), img_qt.size().height(), img_qt.depth()
-    bytes_ = img_qt.bits().asstring(w * h * d // 8)
+    bytes_ = bytes(img_qt.bits())
     img_arr = np.frombuffer(bytes_, dtype=np.uint8).reshape((h, w, d // 8))
     return img_arr
 

--- a/labelme/utils/image.py
+++ b/labelme/utils/image.py
@@ -55,9 +55,13 @@ def img_data_to_png_data(img_data: bytes) -> bytes:
 
 def img_qt_to_arr(img_qt: QtGui.QImage) -> NDArray[np.uint8]:
     w, h, d = img_qt.size().width(), img_qt.size().height(), img_qt.depth()
-    bytes_ = bytes(img_qt.bits())
-    img_arr = np.frombuffer(bytes_, dtype=np.uint8).reshape((h, w, d // 8))
-    return img_arr
+    channels = d // 8
+    # bits() spans bytesPerLine() * height; Qt aligns each scanline to a 4-byte
+    # boundary, so a row may be wider than w * channels. Drop the padding.
+    rows = np.frombuffer(bytes(img_qt.bits()), dtype=np.uint8).reshape(
+        (h, img_qt.bytesPerLine())
+    )
+    return rows[:, : w * channels].reshape((h, w, channels))
 
 
 def apply_exif_orientation(image: PIL.Image.Image) -> PIL.Image.Image:

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -52,7 +52,7 @@ def new_action(
         action.setIconText(text.replace(" ", "\n"))
         action.setIcon(new_icon(icon))
     if isinstance(shortcut, list | tuple):
-        action.setShortcuts(shortcut)
+        action.setShortcuts([QtGui.QKeySequence(s) for s in shortcut])
     elif shortcut is not None:
         action.setShortcut(shortcut)
     if tip is not None:

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -8,9 +8,9 @@ from typing import Final
 
 import numpy as np
 import numpy.typing as npt
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 
 here = Path(__file__).resolve().parent
 
@@ -46,8 +46,8 @@ def new_action(
     checkable: bool = False,
     enabled: bool = True,
     checked: bool = False,
-) -> QtWidgets.QAction:
-    action = QtWidgets.QAction(text, parent)
+) -> QtGui.QAction:
+    action = QtGui.QAction(text, parent)
     if icon is not None:
         action.setIconText(text.replace(" ", "\n"))
         action.setIcon(new_icon(icon))
@@ -69,7 +69,7 @@ def new_action(
 
 def add_actions(
     widget: QtWidgets.QMenu | QtWidgets.QToolBar,
-    actions: Sequence[QtWidgets.QAction | QtWidgets.QMenu | None],
+    actions: Sequence[QtGui.QAction | QtWidgets.QMenu | None],
 ) -> None:
     for entry in actions:
         if entry is None:
@@ -81,8 +81,8 @@ def add_actions(
         widget.addAction(entry)
 
 
-def label_validator() -> QtGui.QRegExpValidator:
-    return QtGui.QRegExpValidator(QtCore.QRegExp(r"^[^ \t].+"), None)
+def label_validator() -> QtGui.QRegularExpressionValidator:
+    return QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"^[^ \t].+"))
 
 
 def distance(p: QtCore.QPointF) -> float:

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -4,10 +4,10 @@ import typing
 from collections.abc import Callable
 
 from loguru import logger
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
 
 from labelme._automation import AiOutputFormat
 
@@ -15,7 +15,7 @@ from ._info_button import InfoButton
 
 
 class AiAssistedAnnotationWidget(QtWidgets.QWidget):
-    hover_highlight_requested = QtCore.pyqtSignal(bool)
+    hover_highlight_requested = QtCore.Signal(bool)
 
     _available_models: list[tuple[str, str]] = [
         ("efficientsam:10m", "EfficientSam (speed)"),

--- a/labelme/widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/widgets/_ai_assisted_annotation_widget.py
@@ -124,9 +124,9 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
             item = model.item(i)
             assert item is not None
             if model_id in disabled_models:
-                item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled)
             else:
-                item.setFlags(item.flags() | Qt.ItemIsEnabled)
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEnabled)
 
     def setEnabled(self, a0: bool) -> None:
         self._body.setEnabled(a0)
@@ -134,7 +134,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
     def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent) -> bool:
         if a0 in (self, self._body) and not self._body.isEnabled():
-            if a1.type() == QtCore.QEvent.Enter:
+            if a1.type() == QtCore.QEvent.Type.Enter:
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),
                     self.tr(
@@ -144,6 +144,6 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
                     self,
                 )
                 self.hover_highlight_requested.emit(True)
-            elif a1.type() == QtCore.QEvent.Leave:
+            elif a1.type() == QtCore.QEvent.Type.Leave:
                 self.hover_highlight_requested.emit(False)
         return super().eventFilter(a0, a1)

--- a/labelme/widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/widgets/_ai_text_to_annotation_widget.py
@@ -69,7 +69,7 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
         run_button = QtWidgets.QToolButton()
         run_button.setText(self.tr("Run"))
         run_button.setFixedHeight(24)
-        run_button.setCursor(QtCore.Qt.PointingHandCursor)
+        run_button.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
         run_button.clicked.connect(on_submit)
         grid.addWidget(run_button, 0, 1)
 
@@ -139,7 +139,7 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
 
     def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent) -> bool:
         if a0 == self._body and not self._body.isEnabled():
-            if a1.type() == QtCore.QEvent.Enter:
+            if a1.type() == QtCore.QEvent.Type.Enter:
                 QtWidgets.QToolTip.showText(
                     QtGui.QCursor.pos(),
                     self.tr(

--- a/labelme/widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/widgets/_ai_text_to_annotation_widget.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 
 from ._info_button import InfoButton
 

--- a/labelme/widgets/_info_button.py
+++ b/labelme/widgets/_info_button.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 
 from labelme.utils.qt import new_icon
 

--- a/labelme/widgets/_info_button.py
+++ b/labelme/widgets/_info_button.py
@@ -24,9 +24,9 @@ class InfoButton(QtWidgets.QToolButton):
             }
             """
         )
-        self.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
+        self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
         self.setToolTip(tooltip)
 
-    def enterEvent(self, a0: QtCore.QEvent) -> None:
+    def enterEvent(self, a0: QtGui.QEnterEvent) -> None:
         super().enterEvent(a0)
         QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), self.toolTip())

--- a/labelme/widgets/_shape_render.py
+++ b/labelme/widgets/_shape_render.py
@@ -373,7 +373,9 @@ def is_hit_by_point(
     if shape.shape_type == "point":
         if len(shape.points) == 0:
             return False
-        return bool(np.linalg.norm(point - shape.points[0]) <= point_size / 2)
+        return bool(
+            np.linalg.norm((point - shape.points[0]) * scale) <= point_size / 2
+        )
     if shape.mask is not None:
         raw_y = int(round(float(point[1]) - float(shape.points[0][1])))
         raw_x = int(round(float(point[0]) - float(shape.points[0][0])))

--- a/labelme/widgets/_shape_render.py
+++ b/labelme/widgets/_shape_render.py
@@ -373,7 +373,7 @@ def is_hit_by_point(
     if shape.shape_type == "point":
         if len(shape.points) == 0:
             return False
-        return bool(np.linalg.norm(point - shape.points[0]) <= point_size / 2)
+        return bool(np.linalg.norm((point - shape.points[0]) * scale) <= point_size / 2)
     if shape.mask is not None:
         raw_y = int(round(float(point[1]) - float(shape.points[0][1])))
         raw_x = int(round(float(point[0]) - float(shape.points[0][0])))

--- a/labelme/widgets/_shape_render.py
+++ b/labelme/widgets/_shape_render.py
@@ -8,8 +8,8 @@ from typing import Literal
 import numpy as np
 import numpy.typing as npt
 import skimage.measure
-from PyQt5 import QtCore
-from PyQt5 import QtGui
+from PySide6 import QtCore
+from PySide6 import QtGui
 
 from labelme import utils
 from labelme._shape import Shape

--- a/labelme/widgets/_shape_render.py
+++ b/labelme/widgets/_shape_render.py
@@ -373,9 +373,7 @@ def is_hit_by_point(
     if shape.shape_type == "point":
         if len(shape.points) == 0:
             return False
-        return bool(
-            np.linalg.norm((point - shape.points[0]) * scale) <= point_size / 2
-        )
+        return bool(np.linalg.norm(point - shape.points[0]) <= point_size / 2)
     if shape.mask is not None:
         raw_y = int(round(float(point[1]) - float(shape.points[0][1])))
         raw_x = int(round(float(point[0]) - float(shape.points[0][0])))

--- a/labelme/widgets/_status.py
+++ b/labelme/widgets/_status.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 
 
 class StatusStats(QtWidgets.QLabel):
@@ -10,5 +10,5 @@ class StatusStats(QtWidgets.QLabel):
 
         font = QtGui.QFont()
         font.setFamily("monospace")
-        font.setStyleHint(QtGui.QFont.Monospace)
+        font.setStyleHint(QtGui.QFont.StyleHint.Monospace)
         self.setFont(font)

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -34,13 +34,13 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
             title_label.setFixedWidth(75)
             layout.addWidget(title_label)
             #
-            slider = QtWidgets.QSlider(Qt.Horizontal)
+            slider = QtWidgets.QSlider(Qt.Orientation.Horizontal)
             slider.setRange(0, 3 * self._base_value)
             slider.setValue(self._base_value)
             layout.addWidget(slider)
             #
             value_label = QtWidgets.QLabel(f"{slider.value() / self._base_value:.2f}")
-            value_label.setAlignment(Qt.AlignRight)
+            value_label.setAlignment(Qt.AlignmentFlag.AlignRight)
             layout.addWidget(value_label)
             #
             slider.valueChanged.connect(lambda _: self.apply())
@@ -90,11 +90,11 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
 
         fmt: QImage.Format
         if self._alpha is None:
-            fmt = QImage.Format_RGB888
+            fmt = QImage.Format.Format_RGB888
         else:
             img = img.convert("RGBA")
             img.putalpha(self._alpha)
-            fmt = QImage.Format_RGBA8888
+            fmt = QImage.Format.Format_RGBA8888
 
         qimage = QImage(
             img.tobytes(), img.width, img.height, img.width * len(img.getbands()), fmt

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -4,9 +4,9 @@ from collections.abc import Callable
 
 import PIL.Image
 import PIL.ImageEnhance
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QImage
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QImage
 
 
 class BrightnessContrastDialog(QtWidgets.QDialog):

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -13,13 +13,13 @@ from typing import cast
 
 import numpy as np
 from loguru import logger
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import QRectF
-from PyQt5.QtCore import Qt
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import QRectF
+from PySide6.QtCore import Qt
 
 import labelme.utils
 from labelme import _automation
@@ -170,19 +170,19 @@ class Canvas(QtWidgets.QWidget):
     _last_hovered_edge: int | None
     _hovered_rotation: int | None
 
-    zoom_request = QtCore.pyqtSignal(int, QPointF)
-    scroll_request = QtCore.pyqtSignal(int, int)
-    pan_request = QtCore.pyqtSignal(QPoint)
-    new_shape = QtCore.pyqtSignal()
-    inference_produced_no_shapes = QtCore.pyqtSignal()
-    degenerate_shape_rejected = QtCore.pyqtSignal()
-    selection_changed = QtCore.pyqtSignal(list)
-    shape_moved = QtCore.pyqtSignal()
-    drawing_polygon = QtCore.pyqtSignal(bool)
-    vertex_selected = QtCore.pyqtSignal(bool)
-    edge_selected = QtCore.pyqtSignal(bool)
-    mouse_moved = QtCore.pyqtSignal(QPointF)
-    status_updated = QtCore.pyqtSignal(str)
+    zoom_request = QtCore.Signal(int, QPointF)
+    scroll_request = QtCore.Signal(int, int)
+    pan_request = QtCore.Signal(QPoint)
+    new_shape = QtCore.Signal()
+    inference_produced_no_shapes = QtCore.Signal()
+    degenerate_shape_rejected = QtCore.Signal()
+    selection_changed = QtCore.Signal(list)
+    shape_moved = QtCore.Signal()
+    drawing_polygon = QtCore.Signal(bool)
+    vertex_selected = QtCore.Signal(bool)
+    edge_selected = QtCore.Signal(bool)
+    mouse_moved = QtCore.Signal(QPointF)
+    status_updated = QtCore.Signal(str)
 
     mode: _CanvasMode = _CanvasMode.EDIT
 
@@ -564,7 +564,7 @@ class Canvas(QtWidgets.QWidget):
 
     def mouseMoveEvent(self, a0: QtGui.QMouseEvent) -> None:
         try:
-            pos = self._transform_point_widget_to_image(a0.localPos())
+            pos = self._transform_point_widget_to_image(a0.position())
         except AttributeError:
             return
         self.mouse_moved.emit(pos)
@@ -592,7 +592,7 @@ class Canvas(QtWidgets.QWidget):
         # Use screen coordinates so the anchor does not drift when our own
         # pan emit shifts the canvas widget under the scroll area — a
         # widget-local frame would oscillate and cause juggling.
-        cursor: QPointF = QPointF(self.mapToGlobal(event.pos()))
+        cursor: QPointF = QPointF(self.mapToGlobal(event.position().toPoint()))
         step: QPointF = cursor - self._pan_anchor
         self._pan_anchor = cursor
         self.pan_request.emit(QPoint(int(step.x()), int(step.y())))
@@ -903,7 +903,7 @@ class Canvas(QtWidgets.QWidget):
         self._is_moving_shape = True  # Save changes
 
     def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
-        pos: QPointF = self._transform_point_widget_to_image(a0.localPos())
+        pos: QPointF = self._transform_point_widget_to_image(a0.position())
         self._dispatch_pointer_press(pos=pos, event=a0)
         self._update_status()
 
@@ -970,7 +970,7 @@ class Canvas(QtWidgets.QWidget):
             self._line = dataclasses.replace(
                 self._line, points=(current.points[-1],) + self._line.points[1:]
             )
-            if int(modifiers) == Qt.ControlModifier:
+            if modifiers == Qt.ControlModifier:
                 self._finalize()
         elif mode == "ai_points_to_shape":
             current = current.add_point(
@@ -1049,7 +1049,7 @@ class Canvas(QtWidgets.QWidget):
             self._capture_rotation_anchors()
         self._select_shape_point(
             pos,
-            multiple_selection_mode=int(modifiers) == Qt.ControlModifier,
+            multiple_selection_mode=modifiers == Qt.ControlModifier,
         )
         self._prev_point = pos
         self.update()
@@ -1069,14 +1069,14 @@ class Canvas(QtWidgets.QWidget):
         ):
             self._select_shape_point(
                 pos,
-                multiple_selection_mode=int(event.modifiers()) == Qt.ControlModifier,
+                multiple_selection_mode=event.modifiers() == Qt.ControlModifier,
             )
             self.update()
         self._prev_point = pos
 
     def _begin_pan(self, event: QtGui.QMouseEvent) -> None:
         self._apply_cursor(CURSOR_GRAB)
-        self._pan_anchor = QPointF(self.mapToGlobal(event.pos()))
+        self._pan_anchor = QPointF(self.mapToGlobal(event.position().toPoint()))
 
     def mouseReleaseEvent(self, a0: QtGui.QMouseEvent) -> None:
         self._dispatch_pointer_release(event=a0)
@@ -1097,7 +1097,7 @@ class Canvas(QtWidgets.QWidget):
     def _release_right(self, event: QtGui.QMouseEvent) -> None:
         menu = self.menus[len(self._selected_shapes_copy) > 0]
         self._release_cursor()
-        if menu.exec_(self.mapToGlobal(event.pos())):  # type: ignore
+        if menu.exec(self.mapToGlobal(event.position().toPoint())):  # type: ignore
             return
         if not self._selected_shapes_copy:
             return
@@ -1379,9 +1379,8 @@ class Canvas(QtWidgets.QWidget):
 
     def _setup_world_transform(self, painter: QtGui.QPainter) -> None:
         for hint in (
-            QtGui.QPainter.Antialiasing,
-            QtGui.QPainter.HighQualityAntialiasing,
-            QtGui.QPainter.SmoothPixmapTransform,
+            QtGui.QPainter.RenderHint.Antialiasing,
+            QtGui.QPainter.RenderHint.SmoothPixmapTransform,
         ):
             painter.setRenderHint(hint)
         painter.translate(self._compute_image_origin_offset() * self.scale)
@@ -1601,11 +1600,11 @@ class Canvas(QtWidgets.QWidget):
     def wheelEvent(self, a0: QtGui.QWheelEvent) -> None:
         mods: Qt.KeyboardModifiers = a0.modifiers()
         delta: QPoint = a0.angleDelta()
-        if Qt.ControlModifier == int(mods):
+        if mods == Qt.ControlModifier:
             # with Ctrl/Command key
             # zoom
-            self.zoom_request.emit(delta.y(), a0.posF())
-        elif int(mods) == int(Qt.ShiftModifier) and delta.x() == 0:
+            self.zoom_request.emit(delta.y(), a0.position())
+        elif mods == Qt.ShiftModifier and delta.x() == 0:
             # Shift+wheel scrolls horizontally. macOS swaps the axis for us,
             # but Linux/Windows deliver the delta on y and expect the app to
             # remap it.
@@ -1649,7 +1648,7 @@ class Canvas(QtWidgets.QWidget):
     def keyReleaseEvent(self, a0: QtGui.QKeyEvent) -> None:
         modifiers = a0.modifiers()
         if self.mode == _CanvasMode.CREATE:
-            if int(modifiers) == 0:
+            if not modifiers:
                 self._snapping = True
         elif self.mode == _CanvasMode.EDIT:
             if (

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -96,11 +96,11 @@ def _shape_to_draft(shape: Shape) -> _DraftShape:
     )
 
 
-CURSOR_DEFAULT = Qt.ArrowCursor
-CURSOR_POINT = Qt.PointingHandCursor
-CURSOR_DRAW = Qt.CrossCursor
-CURSOR_MOVE = Qt.ClosedHandCursor
-CURSOR_GRAB = Qt.OpenHandCursor
+CURSOR_DEFAULT = Qt.CursorShape.ArrowCursor
+CURSOR_POINT = Qt.CursorShape.PointingHandCursor
+CURSOR_DRAW = Qt.CursorShape.CrossCursor
+CURSOR_MOVE = Qt.CursorShape.ClosedHandCursor
+CURSOR_GRAB = Qt.CursorShape.OpenHandCursor
 
 MOVE_SPEED: float = 5.0
 
@@ -264,7 +264,7 @@ class Canvas(QtWidgets.QWidget):
         # 1: right-click with selection and dragging of shapes
         self.menus = (QtWidgets.QMenu(), QtWidgets.QMenu())
         self.setMouseTracking(True)
-        self.setFocusPolicy(Qt.WheelFocus)
+        self.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
 
     def set_fill_drawing(self, value: bool) -> None:
         self._fill_drawing = value
@@ -579,10 +579,10 @@ class Canvas(QtWidgets.QWidget):
             self._track_drawing_cursor(pos=pos, event=event)
             return
         buttons = event.buttons()
-        if buttons & Qt.RightButton:
+        if buttons & Qt.MouseButton.RightButton:
             self._continue_right_button_drag(pos=pos)
             return
-        if buttons & Qt.LeftButton:
+        if buttons & Qt.MouseButton.LeftButton:
             self._continue_left_button_drag(pos=pos, event=event)
             return
         self._refresh_hover_state(pos=pos)
@@ -608,7 +608,7 @@ class Canvas(QtWidgets.QWidget):
             self.update()
             self._update_status()
             return
-        is_shift_pressed = bool(event.modifiers() & Qt.ShiftModifier)
+        is_shift_pressed = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
         pos = self._project_drawing_pos_into_image(pos=pos)
         self._update_drawing_line(pos=pos, is_shift_pressed=is_shift_pressed)
         assert len(self._line.points) == len(self._line.point_labels)
@@ -723,7 +723,7 @@ class Canvas(QtWidgets.QWidget):
     def _continue_left_button_drag(
         self, pos: QPointF, event: QtGui.QMouseEvent
     ) -> None:
-        is_shift_pressed = bool(event.modifiers() & Qt.ShiftModifier)
+        is_shift_pressed = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
         if self._is_vertex_selected():
             self._drag_hovered_vertex(pos=pos, is_shift_pressed=is_shift_pressed)
             return
@@ -909,17 +909,20 @@ class Canvas(QtWidgets.QWidget):
 
     def _dispatch_pointer_press(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         button = event.button()
-        if button == Qt.LeftButton:
+        if button == Qt.MouseButton.LeftButton:
             self._press_left(pos=pos, event=event)
             return
-        if button == Qt.RightButton and self.mode == _CanvasMode.EDIT:
+        if button == Qt.MouseButton.RightButton and self.mode == _CanvasMode.EDIT:
             self._press_right(pos=pos, event=event)
             return
-        if button == Qt.MiddleButton and self._is_image_overflowing_viewport():
+        if (
+            button == Qt.MouseButton.MiddleButton
+            and self._is_image_overflowing_viewport()
+        ):
             self._begin_pan(event=event)
 
     def _press_left(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
-        is_shift_pressed = bool(event.modifiers() & Qt.ShiftModifier)
+        is_shift_pressed = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
         if self.mode == _CanvasMode.CREATE:
             self._press_left_while_drawing(
                 pos=pos, event=event, is_shift_pressed=is_shift_pressed
@@ -970,7 +973,7 @@ class Canvas(QtWidgets.QWidget):
             self._line = dataclasses.replace(
                 self._line, points=(current.points[-1],) + self._line.points[1:]
             )
-            if modifiers == Qt.ControlModifier:
+            if modifiers == Qt.KeyboardModifier.ControlModifier:
                 self._finalize()
         elif mode == "ai_points_to_shape":
             current = current.add_point(
@@ -982,7 +985,7 @@ class Canvas(QtWidgets.QWidget):
                 points=(current.points[-1],) + self._line.points[1:],
                 point_labels=(current.point_labels[-1],) + self._line.point_labels[1:],
             )
-            if modifiers & Qt.ControlModifier:
+            if modifiers & Qt.KeyboardModifier.ControlModifier:
                 self._finalize()
 
     def _lock_oriented_rectangle_first_edge(self, current: _DraftShape) -> None:
@@ -1028,7 +1031,10 @@ class Canvas(QtWidgets.QWidget):
         if mode == "point":
             self._finalize()
             return
-        if mode == "ai_points_to_shape" and event.modifiers() & Qt.ControlModifier:
+        if (
+            mode == "ai_points_to_shape"
+            and event.modifiers() & Qt.KeyboardModifier.ControlModifier
+        ):
             self._finalize()
             return
 
@@ -1049,17 +1055,17 @@ class Canvas(QtWidgets.QWidget):
             self._capture_rotation_anchors()
         self._select_shape_point(
             pos,
-            multiple_selection_mode=modifiers == Qt.ControlModifier,
+            multiple_selection_mode=modifiers == Qt.KeyboardModifier.ControlModifier,
         )
         self._prev_point = pos
         self.update()
 
-    def _maybe_modify_polygon_topology(self, modifiers: Qt.KeyboardModifiers) -> None:
-        if self._is_edge_selected() and modifiers == Qt.AltModifier:
+    def _maybe_modify_polygon_topology(self, modifiers: Qt.KeyboardModifier) -> None:
+        if self._is_edge_selected() and modifiers == Qt.KeyboardModifier.AltModifier:
             self.add_point_to_edge()
             return
         if self._is_vertex_selected() and modifiers == (
-            Qt.AltModifier | Qt.ShiftModifier
+            Qt.KeyboardModifier.AltModifier | Qt.KeyboardModifier.ShiftModifier
         ):
             self.remove_selected_point()
 
@@ -1069,7 +1075,8 @@ class Canvas(QtWidgets.QWidget):
         ):
             self._select_shape_point(
                 pos,
-                multiple_selection_mode=event.modifiers() == Qt.ControlModifier,
+                multiple_selection_mode=event.modifiers()
+                == Qt.KeyboardModifier.ControlModifier,
             )
             self.update()
         self._prev_point = pos
@@ -1085,13 +1092,13 @@ class Canvas(QtWidgets.QWidget):
 
     def _dispatch_pointer_release(self, event: QtGui.QMouseEvent) -> None:
         button = event.button()
-        if button == Qt.RightButton:
+        if button == Qt.MouseButton.RightButton:
             self._release_right(event=event)
             return
-        if button == Qt.LeftButton:
+        if button == Qt.MouseButton.LeftButton:
             self._release_left()
             return
-        if button == Qt.MiddleButton:
+        if button == Qt.MouseButton.MiddleButton:
             self._finish_pan()
 
     def _release_right(self, event: QtGui.QMouseEvent) -> None:
@@ -1598,21 +1605,21 @@ class Canvas(QtWidgets.QWidget):
         return self._compute_canvas_size()
 
     def wheelEvent(self, a0: QtGui.QWheelEvent) -> None:
-        mods: Qt.KeyboardModifiers = a0.modifiers()
+        mods: Qt.KeyboardModifier = a0.modifiers()
         delta: QPoint = a0.angleDelta()
-        if mods == Qt.ControlModifier:
+        if mods == Qt.KeyboardModifier.ControlModifier:
             # with Ctrl/Command key
             # zoom
             self.zoom_request.emit(delta.y(), a0.position())
-        elif mods == Qt.ShiftModifier and delta.x() == 0:
+        elif mods == Qt.KeyboardModifier.ShiftModifier and delta.x() == 0:
             # Shift+wheel scrolls horizontally. macOS swaps the axis for us,
             # but Linux/Windows deliver the delta on y and expect the app to
             # remap it.
-            self.scroll_request.emit(delta.y(), Qt.Horizontal)
+            self.scroll_request.emit(delta.y(), Qt.Orientation.Horizontal)
         else:
             # scroll
-            self.scroll_request.emit(delta.x(), Qt.Horizontal)
-            self.scroll_request.emit(delta.y(), Qt.Vertical)
+            self.scroll_request.emit(delta.x(), Qt.Orientation.Horizontal)
+            self.scroll_request.emit(delta.y(), Qt.Orientation.Vertical)
         a0.accept()
 
     def _move_by_keyboard(self, offset: QPointF) -> None:
@@ -1626,22 +1633,24 @@ class Canvas(QtWidgets.QWidget):
         modifiers = a0.modifiers()
         key = a0.key()
         if self.mode == _CanvasMode.CREATE:
-            if key == Qt.Key_Escape and self._current is not None:
+            if key == Qt.Key.Key_Escape and self._current is not None:
                 self._cancel_current_shape()
-            elif key in (Qt.Key_Return, Qt.Key_Space) and self._can_close_shape():
+            elif (
+                key in (Qt.Key.Key_Return, Qt.Key.Key_Space) and self._can_close_shape()
+            ):
                 self._finalize()
-            elif modifiers == Qt.AltModifier:
+            elif modifiers == Qt.KeyboardModifier.AltModifier:
                 self._snapping = False
         elif self.mode == _CanvasMode.EDIT:
-            if key == Qt.Key_Up:
+            if key == Qt.Key.Key_Up:
                 self._move_by_keyboard(QPointF(0.0, -MOVE_SPEED))
-            elif key == Qt.Key_Down:
+            elif key == Qt.Key.Key_Down:
                 self._move_by_keyboard(QPointF(0.0, MOVE_SPEED))
-            elif key == Qt.Key_Left:
+            elif key == Qt.Key.Key_Left:
                 self._move_by_keyboard(QPointF(-MOVE_SPEED, 0.0))
-            elif key == Qt.Key_Right:
+            elif key == Qt.Key.Key_Right:
                 self._move_by_keyboard(QPointF(MOVE_SPEED, 0.0))
-            elif a0.matches(QtGui.QKeySequence.SelectAll):
+            elif a0.matches(QtGui.QKeySequence.StandardKey.SelectAll):
                 self.select_shapes(shapes=self.shapes[:])
         self._update_status()
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -171,7 +171,7 @@ class Canvas(QtWidgets.QWidget):
     _hovered_rotation: int | None
 
     zoom_request = QtCore.Signal(int, QPointF)
-    scroll_request = QtCore.Signal(int, int)
+    scroll_request = QtCore.Signal(int, Qt.Orientation)
     pan_request = QtCore.Signal(QPoint)
     new_shape = QtCore.Signal()
     inference_produced_no_shapes = QtCore.Signal()

--- a/labelme/widgets/download.py
+++ b/labelme/widgets/download.py
@@ -88,7 +88,7 @@ def download_ai_model(model_name: str, parent: QWidget) -> bool:
         0,
         parent,
     )
-    dialog.setWindowModality(Qt.WindowModal)
+    dialog.setWindowModality(Qt.WindowModality.WindowModal)
     dialog.setMinimumDuration(0)
     dialog.setMinimumWidth(400)
     dialog.setAutoClose(False)

--- a/labelme/widgets/download.py
+++ b/labelme/widgets/download.py
@@ -5,11 +5,11 @@ from typing import Final
 import osam
 import osam.types
 from loguru import logger
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QThread
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QProgressDialog
-from PyQt5.QtWidgets import QWidget
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QThread
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QProgressDialog
+from PySide6.QtWidgets import QWidget
 
 
 class _Cancelled(Exception):
@@ -19,9 +19,9 @@ class _Cancelled(Exception):
 class _DownloadThread(QThread):
     UNKNOWN_SIZE: Final = -1
 
-    progress = pyqtSignal(int, int, str, int, int)
-    succeeded = pyqtSignal()
-    error = pyqtSignal(Exception)
+    progress = Signal(int, int, str, int, int)
+    succeeded = Signal()
+    error = Signal(Exception)
 
     def __init__(self, model_type: type[osam.types.Model], parent: QWidget) -> None:
         super().__init__(parent)
@@ -139,7 +139,7 @@ def download_ai_model(model_name: str, parent: QWidget) -> bool:
 
     dialog.show()
     thread.start()
-    dialog.exec_()
+    dialog.exec()
 
     thread.progress.disconnect(_on_progress)
     thread.succeeded.disconnect(_on_succeeded)

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -19,7 +19,7 @@ class LabelQLineEdit(QtWidgets.QLineEdit):
         self.list_widget = list_widget
 
     def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:
-        if a0.key() in [QtCore.Qt.Key_Up, QtCore.Qt.Key_Down]:
+        if a0.key() in [QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down]:
             self.list_widget.keyPressEvent(a0)
         else:
             super().keyPressEvent(a0)
@@ -88,15 +88,21 @@ class LabelDialog(QtWidgets.QDialog):
     def _build_label_list(self, labels: list[str] | None) -> QtWidgets.QListWidget:
         label_list = QtWidgets.QListWidget()
         if self._fit_to_content["row"]:
-            label_list.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            label_list.setHorizontalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
         if self._fit_to_content["column"]:
-            label_list.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            label_list.setVerticalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
         if labels:
             label_list.addItems(labels)
         if self._sort_labels:
             label_list.sortItems()
         else:
-            label_list.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
+            label_list.setDragDropMode(
+                QtWidgets.QAbstractItemView.DragDropMode.InternalMove
+            )
         label_list.currentItemChanged.connect(self._on_label_selected)
         label_list.itemDoubleClicked.connect(self._on_label_double_clicked)
         label_list.setFixedHeight(150)
@@ -110,8 +116,9 @@ class LabelDialog(QtWidgets.QDialog):
 
     def _build_button_box(self) -> QtWidgets.QDialogButtonBox:
         button_box = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
-            orientation=QtCore.Qt.Horizontal,
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            orientation=QtCore.Qt.Orientation.Horizontal,
             parent=self,
         )
         button_box.accepted.connect(self._validate)
@@ -121,10 +128,14 @@ class LabelDialog(QtWidgets.QDialog):
     def _build_completer(self, mode: str) -> QtWidgets.QCompleter:
         completer = QtWidgets.QCompleter()
         if mode == "startswith":
-            completer.setCompletionMode(QtWidgets.QCompleter.InlineCompletion)
+            completer.setCompletionMode(
+                QtWidgets.QCompleter.CompletionMode.InlineCompletion
+            )
         elif mode == "contains":
-            completer.setCompletionMode(QtWidgets.QCompleter.PopupCompletion)
-            completer.setFilterMode(QtCore.Qt.MatchContains)
+            completer.setCompletionMode(
+                QtWidgets.QCompleter.CompletionMode.PopupCompletion
+            )
+            completer.setFilterMode(QtCore.Qt.MatchFlag.MatchContains)
         else:
             raise ValueError(f"Unsupported completion: {mode}")
         completer.setModel(self.label_list.model())
@@ -133,7 +144,7 @@ class LabelDialog(QtWidgets.QDialog):
     def add_label_history(self, label: str) -> None:
         if label not in self._label_history:
             self._label_history.append(label)
-        if self.label_list.findItems(label, QtCore.Qt.MatchExactly):
+        if self.label_list.findItems(label, QtCore.Qt.MatchFlag.MatchExactly):
             return
         self.label_list.addItem(label)
         if self._sort_labels:
@@ -181,7 +192,10 @@ class LabelDialog(QtWidgets.QDialog):
 
     def _delete_flags(self) -> None:
         while self._flags_layout.count() > 0:
-            widget = self._flags_layout.takeAt(0).widget()
+            item = self._flags_layout.takeAt(0)
+            if item is None:
+                break
+            widget = item.widget()
             if widget is not None:
                 widget.setParent(QtWidgets.QWidget())
 
@@ -205,7 +219,8 @@ class LabelDialog(QtWidgets.QDialog):
         return {
             cb.text(): cb.isChecked()
             for i in range(self._flags_layout.count())
-            if (cb := cast(QtWidgets.QCheckBox, self._flags_layout.itemAt(i).widget()))
+            if (item := self._flags_layout.itemAt(i)) is not None
+            and (cb := cast(QtWidgets.QCheckBox, item.widget())) is not None
         }
 
     def _current_group_id(self) -> int | None:
@@ -241,7 +256,7 @@ class LabelDialog(QtWidgets.QDialog):
             flags=flags,
             flags_disabled=flags_disabled,
         )
-        self.edit.setFocus(QtCore.Qt.PopupFocusReason)
+        self.edit.setFocus(QtCore.Qt.FocusReason.PopupFocusReason)
         if move:
             self.move(QtGui.QCursor.pos())
 
@@ -269,7 +284,11 @@ class LabelDialog(QtWidgets.QDialog):
         self._restore_or_reset_flags(text=text, flags=flags)
         if flags_disabled:
             for i in range(self._flags_layout.count()):
-                self._flags_layout.itemAt(i).widget().setDisabled(True)
+                item = self._flags_layout.itemAt(i)
+                if item is not None:
+                    widget = item.widget()
+                    if widget is not None:
+                        widget.setDisabled(True)
 
         self.edit.setText(text)
         self.edit.selectAll()
@@ -282,7 +301,7 @@ class LabelDialog(QtWidgets.QDialog):
         self._highlight_matching_label(text)
 
     def _highlight_matching_label(self, text: str) -> None:
-        items = self.label_list.findItems(text, QtCore.Qt.MatchFixedString)
+        items = self.label_list.findItems(text, QtCore.Qt.MatchFlag.MatchFixedString)
         if not items:
             return
         if len(items) != 1:

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -4,9 +4,9 @@ import re
 from typing import cast
 
 from loguru import logger
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 
 import labelme.utils
 
@@ -81,7 +81,7 @@ class LabelDialog(QtWidgets.QDialog):
         edit_group_id = QtWidgets.QLineEdit()
         edit_group_id.setPlaceholderText("Group ID")
         edit_group_id.setValidator(
-            QtGui.QRegExpValidator(QtCore.QRegExp(r"\d*"), parent=None)
+            QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"\d*"))
         )
         return edit_group_id
 
@@ -245,7 +245,7 @@ class LabelDialog(QtWidgets.QDialog):
         if move:
             self.move(QtGui.QCursor.pos())
 
-        if not self.exec_():
+        if not self.exec():
             return None, None, None, None
         return self._read_dialog_state()
 

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -5,12 +5,12 @@ from collections.abc import Iterator
 from typing import NamedTuple
 from typing import cast
 
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPalette
-from PyQt5.QtWidgets import QStyle
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPalette
+from PySide6.QtWidgets import QStyle
 
 from labelme._shape import Shape
 
@@ -122,7 +122,7 @@ class LabelListWidgetItem(QtGui.QStandardItem):
 
 
 class _ItemModel(QtGui.QStandardItemModel):
-    item_dropped = QtCore.pyqtSignal()
+    item_dropped = QtCore.Signal()
 
     def removeRows(
         self,
@@ -164,8 +164,8 @@ class _ItemSnapshot(NamedTuple):
 
 
 class LabelListWidget(QtWidgets.QListView):
-    item_double_clicked = QtCore.pyqtSignal(LabelListWidgetItem)
-    item_selection_changed = QtCore.pyqtSignal(list, list)
+    item_double_clicked = QtCore.Signal(LabelListWidgetItem)
+    item_selection_changed = QtCore.Signal(list, list)
 
     def __init__(self) -> None:
         super().__init__()
@@ -230,11 +230,11 @@ class LabelListWidget(QtWidgets.QListView):
             yield self[i]
 
     @property
-    def item_dropped(self) -> QtCore.pyqtBoundSignal:
+    def item_dropped(self) -> QtCore.SignalInstance:
         return self._model.item_dropped
 
     @property
-    def item_changed(self) -> QtCore.pyqtBoundSignal:
+    def item_changed(self) -> QtCore.SignalInstance:
         return self._model.itemChanged
 
     def _on_item_selection_changed(

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -39,7 +39,7 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
         self,
         painter: QtGui.QPainter,
         option: QtWidgets.QStyleOptionViewItem,
-        index: QtCore.QModelIndex,
+        index: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
     ) -> None:
         opt = QtWidgets.QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
@@ -50,17 +50,23 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
         widget_style = (
             opt.widget.style() if opt.widget else QtWidgets.QApplication.style()
         )
-        widget_style.drawControl(QStyle.CE_ItemViewItem, opt, painter)
+        widget_style.drawControl(QStyle.ControlElement.CE_ItemViewItem, opt, painter)
 
         doc = QtGui.QTextDocument()
-        if opt.state & QStyle.State_Selected:
-            text_color = opt.palette.color(QPalette.Active, QPalette.HighlightedText)
+        if opt.state & QStyle.StateFlag.State_Selected:
+            text_color = opt.palette.color(
+                QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText
+            )
         else:
-            text_color = opt.palette.color(QPalette.Active, QPalette.Text)
+            text_color = opt.palette.color(
+                QPalette.ColorGroup.Active, QPalette.ColorRole.Text
+            )
         doc.setDefaultStyleSheet(f"body {{ color: {text_color.name()}; }}")
         doc.setHtml(f"<body>{html}</body>")
 
-        text_rect = widget_style.subElementRect(QStyle.SE_ItemViewItemText, opt)
+        text_rect = widget_style.subElementRect(
+            QStyle.SubElement.SE_ItemViewItemText, opt
+        )
         if index.column() != 0:
             text_rect.adjust(5, 0, 0, 0)
 
@@ -76,17 +82,19 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
 
     def sizeHint(
         self,
-        option: QtWidgets.QStyleOptionViewItem | None,
-        index: QtCore.QModelIndex | None,
+        option: QtWidgets.QStyleOptionViewItem,
+        index: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
     ) -> QtCore.QSize:
         VERT_FUDGE = 4
-        if option is not None and index is not None:
-            opt = QtWidgets.QStyleOptionViewItem(option)
-            self.initStyleOption(opt, index)
-            doc = QtGui.QTextDocument()
-            doc.setHtml(opt.text)
-            height = int(doc.size().height()) - VERT_FUDGE
-            return QtCore.QSize(int(doc.idealWidth()), height)
+        opt = QtWidgets.QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        doc = QtGui.QTextDocument()
+        doc.setHtml(opt.text)
+        height = int(doc.size().height()) - VERT_FUDGE
+        return QtCore.QSize(int(doc.idealWidth()), height)
+
+    def default_size_hint(self) -> QtCore.QSize:
+        VERT_FUDGE = 4
         doc = QtGui.QTextDocument()
         height = int(doc.size().height()) - VERT_FUDGE
         return QtCore.QSize(int(doc.idealWidth()), height)
@@ -100,19 +108,21 @@ class LabelListWidgetItem(QtGui.QStandardItem):
 
         self.setCheckable(True)
         self.setCheckState(
-            Qt.Checked if shape is None or shape.visible else Qt.Unchecked
+            Qt.CheckState.Checked
+            if shape is None or shape.visible
+            else Qt.CheckState.Unchecked
         )
         self.setEditable(False)
-        self.setTextAlignment(Qt.AlignBottom)
+        self.setTextAlignment(Qt.AlignmentFlag.AlignBottom)
 
     def clone(self) -> LabelListWidgetItem:
         return LabelListWidgetItem(self.text(), self.shape())
 
     def set_shape(self, shape: Shape | None) -> None:
-        self.setData(shape, Qt.UserRole)
+        self.setData(shape, Qt.ItemDataRole.UserRole)
 
     def shape(self) -> Shape | None:
-        return self.data(Qt.UserRole)
+        return self.data(Qt.ItemDataRole.UserRole)
 
     def __hash__(self) -> int:
         return id(self)
@@ -128,7 +138,8 @@ class _ItemModel(QtGui.QStandardItemModel):
         self,
         row: int,
         count: int,
-        parent: QtCore.QModelIndex = QtCore.QModelIndex(),
+        parent: QtCore.QModelIndex
+        | QtCore.QPersistentModelIndex = QtCore.QModelIndex(),
     ) -> bool:
         ret = super().removeRows(row, count, parent)
         self.item_dropped.emit()
@@ -140,7 +151,7 @@ class _ItemModel(QtGui.QStandardItemModel):
         action: Qt.DropAction,
         row: int,
         column: int,
-        parent: QtCore.QModelIndex,
+        parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
     ) -> bool:
         # NOTE: By default, PyQt will overwrite items when dropped on them, so we need
         # to adjust the row/parent to insert after the item instead.
@@ -170,16 +181,18 @@ class LabelListWidget(QtWidgets.QListView):
     def __init__(self) -> None:
         super().__init__()
 
-        self.setWindowFlags(Qt.Window)
+        self.setWindowFlags(Qt.WindowType.Window)
 
         self._model: _ItemModel = _ItemModel()
         self._model.setItemPrototype(LabelListWidgetItem())
         self.setModel(self._model)
 
         self.setItemDelegate(HTMLDelegate())
-        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
-        self.setDefaultDropAction(Qt.MoveAction)
+        self.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
+        self.setDefaultDropAction(Qt.DropAction.MoveAction)
 
         self.doubleClicked.connect(self._on_item_double_clicked)
         self.selectionModel().selectionChanged.connect(self._on_item_selection_changed)
@@ -211,7 +224,7 @@ class LabelListWidget(QtWidgets.QListView):
             for item in items_at_press:
                 self.selectionModel().select(
                     self._model.indexFromItem(item),
-                    QtCore.QItemSelectionModel.Select,
+                    QtCore.QItemSelectionModel.SelectionFlag.Select,
                 )
 
         self._press_snapshot = ()
@@ -262,7 +275,8 @@ class LabelListWidget(QtWidgets.QListView):
         if not isinstance(item, LabelListWidgetItem):
             raise TypeError("item must be LabelListWidgetItem")
         self._model.setItem(self._model.rowCount(), 0, item)
-        item.setSizeHint(self.itemDelegate().sizeHint(None, None))  # ty: ignore[invalid-argument-type]
+        delegate = cast(HTMLDelegate, self.itemDelegate())
+        item.setSizeHint(delegate.default_size_hint())
 
     def remove_item(self, item: LabelListWidgetItem) -> None:
         index = self._model.indexFromItem(item)
@@ -270,7 +284,9 @@ class LabelListWidget(QtWidgets.QListView):
 
     def select_item(self, item: LabelListWidgetItem) -> None:
         index = self._model.indexFromItem(item)
-        self.selectionModel().select(index, QtCore.QItemSelectionModel.Select)
+        self.selectionModel().select(
+            index, QtCore.QItemSelectionModel.SelectionFlag.Select
+        )
 
     def find_item_by_shape(self, shape: Shape) -> LabelListWidgetItem:
         for row in range(self._model.rowCount()):

--- a/labelme/widgets/settings_dialog.py
+++ b/labelme/widgets/settings_dialog.py
@@ -113,8 +113,10 @@ class SettingsDialog(QtWidgets.QDialog):
             page.setSizePolicy(policy)
         # Release the previous fixed size (setFixedSize pinned both min and max) so
         # adjustSize can shrink or grow to the active tab before we re-pin it.
+        # PySide6 does not export QWIDGETSIZE_MAX; 16777215 (0xFFFFFF) is its value.
+        QWIDGETSIZE_MAX: typing.Final = 16777215
         self.setMinimumSize(0, 0)
-        self.setMaximumSize(16777215, 16777215)
+        self.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
         self.adjustSize()
         self.setFixedSize(max(640, self.width()), self.height())
 

--- a/labelme/widgets/settings_dialog.py
+++ b/labelme/widgets/settings_dialog.py
@@ -103,11 +103,12 @@ class SettingsDialog(QtWidgets.QDialog):
         active = self._tabs.currentIndex()
         for index in range(self._tabs.count()):
             page = self._tabs.widget(index)
+            assert page is not None
             policy = page.sizePolicy()
             policy.setVerticalPolicy(
-                QtWidgets.QSizePolicy.Preferred
+                QtWidgets.QSizePolicy.Policy.Preferred
                 if index == active
-                else QtWidgets.QSizePolicy.Ignored
+                else QtWidgets.QSizePolicy.Policy.Ignored
             )
             page.setSizePolicy(policy)
         # Release the previous fixed size (setFixedSize pinned both min and max) so
@@ -143,7 +144,9 @@ class SettingsDialog(QtWidgets.QDialog):
                 # A note sits below the control; top-align the label so it pairs with
                 # the control rather than centering against the control+note block.
                 if setting.note:
-                    row_layout.addWidget(label, stretch=1, alignment=QtCore.Qt.AlignTop)
+                    row_layout.addWidget(
+                        label, stretch=1, alignment=QtCore.Qt.AlignmentFlag.AlignTop
+                    )
                 else:
                     row_layout.addWidget(label, stretch=1)
             row_layout.addWidget(self._with_note(editor=editor, setting=setting))
@@ -167,7 +170,8 @@ class SettingsDialog(QtWidgets.QDialog):
         # as a disabled control and carry the platform's washed-out gray.
         palette = note.palette()
         palette.setColor(
-            QtGui.QPalette.WindowText, palette.color(QtGui.QPalette.PlaceholderText)
+            QtGui.QPalette.ColorRole.WindowText,
+            palette.color(QtGui.QPalette.ColorRole.PlaceholderText),
         )
         note.setPalette(palette)
         layout.addWidget(note)

--- a/labelme/widgets/settings_dialog.py
+++ b/labelme/widgets/settings_dialog.py
@@ -4,9 +4,9 @@ import typing
 from collections.abc import Callable
 from collections.abc import Sequence
 
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 
 from labelme import _locale
 from labelme._config import _schema as schema
@@ -15,7 +15,7 @@ ApplySetting = Callable[[tuple[str, ...], object], bool]
 
 
 class _PlainTextEdit(QtWidgets.QPlainTextEdit):
-    editing_finished = QtCore.pyqtSignal()
+    editing_finished = QtCore.Signal()
 
     _committed_text: str = ""
 
@@ -113,7 +113,7 @@ class SettingsDialog(QtWidgets.QDialog):
         # Release the previous fixed size (setFixedSize pinned both min and max) so
         # adjustSize can shrink or grow to the active tab before we re-pin it.
         self.setMinimumSize(0, 0)
-        self.setMaximumSize(QtWidgets.QWIDGETSIZE_MAX, QtWidgets.QWIDGETSIZE_MAX)
+        self.setMaximumSize(16777215, 16777215)
         self.adjustSize()
         self.setFixedSize(max(640, self.width()), self.height())
 

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -12,8 +12,8 @@ class ToolBar(QtWidgets.QToolBar):
         self,
         title: str,
         actions: list[QtGui.QAction | None],
-        orientation: Qt.Orientation = Qt.Horizontal,
-        button_style: Qt.ToolButtonStyle = Qt.ToolButtonTextUnderIcon,
+        orientation: Qt.Orientation = Qt.Orientation.Horizontal,
+        button_style: Qt.ToolButtonStyle = Qt.ToolButtonStyle.ToolButtonTextUnderIcon,
         font_base: QtGui.QFont | None = None,
     ) -> None:
         super().__init__(title)
@@ -24,22 +24,23 @@ class ToolBar(QtWidgets.QToolBar):
             self.setFont(font)
 
         layout = self.layout()
+        assert layout is not None
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
-        self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowType.FramelessWindowHint)
         self.setMovable(False)
         self.setFloatable(False)
 
         self.setObjectName(f"{title}ToolBar")
         self.setOrientation(orientation)
         self.setToolButtonStyle(button_style)
-        if orientation == Qt.Vertical:
+        if orientation == Qt.Orientation.Vertical:
             self.setStyleSheet(
                 "QToolBar::separator { height: 1px; margin: 4px 2px;"
                 " background: palette(mid); }"
             )
         utils.add_actions(widget=self, actions=actions)
-        if orientation == Qt.Vertical:
+        if orientation == Qt.Orientation.Vertical:
             self._equalize_button_widths()
 
     def addAction(self, action: QtGui.QAction) -> None:  # ty: ignore[invalid-method-override]
@@ -51,13 +52,17 @@ class ToolBar(QtWidgets.QToolBar):
         button.setToolButtonStyle(self.toolButtonStyle())
         self.toolButtonStyleChanged.connect(button.setToolButtonStyle)
         self.addWidget(button)
-        self.layout().setAlignment(button, Qt.AlignCenter)
+        layout = self.layout()
+        assert layout is not None
+        layout.setAlignment(button, Qt.AlignmentFlag.AlignCenter)
 
     def _equalize_button_widths(self) -> None:
         layout = self.layout()
+        assert layout is not None
         buttons: list[QtWidgets.QToolButton] = []
         for i in range(layout.count()):
-            widget = layout.itemAt(i).widget()
+            item = layout.itemAt(i)
+            widget = item.widget() if item is not None else None
             if isinstance(widget, QtWidgets.QToolButton):
                 buttons.append(widget)
         if not buttons:

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
 
 from .. import utils
 
@@ -11,7 +11,7 @@ class ToolBar(QtWidgets.QToolBar):
     def __init__(
         self,
         title: str,
-        actions: list[QtWidgets.QAction | None],
+        actions: list[QtGui.QAction | None],
         orientation: Qt.Orientation = Qt.Horizontal,
         button_style: Qt.ToolButtonStyle = Qt.ToolButtonTextUnderIcon,
         font_base: QtGui.QFont | None = None,
@@ -42,7 +42,7 @@ class ToolBar(QtWidgets.QToolBar):
         if orientation == Qt.Vertical:
             self._equalize_button_widths()
 
-    def addAction(self, action: QtWidgets.QAction) -> None:  # ty: ignore[invalid-method-override]
+    def addAction(self, action: QtGui.QAction) -> None:  # ty: ignore[invalid-method-override]
         if isinstance(action, QtWidgets.QWidgetAction):
             super().addAction(action)
             return

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
 
 from .label_list_widget import HTMLDelegate
 from .label_list_widget import format_label_with_color_dot
@@ -22,7 +22,7 @@ class UniqueLabelQListWidget(_EscapableQListWidget):
 
     def mousePressEvent(self, mouseEvent: QtGui.QMouseEvent) -> None:  # ty: ignore[invalid-method-override]
         super().mousePressEvent(mouseEvent)
-        if not self.indexAt(mouseEvent.pos()).isValid():
+        if not self.indexAt(mouseEvent.position().toPoint()).isValid():
             self.clearSelection()
 
     def find_label_item(self, label: str) -> QtWidgets.QListWidgetItem | None:

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -9,9 +9,9 @@ from .label_list_widget import format_label_with_color_dot
 
 
 class _EscapableQListWidget(QtWidgets.QListWidget):
-    def keyPressEvent(self, keyEvent: QtGui.QKeyEvent) -> None:  # ty: ignore[invalid-method-override]
+    def keyPressEvent(self, keyEvent: QtGui.QKeyEvent) -> None:
         super().keyPressEvent(keyEvent)
-        if keyEvent.key() == Qt.Key_Escape:
+        if keyEvent.key() == Qt.Key.Key_Escape:
             self.clearSelection()
 
 
@@ -20,7 +20,7 @@ class UniqueLabelQListWidget(_EscapableQListWidget):
         super().__init__(parent=parent)
         self.setItemDelegate(HTMLDelegate(parent=self))
 
-    def mousePressEvent(self, mouseEvent: QtGui.QMouseEvent) -> None:  # ty: ignore[invalid-method-override]
+    def mousePressEvent(self, mouseEvent: QtGui.QMouseEvent) -> None:
         super().mousePressEvent(mouseEvent)
         if not self.indexAt(mouseEvent.position().toPoint()).isValid():
             self.clearSelection()
@@ -28,7 +28,7 @@ class UniqueLabelQListWidget(_EscapableQListWidget):
     def find_label_item(self, label: str) -> QtWidgets.QListWidgetItem | None:
         for row in range(self.count()):
             item = self.item(row)
-            if item and item.data(Qt.UserRole) == label:
+            if item and item.data(Qt.ItemDataRole.UserRole) == label:
                 return item
         return None
 
@@ -37,6 +37,6 @@ class UniqueLabelQListWidget(_EscapableQListWidget):
             raise ValueError(f"Item for label '{label}' already exists")
 
         item = QtWidgets.QListWidgetItem()
-        item.setData(Qt.UserRole, label)  # for find_label_item
+        item.setData(Qt.ItemDataRole.UserRole, label)  # for find_label_item
         item.setText(format_label_with_color_dot(text=label, color=color))
         self.addItem(item)

--- a/labelme/widgets/zoom_widget.py
+++ b/labelme/widgets/zoom_widget.py
@@ -15,8 +15,8 @@ class ZoomWidget(QtWidgets.QSpinBox):
         self.setRange(1, self.PERCENT_MAX)
         self.setValue(100)
         self.setSuffix(self.PERCENT_SUFFIX)
-        self.setAlignment(QtCore.Qt.AlignCenter)
-        self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+        self.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
         tooltip = "Zoom Level"
         self.setToolTip(tooltip)
         self.setStatusTip(tooltip)

--- a/labelme/widgets/zoom_widget.py
+++ b/labelme/widgets/zoom_widget.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Final
 
-from PyQt5 import QtCore
-from PyQt5 import QtWidgets
+from PySide6 import QtCore
+from PySide6 import QtWidgets
 
 
 class ZoomWidget(QtWidgets.QSpinBox):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,7 @@ dependencies = [
   "numpy>=1.24",
   "osam>=0.4.0",
   "pillow>=2.8",
-  "pyqt5>=5.14.0",
-  "pyqt5-qt5!=5.15.13 ; sys_platform == 'linux'",
-  "pyqt5-qt5!=5.15.11,!=5.15.12,!=5.15.13,!=5.15.14,!=5.15.15,!=5.15.16 ; sys_platform == 'win32'",
+  "pyside6>=6.5",
   "scipy>=1.8",
   "scikit-image>=0.21",
   "tifffile>=2024.1.30",
@@ -59,7 +57,6 @@ dev = [
   "ipython",
   "mdformat-frontmatter>=2.0.10",
   "mdformat>=0.7",
-  "pyqt5-stubs>=5.15.6.0",
   "pytest>=8.3.4",
   "pytest-cov>=7.1.0",
   "pytest-qt>=4.4.0",
@@ -78,7 +75,7 @@ dev = [
 labelme = "labelme.__main__:main"
 
 [tool.pytest.ini_options]
-qt_api = "pyqt5"
+qt_api = "pyside6"
 markers = ["gui: mark a test as a GUI test."]
 
 [tool.ruff.lint]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import imgviz
 import pytest
-from PyQt5.QtWidgets import QWidget
+from PySide6.QtWidgets import QWidget
 from pytestqt.qtbot import QtBot
 
 import labelme.utils

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -226,7 +226,7 @@ def test_annotate_shape_types(
         pos = to_pos(xy)
         qtbot.mouseMove(canvas, pos=pos)
         qtbot.wait(50)
-        qtbot.mouseClick(canvas, Qt.LeftButton, modifier=modifier, pos=pos)
+        qtbot.mouseClick(canvas, Qt.LeftButton, modifier, pos=pos)
         qtbot.wait(50)
 
     for xy in setup_clicks:

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -35,7 +35,7 @@ _AI_MODEL = "efficientsam:10m"
             "polygon",
             [(0.25, 0.25), (0.75, 0.25), (0.75, 0.75), (0.25, 0.75)],
             (0.25, 0.25),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             4,
             None,
             id="polygon",
@@ -44,7 +44,7 @@ _AI_MODEL = "efficientsam:10m"
             "rectangle",
             [(0.25, 0.25)],
             (0.75, 0.75),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             2,
             None,
             id="rectangle",
@@ -53,7 +53,7 @@ _AI_MODEL = "efficientsam:10m"
             "oriented_rectangle",
             [(0.25, 0.5), (0.5, 0.5)],
             (0.5, 0.75),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             4,
             None,
             id="oriented_rectangle",
@@ -62,7 +62,7 @@ _AI_MODEL = "efficientsam:10m"
             "circle",
             [(0.5, 0.5)],
             (0.75, 0.5),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             2,
             None,
             id="circle",
@@ -71,17 +71,19 @@ _AI_MODEL = "efficientsam:10m"
             "line",
             [(0.25, 0.25)],
             (0.75, 0.75),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             2,
             None,
             id="line",
         ),
-        pytest.param("point", [], (0.5, 0.5), Qt.NoModifier, 1, None, id="point"),
+        pytest.param(
+            "point", [], (0.5, 0.5), Qt.KeyboardModifier.NoModifier, 1, None, id="point"
+        ),
         pytest.param(
             "linestrip",
             [(0.25, 0.25), (0.5, 0.5)],
             (0.75, 0.75),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             3,
             None,
             id="linestrip",
@@ -90,7 +92,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_points_to_shape",
             [],
             (0.5, 0.5),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             None,
             "polygon",
             id="ai_points-polygon",
@@ -99,7 +101,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_points_to_shape",
             [],
             (0.5, 0.5),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             2,
             "mask",
             id="ai_points-mask",
@@ -108,7 +110,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_points_to_shape",
             [],
             (0.5, 0.5),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             2,
             "rectangle",
             id="ai_points-rectangle",
@@ -117,7 +119,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_points_to_shape",
             [],
             (0.5, 0.5),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             2,
             "circle",
             id="ai_points-circle",
@@ -126,7 +128,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_points_to_shape",
             [],
             (0.5, 0.5),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             4,
             "oriented_rectangle",
             id="ai_points-oriented_rectangle",
@@ -135,7 +137,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_box_to_shape",
             [(0.3, 0.3)],
             (0.7, 0.7),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             None,
             "polygon",
             id="ai_box-polygon",
@@ -144,7 +146,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_box_to_shape",
             [(0.3, 0.3)],
             (0.7, 0.7),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             2,
             "mask",
             id="ai_box-mask",
@@ -153,7 +155,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_box_to_shape",
             [(0.3, 0.3)],
             (0.7, 0.7),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             2,
             "rectangle",
             id="ai_box-rectangle",
@@ -162,7 +164,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_box_to_shape",
             [(0.3, 0.3)],
             (0.7, 0.7),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             2,
             "circle",
             id="ai_box-circle",
@@ -171,7 +173,7 @@ _AI_MODEL = "efficientsam:10m"
             "ai_box_to_shape",
             [(0.3, 0.3)],
             (0.7, 0.7),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             4,
             "oriented_rectangle",
             id="ai_box-oriented_rectangle",
@@ -221,12 +223,13 @@ def test_annotate_shape_types(
     qtbot.wait(50)
 
     def click(
-        xy: tuple[float, float], modifier: Qt.KeyboardModifier = Qt.NoModifier
+        xy: tuple[float, float],
+        modifier: Qt.KeyboardModifier = Qt.KeyboardModifier.NoModifier,
     ) -> None:
         pos = to_pos(xy)
         qtbot.mouseMove(canvas, pos=pos)
         qtbot.wait(50)
-        qtbot.mouseClick(canvas, Qt.LeftButton, modifier, pos=pos)
+        qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, modifier, pos=pos)
         qtbot.wait(50)
 
     for xy in setup_clicks:
@@ -238,7 +241,7 @@ def test_annotate_shape_types(
             return
         qtbot.keyClicks(win._label_dialog.edit, label)
         qtbot.wait(50)
-        qtbot.keyClick(win._label_dialog.edit, Qt.Key_Enter)
+        qtbot.keyClick(win._label_dialog.edit, Qt.Key.Key_Enter)
 
     QTimer.singleShot(0, enter_label_when_visible)
 
@@ -299,7 +302,7 @@ def test_ai_model_download(
 
     canvas_size = canvas.size()
     pos = QPoint(int(canvas_size.width() * 0.5), int(canvas_size.height() * 0.5))
-    qtbot.mouseClick(canvas, Qt.LeftButton, pos=pos)
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=pos)
 
     # Verify the model was downloaded to the temp dir
     assert any(Path(blob_base).rglob("*"))

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import osam.types._blob
 import pytest
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QTimer
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer
 from pytestqt.qtbot import QtBot
 
 from labelme._automation._types import AiOutputFormat

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -50,9 +50,9 @@ def test_auto_save_on_shape_move(
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
     original_center = QPointF(_shape_bounds(shape=canvas.selected_shapes[0]).center())
 
-    qtbot.keyPress(canvas, Qt.Key_Right)
+    qtbot.keyPress(canvas, Qt.Key.Key_Right)
     qtbot.wait(50)
-    qtbot.keyRelease(canvas, Qt.Key_Right)
+    qtbot.keyRelease(canvas, Qt.Key.Key_Right)
     qtbot.wait(50)
 
     new_center = _shape_bounds(shape=canvas.selected_shapes[0]).center()

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import json
-import sys
 from pathlib import Path
 from typing import Final
 
@@ -688,14 +687,6 @@ def test_select_point_shape_by_click(
     raw_win: MainWindow,
     pause: bool,
 ) -> None:
-    if sys.platform.startswith("linux"):
-        # Under X11/xcb the hover lands the cursor on the point's only vertex,
-        # so the click is interpreted as "move vertex" and deselects instead of
-        # selecting. Point shapes have no body to click off-vertex, unlike other
-        # shape types. Fixing this needs a point-selection UX change tracked
-        # separately; macOS and Windows select the point as expected.
-        pytest.xfail("point-shape click-selection is vertex-ambiguous on X11/xcb")
-
     canvas = raw_win._canvas_widgets.canvas
     raw_win._switch_canvas_mode(edit=False, create_mode="point")
     qtbot.wait(50)

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -10,6 +10,7 @@ import PIL.Image
 import pytest
 from PySide6.QtCore import QPointF
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
 from pytestqt.qtbot import QtBot
 
 from labelme import utils
@@ -687,6 +688,14 @@ def test_select_point_shape_by_click(
     raw_win: MainWindow,
     pause: bool,
 ) -> None:
+    if QApplication.platformName() == "xcb":
+        # On xcb the hover lands the cursor on the point's only vertex, so the
+        # click is interpreted as "move vertex" and deselects instead of
+        # selecting. Point shapes have no body to click off-vertex, unlike other
+        # shape types. Fixing this needs a point-selection UX change tracked
+        # separately; other platforms select the point as expected.
+        pytest.xfail("point-shape click-selection is vertex-ambiguous on xcb")
+
     canvas = raw_win._canvas_widgets.canvas
     raw_win._switch_canvas_mode(edit=False, create_mode="point")
     qtbot.wait(50)

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -46,7 +46,13 @@ def _hover_and_drag(
     end = image_to_widget_pos(canvas=canvas, image_pos=end_image_pos)
     qtbot.mouseMove(canvas, pos=start)
     qtbot.wait(50)
-    drag_canvas(qtbot=qtbot, canvas=canvas, button=Qt.LeftButton, start=start, end=end)
+    drag_canvas(
+        qtbot=qtbot,
+        canvas=canvas,
+        button=Qt.MouseButton.LeftButton,
+        start=start,
+        end=end,
+    )
 
 
 def _cancel_label(
@@ -55,7 +61,7 @@ def _cancel_label(
 ) -> None:
     schedule_on_dialog(
         label_dialog=label_dialog,
-        action=lambda: qtbot.keyClick(label_dialog, Qt.Key_Escape),
+        action=lambda: qtbot.keyClick(label_dialog, Qt.Key.Key_Escape),
     )
 
 
@@ -83,8 +89,8 @@ def _click_to_remove_point(
     qtbot.wait(100)
     qtbot.mouseClick(
         canvas,
-        Qt.LeftButton,
-        Qt.AltModifier | Qt.ShiftModifier,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.AltModifier | Qt.KeyboardModifier.ShiftModifier,
         pos=vtx_widget,
     )
     qtbot.wait(50)
@@ -159,10 +165,10 @@ def test_move_vertex_by_drag(
 @pytest.mark.parametrize(
     ("key", "expected_dx", "expected_dy"),
     [
-        pytest.param(Qt.Key_Up, 0, -5.0, id="up"),
-        pytest.param(Qt.Key_Down, 0, 5.0, id="down"),
-        pytest.param(Qt.Key_Left, -5.0, 0, id="left"),
-        pytest.param(Qt.Key_Right, 5.0, 0, id="right"),
+        pytest.param(Qt.Key.Key_Up, 0, -5.0, id="up"),
+        pytest.param(Qt.Key.Key_Down, 0, 5.0, id="down"),
+        pytest.param(Qt.Key.Key_Left, -5.0, 0, id="left"),
+        pytest.param(Qt.Key.Key_Right, 5.0, 0, id="right"),
     ],
 )
 def test_move_shape_by_arrow_key(
@@ -201,7 +207,7 @@ def test_select_all_shapes_from_canvas(
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=_SHAPE_INDEX)
     assert len(canvas.selected_shapes) == 1
 
-    qtbot.keyClick(canvas, Qt.Key_A, modifier=Qt.ControlModifier)
+    qtbot.keyClick(canvas, Qt.Key.Key_A, modifier=Qt.KeyboardModifier.ControlModifier)
     qtbot.wait(50)
 
     assert set(map(id, canvas.selected_shapes)) == set(map(id, canvas.shapes))
@@ -250,7 +256,12 @@ def test_add_point_on_edge(
     mid_widget = image_to_widget_pos(canvas=canvas, image_pos=edge_mid)
     qtbot.mouseMove(canvas, pos=mid_widget)
     qtbot.wait(100)
-    qtbot.mouseClick(canvas, Qt.LeftButton, Qt.AltModifier, pos=mid_widget)
+    qtbot.mouseClick(
+        canvas,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.AltModifier,
+        pos=mid_widget,
+    )
     qtbot.wait(50)
 
     assert len(shape.points) == num_points_before + 1
@@ -355,7 +366,7 @@ def test_cancel_drawing_with_escape(
 
     assert canvas._current is not None
 
-    qtbot.keyPress(canvas, Qt.Key_Escape)
+    qtbot.keyPress(canvas, Qt.Key.Key_Escape)
     qtbot.wait(50)
 
     assert canvas._current is None
@@ -432,7 +443,7 @@ def test_finalize_polygon_with_enter(
         qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label
     )
 
-    qtbot.keyPress(canvas, Qt.Key_Return)
+    qtbot.keyPress(canvas, Qt.Key.Key_Return)
     qtbot.wait(200)
 
     assert len(canvas.shapes) == num_shapes_before + 1
@@ -464,7 +475,7 @@ def test_undo_shape_creation(
         qtbot=qtbot, label_dialog=annotated_win._label_dialog, label=label
     )
 
-    qtbot.keyPress(canvas, Qt.Key_Return)
+    qtbot.keyPress(canvas, Qt.Key.Key_Return)
     qtbot.wait(200)
 
     assert len(canvas.shapes) == num_shapes_before + 1
@@ -493,7 +504,7 @@ def test_undo_shape_creation(
             "rectangle",
             (0.2, 0.2),
             (0.8, 0.8),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             (0.0, 0.0),
             id="rectangle",
         ),
@@ -501,7 +512,7 @@ def test_undo_shape_creation(
             "circle",
             (0.5, 0.5),
             (0.75, 0.5),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             (0.0, -20.0),
             id="circle",
         ),
@@ -509,7 +520,7 @@ def test_undo_shape_creation(
             "line",
             (0.2, 0.5),
             (0.8, 0.5),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             (0.0, 0.0),
             id="line",
         ),
@@ -517,7 +528,7 @@ def test_undo_shape_creation(
             "linestrip",
             (0.2, 0.5),
             (0.8, 0.5),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             (0.0, 0.0),
             id="two-point-linestrip",
         ),
@@ -556,7 +567,7 @@ def test_select_nonpolygon_shape(
     click_widget = image_to_widget_pos(canvas=canvas, image_pos=click_pos)
     qtbot.mouseMove(canvas, pos=click_widget)
     qtbot.wait(50)
-    qtbot.mouseClick(canvas, Qt.LeftButton, pos=click_widget)
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=click_widget)
     qtbot.wait(50)
 
     assert shape in canvas.selected_shapes
@@ -607,7 +618,7 @@ def test_cancel_label_reopens_shape(
             "polygon",
             [(0.2, 0.2), (0.8, 0.2), (0.5, 0.8)],
             (0.2, 0.2),
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             3,
             id="triangle",
         ),
@@ -615,7 +626,7 @@ def test_cancel_label_reopens_shape(
             "linestrip",
             [(0.3, 0.3)],
             (0.7, 0.7),
-            Qt.ControlModifier,
+            Qt.KeyboardModifier.ControlModifier,
             2,
             id="two-point-linestrip",
         ),
@@ -666,7 +677,7 @@ def test_remove_point_blocked_at_minimum(
 def _click_to_select(qtbot: QtBot, canvas: Canvas, image_pos: QPointF) -> None:
     pos = image_to_widget_pos(canvas=canvas, image_pos=image_pos)
     hover_widget_pos(qtbot=qtbot, canvas=canvas, pos=pos)
-    qtbot.mouseClick(canvas, Qt.LeftButton, pos=pos)
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=pos)
     qtbot.wait(50)
 
 
@@ -727,7 +738,7 @@ def test_right_click_on_shape_opens_context_menu(
     pos = image_to_widget_pos(canvas=canvas, image_pos=bounds_center)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)
-    qtbot.mouseClick(canvas, Qt.RightButton, pos=pos)
+    qtbot.mouseClick(canvas, Qt.MouseButton.RightButton, pos=pos)
     qtbot.wait(50)
 
     assert menu_opened == [0]

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -8,8 +8,8 @@ from typing import Final
 import numpy as np
 import PIL.Image
 import pytest
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme import utils

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import sys
 from pathlib import Path
 from typing import Final
 
@@ -10,7 +11,6 @@ import PIL.Image
 import pytest
 from PySide6.QtCore import QPointF
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QApplication
 from pytestqt.qtbot import QtBot
 
 from labelme import utils
@@ -688,13 +688,13 @@ def test_select_point_shape_by_click(
     raw_win: MainWindow,
     pause: bool,
 ) -> None:
-    if QApplication.platformName() == "xcb":
-        # On xcb the hover lands the cursor on the point's only vertex, so the
-        # click is interpreted as "move vertex" and deselects instead of
+    if sys.platform.startswith("linux"):
+        # Under X11/xcb the hover lands the cursor on the point's only vertex,
+        # so the click is interpreted as "move vertex" and deselects instead of
         # selecting. Point shapes have no body to click off-vertex, unlike other
         # shape types. Fixing this needs a point-selection UX change tracked
-        # separately; other platforms select the point as expected.
-        pytest.xfail("point-shape click-selection is vertex-ambiguous on xcb")
+        # separately; macOS and Windows select the point as expected.
+        pytest.xfail("point-shape click-selection is vertex-ambiguous on X11/xcb")
 
     canvas = raw_win._canvas_widgets.canvas
     raw_win._switch_canvas_mode(edit=False, create_mode="point")

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -84,7 +84,7 @@ def _click_to_remove_point(
     qtbot.mouseClick(
         canvas,
         Qt.LeftButton,
-        modifier=Qt.AltModifier | Qt.ShiftModifier,
+        Qt.AltModifier | Qt.ShiftModifier,
         pos=vtx_widget,
     )
     qtbot.wait(50)
@@ -250,7 +250,7 @@ def test_add_point_on_edge(
     mid_widget = image_to_widget_pos(canvas=canvas, image_pos=edge_mid)
     qtbot.mouseMove(canvas, pos=mid_widget)
     qtbot.wait(100)
-    qtbot.mouseClick(canvas, Qt.LeftButton, modifier=Qt.AltModifier, pos=mid_widget)
+    qtbot.mouseClick(canvas, Qt.LeftButton, Qt.AltModifier, pos=mid_widget)
     qtbot.wait(50)
 
     assert len(shape.points) == num_points_before + 1
@@ -714,12 +714,12 @@ def test_right_click_on_shape_opens_context_menu(
     menu_opened: list[int] = []
     monkeypatch.setattr(
         canvas.menus[0],
-        "exec_",
+        "exec",
         lambda *args, **kwargs: menu_opened.append(0) or None,
     )
     monkeypatch.setattr(
         canvas.menus[1],
-        "exec_",
+        "exec",
         lambda *args, **kwargs: menu_opened.append(1) or None,
     )
 

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -52,7 +52,7 @@ def _pin_canvas_for_snapshot(qtbot: QtBot, canvas: Canvas) -> None:
 
 
 def _render_canvas_offscreen(canvas: Canvas) -> QImage:
-    image = QImage(_RENDER_WIDTH, _RENDER_HEIGHT, QImage.Format_ARGB32)
+    image = QImage(_RENDER_WIDTH, _RENDER_HEIGHT, QImage.Format.Format_ARGB32)
     image.fill(_BACKGROUND_COLOR)
     painter = QPainter(image)
     try:
@@ -62,7 +62,7 @@ def _render_canvas_offscreen(canvas: Canvas) -> QImage:
             painter,
             QPoint(0, 0),
             QRegion(QRect(0, 0, _RENDER_WIDTH, _RENDER_HEIGHT)),
-            QWidget.DrawChildren,
+            QWidget.RenderFlag.DrawChildren,
         )
     finally:
         painter.end()
@@ -70,7 +70,7 @@ def _render_canvas_offscreen(canvas: Canvas) -> QImage:
 
 
 def _qimage_to_numpy(image: QImage) -> np.ndarray:
-    assert image.format() == QImage.Format_ARGB32
+    assert image.format() == QImage.Format.Format_ARGB32
     width = image.width()
     height = image.height()
     bytes_per_line = image.bytesPerLine()
@@ -95,7 +95,9 @@ def _assert_matches_snapshot(actual: QImage, snapshot_path: Path) -> None:
             "Run with --update-snapshots to generate it."
         )
     actual_arr = _qimage_to_numpy(actual)
-    snapshot_qimage = QImage(str(snapshot_path)).convertToFormat(QImage.Format_ARGB32)
+    snapshot_qimage = QImage(str(snapshot_path)).convertToFormat(
+        QImage.Format.Format_ARGB32
+    )
     assert not snapshot_qimage.isNull(), f"Failed to load snapshot PNG: {snapshot_path}"
     snapshot_arr = _qimage_to_numpy(snapshot_qimage)
     assert actual_arr.shape == snapshot_arr.shape, (
@@ -225,7 +227,7 @@ def test_snapshot_polygon_mid_draw(
     )
 
     # Cancel the in-progress shape; without this close_or_pause triggers a dialog.
-    qtbot.keyPress(canvas, Qt.Key_Escape)
+    qtbot.keyPress(canvas, Qt.Key.Key_Escape)
     qtbot.wait(_MODE_SWITCH_SETTLE_MS)
     assert canvas._current is None
 

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -5,15 +5,15 @@ from typing import Final
 
 import numpy as np
 import pytest
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import QRect
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
-from PyQt5.QtGui import QImage
-from PyQt5.QtGui import QPainter
-from PyQt5.QtGui import QRegion
-from PyQt5.QtWidgets import QWidget
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import QRect
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+from PySide6.QtGui import QImage
+from PySide6.QtGui import QPainter
+from PySide6.QtGui import QRegion
+from PySide6.QtWidgets import QWidget
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow
@@ -74,8 +74,7 @@ def _qimage_to_numpy(image: QImage) -> np.ndarray:
     width = image.width()
     height = image.height()
     bytes_per_line = image.bytesPerLine()
-    ptr = image.bits()
-    raw_bytes = ptr.asstring(bytes_per_line * height)
+    raw_bytes = bytes(image.bits())
     arr = np.frombuffer(raw_bytes, dtype=np.uint8).reshape(
         (height, bytes_per_line // 4, 4)
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -170,7 +170,7 @@ def click_canvas_fraction(
     pos = image_to_widget_pos(canvas=canvas, image_pos=image_pos)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)
-    qtbot.mouseClick(canvas, Qt.LeftButton, modifier=modifier, pos=pos)
+    qtbot.mouseClick(canvas, Qt.LeftButton, modifier, pos=pos)
     qtbot.wait(50)
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -40,7 +40,7 @@ def _isolated_qtsettings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Generator[None, None, None]:
     settings_file = tmp_path / "qtsettings.ini"
-    settings: QSettings = QSettings(str(settings_file), QSettings.IniFormat)
+    settings: QSettings = QSettings(str(settings_file), QSettings.Format.IniFormat)
     monkeypatch.setattr(
         labelme.app.QtCore, "QSettings", lambda *args, **kwargs: settings
     )
@@ -160,7 +160,7 @@ def click_canvas_fraction(
     qtbot: QtBot,
     canvas: Canvas,
     xy: tuple[float, float],
-    modifier: Qt.KeyboardModifier = Qt.NoModifier,
+    modifier: Qt.KeyboardModifier = Qt.KeyboardModifier.NoModifier,
 ) -> None:
     # Fractions are interpreted in image-pixel space so callers stay valid
     # regardless of window/canvas size or letterboxing.
@@ -170,7 +170,7 @@ def click_canvas_fraction(
     pos = image_to_widget_pos(canvas=canvas, image_pos=image_pos)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)
-    qtbot.mouseClick(canvas, Qt.LeftButton, modifier, pos=pos)
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, modifier, pos=pos)
     qtbot.wait(50)
 
 
@@ -189,9 +189,9 @@ def drag_canvas(
         QtGui.QMouseEvent.Type.MouseMove,
         QPointF(end),
         global_pos,
-        Qt.NoButton,
+        Qt.MouseButton.NoButton,
         button,
-        Qt.NoModifier,
+        Qt.KeyboardModifier.NoModifier,
     )
     QApplication.sendEvent(canvas, move_event)
     qtbot.wait(50)
@@ -221,7 +221,7 @@ def submit_label_dialog(
         label_dialog.edit.clear()
         qtbot.keyClicks(label_dialog.edit, label)
         qtbot.wait(50)
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+        qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Enter)
 
     schedule_on_dialog(label_dialog=label_dialog, action=_action)
 
@@ -253,7 +253,7 @@ def draw_and_commit_polygon(
     # polygon and opens the dialog, then the queued poller fills it in.
     # Reversing the order deadlocks the test.
     submit_label_dialog(qtbot=qtbot, label_dialog=win._label_dialog, label=label)
-    qtbot.keyPress(canvas, Qt.Key_Return)
+    qtbot.keyPress(canvas, Qt.Key.Key_Return)
 
     def shape_committed() -> None:
         assert len(canvas.shapes) == num_before + 1
@@ -267,7 +267,7 @@ def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
     pos = image_to_widget_pos(canvas=canvas, image_pos=shape_center)
     qtbot.mouseMove(canvas, pos=pos)
     qtbot.wait(50)
-    qtbot.mouseClick(canvas, Qt.LeftButton, pos=pos)
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=pos)
     qtbot.wait(50)
     assert len(canvas.selected_shapes) == 1
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,14 +7,14 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from PyQt5 import QtGui
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import QSettings
-from PyQt5.QtCore import QSize
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication
+from PySide6 import QtGui
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import QSettings
+from PySide6.QtCore import QSize
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
 from pytestqt.qtbot import QtBot
 
 import labelme.app
@@ -118,7 +118,7 @@ def main_win(
         assert isinstance(app, QApplication)
 
         monkeypatch.setattr("labelme.__main__.QtWidgets.QApplication", _QAppProxy(app))
-        monkeypatch.setattr(app, "exec_", lambda: 0)
+        monkeypatch.setattr(app, "exec", lambda: 0)
 
         existing = set(w for w in app.topLevelWidgets() if isinstance(w, MainWindow))
 
@@ -184,9 +184,11 @@ def drag_canvas(
     qtbot.mousePress(canvas, button, pos=start)
     qtbot.wait(50)
     # qtbot.mouseMove does not carry button state, so send a raw event
+    global_pos = QPointF(canvas.mapToGlobal(end))
     move_event = QtGui.QMouseEvent(
-        QtGui.QMouseEvent.MouseMove,
+        QtGui.QMouseEvent.Type.MouseMove,
         QPointF(end),
+        global_pos,
         Qt.NoButton,
         button,
         Qt.NoModifier,

--- a/tests/e2e/drag_and_drop_test.py
+++ b/tests/e2e/drag_and_drop_test.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from PyQt5.QtCore import QMimeData
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QUrl
-from PyQt5.QtGui import QDragEnterEvent
-from PyQt5.QtGui import QDropEvent
-from PyQt5.QtWidgets import QApplication
+from PySide6.QtCore import QMimeData
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QDragEnterEvent
+from PySide6.QtGui import QDropEvent
+from PySide6.QtWidgets import QApplication
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/drag_and_drop_test.py
+++ b/tests/e2e/drag_and_drop_test.py
@@ -28,10 +28,10 @@ def _make_drop_mime(paths: list[Path]) -> QMimeData:
 def _drag_enter_accepted(win: MainWindow, mime: QMimeData) -> bool:
     event = QDragEnterEvent(
         QPoint(0, 0),
-        Qt.CopyAction,
+        Qt.DropAction.CopyAction,
         mime,
-        Qt.LeftButton,
-        Qt.NoModifier,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
     )
     QApplication.sendEvent(win, event)
     return event.isAccepted()
@@ -40,10 +40,10 @@ def _drag_enter_accepted(win: MainWindow, mime: QMimeData) -> bool:
 def _send_drop(win: MainWindow, mime: QMimeData) -> None:
     event = QDropEvent(
         QPointF(0, 0),
-        Qt.CopyAction,
+        Qt.DropAction.CopyAction,
         mime,
-        Qt.LeftButton,
-        Qt.NoModifier,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
     )
     QApplication.sendEvent(win, event)
 

--- a/tests/e2e/file_dialog_actions_test.py
+++ b/tests/e2e/file_dialog_actions_test.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/file_loading_test.py
+++ b/tests/e2e/file_loading_test.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Literal
 
 import pytest
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from ..conftest import assert_labelfile_sanity

--- a/tests/e2e/file_loading_test.py
+++ b/tests/e2e/file_loading_test.py
@@ -88,7 +88,9 @@ def test_MainWindow_open_dir(
 
     assert win._docks.file_list.count() == 3
     expected_check_state = (
-        Qt.Checked if scenario.startswith("annotated") else Qt.Unchecked
+        Qt.CheckState.Checked
+        if scenario.startswith("annotated")
+        else Qt.CheckState.Unchecked
     )
     for index in range(win._docks.file_list.count()):
         item: QtWidgets.QListWidgetItem | None = win._docks.file_list.item(index)

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -91,7 +91,7 @@ def test_delete_label_file_keeps_image(
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
         "warning",
-        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
     )
     win.delete_file()
     qtbot.wait(50)

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -51,12 +51,12 @@ def test_delete_label_file(
 
     item = win._docks.file_list.currentItem()
     assert item is not None
-    assert item.checkState() == Qt.Checked
+    assert item.checkState() == Qt.CheckState.Checked
 
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
         "warning",
-        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
     )
     win.delete_file()
     qtbot.wait(50)
@@ -65,7 +65,7 @@ def test_delete_label_file(
 
     item = win._docks.file_list.currentItem()
     assert item is not None
-    assert item.checkState() == Qt.Unchecked
+    assert item.checkState() == Qt.CheckState.Unchecked
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QCheckBox
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QCheckBox
 from pytestqt.qtbot import QtBot
 
 from labelme.widgets.label_dialog import LabelDialog

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -45,7 +45,7 @@ def _enter_label(
     qtbot.wait(100)
     for flag in flags:
         _check_flag(label_dialog=label_dialog, name=flag)
-    qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+    qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Enter)
 
 
 @pytest.mark.gui

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMessageBox
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
 from ..conftest import close_or_pause

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -52,11 +52,11 @@ def test_blank_input_keeps_dialog_open(
 
     def _try_blank_then_cancel() -> None:
         label_dialog.edit.clear()
-        qtbot.keyClick(label_dialog, Qt.Key_Return)
+        qtbot.keyClick(label_dialog, Qt.Key.Key_Return)
         qtbot.wait(50)
         if label_dialog.isVisible():
             dialog_stayed_open.append(True)
-        qtbot.keyClick(label_dialog, Qt.Key_Escape)
+        qtbot.keyClick(label_dialog, Qt.Key.Key_Escape)
 
     schedule_on_dialog(label_dialog=label_dialog, action=_try_blank_then_cancel)
     click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)
@@ -88,7 +88,7 @@ def test_validate_label_exact_rejects_unknown_label(
 
     def _record_critical(*args: object, **kwargs: object) -> int:
         error_shown.append(True)
-        return QMessageBox.Ok
+        return QMessageBox.StandardButton.Ok
 
     monkeypatch.setattr(QMessageBox, "critical", _record_critical)
 
@@ -96,7 +96,7 @@ def test_validate_label_exact_rejects_unknown_label(
         label_dialog.edit.clear()
         qtbot.keyClicks(label_dialog.edit, "tiger")
         qtbot.wait(50)
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+        qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Enter)
 
     _draw_triangle(qtbot=qtbot, win=win)
     schedule_on_dialog(label_dialog=label_dialog, action=_enter_unknown_label)
@@ -129,12 +129,12 @@ def test_arrow_keys_in_label_edit_navigate_label_list(
         # Sorted labels: cat, dog, person. Pin selection to row 0 so Down
         # forwarded from the line edit advances to row 1.
         label_dialog.label_list.setCurrentRow(0)
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Down)
+        qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Down)
         qtbot.wait(50)
         item = label_dialog.label_list.currentItem()
         if item is not None:
             after_down.append(item.text())
-        qtbot.keyClick(label_dialog, Qt.Key_Escape)
+        qtbot.keyClick(label_dialog, Qt.Key.Key_Escape)
 
     _draw_triangle(qtbot=qtbot, win=win)
     schedule_on_dialog(
@@ -206,10 +206,10 @@ def test_label_completer_autocompletes_typed_prefix(
         # and routes everything else to QLineEdit, so typing 'p' must drive
         # the QCompleter to suggest the only "p"-prefixed label.
         label_dialog.edit.clear()
-        qtbot.keyClick(label_dialog.edit, Qt.Key_P)
+        qtbot.keyClick(label_dialog.edit, Qt.Key.Key_P)
         qtbot.wait(50)
         completion.append(label_dialog.edit.completer().currentCompletion())
-        qtbot.keyClick(label_dialog, Qt.Key_Escape)
+        qtbot.keyClick(label_dialog, Qt.Key.Key_Escape)
 
     _draw_triangle(qtbot=qtbot, win=win)
     schedule_on_dialog(
@@ -246,7 +246,7 @@ def test_trailing_whitespace_label_is_stripped(
         label_dialog.edit.clear()
         qtbot.keyClicks(label_dialog.edit, "cat  ")
         qtbot.wait(50)
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+        qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Enter)
 
     schedule_on_dialog(label_dialog=label_dialog, action=_enter_trailing_space_label)
     click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=_CLOSE_POLYGON_CLICK)

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -170,7 +170,7 @@ def test_delete_shape_removes_label_list_entry(
     monkeypatch.setattr(
         QMessageBox,
         "warning",
-        lambda *args, **kwargs: QMessageBox.Yes,
+        lambda *args, **kwargs: QMessageBox.StandardButton.Yes,
     )
     win.delete_selected_shapes()
     qtbot.waitUntil(lambda: len(label_list) == count_before - 1)
@@ -210,7 +210,7 @@ def test_edit_label_cancel_keeps_labels(
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
     schedule_on_dialog(
         label_dialog=label_dialog,
-        action=lambda: qtbot.keyClick(label_dialog, Qt.Key_Escape),
+        action=lambda: qtbot.keyClick(label_dialog, Qt.Key.Key_Escape),
     )
     label_list.item_double_clicked.emit(label_list[0])
     qtbot.waitUntil(lambda: not label_dialog.isVisible(), timeout=3000)
@@ -242,7 +242,8 @@ def test_edit_label_invalid_label_keeps_labels_and_shows_error(
     monkeypatch.setattr(
         QMessageBox,
         "critical",
-        lambda *args, **kwargs: error_shown.append(True) or QMessageBox.Ok,
+        lambda *args, **kwargs: error_shown.append(True)
+        or QMessageBox.StandardButton.Ok,
     )
 
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
@@ -250,7 +251,7 @@ def test_edit_label_invalid_label_keeps_labels_and_shows_error(
     def submit_unknown_label() -> None:
         label_dialog.edit.clear()
         qtbot.keyClicks(label_dialog.edit, "tiger")
-        qtbot.keyClick(label_dialog.edit, Qt.Key_Enter)
+        qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Enter)
 
     schedule_on_dialog(label_dialog=label_dialog, action=submit_unknown_label)
     label_list.item_double_clicked.emit(label_list[0])
@@ -288,7 +289,7 @@ def test_edit_label_multi_shape_mismatch_disables_text_field(
 
     def capture_disabled_then_cancel() -> None:
         edit_disabled_during_popup.append(not label_dialog.edit.isEnabled())
-        qtbot.keyClick(label_dialog, Qt.Key_Escape)
+        qtbot.keyClick(label_dialog, Qt.Key.Key_Escape)
 
     schedule_on_dialog(label_dialog=label_dialog, action=capture_disabled_then_cancel)
     label_list.item_double_clicked.emit(label_list[0])

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMessageBox
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -50,7 +50,7 @@ def test_last_label_memo(
     _schedule_capture_then_cancel(label_dialog=label_dialog, captured=captured)
 
     _draw_triangle(qtbot=qtbot, win=raw_win)
-    qtbot.keyPress(canvas, Qt.Key_Return)
+    qtbot.keyPress(canvas, Qt.Key.Key_Return)
 
     qtbot.waitUntil(lambda: bool(captured), timeout=_SHAPE_TIMEOUT_MS)
 
@@ -79,7 +79,7 @@ def test_restore_last_shape_via_undo(
     monkeypatch.setattr(
         QMessageBox,
         "warning",
-        lambda *args, **kwargs: QMessageBox.Yes,
+        lambda *args, **kwargs: QMessageBox.StandardButton.Yes,
     )
 
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -4,9 +4,9 @@ from functools import partial
 from typing import Final
 
 import pytest
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMessageBox
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -53,7 +53,7 @@ def test_middle_drag_emits_pan_request_with_widget_pixel_delta(
     drag_canvas(
         qtbot=qtbot,
         canvas=canvas,
-        button=Qt.MiddleButton,
+        button=Qt.MouseButton.MiddleButton,
         start=start,
         end=end,
     )
@@ -92,7 +92,7 @@ def test_middle_drag_no_pan_when_image_fits_viewport(
         drag_canvas(
             qtbot=qtbot,
             canvas=canvas,
-            button=Qt.MiddleButton,
+            button=Qt.MouseButton.MiddleButton,
             start=start,
             end=end,
         )

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Final
 
 import pytest
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/navigation_test.py
+++ b/tests/e2e/navigation_test.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from ..conftest import close_or_pause

--- a/tests/e2e/navigation_test.py
+++ b/tests/e2e/navigation_test.py
@@ -25,15 +25,15 @@ def test_image_navigation_while_selecting_shape(
     # Incident: https://github.com/wkentaro/labelme/pull/1716 {{
     point = QPoint(250, 200)
     qtbot.mouseMove(win._canvas_widgets.canvas, pos=point)
-    qtbot.mouseClick(win._canvas_widgets.canvas, Qt.LeftButton, pos=point)
+    qtbot.mouseClick(win._canvas_widgets.canvas, Qt.MouseButton.LeftButton, pos=point)
     qtbot.wait(100)
 
-    qtbot.mouseClick(win._docks.file_list, Qt.LeftButton)
+    qtbot.mouseClick(win._docks.file_list, Qt.MouseButton.LeftButton)
     qtbot.wait(100)
 
-    qtbot.keyClick(win._docks.file_list, Qt.Key_Down)
+    qtbot.keyClick(win._docks.file_list, Qt.Key.Key_Down)
     qtbot.wait(100)
-    qtbot.keyClick(win._canvas_widgets.canvas, Qt.Key_Down)
+    qtbot.keyClick(win._canvas_widgets.canvas, Qt.Key.Key_Down)
     qtbot.wait(100)
     # }}
 

--- a/tests/e2e/oriented_rectangle_test.py
+++ b/tests/e2e/oriented_rectangle_test.py
@@ -90,7 +90,7 @@ def test_drag_rotation_handle_rotates_oriented_rectangle(
     drag_canvas(
         qtbot=qtbot,
         canvas=canvas,
-        button=Qt.LeftButton,
+        button=Qt.MouseButton.LeftButton,
         start=handle_widget,
         end=target_widget,
     )
@@ -150,7 +150,7 @@ def test_drag_vertex_out_of_pixmap_clips_oriented_rectangle(
     drag_canvas(
         qtbot=qtbot,
         canvas=canvas,
-        button=Qt.LeftButton,
+        button=Qt.MouseButton.LeftButton,
         start=start_widget,
         end=end_widget,
     )
@@ -216,8 +216,8 @@ def test_oriented_rectangle_disallows_add_and_remove_point(
     hover_widget_pos(qtbot=qtbot, canvas=canvas, pos=vertex_widget)
     qtbot.mouseClick(
         canvas,
-        Qt.LeftButton,
-        Qt.AltModifier | Qt.ShiftModifier,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.AltModifier | Qt.KeyboardModifier.ShiftModifier,
         pos=vertex_widget,
     )
     qtbot.wait(50)

--- a/tests/e2e/oriented_rectangle_test.py
+++ b/tests/e2e/oriented_rectangle_test.py
@@ -5,8 +5,8 @@ from typing import Final
 
 import numpy as np
 import pytest
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/oriented_rectangle_test.py
+++ b/tests/e2e/oriented_rectangle_test.py
@@ -217,7 +217,7 @@ def test_oriented_rectangle_disallows_add_and_remove_point(
     qtbot.mouseClick(
         canvas,
         Qt.LeftButton,
-        modifier=Qt.AltModifier | Qt.ShiftModifier,
+        Qt.AltModifier | Qt.ShiftModifier,
         pos=vertex_widget,
     )
     qtbot.wait(50)

--- a/tests/e2e/save_format_contract_test.py
+++ b/tests/e2e/save_format_contract_test.py
@@ -7,7 +7,7 @@ from typing import Final
 
 import numpy as np
 import pytest
-from PyQt5.QtCore import QTimer
+from PySide6.QtCore import QTimer
 from pytestqt.qtbot import QtBot
 
 from labelme import utils

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import cast
 
 import pytest
 from PySide6 import QtWidgets
@@ -89,10 +88,7 @@ def test_label_edit_preserves_label_history(
 
     assert win._label_dialog is old_label_dialog  # updated in place, not rebuilt
     label_list = win._label_dialog.label_list
-    labels = {
-        cast(QtWidgets.QListWidgetItem, label_list.item(i)).text()
-        for i in range(label_list.count())
-    }
+    labels = {label_list.item(i).text() for i in range(label_list.count())}
     assert labels == {"bird", "cat", "dog"}  # history kept, new labels added
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
 from labelme._yaml import safe_load

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -219,7 +219,7 @@ def test_right_drag_copy_here_duplicates_shape(
         copy_here_action.trigger()
         return copy_here_action
 
-    monkeypatch.setattr(canvas.menus[1], "exec_", trigger_copy_here)
+    monkeypatch.setattr(canvas.menus[1], "exec", trigger_copy_here)
 
     drag_canvas(
         qtbot=qtbot,

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import Qt
+from PySide6 import QtWidgets
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -52,7 +52,7 @@ def _delete_selected_shape(
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
         "warning",
-        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
     )
     win.delete_selected_shapes()
     qtbot.wait(50)
@@ -224,7 +224,7 @@ def test_right_drag_copy_here_duplicates_shape(
     drag_canvas(
         qtbot=qtbot,
         canvas=canvas,
-        button=Qt.RightButton,
+        button=Qt.MouseButton.RightButton,
         start=start_widget,
         end=end_widget,
     )

--- a/tests/e2e/status_bar_messages_test.py
+++ b/tests/e2e/status_bar_messages_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5.QtCore import QTimer
+from PySide6.QtCore import QTimer
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/unsaved_changes_dialog_test.py
+++ b/tests/e2e/unsaved_changes_dialog_test.py
@@ -74,7 +74,7 @@ def test_close_with_unsaved_changes_cancel_keeps_window_open(
     assert _is_dirty(win=_raw_win_no_autosave)
 
     prompt_shown = _intercept_question(
-        monkeypatch=monkeypatch, response=QMessageBox.Cancel
+        monkeypatch=monkeypatch, response=QMessageBox.StandardButton.Cancel
     )
 
     _raw_win_no_autosave.close()
@@ -98,7 +98,9 @@ def test_close_choose_save_writes_json_and_closes(
     expected_json = tmp_path / _OUTPUT_JSON_NAME
     assert not expected_json.exists()
 
-    _intercept_question(monkeypatch=monkeypatch, response=QMessageBox.Save)
+    _intercept_question(
+        monkeypatch=monkeypatch, response=QMessageBox.StandardButton.Save
+    )
     monkeypatch.setattr(
         _raw_win_no_autosave,
         "prompt_save_file_path",
@@ -125,7 +127,9 @@ def test_close_choose_discard_no_json_window_closes(
     expected_json = tmp_path / _OUTPUT_JSON_NAME
     assert not expected_json.exists()
 
-    _intercept_question(monkeypatch=monkeypatch, response=QMessageBox.Discard)
+    _intercept_question(
+        monkeypatch=monkeypatch, response=QMessageBox.StandardButton.Discard
+    )
 
     _raw_win_no_autosave.close()
     qtbot.waitUntil(lambda: not _raw_win_no_autosave.isVisible(), timeout=3000)
@@ -147,7 +151,7 @@ def test_navigate_with_unsaved_changes_shows_prompt(
     row_before = file_list.currentRow()
 
     prompt_shown = _intercept_question(
-        monkeypatch=monkeypatch, response=QMessageBox.Discard
+        monkeypatch=monkeypatch, response=QMessageBox.StandardButton.Discard
     )
 
     # _open_next_image does not call _can_continue itself; it bumps
@@ -172,7 +176,7 @@ def test_close_clean_window_no_prompt(
     assert not _is_dirty(win=_raw_win_no_autosave)
 
     prompt_shown = _intercept_question(
-        monkeypatch=monkeypatch, response=QMessageBox.Discard
+        monkeypatch=monkeypatch, response=QMessageBox.StandardButton.Discard
     )
 
     _raw_win_no_autosave.close()

--- a/tests/e2e/unsaved_changes_dialog_test.py
+++ b/tests/e2e/unsaved_changes_dialog_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import Qt
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -27,7 +27,7 @@ def test_toggle_all_shapes(
     qtbot.wait(50)
 
     for item in label_list:
-        assert item.checkState() == Qt.Unchecked
+        assert item.checkState() == Qt.CheckState.Unchecked
     for shape in canvas.shapes:
         assert not shape.visible
 
@@ -35,7 +35,7 @@ def test_toggle_all_shapes(
     qtbot.wait(50)
 
     for item in label_list:
-        assert item.checkState() == Qt.Checked
+        assert item.checkState() == Qt.CheckState.Checked
     for shape in canvas.shapes:
         assert shape.visible
 
@@ -58,11 +58,11 @@ def test_toggle_individual_shape(
     assert first_shape is not None
     assert first_shape.visible
 
-    first_item.setCheckState(Qt.Unchecked)
+    first_item.setCheckState(Qt.CheckState.Unchecked)
     qtbot.wait(50)
     assert not first_shape.visible
 
-    first_item.setCheckState(Qt.Checked)
+    first_item.setCheckState(Qt.CheckState.Checked)
     qtbot.wait(50)
     assert first_shape.visible
 
@@ -81,7 +81,7 @@ def test_visibility_preserved_when_undoing_unrelated_edit(
     assert len(canvas.shapes) == 5
 
     hidden_index = 1
-    label_list[hidden_index].setCheckState(Qt.Unchecked)
+    label_list[hidden_index].setCheckState(Qt.CheckState.Unchecked)
     qtbot.wait(50)
     assert not canvas.shapes[hidden_index].visible
 
@@ -95,7 +95,9 @@ def test_visibility_preserved_when_undoing_unrelated_edit(
     for i, shape in enumerate(canvas.shapes):
         expected_visible = i != hidden_index
         assert shape.visible is expected_visible
-        expected_state = Qt.Checked if expected_visible else Qt.Unchecked
+        expected_state = (
+            Qt.CheckState.Checked if expected_visible else Qt.CheckState.Unchecked
+        )
         assert label_list[i].checkState() == expected_state
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
@@ -113,7 +115,7 @@ def test_undo_recovers_accidental_hide(
     assert len(canvas.shapes) == 5
     hidden_index = 1
 
-    label_list[hidden_index].setCheckState(Qt.Unchecked)
+    label_list[hidden_index].setCheckState(Qt.CheckState.Unchecked)
     qtbot.wait(50)
     assert not canvas.shapes[hidden_index].visible
     assert annotated_win._actions.undo.isEnabled()
@@ -124,7 +126,7 @@ def test_undo_recovers_accidental_hide(
     assert len(canvas.shapes) == 5
     for i, shape in enumerate(canvas.shapes):
         assert shape.visible
-        assert label_list[i].checkState() == Qt.Checked
+        assert label_list[i].checkState() == Qt.CheckState.Checked
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
 
@@ -149,23 +151,23 @@ def test_multi_select_toggle_propagates(
         label_list[i] for i in selected_indices
     }
 
-    label_list[selected_indices[1]].setCheckState(Qt.Unchecked)
+    label_list[selected_indices[1]].setCheckState(Qt.CheckState.Unchecked)
     qtbot.wait(50)
 
     for i in range(len(canvas.shapes)):
         if i in selected_indices:
             assert not canvas.shapes[i].visible
-            assert label_list[i].checkState() == Qt.Unchecked
+            assert label_list[i].checkState() == Qt.CheckState.Unchecked
         else:
             assert canvas.shapes[i].visible
-            assert label_list[i].checkState() == Qt.Checked
+            assert label_list[i].checkState() == Qt.CheckState.Checked
 
     annotated_win._actions.undo.trigger()
     qtbot.wait(50)
 
     for i in range(len(canvas.shapes)):
         assert canvas.shapes[i].visible
-        assert label_list[i].checkState() == Qt.Checked
+        assert label_list[i].checkState() == Qt.CheckState.Checked
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
 
@@ -190,14 +192,14 @@ def test_multi_select_preserves_selection_after_checkbox_click(
     target_index = label_list._model.indexFromItem(label_list[selected_indices[1]])
     rect = label_list.visualRect(target_index)
     checkbox_pos = QPoint(rect.left() + 5, rect.center().y())
-    qtbot.mouseClick(label_list.viewport(), Qt.LeftButton, pos=checkbox_pos)
+    qtbot.mouseClick(label_list.viewport(), Qt.MouseButton.LeftButton, pos=checkbox_pos)
     qtbot.wait(50)
 
     assert {item for item in label_list.selected_items()} == {
         label_list[i] for i in selected_indices
     }
     for i in selected_indices:
-        assert label_list[i].checkState() == Qt.Unchecked
+        assert label_list[i].checkState() == Qt.CheckState.Unchecked
         assert not canvas.shapes[i].visible
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
@@ -222,7 +224,7 @@ def test_multi_select_collapses_on_row_body_click(
     target_index = label_list._model.indexFromItem(label_list[clicked_index])
     rect = label_list.visualRect(target_index)
     row_body_pos = QPoint(rect.center().x(), rect.center().y())
-    qtbot.mouseClick(label_list.viewport(), Qt.LeftButton, pos=row_body_pos)
+    qtbot.mouseClick(label_list.viewport(), Qt.MouseButton.LeftButton, pos=row_body_pos)
     qtbot.wait(50)
 
     assert {item for item in label_list.selected_items()} == {label_list[clicked_index]}

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from typing import Final
 
 import pytest
-from PyQt5 import QtGui
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import Qt
+from PySide6 import QtGui
+from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme.app import MainWindow
@@ -87,9 +87,8 @@ def _make_wheel_event(
     angle_delta: QPoint,
     modifiers: Qt.KeyboardModifiers,
 ) -> QtGui.QWheelEvent:
-    # PyQt5's QWheelEvent has overlapping qt4 and modern overloads; the
-    # all-positional 8-arg form is the only one that disambiguates without
-    # forcing a particular `KeyboardModifier`/`KeyboardModifiers` type.
+    # PySide6's QWheelEvent constructor takes positional args;
+    # the 8-arg form matches the modern Qt6 signature.
     return QtGui.QWheelEvent(
         pos,
         pos,

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -85,7 +85,7 @@ def test_zoom_to_original(
 def _make_wheel_event(
     pos: QPointF,
     angle_delta: QPoint,
-    modifiers: Qt.KeyboardModifiers,
+    modifiers: Qt.KeyboardModifier,
 ) -> QtGui.QWheelEvent:
     # PySide6's QWheelEvent constructor takes positional args;
     # the 8-arg form matches the modern Qt6 signature.
@@ -94,9 +94,9 @@ def _make_wheel_event(
         pos,
         QPoint(0, 0),
         angle_delta,
-        Qt.NoButton,
+        Qt.MouseButton.NoButton,
         modifiers,
-        Qt.NoScrollPhase,
+        Qt.ScrollPhase.NoScrollPhase,
         False,
     )
 
@@ -106,20 +106,24 @@ def _make_wheel_event(
     ("modifiers", "angle_delta", "signal_attr", "expected_orientation"),
     [
         pytest.param(
-            Qt.ControlModifier, QPoint(0, 120), "zoom_request", None, id="ctrl_zoom"
+            Qt.KeyboardModifier.ControlModifier,
+            QPoint(0, 120),
+            "zoom_request",
+            None,
+            id="ctrl_zoom",
         ),
         pytest.param(
-            Qt.NoModifier,
+            Qt.KeyboardModifier.NoModifier,
             QPoint(0, 120),
             "scroll_request",
-            Qt.Vertical,
+            Qt.Orientation.Vertical,
             id="plain_scroll",
         ),
         pytest.param(
-            Qt.ShiftModifier,
+            Qt.KeyboardModifier.ShiftModifier,
             QPoint(0, 120),
             "scroll_request",
-            Qt.Horizontal,
+            Qt.Orientation.Horizontal,
             id="shift_horizontal_scroll",
         ),
     ],
@@ -128,7 +132,7 @@ def test_canvas_wheel_event_dispatches_signal(
     qtbot: QtBot,
     _win: MainWindow,
     pause: bool,
-    modifiers: Qt.KeyboardModifiers,
+    modifiers: Qt.KeyboardModifier,
     angle_delta: QPoint,
     signal_attr: str,
     expected_orientation: Qt.Orientation | None,

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -65,3 +65,20 @@ def test_nearest_vertex_index_returns_none_for_mask() -> None:
             )
             is None
         )
+
+
+def test_nearest_vertex_index_returns_none_for_point() -> None:
+    # A point shape's single point is the shape itself, not a draggable vertex;
+    # it is selected and moved as a whole, so it exposes no vertex to hit.
+    shape = Shape(
+        shape_type="point",
+        points=np.array([(5.0, 5.0)], dtype=np.float64),
+        closed=True,
+    )
+
+    assert (
+        _shape.nearest_vertex_index(
+            shape=shape, point=shape.points[0], scale=1.0, epsilon=10.0
+        )
+        is None
+    )

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 
 import pytest
-from PyQt5.QtCore import QPointF
+from PySide6.QtCore import QPointF
 
 from labelme.utils.qt import direction_angle
 from labelme.utils.qt import distance_to_line

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -6,11 +6,11 @@ from typing import Final
 
 import numpy as np
 import pytest
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5.QtCore import QPointF
-from PyQt5.QtCore import QSize
-from PyQt5.QtCore import Qt
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import QSize
+from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme._shape import Shape

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -299,11 +299,11 @@ def test_extend_after_mode_switch_finalizes_at_last_cursor(
     canvas.create_mode = to_mode
 
     event = QtGui.QMouseEvent(
-        QtCore.QEvent.MouseButtonPress,
+        QtCore.QEvent.Type.MouseButtonPress,
         QPointF(50, 30),
-        Qt.LeftButton,
-        Qt.LeftButton,
-        Qt.NoModifier,
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
     )
     canvas._extend_current_shape(current=canvas._current, event=event)
 
@@ -336,11 +336,11 @@ def test_extend_after_mode_switch_grows_partial_at_last_cursor(
     canvas.create_mode = to_mode
 
     event = QtGui.QMouseEvent(
-        QtCore.QEvent.MouseButtonPress,
+        QtCore.QEvent.Type.MouseButtonPress,
         QPointF(50, 30),
-        Qt.LeftButton,
-        Qt.LeftButton,
-        Qt.NoModifier,
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
     )
     canvas._extend_current_shape(current=canvas._current, event=event)
 

--- a/tests/unit/widgets/label_dialog_test.py
+++ b/tests/unit/widgets/label_dialog_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 import pytest
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
 from labelme.widgets.label_dialog import LabelDialog

--- a/tests/unit/widgets/label_dialog_test.py
+++ b/tests/unit/widgets/label_dialog_test.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
-
 import pytest
-from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
 from labelme.widgets.label_dialog import LabelDialog
@@ -11,10 +8,7 @@ from labelme.widgets.label_dialog import LabelDialog
 
 def _labels(dialog: LabelDialog) -> set[str]:
     label_list = dialog.label_list
-    return {
-        cast(QtWidgets.QListWidgetItem, label_list.item(i)).text()
-        for i in range(label_list.count())
-    }
+    return {label_list.item(i).text() for i in range(label_list.count())}
 
 
 @pytest.fixture

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PySide6 import QtGui
+from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
 from labelme._config import load_config

--- a/uv.lock
+++ b/uv.lock
@@ -1131,9 +1131,7 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "osam" },
     { name = "pillow" },
-    { name = "pyqt5" },
-    { name = "pyqt5-qt5", version = "5.15.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "pyqt5-qt5", version = "5.15.18", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "pyside6" },
     { name = "ruamel-yaml" },
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1152,7 +1150,6 @@ dev = [
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
     { name = "mdformat-gfm" },
-    { name = "pyqt5-stubs" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
@@ -1175,9 +1172,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
     { name = "osam", specifier = ">=0.4.0" },
     { name = "pillow", specifier = ">=2.8" },
-    { name = "pyqt5", specifier = ">=5.14.0" },
-    { name = "pyqt5-qt5", marker = "sys_platform == 'linux'", specifier = "!=5.15.13" },
-    { name = "pyqt5-qt5", marker = "sys_platform == 'win32'", specifier = "!=5.15.11,!=5.15.12,!=5.15.13,!=5.15.14,!=5.15.15,!=5.15.16" },
+    { name = "pyside6", specifier = ">=6.5" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "scikit-image", specifier = ">=0.21" },
     { name = "scipy", specifier = ">=1.8" },
@@ -1190,7 +1185,6 @@ dev = [
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },
     { name = "mdformat-gfm", specifier = ">=1.0.0" },
-    { name = "pyqt5-stubs", specifier = ">=5.15.6.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-qt", specifier = ">=4.4.0" },
@@ -2110,104 +2104,61 @@ wheels = [
 ]
 
 [[package]]
-name = "pyqt5"
-version = "5.15.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyqt5-qt5", version = "5.15.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "pyqt5-qt5", version = "5.15.18", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "pyqt5-sip" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/07/c9ed0bd428df6f87183fca565a79fee19fa7c88c7f00a7f011ab4379e77a/PyQt5-5.15.11.tar.gz", hash = "sha256:fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52", size = 3216775, upload-time = "2024-07-19T08:39:57.756Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/64/42ec1b0bd72d87f87bde6ceb6869f444d91a2d601f2e67cd05febc0346a1/PyQt5-5.15.11-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c8b03dd9380bb13c804f0bdb0f4956067f281785b5e12303d529f0462f9afdc2", size = 6579776, upload-time = "2024-07-19T08:39:19.775Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f5/3fb696f4683ea45d68b7e77302eff173493ac81e43d63adb60fa760b9f91/PyQt5-5.15.11-cp38-abi3-macosx_11_0_x86_64.whl", hash = "sha256:6cd75628f6e732b1ffcfe709ab833a0716c0445d7aec8046a48d5843352becb6", size = 7016415, upload-time = "2024-07-19T08:39:32.977Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/8c/4065950f9d013c4b2e588fe33cf04e564c2322842d84dbcbce5ba1dc28b0/PyQt5-5.15.11-cp38-abi3-manylinux_2_17_x86_64.whl", hash = "sha256:cd672a6738d1ae33ef7d9efa8e6cb0a1525ecf53ec86da80a9e1b6ec38c8d0f1", size = 8188103, upload-time = "2024-07-19T08:39:40.561Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f0/ae5a5b4f9b826b29ea4be841b2f2d951bcf5ae1d802f3732b145b57c5355/PyQt5-5.15.11-cp38-abi3-win32.whl", hash = "sha256:76be0322ceda5deecd1708a8d628e698089a1cea80d1a49d242a6d579a40babd", size = 5433308, upload-time = "2024-07-19T08:39:46.932Z" },
-    { url = "https://files.pythonhosted.org/packages/56/d5/68eb9f3d19ce65df01b6c7b7a577ad3bbc9ab3a5dd3491a4756e71838ec9/PyQt5-5.15.11-cp38-abi3-win_amd64.whl", hash = "sha256:bdde598a3bb95022131a5c9ea62e0a96bd6fb28932cc1619fd7ba211531b7517", size = 6865864, upload-time = "2024-07-19T08:39:53.572Z" },
-]
-
-[[package]]
-name = "pyqt5-qt5"
-version = "5.15.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/7e/ce7c66a541a105fa98b41d6405fe84940564695e29fc7dccf6d9e8c5f898/PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327", size = 43447358, upload-time = "2021-03-10T14:01:17.827Z" },
-    { url = "https://files.pythonhosted.org/packages/37/97/5d3b222b924fa2ed4c2488925155cd0b03fd5d09ee1cfcf7c553c11c9f66/PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962", size = 50075158, upload-time = "2021-03-10T14:05:20.868Z" },
-]
-
-[[package]]
-name = "pyqt5-qt5"
-version = "5.15.18"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/90/bf01ac2132400997a3474051dd680a583381ebf98b2f5d64d4e54138dc42/pyqt5_qt5-5.15.18-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:8bb997eb903afa9da3221a0c9e6eaa00413bbeb4394d5706118ad05375684767", size = 39715743, upload-time = "2025-11-09T12:56:42.936Z" },
-    { url = "https://files.pythonhosted.org/packages/24/8e/76366484d9f9dbe28e3bdfc688183433a7b82e314216e9b14c89e5fab690/pyqt5_qt5-5.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c656af9c1e6aaa7f59bf3d8995f2fa09adbf6762b470ed284c31dca80d686a26", size = 36798484, upload-time = "2025-11-09T12:56:59.998Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/46/ffe177f99f897a59dc237a20059020427bd2d3853d713992b8081933ddfe/pyqt5_qt5-5.15.18-py3-none-manylinux2014_x86_64.whl", hash = "sha256:bf2457e6371969736b4f660a0c153258fa03dbc6a181348218e6f05421682af7", size = 60864590, upload-time = "2025-11-09T12:57:26.724Z" },
-]
-
-[[package]]
-name = "pyqt5-sip"
-version = "12.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/31/5ef342de9faee0f3801088946ae103db9b9eaeba3d6a64fefd5ce74df244/pyqt5_sip-12.18.0.tar.gz", hash = "sha256:71c37db75a0664325de149f43e2a712ec5fa1f90429a21dafbca005cb6767f94", size = 104143, upload-time = "2026-01-13T15:53:19.576Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/8e/9db5c0756134a6501ecf7d472a92f64d2d0b8033b4597e73f138a4cfb605/pyqt5_sip-12.18.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:dc5c30bb9bd8cca6e13d2fedac6e2a75fe2168d798d66f76e74835546b025027", size = 122663, upload-time = "2026-01-13T15:52:40.965Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/4a/c66dfd090d93ef6f3e30093b55bf786c24608258d157cb1951e28c5a2725/pyqt5_sip-12.18.0-cp310-cp310-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b4b743566f67cabfa7b0ba2da30b46d9d635d16cd5bc8cdcec83f620ed14dd93", size = 319778, upload-time = "2026-01-13T15:52:45.339Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/38/608e93888ce5e63978f1668c68e99bfd9e98ef59a7e619a82b14012c8ce5/pyqt5_sip-12.18.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:bbec4c14903bcd585b4e1ee50edccfe224c8c0ee8004a072143993b4eb954442", size = 271455, upload-time = "2026-01-13T15:52:43.453Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/20/d69a96d3134bca5e6623835f39954eb0f8a8e63813022f30d7150565b63e/pyqt5_sip-12.18.0-cp310-cp310-win32.whl", hash = "sha256:a2a0278091d067b17855047ed8bd557e5ca62308a7d9fb5200451d0bd9090afc", size = 49315, upload-time = "2026-01-13T15:52:47.915Z" },
-    { url = "https://files.pythonhosted.org/packages/83/e8/59dc463ff816e2a9001ba873521f8cc40c25bbae31711e42f65a23c36bf4/pyqt5_sip-12.18.0-cp310-cp310-win_amd64.whl", hash = "sha256:65f257e28d06a01c2a9a7c0b2faf2af1dbf25a1420a5a9d905a54aaddce74d79", size = 58802, upload-time = "2026-01-13T15:52:46.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/59/3dd29bcfde479ac241f618235bf7d76e65e47afdcd91743554d490ae0d19/pyqt5_sip-12.18.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13c32e9025d0ab5fe960ef64dcb4c6f7ec26156ddce2cf2f195600aa26e8f9fe", size = 122724, upload-time = "2026-01-13T15:52:49.875Z" },
-    { url = "https://files.pythonhosted.org/packages/87/c4/ac4deee3249d3ceb703103acbbf76d89f3782fa7ad2ca5a15fcb5bcf5c73/pyqt5_sip-12.18.0-cp311-cp311-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:dd855149c724634eb1f92d10e04e1be0751068a8521d5f9f06e5c2dbe32fd89f", size = 327560, upload-time = "2026-01-13T15:52:53.584Z" },
-    { url = "https://files.pythonhosted.org/packages/79/53/64373ba9311288b0ea6b5ab375d9c9743a41ac93df7137655498c95a08e5/pyqt5_sip-12.18.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:521729e4ce44db555005f4e6987c4a5164d45ea03f5a7d08519813d4776acd15", size = 277067, upload-time = "2026-01-13T15:52:51.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/dd/4026bba8355ceaba222db0369fe4a480d55aa61d3f14dbe1458886ccc032/pyqt5_sip-12.18.0-cp311-cp311-win32.whl", hash = "sha256:c738949863d88b78f86f28e13151989ca3b1a302934811af41856dc8a27838bd", size = 49323, upload-time = "2026-01-13T15:52:55.859Z" },
-    { url = "https://files.pythonhosted.org/packages/41/35/39e549ca7f7c9fbb025912a5db7f55f3b9c22d7f9718f41c2e7a17c806e9/pyqt5_sip-12.18.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac0be1a8ce145ed78c7e8d45243749405bee7e3a87e9810b0542bca010c50bd7", size = 58795, upload-time = "2026-01-13T15:52:54.995Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/61/6d78d702016ac23d2b97634a3b6a831c3f7735f0552a1c8b058db96005d1/pyqt5_sip-12.18.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b29e4cda24748e59e5bd1bdad4812091a86b4b5b08c38b7f781eb55a5166f2b7", size = 124614, upload-time = "2026-01-13T15:52:57.59Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bf/8f3efa10ddd3e76c1253865340ab7c2960ef96681d732b1f666c77430612/pyqt5_sip-12.18.0-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:163c2bba5e637c2222ec17d82a2c5aa158184a191923eb7d137cf4cfa0399529", size = 339412, upload-time = "2026-01-13T15:53:00.563Z" },
-    { url = "https://files.pythonhosted.org/packages/72/48/f1bcf6729d01bae6729cd790b22fd579dbe34014e8be031e6f10c5b9b2aa/pyqt5_sip-12.18.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ead5e0a64ad852ac60797989d8444a6a5bd834768536b04a07b40b2937d922f6", size = 282376, upload-time = "2026-01-13T15:52:59.172Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/b7/d84c764ac9f1366be561255ec9bd88ee224fefdbdb349aee250f3003f0ca/pyqt5_sip-12.18.0-cp312-cp312-win32.whl", hash = "sha256:993fe3ed9a62a92e770f32d5344e3df56c2cacf1471f01b7feaf04818a2df1c4", size = 49523, upload-time = "2026-01-13T15:53:03.068Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/e7/ef87178d5afa5f63be38556dc0df8af89f9bf74f2555f4dab6824c0fd150/pyqt5_sip-12.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b689e02e400abd1ce0a30cd6eae8eceabcf1bbba0395cb5c86e64ba74351d68", size = 58001, upload-time = "2026-01-13T15:53:02.15Z" },
-    { url = "https://files.pythonhosted.org/packages/79/67/8d43d0fea10ff48ddecc8534aead8b855dc80df80653b8b1bf9e1f993063/pyqt5_sip-12.18.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9254e5dd7676b76503ba20edcc919e7ac4a97b6c70a6fb2f9dba9e13b4c60509", size = 124605, upload-time = "2026-01-13T15:53:04.991Z" },
-    { url = "https://files.pythonhosted.org/packages/48/2a/b08bc8efeb49c50c6cdac11417dc2c8eaefcac2f0a6382eae7b26dc0f232/pyqt5_sip-12.18.0-cp313-cp313-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c969631ada7293a81e1012b2264a62d69a91995b517586489dfe24421b87b9af", size = 339918, upload-time = "2026-01-13T15:53:08.502Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/99/24f82437b2f073cf39296b7c731b6a8bc0f5207911fdd93841a0ea9abe42/pyqt5_sip-12.18.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d84ac384a63285132e67762c87681191c25e28a1df7560287ec3889d9eb223b5", size = 282088, upload-time = "2026-01-13T15:53:06.632Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/27/20d3924943df34361fae9c6a0489ae89d0b07571693245c61678d185e4a4/pyqt5_sip-12.18.0-cp313-cp313-win32.whl", hash = "sha256:95bba4670ecf5cba73958b85aa2087c17838a402ed251c38e68060c7665c998b", size = 49501, upload-time = "2026-01-13T15:53:11.159Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/36/e251623c12968730730512a9e5150430e36246afbe64894610190b896f61/pyqt5_sip-12.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:aac4adc37df2f2ac1dc259409be1900f07332d140a12c9db7c84112cef64ff59", size = 58076, upload-time = "2026-01-13T15:53:09.928Z" },
-    { url = "https://files.pythonhosted.org/packages/37/3a/b46a0116b1aacbb6156b2957eb5cb928c94b49f4626eb2540ca8d16ee757/pyqt5_sip-12.18.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8372ec8704bfd5e09942d0d055a1657eb4f702f4b30847a5e59df0496f99d67f", size = 124594, upload-time = "2026-01-13T15:53:13.159Z" },
-    { url = "https://files.pythonhosted.org/packages/58/63/df3037f11391c25c5b0ab233d22e58b8f056cb1ce16d7ecadb844421ce75/pyqt5_sip-12.18.0-cp314-cp314-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fdb45c7cd2af7eccd7370b994d432bfc7965079f845392760724f26771bb59dc", size = 339056, upload-time = "2026-01-13T15:53:16.558Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e7/4f96b84520b8f8b7502682fd43f68f63ca6572b5858f56e5f61c76a54fe2/pyqt5_sip-12.18.0-cp314-cp314-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:92abe984becbde768954d6d0951f56d80a9868d2fd9e738e61fc944f0ff83dd6", size = 282439, upload-time = "2026-01-13T15:53:14.856Z" },
-    { url = "https://files.pythonhosted.org/packages/79/8e/ccdf20d373ceba83e1d1b7f818505c375208ffde4a96376dc7dbe592406c/pyqt5_sip-12.18.0-cp314-cp314-win32.whl", hash = "sha256:bd9e3c6f81346f1b08d6db02305cdee20c009b43aa083d44ee2de47a7da0e123", size = 50713, upload-time = "2026-01-13T15:53:18.634Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/21/8486ed45977be615ec5371b24b47298b1cb0e1a455b419eddd0215078dba/pyqt5_sip-12.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:6d948f1be619c645cd3bda54952bfdc1aef7c79242dccea6a6858748e61114b9", size = 59622, upload-time = "2026-01-13T15:53:17.714Z" },
-]
-
-[[package]]
-name = "pyqt5-stubs"
-version = "5.15.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/5b/f96312e01661dff7320366fc948f7597d3e3e28ff7116e9e77dbf41ab937/PyQt5-stubs-5.15.6.0.tar.gz", hash = "sha256:91270ac23ebf38a1dc04cd97aa852cd08af82dc839100e5395af1447e3e99707", size = 395647, upload-time = "2022-04-23T09:53:56.785Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/d5/9b8482ed572be40d51c3fcbb87451e446e56b5e19487cd60340b8ef51eb4/PyQt5_stubs-5.15.6.0-py3-none-any.whl", hash = "sha256:7fb8177c72489a8911f021b7bd7c33f12c87f6dba92dcef3fdcdb5d9400f0f3f", size = 433328, upload-time = "2022-04-23T09:53:52.107Z" },
-]
-
-[[package]]
 name = "pyreadline3"
 version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pyside6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a6/27ba5947ed48918f7b74b7c43a1e280aac069e36f25adeb4c9adfac835c4/pyside6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:537682c3b7530817203e667c1f5a2f00486b37bf52c52eeab438544c7a0917f6", size = 571921, upload-time = "2026-05-13T09:47:36.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/de/af89d71410c83b10654d86ff9aff2a4f87c30163658f1cc145242e222526/pyside6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b1fc521ba2bb5109425ab8add06bddbdd524abcad06cfa012cc39a22a189feb2", size = 572102, upload-time = "2026-05-13T09:47:38.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0e/d583bd3f7bf5046a4497b36f3902cfb64aa29554489a5a25c18e6b4ac0ac/pyside6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:75f0005c3eb95c07cfb65522ec50d0815ac007a96482c21dc3cb4b4c04895d84", size = 572098, upload-time = "2026-05-13T09:47:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f2/d9d8ce1373dabb37e5919f63cd18446556079631d3f2eea3ada03c29f6b8/pyside6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0968877ab1fb4ef3587a284da6fe05e8647ada56a6a3750b6395188e01f4aba6", size = 578377, upload-time = "2026-05-13T09:47:40.76Z" },
+    { url = "https://files.pythonhosted.org/packages/96/02/a6057d8bd2bdb1940820fff2d627fdf4013148c9c57adf69fa40d3452ac3/pyside6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:acee467cb5f256cc47ebb9d815a054c1d8416da380c191b247a76d164aa3f805", size = 561765, upload-time = "2026-05-13T09:47:41.9Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6b/8bc94aff48b63f788f2d84e5467c12362d68906ba742c0942f46cb04c879/pyside6_addons-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:54733c77f789bef5f03c6aff4ad3bec8b2eff021f0cfcbc53d5e6c250ded24f9", size = 331714589, upload-time = "2026-05-13T09:39:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/fb1428a523b2a4541e232aab50d9e789e6b4526f37fd9593452a7ea5b6b3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6c65fbd73a512d6f72cda8d8277444a85a34dc99dd1dae9c21d35b8671bb1f", size = 175063224, upload-time = "2026-05-13T09:39:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9b/2ccd52f66db55c06de65d0501170a1935d04d64d0a230c0d892284a02ce3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:bf1c6c4e954e5eba3d2a7c661ad4b9689e8f09c7f4a16bdf29713371d11af993", size = 170553429, upload-time = "2026-05-13T09:39:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bd/8adc4d350b3b363f3dfc8fccdcf5bfed25f7e36c2fff30c64e106f4f1572/pyside6_addons-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0d13c4dfd671b050a48e4f8d8ddc724b7248f9c0437e7fc47fdf316278572923", size = 168816308, upload-time = "2026-05-13T09:40:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b7/9a840d97f0f0f04e372a87e205dd30ee285b4e3b021b188459a917c9dc76/pyside6_addons-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:3494f480dee92f415be2f2d989c0b3f4755ac332b28045cbf4ba0f5c5a22ba37", size = 35759347, upload-time = "2026-05-13T09:40:21.199Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/da/10d9197e7370eb4fed8df5fc547b7548dec88e5c5949e2d450db4ae96feb/pyside6_essentials-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:228de53c2bc26b07e5021fbe3614fc44ca08e4dab9999af08c2b389d2c239957", size = 110352945, upload-time = "2026-05-13T09:43:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60", size = 79908535, upload-time = "2026-05-13T09:43:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d", size = 78960051, upload-time = "2026-05-13T09:43:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/b663ecc96ca57b5c91b83b6615d6b174380b0faf30338125c26e053d6aa7/pyside6_essentials-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:63311bd48e32c584599ab04b9ef7c324082374cd2c9fa533f978fb893bb47e40", size = 77549267, upload-time = "2026-05-13T09:43:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/eb6723faf5cb7fa581145da1c15f40d641b96e080f0491af2f1859fdeedb/pyside6_essentials-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:11253ea52aabecefe9febddbbe78b43a824129e3af1cec98431028fba7fa954f", size = 57964512, upload-time = "2026-05-13T09:43:52.968Z" },
 ]
 
 [[package]]
@@ -2703,6 +2654,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f3/f2b63df0251e7cd3172ea28e32ede52739de9566bcefcd0178681538ac81/shiboken6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1a16867f103ef1c662a5f09dfed03273a9f81688b174555162c58e83650a3f02", size = 476874, upload-time = "2026-05-13T09:47:01.091Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe", size = 272222, upload-time = "2026-05-13T09:47:02.653Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f", size = 270350, upload-time = "2026-05-13T09:47:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/3f6fb2ee65b534193fb4ef713dd619dc31dadff5d12c16979a7699ad58be/shiboken6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:c2c6863aa80ec18c0f82cea3417837b279cdc60024ac17123461dc9042577df7", size = 1223647, upload-time = "2026-05-13T09:47:05.924Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d1/f15ca0e1666faae02c945f48e745ea35f8fcd8243b176109b4e2c4251f47/shiboken6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:7c8d9af17db4495d4fa5b1c393f218311c4855546b9dfa6a0bd21bcd66b55e9d", size = 1784170, upload-time = "2026-05-13T09:47:07.617Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrates the GUI from PyQt5 to PySide6 (Qt 6). This is almost entirely a
framework port: only the Qt binding and the APIs that differ between Qt 5 and
Qt 6 were updated. The one intentional behavior change is noted below.

## What changed

- **Dependencies**: `pyqt5` (+ `pyqt5-qt5` pins, `pyqt5-stubs`) replaced with
  `pyside6`; `qt_api = "pyside6"` for pytest-qt. `uv.lock` regenerated.
- **Imports**: all `PyQt5.*` imports converted to `PySide6.*`.
- **Qt 6 API updates**: `pyqtSignal`/`pyqtSlot` -> `Signal`/`Slot`;
  `exec_()` -> `exec()`; `QRegExp`/`QRegExpValidator` ->
  `QRegularExpression`/`QRegularExpressionValidator`; `QAction`/`QShortcut`
  moved to `QtGui`; `QAction.associatedWidgets()` -> `associatedObjects()`;
  removed Qt 6 no-op high-DPI attributes; scoped enum/render-hint constants;
  mouse-event position accessors (`position()`, `position().toPoint()`);
  `QImage.bits()` byte access.
- **Signal typing**: the canvas `scroll_request` signal now carries
  `Qt.Orientation` (it emits orientation enum values, which Qt 6 will not
  implicitly coerce to `int`).
- **Tests**: updated pytest-qt stubs/calls for Qt 6 (`QTest.mouseClick` uses a
  positional modifier; menu/dialog stubs patch `exec` rather than `exec_`).
- **CI**: the Ubuntu Xvfb job installs the Qt 6 xcb runtime libraries
  (`libxcb-cursor0` et al.) in place of `libqt5widgets5`.

51 files changed across `labelme/`, `tests/`, packaging, and CI.

## Behavior change

Point shapes are now selected by clicking the marker (the point is selected and
moved as a whole) instead of grabbing its single vertex, and point hit
detection is computed in screen pixels. The xcb/PySide6 port surfaced the
previous behavior as a regression; `nearest_vertex_index` now treats `point`
like `mask` (no draggable vertex) and `is_hit_by_point` scales the distance.
Covered by a new unit test.

## Platform note

This raises the floor to Qt 6 (Python 3.9+, newer macOS; drops Win 7/8). Worth
calling out in the release notes.

## Verification

- Full suite green headless: `371 passed` under
  `QT_QPA_PLATFORM=offscreen pytest tests/unit tests/e2e` (Qt 6 / PySide6).
- `ruff check` clean.
- App smoke: `labelme --version` / `--help` run under PySide6.
- **Please watch the first CI run for the Ubuntu Qt 6 system-library change**
  (the one part that can't be validated locally); adjust the apt package list
  if the Xvfb job reports a missing platform-plugin dependency.

Closes #2144.
