### PR TITLE
fix: raise a clear error for shape labels missing from the labels mapping

### DIFF
--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -64,6 +64,13 @@ def shapes_to_label(
     shapes: list[ShapeDict],
     label_name_to_value: dict[str, int],
 ) -> tuple[NDArray[np.int32], NDArray[np.int32]]:
+    unknown = {s["label"] for s in shapes} - label_name_to_value.keys()
+    if unknown:
+        raise ValueError(
+            f"shape labels not in the provided labels: {sorted(unknown)!r}; "
+            f"add them so every shape label has a value"
+        )
+
     cls = np.zeros(img_shape[:2], dtype=np.int32)
     ins = np.zeros_like(cls)
     instances = []
@@ -75,13 +82,12 @@ def shapes_to_label(
             group_id = uuid.uuid1()
         shape_type = shape.get("shape_type")
 
-        cls_name = label
-        instance = (cls_name, group_id)
+        instance = (label, group_id)
 
         if instance not in instances:
             instances.append(instance)
         ins_id = instances.index(instance) + 1
-        cls_id = label_name_to_value[cls_name]
+        cls_id = label_name_to_value[label]
 
         mask: NDArray[np.bool_]
         if shape_type == "mask":

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
+from labelme._label_file import ShapeDict
 from labelme.utils import shape as shape_module
 
 from .util import get_img_and_data
@@ -18,6 +20,21 @@ def test_shapes_to_label() -> None:
         img.shape, data["shapes"], label_name_to_value
     )
     assert cls.shape == img.shape[:2]
+
+
+def test_shapes_to_label_raises_clear_error_for_unknown_label() -> None:
+    shape = ShapeDict(
+        label="car",
+        points=[[0.0, 0.0], [10.0, 0.0], [10.0, 10.0]],
+        shape_type="polygon",
+        flags={},
+        description="",
+        group_id=None,
+        mask=None,
+        other_data={},
+    )
+    with pytest.raises(ValueError, match="shape labels not in the provided labels"):
+        shape_module.shapes_to_label((20, 20), [shape], {"road": 1})
 
 
 def test_shape_to_mask() -> None:


### PR DESCRIPTION
`shapes_to_label` indexed `label_name_to_value[label]` directly, so a shape whose label wasn't in the provided labels (the common case: a `--labels` file that omits a class which appears in the annotations) failed deep inside with a bare `KeyError: 'car'` and no context - as reported in #1448 when running the `labelme2voc.py` / `labelme2coco.py` examples.

Validate all shape labels up front and raise a `ValueError` that names the missing labels, failing fast before any work. This reports every missing label at once (so the user can fix their labels file in one pass) instead of stopping at the first.

## Test plan
- [x] unit test added (`tests/unit/utils/shape_test.py`): a shape labeled `car` with `{"road": 1}` raises `ValueError` matching "shape labels not in the provided labels"
- [x] `uv run pytest tests/unit` (240 passed) - existing `test_shapes_to_label` happy path unchanged
- [x] `uv run ruff check`, `uv run ty check` clean

Closes #1448
