### PR TITLE
feat: update predefined labels in LabelDialog in place, preserving session history

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2380,20 +2380,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _apply_to_live_widgets(self, key_path: tuple[str, ...]) -> None:
         if key_path[0] == "labels":
-            # Rebuilding from config alone would drop labels accumulated via
-            # add_label_history (learned from loaded/created shapes), so carry the
-            # existing dialog's labels into the new one. Like the dock below, this
-            # keeps removed predefined labels until restart.
-            label_list = self._label_dialog.label_list
-            previous_labels = [
-                cast(QtWidgets.QListWidgetItem, label_list.item(i)).text()
-                for i in range(label_list.count())
-            ]
-            old_label_dialog = self._label_dialog
-            self._label_dialog = self._make_label_dialog()
-            old_label_dialog.deleteLater()
-            for label in previous_labels:
-                self._label_dialog.add_label_history(label)
+            # Update predefined labels in place so session history (labels learned
+            # from loaded/created shapes via add_label_history) is preserved, while
+            # a removed predefined label drops from suggestions unless it was used
+            # this session.
+            self._label_dialog.set_predefined_labels(self._config["labels"] or [])
             # The Label List dock is append-only (a shape's label stays after the
             # shape is deleted), so add new predefined labels and leave removed
             # ones until restart.

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -44,6 +44,8 @@ class LabelDialog(QtWidgets.QDialog):
         self._fit_to_content = fit_to_content
         self._sort_labels = sort_labels
         self._flags = flags or {}
+        self._predefined_labels: list[str] = list(labels or [])
+        self._label_history: list[str] = []
 
         self.edit = self._build_label_edit(placeholder=text, has_flags=bool(flags))
         self.edit_group_id = self._build_group_id_edit()
@@ -130,13 +132,28 @@ class LabelDialog(QtWidgets.QDialog):
         return completer
 
     def add_label_history(self, label: str) -> None:
+        if label not in self._label_history:
+            self._label_history.append(label)
         if self.label_list.findItems(label, QtCore.Qt.MatchExactly):
             return
         self.label_list.addItem(label)
         if self._sort_labels:
             self.label_list.sortItems()
 
-    def _on_label_selected(self, item: QtWidgets.QListWidgetItem) -> None:
+    def set_predefined_labels(self, labels: list[str]) -> None:
+        self._predefined_labels = list(labels)
+        merged = list(dict.fromkeys(self._predefined_labels + self._label_history))
+        # Mutate the existing list widget in place so the completer, which is
+        # bound to its model, keeps working without being rebuilt.
+        self.label_list.clear()
+        self.label_list.addItems(merged)
+        if self._sort_labels:
+            self.label_list.sortItems()
+
+    def _on_label_selected(self, item: QtWidgets.QListWidgetItem | None) -> None:
+        # Clearing the list (e.g. set_predefined_labels) fires this with None.
+        if item is None:
+            return
         self.edit.setText(item.text())
 
     def _validate(self) -> None:

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -58,7 +58,7 @@ def test_setting_change_persists_and_applies(
 
     assert win._config["display_label_popup"] is False
     assert win._config["labels"] == ["cat", "dog"]
-    assert win._label_dialog is not label_dialog_before
+    assert win._label_dialog is label_dialog_before  # updated in place, not rebuilt
     unique_label_list = win._docks.unique_label_list
     assert unique_label_list.find_label_item("cat") is not None
     assert unique_label_list.find_label_item("dog") is not None
@@ -78,8 +78,6 @@ def test_label_edit_preserves_label_history(
     win._label_dialog.add_label_history("bird")  # learned from a loaded/created shape
 
     old_label_dialog = win._label_dialog
-    deleted: list[bool] = []
-    old_label_dialog.destroyed.connect(lambda: deleted.append(True))
 
     win._open_settings()
     dialog = win._settings_dialog
@@ -89,13 +87,13 @@ def test_label_edit_preserves_label_history(
     labels_editor.setPlainText("cat\ndog")
     dialog.accept()
 
+    assert win._label_dialog is old_label_dialog  # updated in place, not rebuilt
     label_list = win._label_dialog.label_list
     labels = {
         cast(QtWidgets.QListWidgetItem, label_list.item(i)).text()
         for i in range(label_list.count())
     }
     assert labels == {"bird", "cat", "dog"}  # history kept, new labels added
-    qtbot.waitUntil(lambda: bool(deleted))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 

--- a/tests/unit/widgets/label_dialog_test.py
+++ b/tests/unit/widgets/label_dialog_test.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from PyQt5 import QtWidgets
+from pytestqt.qtbot import QtBot
+
+from labelme.widgets.label_dialog import LabelDialog
+
+
+def _labels(dialog: LabelDialog) -> set[str]:
+    label_list = dialog.label_list
+    return {
+        cast(QtWidgets.QListWidgetItem, label_list.item(i)).text()
+        for i in range(label_list.count())
+    }
+
+
+@pytest.fixture
+def dialog(qtbot: QtBot) -> LabelDialog:
+    label_dialog = LabelDialog(labels=["cat", "dog"])
+    qtbot.addWidget(label_dialog)
+    return label_dialog
+
+
+def test_set_predefined_labels_adds_new_label(dialog: LabelDialog) -> None:
+    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    assert _labels(dialog) == {"cat", "dog", "bird"}
+
+
+def test_set_predefined_labels_removes_unused_label(dialog: LabelDialog) -> None:
+    dialog.set_predefined_labels(["cat"])
+    assert _labels(dialog) == {"cat"}
+
+
+def test_set_predefined_labels_preserves_session_history(dialog: LabelDialog) -> None:
+    dialog.add_label_history("ad-hoc")
+    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    assert _labels(dialog) == {"cat", "dog", "bird", "ad-hoc"}
+
+
+def test_removed_predefined_label_kept_when_used_this_session(
+    dialog: LabelDialog,
+) -> None:
+    dialog.add_label_history("dog")
+    dialog.set_predefined_labels(["cat"])
+    assert _labels(dialog) == {"cat", "dog"}
+
+
+def test_completer_model_stays_bound_after_update(dialog: LabelDialog) -> None:
+    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    assert dialog.edit.completer().model() is dialog.label_list.model()
+
+
+def test_set_predefined_labels_with_selected_item_does_not_raise(
+    dialog: LabelDialog,
+) -> None:
+    dialog.label_list.setCurrentRow(0)
+    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    assert _labels(dialog) == {"cat", "dog", "bird"}
+
+
+def test_set_predefined_labels_empty_keeps_only_session_history(
+    dialog: LabelDialog,
+) -> None:
+    dialog.add_label_history("ad-hoc")
+    dialog.set_predefined_labels([])
+    assert _labels(dialog) == {"ad-hoc"}


### PR DESCRIPTION
## Summary
- `LabelDialog` tracked predefined labels (`config["labels"]`) and session label-history (accumulated via `add_label_history`) in one merged `QListWidget` with no way to distinguish them. Live-applying a labels edit (from the Settings dialog, PR #2120) therefore rebuilt the whole dialog and dropped session history.
- Track the two sources separately (`_predefined_labels`, `_label_history`) and add `set_predefined_labels()`, which rebuilds the visible list in place from their union. Mutating the existing list widget (rather than reconstructing the dialog) keeps the completer's model binding intact.
- The main window now calls `set_predefined_labels()` instead of reconstructing the dialog: removing a predefined label drops it from suggestions unless it was used this session, and session-used labels survive the edit.
- Guard `_on_label_selected` against the `None` that `QListWidget.clear()` emits through `currentItemChanged` (would otherwise raise in the slot during the in-place rebuild).

## Test plan
- [x] unit tests added (`tests/unit/widgets/label_dialog_test.py`): live add, live remove, history preserved across an edit, removed-but-session-used label kept, empty predefined list keeps history, completer model stays bound, and no crash when an item is selected during the update
- [x] updated `tests/e2e/settings_test.py` to assert the dialog is updated in place (not reconstructed) while still preserving history
- [x] `uv run pytest tests/unit tests/e2e/settings_test.py` (all green)
- [x] `uv run ruff check`, `uv run ty check` clean
