### PR TITLE
refactor(image): drop redundant write-then-open BytesIO ceremony

### DIFF
--- a/labelme/utils/image.py
+++ b/labelme/utils/image.py
@@ -15,10 +15,7 @@ from PyQt5 import QtGui
 
 
 def img_data_to_pil(img_data: bytes) -> PIL.Image.Image:
-    f = io.BytesIO()
-    f.write(img_data)
-    img_pil = PIL.Image.open(f)
-    return img_pil
+    return PIL.Image.open(io.BytesIO(img_data))
 
 
 def img_data_to_arr(img_data: bytes) -> NDArray[np.uint8]:
@@ -53,14 +50,7 @@ def img_arr_to_data(img_arr: NDArray[np.uint8]) -> bytes:
 
 
 def img_data_to_png_data(img_data: bytes) -> bytes:
-    with io.BytesIO() as f:
-        f.write(img_data)
-        img = PIL.Image.open(f)
-
-        with io.BytesIO() as f:
-            img.save(f, "PNG")
-            f.seek(0)
-            return f.read()
+    return img_pil_to_data(img_data_to_pil(img_data))
 
 
 def img_qt_to_arr(img_qt: QtGui.QImage) -> NDArray[np.uint8]:

--- a/tests/unit/utils/image_test.py
+++ b/tests/unit/utils/image_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+
 import numpy as np
 import PIL.Image
 
@@ -25,7 +27,11 @@ def test_img_arr_to_b64() -> None:
 
 def test_img_data_to_png_data() -> None:
     img_file = data_dir / "annotated_with_data/apc2016_obj3.jpg"
-    with open(img_file, "rb") as f:
-        img_data = f.read()
+    img_data = img_file.read_bytes()
     png_data = image_module.img_data_to_png_data(img_data)
-    assert isinstance(png_data, bytes)
+    assert png_data[:8] == b"\x89PNG\r\n\x1a\n"
+    np.testing.assert_array_equal(
+        np.asarray(PIL.Image.open(io.BytesIO(png_data))),
+        np.asarray(PIL.Image.open(io.BytesIO(img_data))),
+        err_msg="pixels must survive the PNG re-encode",
+    )


### PR DESCRIPTION
`labelme/utils/image.py` had two helpers carrying the same redundant
write-then-open `BytesIO` ceremony, and `img_data_to_png_data` re-implemented by
hand what its sibling helpers already do (with a confusingly shadowed `f`).

- `img_data_to_pil`: `f = BytesIO(); f.write(...); PIL.Image.open(f)` becomes the
  canonical `PIL.Image.open(io.BytesIO(img_data))`.
- `img_data_to_png_data`: a nested-`BytesIO` block with a shadowed variable
  becomes `img_pil_to_data(img_data_to_pil(img_data))`, composing the existing
  helpers.

Behavior is unchanged (same PNG bytes out). The `img_data_to_png_data` test,
which previously only asserted `isinstance(bytes)`, now verifies the PNG
signature and that pixels survive the re-encode, so the refactor is provably
behavior-preserving.

## Test plan
- [x] `uv run pytest tests/unit/utils/image_test.py` (3 passed)
- [x] `uv run pytest tests/unit` (239 passed)
- [x] `uv run ruff check` and `uv run ty check` clean
