### PR TITLE
fix: round linestrip mask joints to remove notches at turning points

### DIFF
--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -41,7 +41,8 @@ def shape_to_mask(
         assert len(xy) == 2, "Shape of shape_type=line must have 2 points"
         draw.line(xy=xy, fill=1, width=line_width)  # ty: ignore[invalid-argument-type]
     elif shape_type == "linestrip":
-        draw.line(xy=xy, fill=1, width=line_width)  # ty: ignore[invalid-argument-type]
+        # joint="curve" rounds the joints so wide lines have no notch at turns.
+        draw.line(xy=xy, fill=1, width=line_width, joint="curve")  # ty: ignore[invalid-argument-type]
     elif shape_type == "point":
         assert len(xy) == 1, "Shape of shape_type=point must have 1 points"
         cx, cy = xy[0]

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -42,6 +42,40 @@ def test_shape_to_mask_oriented_rectangle_marks_inside_pixels() -> None:
     assert not mask[outside_row, outside_col]
 
 
+def test_shape_to_mask_linestrip_fills_notch_at_turning_point() -> None:
+    # Acute V with the apex at (50, 50) and both arms going up; the convex side
+    # is below the apex. A plain wide line leaves an unfilled notch there (#2124).
+    img_shape = (100, 100)
+    line_width = 25
+    apex_x, apex_y = 50, 50
+    mask = shape_module.shape_to_mask(
+        img_shape=img_shape,
+        points=[[40.0, 10.0], [apex_x, apex_y], [60.0, 10.0]],
+        shape_type="linestrip",
+        line_width=line_width,
+    )
+    join_below_apex = mask[apex_y : apex_y + line_width // 2, apex_x]
+    assert join_below_apex.all(), f"notch left unfilled below apex: {join_below_apex}"
+
+
+def test_shape_to_mask_linestrip_collinear_point_does_not_change_mask() -> None:
+    img_shape = (100, 100)
+    line_width = 25
+    with_midpoint = shape_module.shape_to_mask(
+        img_shape,
+        [[10.0, 50.0], [50.0, 50.0], [90.0, 50.0]],
+        shape_type="linestrip",
+        line_width=line_width,
+    )
+    without_midpoint = shape_module.shape_to_mask(
+        img_shape,
+        [[10.0, 50.0], [90.0, 50.0]],
+        shape_type="linestrip",
+        line_width=line_width,
+    )
+    assert np.array_equal(with_midpoint, without_midpoint)
+
+
 def test_shape_to_mask_rectangle_reversed_coords() -> None:
     img_shape = (100, 100)
     mask_tl_br = shape_module.shape_to_mask(


### PR DESCRIPTION
`shape_to_mask` rendered a `linestrip` as a single wide `draw.line`. PIL's wide-line rasterizer draws each segment as its own rectangle and does not fill the wedge where two segments meet, so the generated mask had an unfilled notch at every interior vertex (most visible at acute angles, as in the screenshot on #760/#2124).

Passing `joint="curve"` makes PIL round each joint to the line half-width, leaving the joint solid. Other `shape_type` branches are untouched, and a collinear linestrip is unchanged (no real joint to round).

This re-implements just the notch fix from the stale PR #761 by @nico-zck, without the unrelated changes that PR bundled.

Note: `joint="curve"` was added in Pillow 5.3 (2018) and is a no-op for `line_width <= 4`. The declared `pillow>=2.8` floor is already understated (the codebase uses `PIL.UnidentifiedImageError`, Pillow 7.0+), so the feature is satisfied in practice; I left the stale floor as a separate pre-existing concern rather than bump it here.

## Test plan
- [x] tests added: `tests/unit/utils/shape_test.py` - an acute-V linestrip has its notch filled (fails on `main`), and adding a collinear vertex does not change the mask
- [x] `uv run pytest tests/unit` (232 passed)
- [x] `uv run ruff check` and `uv run ty check` clean
