### PR TITLE
fix: repaint the canvas immediately after adding or removing a polygon point

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2537,7 +2537,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def remove_selected_point(self) -> None:
         self._canvas_widgets.canvas.remove_selected_point()
-        self._canvas_widgets.canvas.update()
         if (
             self._canvas_widgets.canvas.hovered_shape
             and len(self._canvas_widgets.canvas.hovered_shape.points) == 0

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -890,6 +890,8 @@ class Canvas(QtWidgets.QWidget):
         self._hovered_vertex = index
         self._hovered_edge = None
         self._is_moving_shape = True
+        # Repaint now; otherwise the edit is invisible until the next mouse move.
+        self.update()
 
     def remove_selected_point(self) -> None:
         shape = self._last_hovered_shape
@@ -901,6 +903,8 @@ class Canvas(QtWidgets.QWidget):
         self.hovered_shape = shape
         self._last_hovered_vertex = None
         self._is_moving_shape = True  # Save changes
+        # Repaint now; otherwise the edit is invisible until the next mouse move.
+        self.update()
 
     def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
         pos: QPointF = self._transform_point_widget_to_image(a0.position())

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import math
 from typing import Final
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -610,3 +611,48 @@ def test_project_oriented_rectangle_corners_with_cursor_off_locked_edge() -> Non
 )
 def test_compute_overscroll_slack(scaled: int, viewport: int, expected: int) -> None:
     assert _compute_overscroll_slack(scaled=scaled, viewport=viewport) == expected
+
+
+def _make_polygon() -> Shape:
+    return Shape(
+        shape_type="polygon",
+        points=np.array([(10, 10), (40, 10), (40, 40), (10, 40)], dtype=np.float64),
+        closed=True,
+    )
+
+
+@pytest.mark.gui
+def test_add_point_to_edge_repaints(
+    canvas: Canvas, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shape = _make_polygon()
+    canvas.load_shapes(shapes=[shape])
+    canvas._last_hovered_shape = shape
+    canvas._last_hovered_edge = 0
+    canvas._prev_move_point = QPointF(25, 10)
+    update = Mock()
+    monkeypatch.setattr(canvas, "update", update)
+
+    n_before = len(shape.points)
+    canvas.add_point_to_edge()
+
+    assert len(shape.points) == n_before + 1
+    update.assert_called_once()  # repaint now, not only on the next mouse move (#890)
+
+
+@pytest.mark.gui
+def test_remove_selected_point_repaints(
+    canvas: Canvas, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shape = _make_polygon()
+    canvas.load_shapes(shapes=[shape])
+    canvas._last_hovered_shape = shape
+    canvas._last_hovered_vertex = 1
+    update = Mock()
+    monkeypatch.setattr(canvas, "update", update)
+
+    n_before = len(shape.points)
+    canvas.remove_selected_point()
+
+    assert len(shape.points) == n_before - 1
+    update.assert_called_once()  # repaint now, not only on the next mouse move (#890)


### PR DESCRIPTION
`add_point_to_edge` and `remove_selected_point` mutated the polygon geometry but never called `self.update()`, so the edit was invisible until the next mouse-move event happened to repaint the canvas - the behavior reported in #890 (point added via the shortcut/action doesn't show until you move the mouse).

Call `self.update()` at the end of both methods so they repaint themselves, matching every other geometry-mutating method on `Canvas`. This also makes the explicit `canvas.update()` in `MainWindow.remove_selected_point` redundant (Qt defers the paint to after the whole synchronous handler, so the post-delete state still renders), so it's dropped.

## Test plan
- [x] unit tests added (`tests/unit/widgets/canvas_test.py`): adding/removing a point calls `update()` exactly once (spied via `Mock`) and mutates the point count; both verified to fail without the fix
- [x] `uv run pytest tests/unit` (241 passed) and `tests/e2e/canvas_interaction_test.py tests/e2e/oriented_rectangle_test.py` (28 passed)
- [x] `uv run ruff check`, `uv run ty check` clean

Closes #890
