### PR TITLE
refactor: drop the write-only _predefined_labels field from LabelDialog

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -44,7 +44,6 @@ class LabelDialog(QtWidgets.QDialog):
         self._fit_to_content = fit_to_content
         self._sort_labels = sort_labels
         self._flags = flags or {}
-        self._predefined_labels: list[str] = list(labels or [])
         self._label_history: list[str] = []
 
         self.edit = self._build_label_edit(placeholder=text, has_flags=bool(flags))
@@ -141,8 +140,7 @@ class LabelDialog(QtWidgets.QDialog):
             self.label_list.sortItems()
 
     def set_predefined_labels(self, labels: list[str]) -> None:
-        self._predefined_labels = list(labels)
-        merged = list(dict.fromkeys(self._predefined_labels + self._label_history))
+        merged = list(dict.fromkeys(labels + self._label_history))
         # Mutate the existing list widget in place so the completer, which is
         # bound to its model, keeps working without being rebuilt.
         self.label_list.clear()


### PR DESCRIPTION
Cleanup follow-up from the review of #2164 (merged).

`LabelDialog._predefined_labels` was assigned in `__init__` and then reassigned by `set_predefined_labels` before it was ever read, so the constructor value was never observed - the field was effectively write-only. Remove it and have `set_predefined_labels` use its `labels` argument directly. The `labels + self._label_history` concatenation already produces a fresh list, so the previous `list(labels)` copy is unnecessary. No behavior change; the existing `LabelDialog` unit tests and the settings e2e tests cover it unchanged.

This addresses items 1 and 2 of #2167. Item 3 (preserving manual drag-reorder when `sort_labels=False` across a predefined-labels edit) is left as **wontfix**: it only applies to the non-default `sort_labels=False` mode, was already lost by the previous dialog-reconstruction approach (not a regression), and preserving it would add real complexity for a narrow case. Happy to revisit if desired.

## Test plan
- [x] `uv run pytest tests/unit/widgets/label_dialog_test.py tests/e2e/settings_test.py` (14 passed, behavior unchanged)
- [x] `uv run ruff check`, `uv run ty check` clean
