### PR TITLE
fix(test): use non-deprecated QMouseEvent constructor in canvas_test

### DIFF
--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -301,6 +301,7 @@ def test_extend_after_mode_switch_finalizes_at_last_cursor(
     event = QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseButtonPress,
         QPointF(50, 30),
+        QPointF(50, 30),
         Qt.MouseButton.LeftButton,
         Qt.MouseButton.LeftButton,
         Qt.KeyboardModifier.NoModifier,
@@ -337,6 +338,7 @@ def test_extend_after_mode_switch_grows_partial_at_last_cursor(
 
     event = QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseButtonPress,
+        QPointF(50, 30),
         QPointF(50, 30),
         Qt.MouseButton.LeftButton,
         Qt.MouseButton.LeftButton,


### PR DESCRIPTION
Switch the two `QMouseEvent` constructions in `canvas_test.py` from the Qt6-deprecated 5-arg overload to the supported 6-arg form by adding the `globalPos` argument. The event is fed to `canvas._extend_current_shape`, which does not read the global position, so `localPos` is reused. Matches the pattern already used by `drag_canvas` in `tests/e2e/conftest.py`.

Closes #2177.

## Test plan
- [x] `uv run pytest tests/unit/widgets/canvas_test.py -W error::DeprecationWarning` (64 passed, no QMouseEvent DeprecationWarning)
