### PR TITLE
fix: deselect the vertex after removing a polygon point

### DIFF
--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -902,6 +902,8 @@ class Canvas(QtWidgets.QWidget):
         self._clear_highlight_state()
         self.hovered_shape = shape
         self._last_hovered_vertex = None
+        # Deselect the vertex; its index now aliases the adjacent point (#968).
+        self._hovered_vertex = None
         self._is_moving_shape = True  # Save changes
         # Repaint now; otherwise the edit is invisible until the next mouse move.
         self.update()

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -656,3 +656,18 @@ def test_remove_selected_point_repaints(
 
     assert len(shape.points) == n_before - 1
     update.assert_called_once()  # repaint now, not only on the next mouse move (#890)
+
+
+@pytest.mark.gui
+def test_remove_selected_point_deselects_vertex(canvas: Canvas) -> None:
+    shape = _make_polygon()
+    canvas.load_shapes(shapes=[shape])
+    canvas._last_hovered_shape = shape
+    canvas._last_hovered_vertex = 1
+    canvas._hovered_vertex = 1
+
+    canvas.remove_selected_point()
+
+    assert len(shape.points) == 3  # the point was removed
+    # Vertex is no longer selected, so the next move won't drag the neighbor (#968).
+    assert not canvas._is_vertex_selected()


### PR DESCRIPTION
`remove_selected_point` cleared `_last_hovered_vertex` but left `_hovered_vertex` pointing at the just-removed index. Because `_is_vertex_selected()` reads `_hovered_vertex` and the left-button drag path (`_continue_left_button_drag` -> `_drag_hovered_vertex`) drags `vertex_index=self._hovered_vertex`, a drag continued right after deleting a point moved the *adjacent* point (indices shifted by the removal) instead of leaving everything deselected - the behavior reported in #968.

Clear `_hovered_vertex` in `remove_selected_point` so the vertex is fully deselected after a removal.

Note: this touches the same method as #2174 (which adds `self.update()` there); whichever merges second will need a trivial one-line rebase.

## Test plan
- [x] unit test added (`tests/unit/widgets/canvas_test.py`): after `remove_selected_point`, the point is gone and `_is_vertex_selected()` is False - verified to fail without the fix
- [x] `uv run pytest tests/unit/widgets/canvas_test.py` (65 passed) and `tests/e2e/canvas_interaction_test.py` (25 passed)
- [x] `uv run ruff check`, `uv run ty check` clean

Closes #968
