### PR TITLE
fix: fall back to image basename when label file's imagePath fails to load

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -220,6 +220,29 @@ def _check_image_dimensions(
         )
 
 
+def _read_image_with_basename_fallback(*, label_dir: Path, image_path: str) -> bytes:
+    primary = label_dir / image_path
+    try:
+        return read_image_file(filename=str(primary))
+    except OSError:
+        fallback = label_dir / Path(image_path).name
+        if fallback == primary:
+            raise
+        try:
+            image_data = read_image_file(filename=str(fallback))
+        except OSError as e:
+            raise LabelFileReadError(
+                f"failed to load image: tried {str(primary)!r} "
+                f"and {str(fallback)!r}: {e}"
+            ) from e
+        logger.warning(
+            "imagePath {!r} not found; loaded {!r} by basename instead",
+            str(primary),
+            str(fallback),
+        )
+        return image_data
+
+
 def read_label_file(filename: str) -> Annotation:
     try:
         with open(filename, encoding="utf-8") as f:
@@ -228,8 +251,8 @@ def read_label_file(filename: str) -> Annotation:
         if raw["imageData"] is not None:
             image_data = base64.b64decode(raw["imageData"])
         else:
-            image_data = read_image_file(
-                filename=str(Path(filename).parent / image_path)
+            image_data = _read_image_with_basename_fallback(
+                label_dir=Path(filename).parent, image_path=image_path
             )
         _check_image_dimensions(
             image_data=image_data,

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import shutil
 from collections.abc import Callable
@@ -8,6 +9,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from loguru import logger
 
 from labelme._label_file import Annotation
 from labelme._label_file import LabelFile
@@ -140,6 +142,102 @@ def test_read_label_file_raises_read_error_on_malformed(
 
     with pytest.raises(LabelFileReadError, match=error_match):
         read_label_file(filename=str(annotated_dst))
+
+
+@pytest.fixture()
+def expected_image_data(data_path: Path) -> bytes:
+    return read_label_file(
+        filename=str(data_path / "annotated" / "2011_000003.json")
+    ).image_data
+
+
+def test_read_label_file_falls_back_to_basename_for_absolute_path(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+    expected_image_data: bytes,
+) -> None:
+    annotated_raw["imagePath"] = str(annotated_dst.parent / "gone" / "2011_000003.jpg")
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    label_data = read_label_file(filename=str(annotated_dst))
+
+    assert label_data.image_data == expected_image_data
+
+
+def test_read_label_file_falls_back_to_basename_for_stale_relative_path(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+    expected_image_data: bytes,
+) -> None:
+    annotated_raw["imagePath"] = "../old/2011_000003.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    label_data = read_label_file(filename=str(annotated_dst))
+
+    assert label_data.image_data == expected_image_data
+
+
+def test_read_label_file_warns_when_falling_back_to_basename(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+    expected_image_data: bytes,
+) -> None:
+    annotated_raw["imagePath"] = "/nonexistent/2011_000003.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    messages: list[str] = []
+    handler_id = logger.add(messages.append, level="WARNING")
+    try:
+        read_label_file(filename=str(annotated_dst))
+    finally:
+        logger.remove(handler_id)
+
+    assert any("basename" in message for message in messages)
+
+
+def test_read_label_file_raises_naming_both_paths_when_fallback_fails(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    annotated_raw["imagePath"] = "/nonexistent/subdir/missing.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    with pytest.raises(
+        LabelFileReadError, match=r"tried.*nonexistent/subdir.*and.*missing\.jpg"
+    ):
+        read_label_file(filename=str(annotated_dst))
+
+
+def test_read_label_file_raises_without_fallback_when_basename_missing(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    annotated_dst.parent.joinpath("2011_000003.jpg").unlink()
+    annotated_raw["imagePath"] = "2011_000003.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    with pytest.raises(LabelFileReadError) as excinfo:
+        read_label_file(filename=str(annotated_dst))
+    assert "tried" not in str(excinfo.value)
+
+
+def test_read_label_file_with_embedded_data_skips_disk(
+    monkeypatch: pytest.MonkeyPatch,
+    data_path: Path,
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+) -> None:
+    src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
+    annotated_raw["imageData"] = base64.b64encode(src.image_data).decode("utf-8")
+    annotated_raw["imagePath"] = "does-not-exist.jpg"
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    def fail(*, filename: str) -> bytes:
+        raise AssertionError("read_image_file should not be called")
+
+    monkeypatch.setattr("labelme._label_file.read_image_file", fail)
+
+    assert read_label_file(filename=str(annotated_dst)).image_data == src.image_data
 
 
 def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
A label file produced by an old labelme version, external tooling, or a manual edit can record an `imagePath` that does not resolve on the current machine (an absolute path, or a relative path with a stale subdirectory). `read_label_file` attempted a single resolution and raised on failure, so a dataset whose images sit right next to their `.json` files still failed to open after being moved between machines.

When the primary resolution fails, this retries once against the label file's directory joined with the basename of `imagePath`, logging a warning so the substitution is visible. If that also fails, the existing read error is raised naming both attempted paths. The happy path, embedded-`imageData` loads, and the write/serialization side are all unchanged.

Re-specified from the original idea in #1035 by @drjasonharrison (that PR predated a refactor of the label-file reader and no longer applied).

Closes #2125

## Test plan
- [x] tests added: `tests/unit/_label_file_test.py` covering absolute-path fallback, stale relative-path fallback, the warning emitted on fallback, the both-fail error naming both paths, a bare-basename miss raising without fallback, and embedded `imageData` skipping disk
- [x] `uv run pytest tests/unit/_label_file_test.py` (29 passed)
- [x] `uv run ruff check` and `uv run ty check` clean
