### PR TITLE
refactor(app): drop unused queue_event and has_labels methods

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import time
 import webbrowser
-from collections.abc import Callable
 from pathlib import Path
 from typing import Final
 from typing import Literal
@@ -1263,9 +1262,6 @@ class MainWindow(QtWidgets.QMainWindow):
         for action in (*self._actions.zoom, *self._actions.on_load_active):
             action.setEnabled(value)
 
-    def queue_event(self, function: Callable[[], None]) -> None:
-        QtCore.QTimer.singleShot(0, function)
-
     def show_status_message(self, message: str, delay: int = 500) -> None:
         self.statusBar().showMessage(message, delay)
 
@@ -2443,16 +2439,6 @@ class MainWindow(QtWidgets.QMainWindow):
             os.startfile(config_file)  # ty: ignore[unresolved-attribute]  # Windows-only
         else:
             subprocess.Popen(["xdg-open", config_file])
-
-    # Message Dialogs. #
-    def has_labels(self) -> bool:
-        if self.has_no_shapes():
-            self.show_error_message(
-                "No objects labeled",
-                "You must label at least one object to save the file.",
-            )
-            return False
-        return True
 
     def has_label_file(self) -> bool:
         if self._image_path is None:


### PR DESCRIPTION
Two `MainWindow` methods have no callers anywhere in `labelme/`, `tests/`, or
`examples/`:

- `queue_event` — a one-line wrapper over `QtCore.QTimer.singleShot(0, ...)`
  left behind after its call site was removed.
- `has_labels` — the "you must label at least one object to save" guard, dead
  since `6a9913af` ("allow saving file without any labels") deliberately removed
  it from the save path.

Removing `queue_event` also orphaned `from collections.abc import Callable`
(its only use), and the `# Message Dialogs. #` section comment headed only the
removed `has_labels`, so both go too. No behavior change: the methods were
unreferenced, including via dynamic dispatch and Qt signal connections.

## Test plan
- [x] `grep` confirms zero references to either method across the repo
- [x] `uv run python -c "import labelme.app"` imports cleanly
- [x] `uv run pytest tests/unit` (239 passed)
- [x] `uv run ruff check` and `uv run ty check` clean
