### PR TITLE
fix(canvas): select point shapes by click

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -98,7 +98,7 @@ def nearest_vertex_index(
     scale: float,
     epsilon: float,
 ) -> int | None:
-    if shape.shape_type == "mask" or len(shape.points) == 0:
+    if shape.shape_type in ("mask", "point") or len(shape.points) == 0:
         return None
     distances = np.linalg.norm((shape.points - point) * scale, axis=1)
     nearest = int(np.argmin(distances))

--- a/labelme/widgets/_shape_render.py
+++ b/labelme/widgets/_shape_render.py
@@ -373,7 +373,7 @@ def is_hit_by_point(
     if shape.shape_type == "point":
         if len(shape.points) == 0:
             return False
-        return bool(np.linalg.norm(point - shape.points[0]) <= point_size / 2)
+        return bool(np.linalg.norm((point - shape.points[0]) * scale) <= point_size / 2)
     if shape.mask is not None:
         raw_y = int(round(float(point[1]) - float(shape.points[0][1])))
         raw_x = int(round(float(point[0]) - float(shape.points[0][0])))

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import json
-import sys
 from pathlib import Path
 from typing import Final
 
@@ -688,14 +687,6 @@ def test_select_point_shape_by_click(
     raw_win: MainWindow,
     pause: bool,
 ) -> None:
-    if sys.platform.startswith("linux"):
-        # Under X11/xcb the hover lands the cursor on the point's only vertex,
-        # so the click is interpreted as "move vertex" and deselects instead of
-        # selecting. Point shapes have no body to click off-vertex, unlike other
-        # shape types. Fixing this needs a point-selection UX change tracked
-        # separately; macOS and Windows select the point as expected.
-        pytest.xfail("point-shape click-selection is vertex-ambiguous on X11/xcb")
-
     canvas = raw_win._canvas_widgets.canvas
     raw_win._switch_canvas_mode(edit=False, create_mode="point")
     qtbot.wait(50)

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -65,3 +65,20 @@ def test_nearest_vertex_index_returns_none_for_mask() -> None:
             )
             is None
         )
+
+
+def test_nearest_vertex_index_returns_none_for_point() -> None:
+    # A point shape's single point is the shape itself, not a draggable vertex;
+    # it is selected and moved as a whole, so it exposes no vertex to hit.
+    shape = Shape(
+        shape_type="point",
+        points=np.array([(5.0, 5.0)], dtype=np.float64),
+        closed=True,
+    )
+
+    assert (
+        _shape.nearest_vertex_index(
+            shape=shape, point=shape.points[0], scale=1.0, epsilon=10.0
+        )
+        is None
+    )


### PR DESCRIPTION
Follow-up to #2158 (stacked on `migrate-pyside6`; will retarget to `main` once that merges).

#2158 had to `xfail` `test_select_point_shape_by_click` on Linux because a point shape could not be selected by clicking it there. This resolves the underlying behavior and removes the xfail.

## Root cause

A point shape's single point was exposed as a draggable **vertex** by hit-testing. Clicking it was therefore read as "start a vertex move" (`_select_shape_point` highlights the vertex and *deselects*) instead of "select the shape". Whether the hover registered that vertex before the click depended on platform-specific mouse-event delivery, so the shape selected on macOS/Windows but not under X11/xcb.

A point shape has no independently editable vertex: it can't add or remove points, and moving its point just moves the shape.

## Fix

- Exclude `point` shapes from `nearest_vertex_index` (same as `mask`), so a click selects the shape and a drag moves it as a body.
- Scale the point hit radius to screen pixels in `is_hit_by_point`, consistent with the vertex/edge hit-tests, so selection is reliable when zoomed out.
- Remove the platform-gated `xfail`; add a unit test that `nearest_vertex_index` returns `None` for point shapes.

## Verification

- `make lint` clean; `make test` 372 passed (the point-selection e2e test now runs and passes on all platforms; CI is the real check for X11/xcb).
