### PR TITLE
build(translate): migrate update_translate.py to PySide6 tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,5 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.10'
-      - uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: qttools5-dev
-          version: 1.0
       - run: make setup
       - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 setup:  # Setup the development environment
 	$(call exec,uv sync)
 
-lint:  # Lint code
+lint: update_translate  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
 	$(call exec,uv run ty check --no-progress)

--- a/labelme/_config/_schema.py
+++ b/labelme/_config/_schema.py
@@ -11,7 +11,7 @@ from PySide6.QtCore import QT_TRANSLATE_NOOP
 Section = Literal["General", "Labels"]
 Kind = Literal["bool", "enum", "str_list", "language"]
 
-# Section names double as tab titles. QT_TRANSLATE_NOOP marks them for pylupdate
+# Section names double as tab titles. QT_TRANSLATE_NOOP marks them for pyside6-lupdate
 # under the SettingsDialog context (where they are resolved via self.tr) without
 # translating here; the labels below are marked the same way at their call site.
 # The assert keeps the markers in sync with Section so a newly added section

--- a/labelme/translate/de_DE.ts
+++ b/labelme/translate/de_DE.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>KI-gestützte Annotation</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI schlägt Annotationen in den Modi 'AI-Points' und 'AI-Box' vor</translation>
+        <translation>AI schlägt Annotationen in den Modi &apos;AI-Points&apos; und &apos;AI-Box&apos; vor</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Wählen Sie den Modus 'AI-Points' oder 'AI-Box', um die KI-gestützte Annotation zu aktivieren</translation>
+        <translation>Wählen Sie den Modus &apos;AI-Points&apos; oder &apos;AI-Box&apos;, um die KI-gestützte Annotation zu aktivieren</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>KI-Prompt</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>z.B. Hund,Katze,Vogel</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Ausführen</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Score</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>KI erstellt Annotationen aus dem Textprompt</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>'Polygon'-, 'Rectangle'- oder 'AI-Points'-Modus auswählen zum Aktivieren</translation>
+        <translation>&apos;Polygon&apos;-, &apos;Rectangle&apos;- oder &apos;AI-Points&apos;-Modus auswählen zum Aktivieren</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Helligkeit/Kontrast</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>%r wird erstellt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC zum Abbrechen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter oder Leertaste zum Abschließen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Formen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Startpunkt der Linie anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Endpunkt der Linie anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Startpunkt der Linienfolge anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Nächsten Punkt anklicken oder mit Ctrl/Cmd+Klick abschließen (Linienfolge)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Mittelpunkt des Kreises anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Punkt auf dem Kreisumfang anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Erste Ecke des Rechtecks anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Klicken zum Hinzufügen eines Punktes</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Klicken und ziehen zum Verschieben des Punktes</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Klick zum Löschen des Punktes</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Klick zum Erstellen eines Punktes auf der Form</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Klicken und ziehen zum Verschieben der Form</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Rechtsklick und Ziehen, um die Form zu kopieren</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Gegenüberliegende Ecke des Rechtecks anklicken (Shift für Quadrat)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Punkte anklicken zum Einschließen oder Shift+Click zum Ausschließen. Ctrl+LeftClick beendet die Erstellung.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Erste Ecke der bbox für AI-Segmentierung anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Gegenüberliegende Ecke anklicken, um Objekt zu segmentieren</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Erste Ecke des orientierten Rechtecks anklicken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Zweite Ecke anklicken, um die Ausrichtung festzulegen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Dritte Ecke anklicken, um das orientierte Rechteck zu schließen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Klicken und ziehen zum Drehen der Form</translation>
     </message>
@@ -196,706 +160,568 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Markierungen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Annotationsliste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Label auswählen, um mit der Annotation zu beginnen. Mit 'Esc' abwählen.</translation>
+        <translation>Label auswählen, um mit der Annotation zu beginnen. Mit &apos;Esc&apos; abwählen.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Label-Liste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Dateiname suchen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Dateiliste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Anwendung beenden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Öffnen
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Bild- oder Label-Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Verzeichnis öffnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>&amp;Nächstes Bild</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Nächstes öffnen (Strg+Umschalt gedrückt halten, um Labels zu kopieren)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>&amp;Vorheriges Bild</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Vorheriges öffnen (Strg+Umschalt gedrückt halten, um Labels zu kopieren)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Speichern
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Labels in Datei speichern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Speichern &amp;unter</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Labels in anderer Datei speichern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Datei löschen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Aktuelle Label-Datei löschen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Ausgabeverzeichnis ändern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Ändern, wo Annotationen geladen/gespeichert werden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>&amp;Automatisch speichern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Automatisch speichern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Mit Bilddaten speichern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Bilddaten in Label-Datei speichern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Schließen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Aktuelle Datei schließen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Vorherige Annotation beibehalten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>&quot;Vorherige Annotation beibehalten&quot; Modus umschalten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Mit dem Zeichnen von Polygonen beginnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Mit dem Zeichnen von Rechtecken beginnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Mit dem Zeichnen von Kreisen beginnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Mit dem Zeichnen von Linien beginnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Mit dem Zeichnen von Punkten beginnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Mit dem Zeichnen einer Linienfolge beginnen. Strg+Linksklick beendet die Erstellung.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Formen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Ausgewählte Formen verschieben und bearbeiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Formen löschen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Ausgewählte Formen löschen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Formen duplizieren</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Duplikat der ausgewählten Formen erstellen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Formen kopieren</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Ausgewählte Formen in Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Formen einfügen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Kopierte Formen einfügen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Letzten Punkt rückgängig machen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Letzten gezeichneten Punkt rückgängig machen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Ausgewählten Punkt entfernen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Ausgewählten Punkt aus Polygon entfernen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Rückgängig
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Letztes Hinzufügen und Bearbeiten der Form rückgängig machen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Verbergen
 Formen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Alle Formen verbergen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>&amp;Anzeigen
 Formen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Alle Formen anzeigen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>&amp;Umschalten
 Formen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Alle Formen umschalten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Tutorial-Seite anzeigen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Strg+Mausrad</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Vergrößern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Zoomstufe erhöhen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Verkleinern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Zoomstufe verringern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp;Originalgröße</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Auf Originalgröße zoomen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>&amp;An Fenster anpassen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Zoom folgt der Fenstergröße</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>&amp;An Breite anpassen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Zoom folgt der Fensterbreite</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Helligkeit/Kontrast</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Helligkeit und Kontrast einstellen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Label bearbeiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Label der ausgewählten Form ändern</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Gezeichnetes Polygon füllen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Polygon beim Zeichnen füllen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Vorherige Helligkeit/Kontrast beibehalten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Ansicht</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s gestartet.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Ungültiges Label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Ungültiges Label '{}' mit Validierungstyp '{}'</translation>
+        <translation>Ungültiges Label &apos;{}&apos; mit Validierungstyp &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Fehler beim Speichern der Labeldaten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Fehler beim Öffnen der Datei</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Datei nicht gefunden: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>%s wird geladen...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s geladen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Bild- und Label-Dateien (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Bild- oder Label-Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Annotationen im Verzeichnis speichern/laden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Annotationen werden in %s gespeichert/geladen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Label-Dateien (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Achtung</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Annotationen in &quot;{}&quot; speichern vor dem Schließen?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Annotationen speichern?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Verzeichnis öffnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Konfigurationsfehler</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Beim Laden der Konfiguration wurden Fehler gefunden. Bitte überprüfen Sie die folgenden Fehler und laden Sie Ihre Konfiguration neu oder ignorieren Sie die fehlerhaften Zeilen.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Layout zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Polygon</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Rechteck</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Kreis</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Linienfolge</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Punkte anklicken, um Objekt zu segmentieren. Ctrl+LeftClick beendet die Erstellung.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Einen Begrenzungsrahmen zeichnen, um Objekt zu segmentieren.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s unterstützt keine Punkt-Eingaben.
 Bitte wählen Sie ein anderes Modell oder verwenden Sie den AI-Box-Modus.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Die Dateiliste ist deaktiviert, wenn eine Label-Datei geöffnet ist</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Punkt zur Kante hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Neuen Punkt an der ausgewählten Polygonkante einfügen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>&amp;Vorherigen Zoom beibehalten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Diese Label-Datei endgültig löschen? Diese Aktion kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>{} Formen endgültig löschen? Diese Aktion kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Bild vergrößern oder verkleinern. Die Tastenkürzel {} und {} funktionieren auch auf der Leinwand.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Erlaubte Formate: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Die ausgewählte Label-Datei konnte nicht geöffnet werden: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Die ausgewählte Bilddatei konnte nicht geöffnet werden: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Laden fehlgeschlagen: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Orientiertes Rechteck</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Mit dem Zeichnen von orientierten Rechtecken beginnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>KI-Inferenz hat keine neue Annotation erzeugt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Form hat keine Fläche – nichts wurde erstellt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Einstellungen…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Einstellungen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Einstellungen werden für diese Sitzung über --config verwaltet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Konfigurationsfehler</translation>
     </message>
@@ -903,82 +729,66 @@ Bitte wählen Sie ein anderes Modell oder verwenden Sie den AI-Box-Modus.</trans
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Labels</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Label-Eingabe bei neuer Form anzeigen</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Vordefinierte Labels</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Label-Validierung</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Konfigurationsdatei als Text öffnen…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Änderungen in der Textdatei werden nach dem Neustart übernommen</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(keine)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>ein Eintrag pro Zeile</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Konfigurationsfehler</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Vordefinierte Labels dürfen nicht leer sein, solange die Label-Validierung auf „exact“ gesetzt ist. Deaktivieren Sie zuerst die „exact“-Validierung.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Wird nach dem Neustart wirksam.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Systemstandard</translation>
     </message>

--- a/labelme/translate/el_GR.ts
+++ b/labelme/translate/el_GR.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Σχολιασμός υποβοηθούμενος από τεχνητή νοημοσύνη</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>Το AI προτείνει σχολιασμό στις λειτουργίες 'AI-Points' και 'AI-Box'</translation>
+        <translation>Το AI προτείνει σχολιασμό στις λειτουργίες &apos;AI-Points&apos; και &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Επιλέξτε τη λειτουργία 'AI-Points' ή 'AI-Box' για να ενεργοποιήσετε τον σχολιασμό υποβοηθούμενο από AI</translation>
+        <translation>Επιλέξτε τη λειτουργία &apos;AI-Points&apos; ή &apos;AI-Box&apos; για να ενεργοποιήσετε τον σχολιασμό υποβοηθούμενο από AI</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI Text-to-Annotation</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>Η τεχνητή νοημοσύνη δημιουργεί σχολιασμούς από την προτροπή κειμένου</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>π.χ. σκύλος,γάτα,πουλί</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Εκτέλεση</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Βαθμολογία</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Επιλέξτε τη λειτουργία 'Polygon', 'Rectangle' ή 'AI-Points' για ενεργοποίηση</translation>
+        <translation>Επιλέξτε τη λειτουργία &apos;Polygon&apos;, &apos;Rectangle&apos; ή &apos;AI-Points&apos; για ενεργοποίηση</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Φωτεινότητα/Αντίθεση</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Δημιουργία %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>(Esc για ακύρωση)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Είσοδος ή χώρος για οριστικοποίηση</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Επεξεργασία σχημάτων</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Κάντε κλικ στο σημείο έναρξης για τη γραμμή</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Κάντε κλικ στο τελικό σημείο για τη γραμμή</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Κάντε κλικ στο σημείο έναρξης για το linestrip</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Κάντε κλικ στο επόμενο σημείο ή ολοκληρώστε μέχρι τις Ctrl/Cmd+Click για το linestrip</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Κάντε κλικ στο κεντρικό σημείο για τον κύκλο</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Κάντε κλικ στο σημείο στην περιφέρεια για τον κύκλο</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Κάντε κλικ στην πρώτη γωνία για ορθογώνιο</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Κάντε κλικ στην αντίθετη γωνία για ορθογώνιο (Shift για τετράγωνο)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Κάντε κλικ για να προσθέσετε πόντο</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Πάτημα και μεταφορά για μετακίνηση αυτού του σημείου</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Κάντε κλικ για διαγραφή σημείου</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Κάντε κλικ για να δημιουργήσετε σημείο στο σχήμα</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Κάντε κλικ και σύρετε για να μετακινήσετε το σχήμα</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Δεξί κλικ &amp; σύρσιμο για αντιγραφή σχήματος</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Κάντε κλικ σε σημεία για συμπερίληψη ή Shift+Click για εξαίρεση. Ctrl+LeftClick ολοκληρώνει τη δημιουργία.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Κάντε κλικ στην πρώτη γωνία του bbox για τμηματοποίηση AI</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Κάντε κλικ στην απέναντι γωνία για τμηματοποίηση αντικειμένου</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Κάντε κλικ στην πρώτη γωνία για προσανατολισμένο ορθογώνιο</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Κάντε κλικ στη δεύτερη γωνία για να ορίσετε τον προσανατολισμό</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Κάντε κλικ στην τρίτη γωνία για να κλείσετε το προσανατολισμένο ορθογώνιο</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Κάντε κλικ και σύρετε για να περιστρέψετε το σχήμα</translation>
     </message>
@@ -196,702 +160,564 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Αποθήκευση ετικετών σε αρχείο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Αποθήκευση &amp;Ως</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Αποθήκευση ετικετών σε διαφορετικό αρχείο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Αποθήκευση &amp;αυτόματα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Αυτόματη αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Αποθήκευση με δεδομένα εικόνας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Αποθήκευση δεδομένων εικόνας σε αρχείο ετικέτας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Αλλαγή Οδηγίας Εξόδου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Αλλαγή του πού φορτώνονται/αποθηκεύονται οι σχολιασμοί</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>Ανοιγμα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Άνοιγμα αρχείου εικόνας ή ετικέτας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Άνοιγμα Dir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Κλείσιμο τρέχοντος αρχείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp; Διαγραφή αρχείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Διαγραφή τρέχοντος αρχείου ετικέτας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Διατήρηση προηγούμενου σχολιασμού</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Εναλλαγή λειτουργίας &quot;Διατήρηση προηγούμενου σχολιασμού&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Διατήρηση προηγούμενης φωτεινότητας/αντίθεσης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Διαγραφή σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Διαγραφή των επιλεγμένων σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>Επεξεργασία ετικέτας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Τροποποιήστε την ετικέτα του επιλεγμένου σχήματος</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Διπλότυπα σχήματα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Δημιουργήστε ένα αντίγραφο των επιλεγμένων σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Αντιγραφή σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Αντιγραφή επιλεγμένων σχημάτων στο πρόχειρο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Επικόλληση σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Επικόλληση αντιγραμμένων σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Τελευταίο σημείο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Αναίρεση τελευταίου σημείου έλξης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Αναίρεση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Αναίρεση τελευταίας προσθήκης και επεξεργασίας σχήματος</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Κατάργηση επιλεγμένου σημείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Αφαίρεση επιλεγμένου σημείου από πολύγωνο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Ξεκινήστε να σχεδιάζετε πολύγωνα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Επεξεργασία σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Μετακίνηση και επεξεργασία των επιλεγμένων σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Ξεκινήστε να σχεδιάζετε ορθογώνια</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Έναρξη σχεδίασης κύκλων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Έναρξη σχεδίασης γραμμών</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Έναρξη σχεδίασης σημείων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Ξεκινήστε να σχεδιάζετε linestrip. Ctrl+LeftClick τελειώνει τη δημιουργία.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Επόμενη εικόνα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Ανοίξτε το επόμενο (κρατήστε πατημένο το πλήκτρο Ctl+Shift για να αντιγράψετε τις ετικέτες)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>&amp;Προηγούμενη εικόνα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Άνοιγμα προηγούμενου (κρατήστε πατημένο το πλήκτρο Ctl+Shift για να αντιγράψετε τις ετικέτες)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>&amp;Προσαρμογή παραθύρου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Το ζουμ ακολουθεί το μέγεθος παραθύρου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Προσαρμογή στο &amp; πλάτος</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Η μεγέθυνση ακολουθεί το πλάτος του παραθύρου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>αντίθεση φωτεινότητας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Ρύθμιση της φωτεινότητας και της αντίθεσης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp; Μεγέθυνση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Αύξηση επιπέδου ζουμ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Σμίκρυνση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Μείωση επιπέδου ζουμ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp; Αρχικό μέγεθος</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Μεγέθυνση στο αρχικό μέγεθος</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Επαναφορά Διάταξης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Γεμίστε το πολύγωνο σχεδίασης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Γεμίστε πολύγωνο ενώ σχεδιάζετε</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Απόκρυψη
 Σχήματα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Όλα τα σχήματα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Προβολή σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Όλα τα σχήματα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>&amp;Εναλλαγή
 Σχήματα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Εναλλαγή όλων των σχημάτων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Εστίαση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Wheel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>Τερματισμός</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Έξοδος από την εφαρμογή</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp; Εκμάθηση</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Εμφάνιση σελίδας εκμάθησης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>Αρχείο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>Επεξεργασία</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>Προβολή</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>Βοήθεια</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s ξεκίνησε.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Σημάνσεις</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Λίστα σχολίων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Επιλέξτε την ετικέτα για να ξεκινήσετε να την σχολιάζετε. Πατήστε 'Esc' για αποεπιλογή.</translation>
+        <translation>Επιλέξτε την ετικέτα για να ξεκινήσετε να την σχολιάζετε. Πατήστε &apos;Esc&apos; για αποεπιλογή.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Λίστα ετικετών</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Αναζήτηση ονόματος αρχείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Λίστα αρχείων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Σφάλματα διαμόρφωσης</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Βρέθηκαν σφάλματα κατά τη φόρτωση της διαμόρφωσης. Ελέγξτε τα παρακάτω σφάλματα και φορτώστε ξανά τη διαμόρφωσή σας ή αγνοήστε τις λανθασμένες γραμμές.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Μη έγκυρη ετικέτα</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Μη έγκυρη ετικέτα '{}' με τύπο επικύρωσης '{}'</translation>
+        <translation>Μη έγκυρη ετικέτα &apos;{}&apos; με τύπο επικύρωσης &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Σφάλμα κατά την αποθήκευση δεδομένων ετικέτας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Σφάλμα κατά το άνοιγμα του αρχείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Δεν υπάρχει τέτοιο αρχείο: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Φόρτωση %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Φορτώθηκε %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Αρχεία εικόνας και ετικέτας (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Επιλέξτε αρχείο εικόνας ή ετικέτας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Αποθήκευση/Φόρτωση σχολιασμών στον κατάλογο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Οι σχολιασμοί θα αποθηκεύονται/φορτώνονται στο %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Επιλογή αρχείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Αρχεία ετικετών (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Επιλογή αρχείου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Προσοχή</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Να αποθηκευτούν οι σχολιασμοί στο &quot;{}&quot; πριν το κλείσιμο;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Αποθήκευση σχολιασμών;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Άνοιγμα καταλόγου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Πολύγωνο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Ορθογώνιο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Κύκλος</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Γραμμή</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Σημείο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>LineStrip</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Κάντε κλικ σε σημεία για κατάτμηση αντικειμένου. Ctrl+LeftClick ολοκληρώνει τη δημιουργία.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Σχεδιάστε ένα πλαίσιο οριοθέτησης για τμηματοποίηση αντικειμένου.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points μη διαθέσιμο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s δεν υποστηρίζει εντολές σημείων.
 Επιλέξτε διαφορετικό μοντέλο ή χρησιμοποιήστε τη λειτουργία AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Η λίστα αρχείων είναι απενεργοποιημένη όταν ανοίγεται ένα αρχείο ετικετών</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Προσθήκη σημείου στην ακμή</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Εισαγωγή νέου σημείου στην επιλεγμένη ακμή πολυγώνου</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>&amp;Διατήρηση προηγούμενου ζουμ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Οριστική διαγραφή αυτού του αρχείου ετικετών; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Οριστική διαγραφή {} σχημάτων; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Μεγέθυνση ή σμίκρυνση της εικόνας. Τα πλήκτρα {} και {} λειτουργούν επίσης πάνω στον καμβά.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Επιτρεπόμενες μορφές: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Δεν ήταν δυνατό το άνοιγμα του επιλεγμένου αρχείου ετικετών: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Δεν ήταν δυνατό το άνοιγμα του επιλεγμένου αρχείου εικόνας: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Αποτυχία φόρτωσης: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Προσανατολισμένο Ορθογώνιο</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Ξεκινήστε να σχεδιάζετε προσανατολισμένα ορθογώνια</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Η συμπερασματική επεξεργασία ΤΝ δεν δημιούργησε νέο σχολιασμό.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Το σχήμα δεν είχε εμβαδό· δεν δημιουργήθηκε τίποτα.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Ρυθμίσεις…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Επεξεργασία ρυθμίσεων</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Οι ρυθμίσεις διαχειρίζονται μέσω --config για αυτή την περίοδο λειτουργίας</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Σφάλμα διαμόρφωσης</translation>
     </message>
@@ -899,82 +725,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Γενικά</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Ετικέτες</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Εμφάνιση αναδυόμενου παραθύρου ετικέτας σε νέο σχήμα</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Προκαθορισμένες ετικέτες</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Επικύρωση ετικέτας</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Άνοιγμα αρχείου ρυθμίσεων ως κείμενο…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Οι αλλαγές στο αρχείο κειμένου εφαρμόζονται μετά την επανεκκίνηση</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(καμία)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>ένα στοιχείο ανά γραμμή</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Σφάλμα διαμόρφωσης</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Οι προκαθορισμένες ετικέτες δεν μπορούν να είναι κενές όταν η επικύρωση ετικέτας έχει οριστεί σε «exact». Απενεργοποιήστε πρώτα την επικύρωση «exact».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Εφαρμόζεται μετά την επανεκκίνηση.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Προεπιλογή συστήματος</translation>
     </message>

--- a/labelme/translate/es_ES.ts
+++ b/labelme/translate/es_ES.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Anotación asistida por IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>La IA sugiere anotaciones en los modos 'AI-Points' y 'AI-Box'</translation>
+        <translation>La IA sugiere anotaciones en los modos &apos;AI-Points&apos; y &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Seleccione el modo 'AI-Points' o 'AI-Box' para habilitar la Anotación Asistida por IA</translation>
+        <translation>Seleccione el modo &apos;AI-Points&apos; o &apos;AI-Box&apos; para habilitar la Anotación Asistida por IA</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>Indicación IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>p. ej., perro, gato, pájaro</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Ejecutar</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Puntuación</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>La IA crea anotaciones a partir del texto</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Selecciona el modo 'Polygon', 'Rectangle' o 'AI-Points' para habilitar</translation>
+        <translation>Selecciona el modo &apos;Polygon&apos;, &apos;Rectangle&apos; o &apos;AI-Points&apos; para habilitar</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Brillo/Contraste</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Haz clic y arrastra para mover el punto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Haz clic y arrastra para mover la forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Creando %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC para cancelar</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter o Espacio para finalizar</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Editando formas</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Haz clic en el punto inicial de la línea</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Haz clic en el punto final de la línea</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Haz clic en el punto inicial de la línea continua</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Haz clic en el siguiente punto o Ctrl/Cmd+Clic para finalizar (línea continua)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Haz clic en el punto central del círculo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Haz clic en un punto de la circunferencia del círculo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Haz clic en la primera esquina del rectángulo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Haz clic para añadir un punto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + MAYÚS + Clic para eliminar el punto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Clic para crear un punto en la forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Clic derecho y arrastra para copiar la forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Haz clic en la esquina opuesta del rectángulo (Shift para cuadrado)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Haz clic en puntos para incluir o Shift+Click para excluir. Ctrl+LeftClick finaliza la creación.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Haga clic en la primera esquina del bbox para segmentación con IA</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Haga clic en la esquina opuesta para segmentar el objeto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Haz clic en la primera esquina del rectángulo orientado</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Haz clic en la segunda esquina para establecer la orientación</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Haz clic en la tercera esquina para cerrar el rectángulo orientado</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Haz clic y arrastra para rotar la forma</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Marcadores</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Lista de anotaciones</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Selecciona una etiqueta para comenzar a anotar. Presiona 'Esc' para deseleccionar.</translation>
+        <translation>Selecciona una etiqueta para comenzar a anotar. Presiona &apos;Esc&apos; para deseleccionar.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Lista de etiquetas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Buscar nombre de archivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Lista de archivos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Salir de la aplicación</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Abrir archivo de imagen o etiqueta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Abrir directorio</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Imagen &amp;siguiente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Abrir siguiente (mantén Ctrl+Mayús para copiar etiquetas)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Imagen &amp;anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Abrir anterior (mantén Ctrl+Mayús para copiar etiquetas)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Guardar etiquetas en archivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Guardar &amp;como</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Guardar etiquetas en un archivo diferente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Eliminar archivo de etiqueta actual</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Cambiar directorio de &amp;salida</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Cambiar dónde se cargan/guardan las anotaciones</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Guardar &amp;automáticamente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Guardar automáticamente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Guardar con datos de imagen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Guardar datos de imagen en el archivo de etiqueta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Cerrar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Cerrar archivo actual</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Mantener anotación anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Empezar a dibujar polígonos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Empezar a dibujar rectángulos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Empezar a dibujar círculos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Empezar a dibujar líneas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Empezar a dibujar puntos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Empezar a dibujar línea continua. Ctrl+Clic izquierdo finaliza la creación.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Editar formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Mover y editar las formas seleccionadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Eliminar formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Eliminar las formas seleccionadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Duplicar formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Crear un duplicado de las formas seleccionadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Copiar formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Copiar formas seleccionadas al portapapeles</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Pegar formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Pegar formas copiadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Deshacer último punto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Deshacer último punto dibujado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Eliminar punto seleccionado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Eliminar punto seleccionado del polígono</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Deshacer última adición y edición de forma</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Ocultar &amp;formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Ocultar todas las formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Mostrar &amp;formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Mostrar todas las formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Alternar &amp;formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Alternar todas las formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Mostrar página del tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Rueda</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Acercar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Aumentar nivel de zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Alejar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Disminuir nivel de zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>Tamaño &amp;original</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Zoom al tamaño original</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Ajustar a &amp;ventana</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>El zoom sigue el tamaño de la ventana</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Ajustar a &amp;ancho</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>El zoom sigue el ancho de la ventana</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>Brillo y &amp;contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Ajustar brillo y contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Editar etiqueta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Modificar la etiqueta de la forma seleccionada</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Rellenar polígono al dibujar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Rellenar polígono mientras se dibuja</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s iniciado.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Etiqueta no válida</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Etiqueta no válida '{}' con tipo de validación '{}'</translation>
+        <translation>Etiqueta no válida &apos;{}&apos; con tipo de validación &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Error al guardar datos de etiqueta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Error al abrir archivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>No existe el archivo: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Cargando %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Cargado %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Archivos de imagen y etiqueta (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Elegir archivo de imagen o etiqueta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Guardar/Cargar anotaciones en directorio</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Las anotaciones se guardarán/cargarán en %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Elegir archivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Archivos de etiqueta (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Elegir archivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Atención</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>¿Guardar anotaciones en &quot;{}&quot; antes de cerrar?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>¿Guardar anotaciones?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Abrir directorio</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Alternar modo &quot;mantener anotación anterior&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Mantener brillo/contraste anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Errores de Configuración</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Se encontraron errores al cargar la configuración. Por favor, revise los errores a continuación y recargue su configuración o ignore las líneas erróneas.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Restablecer diseño</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Polígono</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Rectángulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Círculo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Línea continua</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Haz clic en puntos para segmentar el objeto. Ctrl+LeftClick finaliza la creación.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Dibuje un cuadro delimitador para segmentar el objeto.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points no disponible</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s no admite indicaciones de puntos.
 Seleccione un modelo diferente o use el modo AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>La lista de archivos está desactivada cuando se abre un archivo de etiquetas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Añadir punto al borde</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Insertar un nuevo punto en el borde del polígono seleccionado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Mantener &amp;zoom anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>¿Eliminar permanentemente este archivo de etiqueta? Esta acción no se puede deshacer.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>¿Eliminar permanentemente {} formas? Esta acción no se puede deshacer.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Acercar o alejar la imagen. Los atajos {} y {} también funcionan sobre el lienzo.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Formatos permitidos: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>No se pudo abrir el archivo de etiquetas seleccionado: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>No se pudo abrir el archivo de imagen seleccionado: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Error al cargar: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Rectángulo Orientado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Empezar a dibujar rectángulos orientados</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>La inferencia de IA no produjo una nueva anotación.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>La figura no tenía área; no se creó nada.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Ajustes…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Editar ajustes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Los ajustes se gestionan mediante --config para esta sesión</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Error de configuración</translation>
     </message>
@@ -897,82 +723,66 @@ Seleccione un modelo diferente o use el modo AI-Box.</translation>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Mostrar ventana emergente de etiqueta al crear una forma</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Etiquetas predefinidas</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Validación de etiquetas</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Abrir archivo de configuración como texto…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Los cambios realizados en el archivo de texto se aplican al reiniciar</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(ninguno)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>un elemento por línea</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Error de configuración</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Las etiquetas predefinidas no pueden estar vacías mientras la validación de etiquetas esté configurada como «exact». Desactiva primero la validación «exact».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Se aplica al reiniciar.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Predeterminado del sistema</translation>
     </message>

--- a/labelme/translate/fa_IR.ts
+++ b/labelme/translate/fa_IR.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>حاشیه‌نویسی با کمک هوش مصنوعی</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI در حالت‌های 'AI-Points' و 'AI-Box' حاشیه‌نویسی پیشنهاد می‌دهد</translation>
+        <translation>AI در حالت‌های &apos;AI-Points&apos; و &apos;AI-Box&apos; حاشیه‌نویسی پیشنهاد می‌دهد</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>حالت 'AI-Points' یا 'AI-Box' را برای فعال‌سازی حاشیه‌نویسی با کمک AI انتخاب کنید</translation>
+        <translation>حالت &apos;AI-Points&apos; یا &apos;AI-Box&apos; را برای فعال‌سازی حاشیه‌نویسی با کمک AI انتخاب کنید</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>پیشنهاد هوش مصنوعی</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>مثال: سگ، گربه، پرنده</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>اجرا</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>امتیاز</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>هوش مصنوعی حاشیه‌نویسی‌ها را از متن ایجاد می‌کند</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>حالت 'Polygon'، 'Rectangle' یا 'AI-Points' را برای فعال‌سازی انتخاب کنید</translation>
+        <translation>حالت &apos;Polygon&apos;، &apos;Rectangle&apos; یا &apos;AI-Points&apos; را برای فعال‌سازی انتخاب کنید</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>روشنایی/کنتراست</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>کلیک و کشیدن برای جابجایی نقطه</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>کلیک و کشیدن برای جابجایی شکل</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>در حال ایجاد %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC برای لغو</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter یا Space برای نهایی کردن</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>ویرایش اشکال</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>کلیک روی نقطه شروع خط</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>کلیک روی نقطه پایان خط</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>کلیک روی نقطه شروع خط چندتکه‌ای</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>کلیک روی نقطه بعدی یا Ctrl/Cmd+کلیک برای پایان خط چندتکه‌ای</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>کلیک روی نقطه مرکز دایره</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>کلیک روی نقطه روی محیط دایره</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>کلیک روی گوشه اول مستطیل</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>کلیک برای افزودن نقطه</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + کلیک برای حذف نقطه</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + کلیک برای ایجاد نقطه روی شکل</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>کلیک راست و کشیدن برای کپی شکل</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>کلیک روی گوشه مقابل مستطیل (Shift برای مربع)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>روی نقاط کلیک کنید تا شامل شوند یا Shift+Click برای حذف. Ctrl+LeftClick ایجاد را پایان می‌دهد.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>برای قطعه‌بندی AI روی اولین گوشه bbox کلیک کنید</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>روی گوشه مقابل برای قطعه‌بندی شیء کلیک کنید</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>کلیک روی گوشه اول مستطیل جهت‌دار</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>کلیک روی گوشه دوم برای تنظیم جهت</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>کلیک روی گوشه سوم برای بستن مستطیل جهت‌دار</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>کلیک و کشیدن برای چرخاندن شکل</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>پرچم‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>فهرست حاشیه‌نویسی‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>برچسب را انتخاب کنید تا شروع به حاشیه‌نویسی کنید. 'Esc' را فشار دهید تا انتخاب لغو شود.</translation>
+        <translation>برچسب را انتخاب کنید تا شروع به حاشیه‌نویسی کنید. &apos;Esc&apos; را فشار دهید تا انتخاب لغو شود.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>فهرست برچسب‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>جستجوی نام فایل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>فهرست فایل‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>خروج(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>خروج از برنامه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>باز کردن(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>باز کردن فایل تصویر یا برچسب</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>باز کردن پوشه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>تصویر بعدی(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>باز کردن بعدی (Ctrl+Shift را نگه دارید تا برچسب‌ها کپی شوند)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>تصویر قبلی(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>باز کردن قبلی (Ctrl+Shift را نگه دارید تا برچسب‌ها کپی شوند)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>ذخیره(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>ذخیره برچسب‌ها در فایل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>ذخیره با نام دیگر(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>ذخیره برچسب‌ها در فایل دیگر</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>حذف(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>حذف فایل برچسب فعلی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>تغییر مسیر خروجی(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>تغییر محل بارگذاری/ذخیره حاشیه‌نویسی‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>ذخیره خودکار(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>ذخیره خودکار</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>ذخیره با داده تصویر</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>ذخیره داده تصویر در فایل برچسب</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>بستن(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>بستن فایل فعلی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>نگه داشتن حاشیه‌نویسی قبلی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>شروع رسم چندضلعی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>شروع رسم مستطیل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>شروع رسم دایره</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>شروع رسم خط</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>شروع رسم نقطه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>شروع رسم خط چندتکه‌ای. Ctrl+کلیک چپ برای پایان.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>ویرایش شکل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>جابجایی و ویرایش شکل‌های انتخاب شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>حذف شکل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>حذف شکل‌های انتخاب شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>تکثیر شکل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>ایجاد کپی از شکل‌های انتخاب شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>کپی شکل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>کپی شکل‌های انتخاب شده به کلیپ‌بورد</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>چسباندن شکل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>چسباندن شکل‌های کپی شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>بازگشت آخرین نقطه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>بازگشت آخرین نقطه رسم شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>حذف نقطه انتخاب شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>حذف نقطه انتخاب شده از چندضلعی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>بازگشت</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>بازگشت آخرین افزودن و ویرایش شکل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>مخفی کردن شکل(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>مخفی کردن همه شکل‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>نمایش شکل(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>نمایش همه شکل‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>تغییر وضعیت شکل(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>تغییر وضعیت همه شکل‌ها</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>آموزش(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>نمایش صفحه آموزش</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>زوم</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+چرخ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>بزرگ‌نمایی(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>افزایش سطح زوم</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>کوچک‌نمایی(&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>کاهش سطح زوم</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>اندازه اصلی(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>زوم به اندازه اصلی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>تناسب با پنجره(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>زوم متناسب با اندازه پنجره</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>تناسب با عرض(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>زوم متناسب با عرض پنجره</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>روشنایی و کنتراست(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>تنظیم روشنایی و کنتراست</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>ویرایش برچسب(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>تغییر برچسب شکل انتخاب شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>پر کردن چندضلعی رسم شده</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>پر کردن چندضلعی هنگام رسم</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>فایل(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>ویرایش(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>نمایش(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>راهنما(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s راه‌اندازی شد.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>برچسب نامعتبر</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>برچسب نامعتبر '{}' با نوع اعتبارسنجی '{}'</translation>
+        <translation>برچسب نامعتبر &apos;{}&apos; با نوع اعتبارسنجی &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>خطا در ذخیره داده برچسب</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>خطا در باز کردن فایل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>چنین فایلی وجود ندارد: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>در حال بارگذاری %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>بارگذاری شد %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>فایل‌های تصویر و برچسب (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - انتخاب فایل تصویر یا برچسب</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - ذخیره/بارگذاری حاشیه‌نویسی‌ها در پوشه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . حاشیه‌نویسی‌ها در %s ذخیره/بارگذاری خواهند شد</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - انتخاب فایل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>فایل‌های برچسب (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>انتخاب فایل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>توجه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>قبل از بستن، حاشیه‌نویسی‌ها را در &quot;{}&quot; ذخیره کنید؟</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>ذخیره حاشیه‌نویسی‌ها؟</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - باز کردن پوشه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>تغییر وضعیت حالت &quot;نگه داشتن حاشیه‌نویسی قبلی&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>نگه داشتن روشنایی/کنتراست قبلی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>خطاهای پیکربندی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>هنگام بارگیری پیکربندی خطاهایی یافت شد. لطفاً خطاهای زیر را بررسی کنید و پیکربندی خود را مجدداً بارگیری کنید یا خطوط نادرست را نادیده بگیرید.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>بازنشانی چیدمان</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>چندضلعی</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>مستطیل</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>دایره</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>خط</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>نقطه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>خط چندتکه‌ای</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>روی نقاط کلیک کنید تا شیء بخش‌بندی شود. Ctrl+LeftClick ایجاد را پایان می‌دهد.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>یک کادر محصورکننده برای قطعه‌بندی شیء رسم کنید.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points در دسترس نیست</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s از دستورات نقطه‌ای پشتیبانی نمی‌کند.
 لطفاً مدل دیگری انتخاب کنید یا از حالت AI-Box استفاده کنید.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>فهرست فایل‌ها هنگام باز بودن یک فایل برچسب غیرفعال است</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>افزودن نقطه به لبه</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>درج یک نقطه جدید در لبه پلیگانی که اشاره‌گر روی آن است</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>نگه داشتن بزرگ‌نمایی قبلی(&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>حذف دائمی این فایل برچسب؟ این عمل قابل بازگشت نیست.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>حذف دائمی {} شکل؟ این عمل قابل بازگشت نیست.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>بزرگ‌نمایی یا کوچک‌نمایی تصویر. میانبرهای {} و {} نیز روی بوم کار می‌کنند.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>قالب‌های مجاز: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>پرونده برچسب انتخاب‌شده باز نشد: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>پرونده تصویر انتخاب‌شده باز نشد: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>بارگذاری ناموفق بود: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>مستطیل جهت‌دار</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>شروع رسم مستطیل جهت‌دار</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>استنتاج هوش مصنوعی حاشیه‌نویسی جدیدی تولید نکرد.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>شکل فاقد مساحت بود؛ چیزی ایجاد نشد.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>تنظیمات…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>ویرایش تنظیمات</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>تنظیمات این نشست از طریق --config مدیریت می‌شوند</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>خطای پیکربندی</translation>
     </message>
@@ -897,82 +723,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>عمومی</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>برچسب‌ها</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>نمایش پنجره برچسب هنگام رسم شکل جدید</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>برچسب‌های از پیش تعریف‌شده</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>اعتبارسنجی برچسب</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>تنظیمات</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>باز کردن فایل پیکربندی به صورت متن…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>تغییرات فایل متنی پس از راه‌اندازی مجدد اعمال می‌شوند</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>بستن</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(هیچ‌کدام)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>یک مورد در هر خط</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>خطای پیکربندی</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>برچسب‌های از پیش تعریف‌شده نمی‌توانند خالی باشند در حالی که اعتبارسنجی برچسب روی «exact» تنظیم شده است. ابتدا اعتبارسنجی «exact» را غیرفعال کنید.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>زبان</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>پس از راه‌اندازی مجدد اعمال می‌شود.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>پیش‌فرض سیستم</translation>
     </message>

--- a/labelme/translate/fr_FR.ts
+++ b/labelme/translate/fr_FR.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Annotation assistée par IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>L'IA suggère des annotations dans les modes 'AI-Points' et 'AI-Box'</translation>
+        <translation>L&apos;IA suggère des annotations dans les modes &apos;AI-Points&apos; et &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Sélectionnez le mode 'AI-Points' ou 'AI-Box' pour activer l'annotation assistée par IA</translation>
+        <translation>Sélectionnez le mode &apos;AI-Points&apos; ou &apos;AI-Box&apos; pour activer l&apos;annotation assistée par IA</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>Invite IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>ex. : chien,chat,oiseau</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Exécuter</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Score</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
-        <translation>L'IA crée des annotations à partir du texte</translation>
+        <translation>L&apos;IA crée des annotations à partir du texte</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Sélectionner le mode 'Polygon', 'Rectangle' ou 'AI-Points' pour activer</translation>
+        <translation>Sélectionner le mode &apos;Polygon&apos;, &apos;Rectangle&apos; ou &apos;AI-Points&apos; pour activer</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Luminosité/Contraste</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Cliquer et glisser pour déplacer le point</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Cliquer et glisser pour déplacer la forme</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Création de %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC pour annuler</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Entrée ou Espace pour finaliser</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Modification des formes</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Cliquer sur le point de départ de la ligne</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
-        <translation>Cliquer sur le point d'arrivée de la ligne</translation>
+        <translation>Cliquer sur le point d&apos;arrivée de la ligne</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Cliquer sur le point de départ de la polyligne</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Cliquer sur le point suivant ou Ctrl/Cmd+Cliquer pour terminer la polyligne</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Cliquer sur le point central du cercle</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Cliquer sur un point de la circonférence du cercle</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Cliquer sur le premier coin du rectangle</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Cliquer pour ajouter un point</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + MAJ + Cliquer pour supprimer le point</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Cliquer pour créer un point sur la forme</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Clic droit et glisser pour copier la forme</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Cliquer sur le coin opposé du rectangle (Shift pour carré)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Cliquer sur les points à inclure ou Shift+Click pour exclure. Ctrl+LeftClick termine la création.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Cliquez sur le premier coin de la bbox pour la segmentation IA</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
-        <translation>Cliquez sur le coin opposé pour segmenter l'objet</translation>
+        <translation>Cliquez sur le coin opposé pour segmenter l&apos;objet</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Cliquer sur le premier coin du rectangle orienté</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
-        <translation>Cliquer sur le deuxième coin pour définir l'orientation</translation>
+        <translation>Cliquer sur le deuxième coin pour définir l&apos;orientation</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Cliquer sur le troisième coin pour fermer le rectangle orienté</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Cliquer et glisser pour faire pivoter la forme</translation>
     </message>
@@ -196,706 +160,568 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Drapeaux</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Liste des annotations</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Sélectionner une étiquette pour commencer l'annotation. Appuyer sur 'Esc' pour désélectionner.</translation>
+        <translation>Sélectionner une étiquette pour commencer l&apos;annotation. Appuyer sur &apos;Esc&apos; pour désélectionner.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Liste des étiquettes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Rechercher un nom de fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Liste des fichiers</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
-        <translation>Quitter l'application</translation>
+        <translation>Quitter l&apos;application</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Ouvrir
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
-        <translation>Ouvrir une image ou un fichier d'étiquettes</translation>
+        <translation>Ouvrir une image ou un fichier d&apos;étiquettes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Ouvrir le répertoire</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Image &amp;suivante</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Ouvrir la suivante (maintenir Ctrl+Maj pour copier les étiquettes)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Image &amp;précédente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Ouvrir la précédente (maintenir Ctrl+Maj pour copier les étiquettes)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Enregistrer
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Enregistrer les étiquettes dans un fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Enregistrer &amp;sous</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Enregistrer les étiquettes dans un autre fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Supprimer le fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
-        <translation>Supprimer le fichier d'étiquettes actuel</translation>
+        <translation>Supprimer le fichier d&apos;étiquettes actuel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Changer le répertoire de sortie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Changer où les annotations sont chargées/enregistrées</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Enregistrer &amp;automatiquement</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Enregistrer automatiquement</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
-        <translation>Enregistrer avec les données d'image</translation>
+        <translation>Enregistrer avec les données d&apos;image</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
-        <translation>Enregistrer les données d'image dans le fichier d'étiquettes</translation>
+        <translation>Enregistrer les données d&apos;image dans le fichier d&apos;étiquettes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Fermer</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Fermer le fichier actuel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
-        <translation>Conserver l'annotation précédente</translation>
+        <translation>Conserver l&apos;annotation précédente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Commencer à dessiner des polygones</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Commencer à dessiner des rectangles</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Commencer à dessiner des cercles</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Commencer à dessiner des lignes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Commencer à dessiner des points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Commencer à dessiner une polyligne. Ctrl+Clic gauche termine la création.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Modifier les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Déplacer et modifier les formes sélectionnées</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Supprimer les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Supprimer les formes sélectionnées</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Dupliquer les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Créer un doublon des formes sélectionnées</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Copier les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Copier les formes sélectionnées dans le presse-papiers</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Coller les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Coller les formes copiées</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Annuler le dernier point</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Annuler le dernier point dessiné</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Supprimer le point sélectionné</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Supprimer le point sélectionné du polygone</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Annuler
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Annuler le dernier ajout et la dernière modification de forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Masquer
 les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Masquer toutes les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>&amp;Afficher
 les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Afficher toutes les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>&amp;Basculer
 les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Basculer toutes les formes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutoriel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Afficher la page du tutoriel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Molette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>Zoom &amp;avant</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Augmenter le niveau de zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>Zoom &amp;arrière</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Diminuer le niveau de zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
-        <translation>Taille &amp;d'origine</translation>
+        <translation>Taille &amp;d&apos;origine</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
-        <translation>Zoomer à la taille d'origine</translation>
+        <translation>Zoomer à la taille d&apos;origine</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>&amp;Adapter à la fenêtre</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Le zoom suit la taille de la fenêtre</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Adapter la &amp;largeur</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Le zoom suit la largeur de la fenêtre</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Luminosité et contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Ajuster la luminosité et le contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
-        <translation>&amp;Modifier l'étiquette</translation>
+        <translation>&amp;Modifier l&apos;étiquette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
-        <translation>Modifier l'étiquette de la forme sélectionnée</translation>
+        <translation>Modifier l&apos;étiquette de la forme sélectionnée</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Remplir le polygone en cours de dessin</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Remplir le polygone pendant le dessin</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modifier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Affichage</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s démarré.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Étiquette invalide</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Étiquette invalide '{}' avec le type de validation '{}'</translation>
+        <translation>Étiquette invalide &apos;{}&apos; avec le type de validation &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
-        <translation>Erreur lors de l'enregistrement des données d'étiquettes</translation>
+        <translation>Erreur lors de l&apos;enregistrement des données d&apos;étiquettes</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
-        <translation>Erreur lors de l'ouverture du fichier</translation>
+        <translation>Erreur lors de l&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Fichier introuvable : &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Chargement de %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s chargé</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Fichiers Image &amp; Étiquettes (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Choisir un fichier Image ou Étiquette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Enregistrer/Charger les annotations dans le répertoire</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Les annotations seront enregistrées/chargées dans %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Choisir un fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
-        <translation>Fichiers d'étiquettes (*%s)</translation>
+        <translation>Fichiers d&apos;étiquettes (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Choisir un fichier</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Enregistrer les annotations dans &quot;{}&quot; avant de fermer ?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Enregistrer les annotations ?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Ouvrir le répertoire</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
-        <translation>Activer/désactiver le mode &quot;conserver l'annotation précédente&quot;</translation>
+        <translation>Activer/désactiver le mode &quot;conserver l&apos;annotation précédente&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Conserver les réglages de luminosité/contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Erreurs de Configuration</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Des erreurs ont été trouvées lors du chargement de la configuration. Veuillez examiner les erreurs ci-dessous et recharger votre configuration ou ignorer les lignes erronées.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Réinitialiser la disposition</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Polygone</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Rectangle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Cercle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Polyligne</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
-        <translation>Cliquer sur les points pour segmenter l'objet. Ctrl+LeftClick termine la création.</translation>
+        <translation>Cliquer sur les points pour segmenter l&apos;objet. Ctrl+LeftClick termine la création.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
-        <translation>Dessinez un cadre englobant pour segmenter l'objet.</translation>
+        <translation>Dessinez un cadre englobant pour segmenter l&apos;objet.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points indisponible</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s ne prend pas en charge les invites par points.
 Veuillez sélectionner un autre modèle ou utiliser le mode AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
-        <translation>La liste des fichiers est désactivée lorsqu'un fichier d'étiquettes est ouvert</translation>
+        <translation>La liste des fichiers est désactivée lorsqu&apos;un fichier d&apos;étiquettes est ouvert</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
-        <translation>Ajouter un point à l'arête</translation>
+        <translation>Ajouter un point à l&apos;arête</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
-        <translation>Insérer un nouveau point sur l'arête du polygone survolée</translation>
+        <translation>Insérer un nouveau point sur l&apos;arête du polygone survolée</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>&amp;Conserver le zoom précédent</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
-        <translation>Supprimer définitivement ce fichier d'étiquettes ? Cette action est irréversible.</translation>
+        <translation>Supprimer définitivement ce fichier d&apos;étiquettes ? Cette action est irréversible.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Supprimer définitivement {} formes ? Cette action est irréversible.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
-        <translation>Zoomer ou dézoomer l'image. Les raccourcis {} et {} fonctionnent également sur le canevas.</translation>
+        <translation>Zoomer ou dézoomer l&apos;image. Les raccourcis {} et {} fonctionnent également sur le canevas.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Formats autorisés : {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
-        <translation>Impossible d'ouvrir le fichier d'étiquettes sélectionné : {path}</translation>
+        <translation>Impossible d&apos;ouvrir le fichier d&apos;étiquettes sélectionné : {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
-        <translation>Impossible d'ouvrir le fichier image sélectionné : {path}</translation>
+        <translation>Impossible d&apos;ouvrir le fichier image sélectionné : {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Échec du chargement : {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Rectangle Orienté</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Commencer à dessiner des rectangles orientés</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
-        <translation>L'inférence IA n'a produit aucune nouvelle annotation.</translation>
+        <translation>L&apos;inférence IA n&apos;a produit aucune nouvelle annotation.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
-        <translation>La forme était vide ; rien n'a été créé.</translation>
+        <translation>La forme était vide&#xa0;; rien n&apos;a été créé.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Réglages…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Modifier les réglages</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Les réglages sont gérés via --config pour cette session</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Erreur de configuration</translation>
     </message>
@@ -903,82 +729,66 @@ Veuillez sélectionner un autre modèle ou utiliser le mode AI-Box.</translation
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Étiquettes</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
-        <translation>Afficher la fenêtre d'étiquette à la création d'une forme</translation>
+        <translation>Afficher la fenêtre d&apos;étiquette à la création d&apos;une forme</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Étiquettes prédéfinies</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Validation des étiquettes</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Réglages</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Ouvrir le fichier de configuration en texte…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
-        <translation>Les modifications dans le fichier texte s'appliquent après redémarrage</translation>
+        <translation>Les modifications dans le fichier texte s&apos;appliquent après redémarrage</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(aucun)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>un élément par ligne</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Erreur de configuration</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Les étiquettes prédéfinies ne peuvent pas être vides lorsque la validation des étiquettes est définie sur « exact ». Désactivez d’abord la validation « exact ».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Prend effet après le redémarrage.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Langue du système</translation>
     </message>

--- a/labelme/translate/hu_HU.ts
+++ b/labelme/translate/hu_HU.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>MI-támogatott annotáció</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>Az AI annotációt javasol 'AI-Points' és 'AI-Box' módokban</translation>
+        <translation>Az AI annotációt javasol &apos;AI-Points&apos; és &apos;AI-Box&apos; módokban</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Válassza az 'AI-Points' vagy 'AI-Box' módot az AI-támogatott annotáció engedélyezéséhez</translation>
+        <translation>Válassza az &apos;AI-Points&apos; vagy &apos;AI-Box&apos; módot az AI-támogatott annotáció engedélyezéséhez</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI prompt</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>pl. kutya,macska,madár</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Futtatás</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Pontszám</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>Az AI annotációkat hoz létre a szöveges promptból</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Válassza a 'Polygon', 'Rectangle' vagy 'AI-Points' módot az engedélyezéshez</translation>
+        <translation>Válassza a &apos;Polygon&apos;, &apos;Rectangle&apos; vagy &apos;AI-Points&apos; módot az engedélyezéshez</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Fényerő/Kontraszt</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>%r létrehozása</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC a megszakításhoz</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter vagy Szóköz a befejezéshez</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Alakzatok szerkesztése</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Kattintson a vonal kezdőpontjára</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Kattintson a vonal végpontjára</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Kattintson a vonallánc kezdőpontjára</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Kattintson a következő pontra vagy Ctrl/Cmd+Kattintás a befejezéshez (vonallánc)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Kattintson a kör középpontjára</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Kattintson a kör kerületén lévő pontra</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Kattintson a téglalap első sarkára</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Kattintson pont hozzáadásához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Kattintson és húzza a pont mozgatásához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Kattintás a pont törléséhez</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Kattintás pont létrehozásához az alakzaton</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Kattintson és húzza az alakzat mozgatásához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Jobb gombbal kattintás és húzás az alakzat másolásához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Kattintson a téglalap ellentétes sarkára (Shift a négyzethez)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Kattintson pontokra a hozzáadáshoz vagy Shift+Click a kizáráshoz. Ctrl+LeftClick befejezi a létrehozást.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Kattintson a bbox első sarkára az AI szegmentáláshoz</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Kattintson az átellenes sarokra az objektum szegmentálásához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Kattintson az irányított téglalap első sarkára</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Kattintson a második sarokra az irány beállításához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Kattintson a harmadik sarokra az irányított téglalap bezárásához</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Kattintson és húzza az alakzat elforgatásához</translation>
     </message>
@@ -196,706 +160,568 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Jelzők</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Annotációlista</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Válasszon címkét az annotálás megkezdéséhez. Nyomja meg az 'Esc' gombot a kijelölés megszüntetéséhez.</translation>
+        <translation>Válasszon címkét az annotálás megkezdéséhez. Nyomja meg az &apos;Esc&apos; gombot a kijelölés megszüntetéséhez.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Címkelista</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Fájlnév keresése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Fájllista</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Kilépés</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Alkalmazás bezárása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Megnyitás
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Kép vagy címke fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Könyvtár megnyitása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>&amp;Következő kép</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Következő megnyitása (tartsa lenyomva a Ctrl+Shift-et a címkék másolásához)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>&amp;Előző kép</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Előző megnyitása (tartsa lenyomva a Ctrl+Shift-et a címkék másolásához)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Mentés
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Címkék mentése fájlba</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Mentés &amp;másként</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Címkék mentése másik fájlba</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Fájl törlése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Jelenlegi címke fájl törlése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Kimeneti könyvtár módosítása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Az annotációk betöltési/mentési helyének módosítása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>&amp;Automatikus mentés</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Automatikus mentés</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Mentés kép adatokkal</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Kép adatok mentése a címke fájlba</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Bezárás</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Jelenlegi fájl bezárása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Előző annotáció megtartása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>&quot;Előző annotáció megtartása&quot; mód váltása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Sokszögek rajzolásának megkezdése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Téglalapok rajzolásának megkezdése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Körök rajzolásának megkezdése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Vonalak rajzolásának megkezdése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Pontok rajzolásának megkezdése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Vonallánc rajzolásának megkezdése. Ctrl+Bal klikk befejezi a létrehozást.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Alakzatok szerkesztése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>A kijelölt alakzatok mozgatása és szerkesztése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Alakzatok törlése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>A kijelölt alakzatok törlése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Alakzatok duplikálása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>A kijelölt alakzatok másolatának létrehozása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Alakzatok másolása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Kijelölt alakzatok másolása a vágólapra</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Alakzatok beillesztése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Másolt alakzatok beillesztése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Utolsó pont visszavonása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Utolsó rajzolt pont visszavonása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Kijelölt pont eltávolítása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Kijelölt pont eltávolítása a sokszögből</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Visszavonás
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Alakzat utolsó hozzáadásának és szerkesztésének visszavonása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Alakzatok
 &amp;elrejtése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Összes alakzat elrejtése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Alakzatok
 &amp;megjelenítése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Összes alakzat megjelenítése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Alakzatok
 &amp;váltása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Összes alakzat váltása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Oktatóanyag</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Oktatóanyag oldal megjelenítése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Nagyítás</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Görgő</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Nagyítás</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Nagyítási szint növelése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Kicsinyítés</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Nagyítási szint csökkentése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp;Eredeti méret</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Nagyítás eredeti méretre</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>&amp;Ablakhoz igazítás</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>A nagyítás követi az ablak méretét</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>&amp;Szélességhez igazítás</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>A nagyítás követi az ablak szélességét</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Fényerő/Kontraszt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Fényerő és kontraszt beállítása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Címke szerkesztése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>A kijelölt alakzat címkéjének módosítása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Rajzolt sokszög kitöltése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Sokszög kitöltése rajzolás közben</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Előző fényerő/kontraszt megtartása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Fájl</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Szerkesztés</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Nézet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Súgó</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s elindítva.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Érvénytelen címke</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Érvénytelen címke '{}' '{}' validációs típussal</translation>
+        <translation>Érvénytelen címke &apos;{}&apos; &apos;{}&apos; validációs típussal</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Hiba a címke adatok mentésekor</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Hiba a fájl megnyitásakor</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Nincs ilyen fájl: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>%s betöltése...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s betöltve</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Kép és címke fájlok (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Válasszon képet vagy címke fájlt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Annotációk mentése/betöltése könyvtárból</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Az annotációk a %s könyvtárban lesznek mentve/betöltve</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Fájl kiválasztása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Címke fájlok (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Fájl kiválasztása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Figyelem</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Mentse az annotációkat a &quot;{}&quot; fájlba bezárás előtt?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Mentse az annotációkat?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Könyvtár megnyitása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Konfigurációs Hibák</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Hibák találhatók a konfiguráció betöltése közben. Kérjük, tekintse át az alábbi hibákat, és töltse újra a konfigurációt, vagy hagyja figyelmen kívül a hibás sorokat.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Elrendezés visszaállítása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Sokszög</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Téglalap</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Kör</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Vonal</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Pont</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Vonallánc</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Kattintson pontokra az objektum szegmentálásához. Ctrl+LeftClick befejezi a létrehozást.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Rajzoljon befoglaló keretet az objektum szegmentálásához.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points nem elérhető</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s nem támogatja a pont alapú promptokat.
 Kérjük, válasszon másik modellt vagy használja az AI-Box módot.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>A fájllista le van tiltva, ha egy címke fájl van megnyitva</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Pont hozzáadása az élhez</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Új pont beszúrása a kijelölt sokszög élre</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>&amp;Előző nagyítás megtartása</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Véglegesen törli ezt a címke fájlt? Ez a művelet nem vonható vissza.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Véglegesen törli a {} alakzatot? Ez a művelet nem vonható vissza.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Kép nagyítása vagy kicsinyítése. A {} és {} billentyűparancsok a vásznon is működnek.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Megengedett formátumok: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>A kiválasztott címkefájl nem nyitható meg: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>A kiválasztott képfájl nem nyitható meg: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>A betöltés sikertelen: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Irányított téglalap</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Irányított téglalapok rajzolásának megkezdése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Az MI-következtetés nem hozott létre új annotációt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Az alakzatnak nincs területe; nem jött létre semmi.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Beállítások…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Beállítások szerkesztése</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>A beállítások ebben a munkamenetben --config segítségével vannak kezelve</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Konfigurációs hiba</translation>
     </message>
@@ -903,82 +729,66 @@ Kérjük, válasszon másik modellt vagy használja az AI-Box módot.</translati
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Általános</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Címkék</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Címkefelugró ablak megjelenítése új alakzatnál</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Előre definiált címkék</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Címkeellenőrzés</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Konfigurációs fájl megnyitása szövegként…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>A szövegfájlban végzett módosítások újraindítás után lépnek érvénybe</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(nincs)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>soronként egy elem</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Konfigurációs hiba</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Az előre definiált címkék nem lehetnek üresek, amíg a címkeellenőrzés „exact” értékre van állítva. Először kapcsolja ki az „exact” ellenőrzést.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Nyelv</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Az újraindítás után lép érvénybe.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Rendszer alapértelmezése</translation>
     </message>

--- a/labelme/translate/id_ID.ts
+++ b/labelme/translate/id_ID.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Anotasi berbasis AI</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI menyarankan anotasi dalam mode 'AI-Points' dan 'AI-Box'</translation>
+        <translation>AI menyarankan anotasi dalam mode &apos;AI-Points&apos; dan &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Pilih mode 'AI-Points' atau 'AI-Box' untuk mengaktifkan Anotasi yang berbasis AI</translation>
+        <translation>Pilih mode &apos;AI-Points&apos; atau &apos;AI-Box&apos; untuk mengaktifkan Anotasi yang berbasis AI</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>Anotasi dari teks (AI)</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>contoh: anjing, kucing, burung</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Jalankan</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Skor</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI membuat anotasi dari prompt teks</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Pilih mode 'Polygon', 'Rectangle', atau 'AI-Points' untuk mengaktifkan</translation>
+        <translation>Pilih mode &apos;Polygon&apos;, &apos;Rectangle&apos;, atau &apos;AI-Points&apos; untuk mengaktifkan</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Kecerahan/Kontras</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Klik &amp; seret untuk memindahkan titik</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Klik &amp; seret untuk memindahkan bentuk</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Membuat %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC untuk membatalkan</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter atau Spasi untuk finalisasi</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Mengedit bentuk</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Klik titik awal untuk garis</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Klik titik akhir untuk garis</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Klik titik awal untuk garis patah</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Klik titik berikutnya atau selesaikan dengan Ctrl/Cmd+Klik untuk garis patah</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Klik titik pusat untuk lingkaran</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Klik titik pada keliling untuk membuat lingkaran</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Klik sudut pertama untuk membuat persegi panjang</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Klik untuk menambahkan titik</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Klik untuk menghapus titik</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Klik untuk membuat titik pada bentuk</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Klik kanan &amp; seret untuk menyalin bentuk</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Klik sudut berlawanan untuk persegi panjang (Shift untuk persegi)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Klik titik-titik untuk menyertakan, atau Shift+Klik untuk mengecualikan. Ctrl+Klik Kiri untuk mengakhiri pembuatan.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Klik sudut pertama bbox untuk segmentasi AI</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Klik sudut berlawanan untuk segmentasi objek</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Klik sudut pertama untuk persegi panjang berorientasi</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Klik sudut kedua untuk mengatur orientasi</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Klik sudut ketiga untuk menutup persegi panjang berorientasi</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Klik &amp; seret untuk merotasi bentuk</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Penanda</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Daftar Anotasi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Pilih label untuk memulai anotasi. Tekan 'Esc' untuk membatalkan pilihan.</translation>
+        <translation>Pilih label untuk memulai anotasi. Tekan &apos;Esc&apos; untuk membatalkan pilihan.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Daftar Label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Cari Nama File</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Daftar File</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>Keluar (&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Keluar Aplikasi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Buka file gambar atau label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Buka Direktori</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Gambar Berikutnya (&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Buka Berikutnya (Tahan Ctrl+Shift untuk menyalin label)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Gambar Sebelumnya (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Buka Sebelumnya (Tahan Ctrl+Shift untuk menyalin label)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Simpan</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Simpan label ke file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>&amp;Simpan Sebagai</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Simpan label ke file yang berbeda</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>Hapus File (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Hapus file label ini</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Ubah Direktori Output (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Ubah tempat pengambilan/penyimpanan anotasi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Simpan Otomatis (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Simpan otomatis</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Simpan Dengan Data Gambar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Simpan data gambar dalam file label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>Tutup (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Tutup file ini</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Pertahankan Anotasi Sebelumnya</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Mulai menggambar poligon</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Mulai menggambar persegi panjang</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Mulai menggambar lingkaran</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Mulai menggambar garis</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Mulai menggambar titik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Mulai menggambar garis patah. Ctrl+Klik Kiri untuk mengakhiri.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Edit Bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Pindah dan edit bentuk terpilih</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Hapus Bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Hapus bentuk terpilih</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Duplikat Bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Buat duplikat dari bentuk terpilih</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Salin Bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Salin bentuk terpilih ke clipboard</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Tempel Bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Tempel bentuk yang disalin</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Urungkan titik terakhir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Urungkan titik terakhir yang digambar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Hapus Titik Terpilih</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Hapus titik terpilih dari poligon</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Urungkan penambahan dan pengeditan bentuk terakhir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Sembunyikan semua bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Tampilkan semua bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Tampilkan/sembunyikan semua bentuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Tampilkan halaman tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Scroll</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>Perbesar (&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Tingkatkan level zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>Perkecil (&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Kurangi level zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>Ukuran &amp;Original</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Zoom ke ukuran original</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Sesuaikan Jendela (&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Zoom menyesuaikan ukuran jendela</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Sesuaikan Lebar (&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Zoom menyesuaikan lebar jendela</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>Kecerahan Kontras (&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Atur kecerahan dan kontras</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Edit Label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Ubah label bentuk yang dipilih</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Isi Poligon yang Digambar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Isi poligon saat menggambar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>Berkas (&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>Edit (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>Tampilan (&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>Bantuan (&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s dimulai.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Label tidak valid</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Label '{}' tidak valid dengan tipe validasi '{}'</translation>
+        <translation>Label &apos;{}&apos; tidak valid dengan tipe validasi &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Error menyimpan data label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Error membuka file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>File tidak ditemukan: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Memuat %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s dimuat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Gambar &amp; File Label (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Pilih File Gambar atau Label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Simpan/Muat Anotasi di Direktori</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s - Anotasi akan disimpan/dimuat di %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Pilih File</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>File label (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Pilih File</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Perhatian</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Simpan anotasi ke &quot;{}&quot; sebelum menutup?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Simpan anotasi?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Buka Direktori</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Aktifkan/nonaktifkan mode &quot;simpan anotasi sebelumnya&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Pertahankan kecerahan/kontras sebelumnya</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Error Konfigurasi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Terjadi error saat memuat konfigurasi. Silakan periksa error di bawah ini dan muat ulang konfigurasi Anda atau abaikan baris yang bermasalah.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Reset Tata Letak</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Poligon</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Persegi Panjang</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Lingkaran</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Garis</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Titik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Garis Patah</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Klik titik untuk mensegmentasi objek. Ctrl+Klik Kiri untuk mengakhiri pembuatan.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Gambar bounding box untuk mensegmentasi objek.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s tidak mendukung point prompt.
 Silakan pilih model lain atau gunakan mode AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Daftar file dinonaktifkan saat file label dibuka</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Tambah Titik ke Sisi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Tambahkan titik baru pada sisi poligon yang ditunjuk</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Pertahankan Zoom Sebelumnya (&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Hapus permanen file label ini? Tindakan ini tidak dapat dibatalkan.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Hapus permanen {} bentuk? Tindakan ini tidak dapat dibatalkan.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Lakukan zoom in atau zoom out pada gambar. Pintasan {} dan {} juga berfungsi di kanvas.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Format yang didukung: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>File label yang dipilih tidak dapat dibuka: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>File gambar yang dipilih tidak dapat dibuka: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Gagal memuat: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Persegi Panjang Berorientasi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Mulai menggambar persegi panjang berorientasi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Inferensi AI tidak menghasilkan anotasi baru.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Bentuk tidak memiliki area; tidak ada yang dibuat.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>Buka (&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Urungkan</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Sembunyikan Bentuk (&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Tampilkan Bentuk (&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Tampilkan/Sembunyikan Bentuk (&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Pengaturan…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Edit pengaturan</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Pengaturan dikelola melalui --config untuk sesi ini</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Error Konfigurasi</translation>
     </message>
@@ -897,82 +723,66 @@ Shapes</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Buka file config sebagai teks…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Perubahan yang dibuat di file teks akan diterapkan setelah restart</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(tidak ada)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Default sistem</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>satu item per baris</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Error Konfigurasi</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
-        <translation>Label yang telah ditentukan tidak boleh kosong saat validasi label diatur ke 'eksak'. Nonaktifkan validasi eksak terlebih dahulu.</translation>
+        <translation>Label yang telah ditentukan tidak boleh kosong saat validasi label diatur ke &apos;eksak&apos;. Nonaktifkan validasi eksak terlebih dahulu.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Umum</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Tampilkan popup label pada bentuk baru</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Berlaku setelah restart.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Label yang telah ditentukan</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Validasi label</translation>
     </message>

--- a/labelme/translate/it_IT.ts
+++ b/labelme/translate/it_IT.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Annotazione assistita da IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>L'IA suggerisce annotazioni nelle modalità 'AI-Points' e 'AI-Box'</translation>
+        <translation>L&apos;IA suggerisce annotazioni nelle modalità &apos;AI-Points&apos; e &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Selezionare la modalità 'AI-Points' o 'AI-Box' per abilitare l'Annotazione Assistita da IA</translation>
+        <translation>Selezionare la modalità &apos;AI-Points&apos; o &apos;AI-Box&apos; per abilitare l&apos;Annotazione Assistita da IA</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>Prompt IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>es. : cane,gatto,uccello</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Esegui</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Punteggio</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
-        <translation>L'IA crea annotazioni dal testo</translation>
+        <translation>L&apos;IA crea annotazioni dal testo</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Selezionare la modalità 'Polygon', 'Rectangle' o 'AI-Points' per abilitare</translation>
+        <translation>Selezionare la modalità &apos;Polygon&apos;, &apos;Rectangle&apos; o &apos;AI-Points&apos; per abilitare</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Luminosità/Contrasto</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Clicca e trascina per spostare il punto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Clicca e trascina per spostare la forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Creazione di %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC per annullare</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Invio o Spazio per finalizzare</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Modifica delle forme</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Clicca sul punto di partenza della linea</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Clicca sul punto finale della linea</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Clicca sul punto di partenza della polilinea</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Clicca sul punto successivo o Ctrl/Cmd+Clicca per terminare la polilinea</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Clicca sul punto centrale del cerchio</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Clicca su un punto della circonferenza del cerchio</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Clicca sul primo angolo del rettangolo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Clicca per aggiungere un punto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + MAIUSC + Clicca per eliminare il punto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Clicca per creare un punto sulla forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Tasto destro e trascina per copiare la forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
-        <translation>Clicca sull'angolo opposto del rettangolo (Shift per quadrato)</translation>
+        <translation>Clicca sull&apos;angolo opposto del rettangolo (Shift per quadrato)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Clicca i punti da includere o Shift+Click per escludere. Ctrl+LeftClick per terminare la creazione.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Fare clic sul primo angolo del bbox per la segmentazione IA</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
-        <translation>Fare clic sull'angolo opposto per segmentare l'oggetto</translation>
+        <translation>Fare clic sull&apos;angolo opposto per segmentare l&apos;oggetto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Clicca sul primo angolo del rettangolo orientato</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
-        <translation>Clicca sul secondo angolo per impostare l'orientamento</translation>
+        <translation>Clicca sul secondo angolo per impostare l&apos;orientamento</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Clicca sul terzo angolo per chiudere il rettangolo orientato</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Clicca e trascina per ruotare la forma</translation>
     </message>
@@ -196,706 +160,568 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Flag</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Lista annotazioni</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Seleziona un'etichetta per iniziare ad annotare. Premi 'Esc' per deselezionare.</translation>
+        <translation>Seleziona un&apos;etichetta per iniziare ad annotare. Premi &apos;Esc&apos; per deselezionare.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Lista etichette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Cerca nome file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Lista file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Esci</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
-        <translation>Esci dall'applicazione</translation>
+        <translation>Esci dall&apos;applicazione</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Apri
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
-        <translation>Apri un'immagine o un file di etichette</translation>
+        <translation>Apri un&apos;immagine o un file di etichette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Apri directory</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Immagine &amp;successiva</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Apri la successiva (tieni premuto Ctrl+Maiusc per copiare le etichette)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Immagine &amp;precedente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Apri la precedente (tieni premuto Ctrl+Maiusc per copiare le etichette)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Salva
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Salva le etichette in un file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Salva &amp;come</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Salva le etichette in un file diverso</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Elimina file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Elimina il file di etichette corrente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Cambia directory di output</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Cambia dove vengono caricate/salvate le annotazioni</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Salva &amp;automaticamente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Salva automaticamente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Salva con dati immagine</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
-        <translation>Salva i dati dell'immagine nel file di etichette</translation>
+        <translation>Salva i dati dell&apos;immagine nel file di etichette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Chiudi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Chiudi il file corrente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Mantieni annotazione precedente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Inizia a disegnare poligoni</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Inizia a disegnare rettangoli</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Inizia a disegnare cerchi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Inizia a disegnare linee</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Inizia a disegnare punti</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Inizia a disegnare una polilinea. Ctrl+Clic sinistro termina la creazione.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Modifica forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Sposta e modifica le forme selezionate</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Elimina forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Elimina le forme selezionate</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Duplica forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Crea un duplicato dele forme selezionate</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Copia forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Copia le forme selezionate negli appunti</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Incolla forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Incolla le forme copiate</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Annulla ultimo punto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
-        <translation>Annulla l'ultimo punto disegnato</translation>
+        <translation>Annulla l&apos;ultimo punto disegnato</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Rimuovi punto selezionato</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Rimuovi il punto selezionato dal poligono</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Annulla
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
-        <translation>Annulla l'ultimo aggiunto e la modifica della forma</translation>
+        <translation>Annulla l&apos;ultimo aggiunto e la modifica della forma</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Nascondi
 forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Nascondi tutte le forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>&amp;Mostra
 forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Mostra tutte le forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>&amp;Commuta
 forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Commuta tutte le forme</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Mostra la pagina del tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Rotella</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>Zoom &amp;avanti</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Aumenta il livello di zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>Zoom &amp;indietro</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Diminuisci il livello di zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>Dimensione &amp;originale</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Zoom alla dimensione originale</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>&amp;Adatta alla finestra</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Lo zoom segue la dimensione della finestra</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Adatta &amp;larghezza</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Lo zoom segue la larghezza della finestra</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Luminosità e contrasto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Regola luminosità e contrasto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Modifica etichetta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
-        <translation>Modifica l'etichetta della forma selezionata</translation>
+        <translation>Modifica l&apos;etichetta della forma selezionata</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Riempire poligono in disegno</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Riempire il poligono durante il disegno</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modifica</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Visualizza</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Aiuto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s avviato.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Etichetta non valida</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Etichetta non valida '{}' con tipo di validazione '{}'</translation>
+        <translation>Etichetta non valida &apos;{}&apos; con tipo di validazione &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Errore nel salvataggio dei dati delle etichette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
-        <translation>Errore nell'apertura del file</translation>
+        <translation>Errore nell&apos;apertura del file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>File non trovato : &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Caricamento di %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s caricato</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>File Immagine &amp; Etichette (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Scegli un file Immagine o Etichetta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Salva/Carica annotazioni nella directory</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Le annotazioni saranno salvate/caricate in %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Scegli un file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>File di etichette (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Scegli un file</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Salvare le annotazioni in &quot;{}&quot; prima di chiudere?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Salvare le annotazioni?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Apri directory</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Attiva/disattiva la modalità &quot;mantieni annotazione precedente&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Mantieni luminosità/contrasto precedenti</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Errori di Configurazione</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Sono stati trovati errori durante il caricamento della configurazione. Si prega di esaminare gli errori sottostanti e ricaricare la configurazione o ignorare le righe errate.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Ripristina layout</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Poligono</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Rettangolo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Cerchio</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Linea</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Polilinea</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
-        <translation>Clicca i punti per segmentare l'oggetto. Ctrl+LeftClick per terminare la creazione.</translation>
+        <translation>Clicca i punti per segmentare l&apos;oggetto. Ctrl+LeftClick per terminare la creazione.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
-        <translation>Disegnare un riquadro di delimitazione per segmentare l'oggetto.</translation>
+        <translation>Disegnare un riquadro di delimitazione per segmentare l&apos;oggetto.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points non disponibile</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s non supporta i prompt a punti.
 Selezionare un modello diverso o utilizzare la modalità AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
-        <translation>L'elenco dei file è disabilitato quando è aperto un file di etichette</translation>
+        <translation>L&apos;elenco dei file è disabilitato quando è aperto un file di etichette</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Aggiungi punto al bordo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Inserisci un nuovo punto sul bordo del poligono selezionato</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>&amp;Mantieni zoom precedente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Eliminare definitivamente questo file di etichette? Questa azione non può essere annullata.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Eliminare definitivamente {} forme? Questa azione non può essere annullata.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
-        <translation>Ingrandisci o riduci l'immagine. I tasti di scelta rapida {} e {} funzionano anche sulla tela.</translation>
+        <translation>Ingrandisci o riduci l&apos;immagine. I tasti di scelta rapida {} e {} funzionano anche sulla tela.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Formati consentiti: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Impossibile aprire il file di etichette selezionato: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Impossibile aprire il file immagine selezionato: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Caricamento non riuscito: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Rettangolo Orientato</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Inizia a disegnare rettangoli orientati</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
-        <translation>L'inferenza dell'IA non ha prodotto una nuova annotazione.</translation>
+        <translation>L&apos;inferenza dell&apos;IA non ha prodotto una nuova annotazione.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>La forma era vuota; nessun elemento creato.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Impostazioni…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Modifica le impostazioni</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Le impostazioni sono gestite tramite --config per questa sessione</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Errore di configurazione</translation>
     </message>
@@ -903,82 +729,66 @@ Selezionare un modello diverso o utilizzare la modalità AI-Box.</translation>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Generali</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Etichette</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
-        <translation>Mostra il popup dell'etichetta per le nuove forme</translation>
+        <translation>Mostra il popup dell&apos;etichetta per le nuove forme</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Etichette predefinite</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Validazione delle etichette</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Apri il file di configurazione come testo…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Le modifiche al file di testo vengono applicate al riavvio</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(nessuna)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>un elemento per riga</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Errore di configurazione</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Le etichette predefinite non possono essere vuote quando la validazione delle etichette è impostata su «exact». Disattiva prima la validazione «exact».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Le modifiche verranno applicate al riavvio.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Predefinita di sistema</translation>
     </message>

--- a/labelme/translate/ja_JP.ts
+++ b/labelme/translate/ja_JP.ts
@@ -4,55 +4,45 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>AI支援アノテーション</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AIが'AI-Points'および'AI-Box'モードでアノテーションを提案</translation>
+        <translation>AIが&apos;AI-Points&apos;および&apos;AI-Box&apos;モードでアノテーションを提案</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>'AI-Points'または'AI-Box'モードを選択してAI支援アノテーションを有効化</translation>
+        <translation>&apos;AI-Points&apos;または&apos;AI-Box&apos;モードを選択してAI支援アノテーションを有効化</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AIプロンプト</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>例: dog,cat,bird</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>実行</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>スコア</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AIがテキストプロンプトからアノテーションを作成</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
         <translation>「Polygon」「Rectangle」または「AI-Points」モードで有効</translation>
     </message>
@@ -60,7 +50,6 @@
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>明るさ/コントラスト</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>クリック &amp; ドラッグで頂点を移動</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>クリック &amp; ドラッグで図形を移動</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>%r を作成中</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC でキャンセル</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter または Space で確定</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>図形を編集中</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>直線の始点をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>直線の終点をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>折れ線の始点をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>次の点をクリック、または Ctrl/Cmd+クリックで完了</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>円の中心点をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>円周上の点をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>矩形の最初の角をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>クリックで頂点を追加</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + クリックで頂点を削除</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + クリックで図形上に頂点を作成</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>右クリック &amp; ドラッグで図形をコピー</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>矩形の対角をクリック（Shiftで正方形）</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>クリックで含める点を、Shift+Clickで除外する点を指定。Ctrl+LeftClickで作成を完了。</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>AIセグメンテーション用にbboxの最初の角をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>対角をクリックしてオブジェクトをセグメント</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>向き付き矩形の最初の角をクリック</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>2番目の角をクリックして向きを設定</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>3番目の角をクリックして向き付き矩形を閉じる</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>クリック &amp; ドラッグで図形を回転</translation>
     </message>
@@ -196,714 +160,576 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>フラグ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>アノテーション一覧</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>ラベルを選択してアノテーションを開始。'Esc' で選択解除。</translation>
+        <translation>ラベルを選択してアノテーションを開始。&apos;Esc&apos; で選択解除。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>ラベル一覧</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>ファイル名で検索</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>ファイル一覧</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>終了(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>アプリケーションを終了</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>開く(&amp;O)
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>画像またはラベルファイルを開く</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>ディレクトリを
 開く</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>次の
 画像(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>次を開く (Ctrl+Shift でラベルをコピー)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>前の
 画像(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>前を開く (Ctrl+Shift でラベルをコピー)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>保存(&amp;S)
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>ラベルをファイルに保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>名前を付けて保存(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>ラベルを別のファイルに保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>ファイルを
 削除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>現在のラベルファイルを削除</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>出力先を変更(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>アノテーションの読み込み/保存先を変更</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>自動保存(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>自動で保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>画像データと共に保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>ラベルファイルに画像データを含める</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>閉じる(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>現在のファイルを閉じる</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>前のアノテーションを保持</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>ポリゴンの描画を開始</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>矩形の描画を開始</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>円の描画を開始</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>直線の描画を開始</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>点の描画を開始</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>折れ線の描画を開始。Ctrl+左クリックで完了。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>図形を
 編集</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>選択した図形を移動・編集</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>図形を
 削除</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>選択した図形を削除</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>図形を
 複製</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>選択した図形の複製を作成</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>図形をコピー</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>選択した図形をクリップボードにコピー</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>図形を貼り付け</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>コピーした図形を貼り付け</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>最後の頂点を取り消し</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>最後に描画した頂点を取り消し</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>選択した頂点を削除</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>ポリゴンから選択した頂点を削除</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>元に戻す</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>最後の図形追加・編集を元に戻す</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>図形を
 非表示(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>すべての図形を非表示</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>図形を
 表示(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>すべての図形を表示</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>図形を
 切り替え(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>すべての図形の表示を切り替え</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>チュートリアル(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>チュートリアルページを表示</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>ズーム</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+ホイール</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>拡大(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>拡大率を上げる</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>縮小(&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>拡大率を下げる</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>原寸大(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>原寸大で表示</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>ウィンドウに
 合わせる(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>ウィンドウサイズに合わせてズーム</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>幅に合わせる(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>ウィンドウ幅に合わせてズーム</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>明るさ・
 コントラスト(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>明るさとコントラストを調整</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>ラベルを編集(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>選択した図形のラベルを変更</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>描画中のポリゴンを塗りつぶす</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>描画中にポリゴンを塗りつぶす</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>編集(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>表示(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>ヘルプ(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s を起動しました</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>無効なラベル</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>ラベル '{}' は検証タイプ '{}' では無効です</translation>
+        <translation>ラベル &apos;{}&apos; は検証タイプ &apos;{}&apos; では無効です</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>ラベルデータの保存エラー</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>ファイルを開けませんでした</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>ファイルが見つかりません: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>%s を読み込み中...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s を読み込みました</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>画像とラベルファイル (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - 画像またはラベルファイルを選択</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - アノテーションの保存/読み込みディレクトリ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s - アノテーションは %s に保存/読み込みされます</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - ファイルを選択</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>ラベルファイル (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>ファイルを選択</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>閉じる前にアノテーションを &quot;{}&quot; に保存しますか？</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>アノテーションを保存しますか？</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - ディレクトリを開く</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>「前のアノテーションを保持」モードを切り替え</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>前の明るさ/コントラストを保持</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>設定エラー</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>設定の読み込み中にエラーが見つかりました。以下のエラーを確認し、設定を再読み込みするか、エラーのある行を無視してください。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>レイアウトをリセット</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>ポリゴン</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>円</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>直線</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>折れ線</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>クリックでオブジェクトをセグメント。Ctrl+LeftClickで作成を完了。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>バウンディングボックスを描画してオブジェクトをセグメント。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Pointsは利用できません</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s はポイントプロンプトに対応していません。
 別のモデルを選択するか、AI-Boxモードを使用してください。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>ラベルファイルを開いている場合、ファイルリストは無効です</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>辺に頂点を追加</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>カーソル位置のポリゴンの辺に新しい頂点を挿入</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>前のズームを保持(&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>このラベルファイルを完全に削除しますか？この操作は元に戻せません。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>{} 個の図形を完全に削除しますか？この操作は元に戻せません。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>画像を拡大・縮小します。キャンバス上で {} と {} も使用できます。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>対応形式: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>選択されたラベルファイルを開けませんでした: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>選択された画像ファイルを開けませんでした: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>読み込みに失敗しました: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>向き付き矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>向き付き矩形の描画を開始</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>AI推論で新しいアノテーションは生成されませんでした。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>図形に面積がないため、作成されませんでした。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>設定…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>設定を編集</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>このセッションの設定は --config で管理されています</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>設定エラー</translation>
     </message>
@@ -911,82 +737,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>新しい図形の作成時にラベルポップアップを表示</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>定義済みラベル</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>ラベルの検証</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>設定ファイルをテキストとして開く…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>テキストファイルでの変更は再起動後に反映されます</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>（なし）</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>1行に1項目</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>設定エラー</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>ラベルの検証が「exact」に設定されている間は、定義済みラベルを空にできません。先に「exact」検証を無効にしてください。</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>再起動後に反映されます。</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>システム言語</translation>
     </message>

--- a/labelme/translate/ko_KR.ts
+++ b/labelme/translate/ko_KR.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>AI 지원 주석</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI가 'AI-Points' 및 'AI-Box' 모드에서 주석을 제안합니다</translation>
+        <translation>AI가 &apos;AI-Points&apos; 및 &apos;AI-Box&apos; 모드에서 주석을 제안합니다</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>'AI-Points' 또는 'AI-Box' 모드를 선택하여 AI 지원 주석을 활성화</translation>
+        <translation>&apos;AI-Points&apos; 또는 &apos;AI-Box&apos; 모드를 선택하여 AI 지원 주석을 활성화</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI 프롬프트</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>예: 개, 고양이, 새</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>실행</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>점수</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI가 텍스트 프롬프트에서 주석을 생성합니다</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>'Polygon', 'Rectangle' 또는 'AI-Points' 모드를 선택하여 활성화</translation>
+        <translation>&apos;Polygon&apos;, &apos;Rectangle&apos; 또는 &apos;AI-Points&apos; 모드를 선택하여 활성화</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>밝기/대비</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>클릭하고 드래그하여 점 이동</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>클릭하고 드래그하여 도형 이동</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>%r 생성 중</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC 키를 눌러 취소</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter 또는 Space로 완료</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>도형 편집 중</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>선의 시작점 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>선의 끝점 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>연속선의 시작점 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>다음 점을 클릭하거나 Ctrl/Cmd+클릭으로 완료 (연속선)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>원의 중심점 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>원의 둘레 위 점 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>사각형의 첫 번째 모서리 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>점 추가를 위해 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + 클릭으로 점 삭제</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + 클릭으로 도형 위에 점 생성</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>우클릭하고 드래그하여 도형 복사</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>사각형의 대각 모서리 클릭 (Shift로 정사각형)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>클릭으로 포함할 점을, Shift+Click으로 제외할 점을 지정. Ctrl+LeftClick으로 생성 완료.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>AI 세그멘테이션을 위해 bbox의 첫 번째 모서리 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>대각 모서리를 클릭하여 객체를 세그먼트</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>방향 있는 사각형의 첫 번째 모서리 클릭</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>두 번째 모서리를 클릭하여 방향 설정</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>세 번째 모서리를 클릭하여 방향 있는 사각형 닫기</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>클릭하고 드래그하여 도형 회전</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>플래그</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>주석 목록</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>주석을 시작할 레이블을 선택하세요. 'Esc'를 눌러 선택 해제합니다.</translation>
+        <translation>주석을 시작할 레이블을 선택하세요. &apos;Esc&apos;를 눌러 선택 해제합니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>레이블 목록</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>파일명 검색</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>파일 목록</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>종료(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>애플리케이션 종료</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>열기(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>이미지 또는 레이블 파일 열기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>폴더 열기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>다음 이미지(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>다음 열기 (Ctrl+Shift를 누르면 레이블 복사)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>이전 이미지(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>이전 열기 (Ctrl+Shift를 누르면 레이블 복사)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>저장(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>레이블을 파일로 저장</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>다른 이름으로 저장(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>레이블을 다른 파일로 저장</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>삭제(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>현재 레이블 파일 삭제</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>출력 폴더 변경(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>주석을 로드/저장할 위치 변경</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>자동 저장(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>자동 저장</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>이미지 데이터와 함께 저장</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>레이블 파일에 이미지 데이터 저장</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>닫기(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>현재 파일 닫기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>이전 주석 유지</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>다각형 그리기 시작</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>사각형 그리기 시작</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>원 그리기 시작</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>선 그리기 시작</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>점 그리기 시작</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>연속선 그리기 시작. Ctrl+좌클릭으로 완료.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>도형 편집</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>선택한 도형 이동 및 편집</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>도형 삭제</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>선택한 도형 삭제</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>도형 복제</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>선택한 도형의 복사본 생성</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>도형 복사</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>선택한 도형을 클립보드에 복사</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>도형 붙여넣기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>복사한 도형 붙여넣기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>마지막 점 실행 취소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>마지막으로 그린 점 실행 취소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>선택한 점 제거</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>다각형에서 선택한 점 제거</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>실행 취소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>도형의 마지막 추가 및 편집 실행 취소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>도형 숨기기(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>모든 도형 숨기기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>도형 표시(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>모든 도형 표시</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>도형 토글(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>모든 도형 토글</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>튜토리얼(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>튜토리얼 페이지 표시</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>확대/축소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+휠</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>확대(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>확대 수준 증가</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>축소(&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>확대 수준 감소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>원본 크기(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>원본 크기로 확대/축소</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>창에 맞추기(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>확대/축소가 창 크기에 맞춤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>너비에 맞추기(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>확대/축소가 창 너비에 맞춤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>밝기 대비(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>밝기 및 대비 조정</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>레이블 편집(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>선택한 도형의 레이블 수정</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>그리기 다각형 채우기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>그리는 동안 다각형 채우기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>파일(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>편집(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>보기(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>도움말(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s가 시작되었습니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>잘못된 레이블</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>검증 유형 '{}'에 대한 잘못된 레이블 '{}'</translation>
+        <translation>검증 유형 &apos;{}&apos;에 대한 잘못된 레이블 &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>레이블 데이터 저장 오류</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>파일 열기 오류</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>파일이 없습니다: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>%s 로드 중...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s 로드됨</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>이미지 및 레이블 파일 (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - 이미지 또는 레이블 파일 선택</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - 폴더에 주석 저장/로드</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . 주석이 %s에 저장/로드됩니다</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - 파일 선택</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>레이블 파일 (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>파일 선택</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>주의</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>닫기 전에 주석을 &quot;{}&quot;에 저장하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>주석을 저장하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - 폴더 열기</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>&quot;이전 주석 유지&quot; 모드 토글</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>이전 밝기/대비 유지</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>구성 오류</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>구성을 불러오는 중 오류가 발견되었습니다. 아래 오류를 검토하고 구성을 다시 불러오거나 잘못된 줄을 무시하세요.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>레이아웃 초기화</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>다각형</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>사각형</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>원</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>선</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>점</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>연결선</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>클릭으로 객체를 세그먼트. Ctrl+LeftClick으로 생성 완료.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>바운딩 박스를 그려서 객체를 세그먼트.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points 사용 불가</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s은(는) 포인트 프롬프트를 지원하지 않습니다.
 다른 모델을 선택하거나 AI-Box 모드를 사용하세요.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>라벨 파일이 열려 있을 때 파일 목록이 비활성화됩니다</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>모서리에 점 추가</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>마우스가 가리키는 다각형 모서리에 새 점 삽입</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>이전 줌 유지(&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>이 레이블 파일을 영구적으로 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>{}개의 도형을 영구적으로 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>이미지 확대 또는 축소. 캔버스에서 {} 및 {}로도 사용 가능합니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>지원 형식: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>선택한 레이블 파일을 열 수 없습니다: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>선택한 이미지 파일을 열 수 없습니다: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>불러오기 실패: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>방향 있는 사각형</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>방향 있는 사각형 그리기 시작</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>AI 추론에서 새 주석이 생성되지 않았습니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>도형에 면적이 없어 생성되지 않았습니다.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>설정…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>설정 편집</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>이 세션의 설정은 --config로 관리됩니다</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>구성 오류</translation>
     </message>
@@ -897,82 +723,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>레이블</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>새 도형에서 레이블 팝업 표시</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>사전 정의된 레이블</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>레이블 검증</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>텍스트로 구성 파일 열기…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>텍스트 파일에서 편집한 내용은 재시작 후 적용됩니다</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(없음)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>한 줄에 하나씩 입력</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>구성 오류</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
-        <translation>레이블 검증이 'exact'로 설정된 동안에는 사전 정의된 레이블을 비울 수 없습니다. 먼저 'exact' 검증을 비활성화하세요.</translation>
+        <translation>레이블 검증이 &apos;exact&apos;로 설정된 동안에는 사전 정의된 레이블을 비울 수 없습니다. 먼저 &apos;exact&apos; 검증을 비활성화하세요.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>재시작 후 적용됩니다.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>시스템 기본값</translation>
     </message>

--- a/labelme/translate/nl_NL.ts
+++ b/labelme/translate/nl_NL.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>AI-Ondersteunde Annotatie</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI stelt annotaties voor in de modi 'AI-Points' en 'AI-Box'</translation>
+        <translation>AI stelt annotaties voor in de modi &apos;AI-Points&apos; en &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Selecteer de modus 'AI-Points' of 'AI-Box' om AI-ondersteunde annotatie in te schakelen</translation>
+        <translation>Selecteer de modus &apos;AI-Points&apos; of &apos;AI-Box&apos; om AI-ondersteunde annotatie in te schakelen</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI Tekst-naar-Annotatie</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI maakt annotaties van de tekstprompt</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>bijv. hond, kat, vogel</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Uitvoeren</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Score</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Selecteer 'Polygon', 'Rectangle' of 'AI-Points'-modus om in te schakelen</translation>
+        <translation>Selecteer &apos;Polygon&apos;, &apos;Rectangle&apos; of &apos;AI-Points&apos;-modus om in te schakelen</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Helderheid/Contrast</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Klik en sleep om punt te verplaatsen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Klik en sleep om vorm te verplaatsen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Maken van %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC om te annuleren</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter of Spatie om te voltooien</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Vormen bewerken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Klik op startpunt voor lijn</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Klik op eindpunt voor lijn</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Klik op startpunt voor lijnstrook</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Klik op volgend punt of Ctrl/Cmd+Klik om te voltooien (lijnstrook)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Klik op middelpunt voor cirkel</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Klik op punt op omtrek voor cirkel</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Klik op eerste hoek voor rechthoek</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Klik om punt toe te voegen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Klik om punt te verwijderen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Klik om punt op vorm te maken</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Rechtsklik en sleep om vorm te kopiëren</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Klik op tegenoverliggende hoek voor rechthoek (Shift voor vierkant)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Klik op punten om toe te voegen of Shift+Click om uit te sluiten. Ctrl+LeftClick beëindigt het maken.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Klik op de eerste hoek van de bbox voor AI-segmentatie</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Klik op de tegenoverliggende hoek om het object te segmenteren</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Klik op eerste hoek voor georiënteerde rechthoek</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Klik op tweede hoek om oriëntatie in te stellen</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Klik op derde hoek om georiënteerde rechthoek te sluiten</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Klik en sleep om vorm te draaien</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Vlaggen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Annotatielijst</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Selecteer label om te beginnen met annoteren. Druk op 'Esc' om te deselecteren.</translation>
+        <translation>Selecteer label om te beginnen met annoteren. Druk op &apos;Esc&apos; om te deselecteren.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Labellijst</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Zoek Bestandsnaam</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Bestandslijst</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Applicatie afsluiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Openen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Afbeelding of labelbestand openen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Map Openen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Volgende &amp;Afbeelding</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Volgende openen (houd Ctrl+Shift ingedrukt om labels te kopiëren)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Vorige &amp;Afbeelding</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Vorige openen (houd Ctrl+Shift ingedrukt om labels te kopiëren)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Opslaan</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Labels opslaan naar bestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Opslaan &amp;als</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Labels opslaan naar ander bestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>Bestand &amp;verwijderen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Huidig labelbestand verwijderen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Uitvoermap &amp;wijzigen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Wijzig waar annotaties worden geladen/opgeslagen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>&amp;Automatisch opslaan</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Automatisch opslaan</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Opslaan met Afbeeldingsgegevens</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Afbeeldingsgegevens opslaan in labelbestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Sluiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Huidig bestand sluiten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Vorige Annotatie Behouden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Begin met tekenen van polygonen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Begin met tekenen van rechthoeken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Begin met tekenen van cirkels</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Begin met tekenen van lijnen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Begin met tekenen van punten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Begin met tekenen van lijnstrook. Ctrl+Linkerklik beëindigt het maken.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Vormen Bewerken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Verplaats en bewerk de geselecteerde vormen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Vormen Verwijderen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Geselecteerde vormen verwijderen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Vormen Dupliceren</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Maak een duplicaat van de geselecteerde vormen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Vormen Kopiëren</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Geselecteerde vormen naar klembord kopiëren</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Vormen Plakken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Gekopieerde vormen plakken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Laatste punt ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Laatste getekende punt ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Geselecteerd Punt Verwijderen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Geselecteerd punt uit polygoon verwijderen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Ongedaan Maken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Laatste toevoeging en bewerking van vorm ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Vormen &amp;verbergen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Alle vormen verbergen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Vormen &amp;tonen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Alle vormen tonen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Vormen &amp;omschakelen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Alle vormen omschakelen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Tutorialpagina tonen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Wiel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Inzoomen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Zoomniveau verhogen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Uitzoomen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Zoomniveau verlagen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp;Originele grootte</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Zoomen naar originele grootte</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Aanpassen aan &amp;venster</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Zoom volgt venstergrootte</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Aanpassen aan &amp;breedte</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Zoom volgt vensterbreedte</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>Helderheid en &amp;contrast</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Helderheid en contrast aanpassen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>Label &amp;bewerken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Label van geselecteerde vorm wijzigen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Polygoon Vullen bij Tekenen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Polygoon vullen tijdens tekenen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Bestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Bewerken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Beeld</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s gestart.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Ongeldig label</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Ongeldig label '{}' met validatietype '{}'</translation>
+        <translation>Ongeldig label &apos;{}&apos; met validatietype &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Fout bij opslaan van labelgegevens</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Fout bij openen van bestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Bestand niet gevonden: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Laden van %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Geladen %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Afbeelding- en labelbestanden (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Kies Afbeelding- of labelbestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Annotaties Opslaan/Laden in Map</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Annotaties worden opgeslagen/geladen in %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Kies Bestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Labelbestanden (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Kies Bestand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Let op</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Annotaties opslaan naar &quot;{}&quot; voordat u sluit?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Annotaties opslaan?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Map Openen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Modus &quot;vorige annotatie behouden&quot; omschakelen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Vorige Helderheid/Contrast Behouden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Configuratiefouten</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Er zijn fouten gevonden bij het laden van de configuratie. Bekijk de onderstaande fouten en herlaad uw configuratie of negeer de foutieve regels.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Layout herstellen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Polygoon</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Rechthoek</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Lijnstrip</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Klik op punten om object te segmenteren. Ctrl+LeftClick beëindigt het maken.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Teken een begrenzingskader om een object te segmenteren.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s ondersteunt geen puntinvoer.
 Selecteer een ander model of gebruik de AI-Box-modus.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>De bestandslijst is uitgeschakeld wanneer een labelbestand is geopend</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Punt aan rand toevoegen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Nieuw punt invoegen op de aangewezen polygoonrand</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Vorige Zoom &amp;behouden</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Dit labelbestand permanent verwijderen? Deze actie kan niet ongedaan worden gemaakt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>{} vormen permanent verwijderen? Deze actie kan niet ongedaan worden gemaakt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>In- of uitzoomen op de afbeelding. De sneltoetsen {} en {} werken ook op het canvas.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Toegestane formaten: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Het geselecteerde labelbestand kon niet worden geopend: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Het geselecteerde afbeeldingsbestand kon niet worden geopend: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Laden mislukt: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Georiënteerde Rechthoek</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Begin met tekenen van georiënteerde rechthoeken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>AI-inferentie heeft geen nieuwe annotatie geproduceerd.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Vorm heeft geen oppervlak; niets aangemaakt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Instellingen…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Instellingen bewerken</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Instellingen worden voor deze sessie beheerd via --config</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Configuratiefout</translation>
     </message>
@@ -897,82 +723,66 @@ Selecteer een ander model of gebruik de AI-Box-modus.</translation>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Labels</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Labeldialoog tonen bij nieuwe vorm</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Voorgedefinieerde labels</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Labelvalidatie</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Configuratiebestand openen als tekst…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Wijzigingen in het tekstbestand worden na herstart toegepast</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(geen)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>één item per regel</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Configuratiefout</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
-        <translation>Voorgedefinieerde labels mogen niet leeg zijn wanneer labelvalidatie is ingesteld op 'exact'. Schakel eerst de 'exact'-validatie uit.</translation>
+        <translation>Voorgedefinieerde labels mogen niet leeg zijn wanneer labelvalidatie is ingesteld op &apos;exact&apos;. Schakel eerst de &apos;exact&apos;-validatie uit.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Van kracht na opnieuw opstarten.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Systeemstandaard</translation>
     </message>

--- a/labelme/translate/pl_PL.ts
+++ b/labelme/translate/pl_PL.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Adnotacja wspomagana przez AI</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI sugeruje adnotacje w trybach 'AI-Points' i 'AI-Box'</translation>
+        <translation>AI sugeruje adnotacje w trybach &apos;AI-Points&apos; i &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Wybierz tryb 'AI-Points' lub 'AI-Box', aby włączyć adnotację wspomaganą przez AI</translation>
+        <translation>Wybierz tryb &apos;AI-Points&apos; lub &apos;AI-Box&apos;, aby włączyć adnotację wspomaganą przez AI</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI — tekst na adnotację</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>np. pies,kot,ptak</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Uruchom</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Wynik</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI tworzy adnotacje na podstawie podanego tekstu</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Wybierz tryb 'Polygon', 'Rectangle' lub 'AI-Points', aby włączyć</translation>
+        <translation>Wybierz tryb &apos;Polygon&apos;, &apos;Rectangle&apos; lub &apos;AI-Points&apos;, aby włączyć</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Jasność/Kontrast</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Kliknij i przeciągnij, aby przesunąć punkt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Kliknij i przeciągnij, aby przesunąć kształt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Tworzenie %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC — anuluj</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter lub Spacja — zatwierdź</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Edycja kształtów</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Kliknij punkt początkowy linii</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Kliknij punkt końcowy linii</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Kliknij punkt początkowy polilinii</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Kliknij następny punkt lub Ctrl/Cmd+Klik, aby zakończyć polilinię</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Kliknij środek okręgu</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Kliknij punkt na obwodzie okręgu</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Kliknij pierwszy róg prostokąta</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Kliknij, aby dodać punkt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Klik — usuń punkt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Klik — utwórz punkt na kształcie</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Prawy przycisk i przeciągnij — skopiuj kształt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Kliknij przeciwległy róg prostokąta (Shift — kwadrat)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Kliknij punkty, aby dodać, lub Shift+Click, aby wykluczyć. Ctrl+LeftClick kończy tworzenie.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Kliknij pierwszy róg bbox dla segmentacji AI</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Kliknij przeciwległy róg, aby segmentować obiekt</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Kliknij pierwszy róg prostokąta zorientowanego</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Kliknij drugi róg, aby ustawić orientację</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Kliknij trzeci róg, aby zamknąć prostokąt zorientowany</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Kliknij i przeciągnij — obróć kształt</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Flagi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Lista adnotacji</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Wybierz etykietę, aby zacząć adnotację. Naciśnij 'Esc', aby odznaczyć.</translation>
+        <translation>Wybierz etykietę, aby zacząć adnotację. Naciśnij &apos;Esc&apos;, aby odznaczyć.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Lista etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Szukaj nazwy pliku</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Lista plików</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Zakończ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Zamknij aplikację</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Otwórz</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Otwórz obraz lub plik etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Otwórz folder</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>&amp;Następny obraz</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Otwórz następny (Ctrl+Shift — kopiuj etykiety)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>&amp;Poprzedni obraz</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Otwórz poprzedni (Ctrl+Shift — kopiuj etykiety)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Zapisz</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Zapisz etykiety do pliku</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Zapisz &amp;jako</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Zapisz etykiety do innego pliku</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Usuń plik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Usuń bieżący plik etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Zmień folder wynikowy</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Zmień miejsce wczytywania/zapisywania adnotacji</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Zapisuj &amp;automatycznie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Zapisuj automatycznie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Zapisz z danymi obrazu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Zapisz dane obrazu w pliku etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Zamknij</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Zamknij bieżący plik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Zachowaj poprzednią adnotację</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Rozpocznij rysowanie wielokątów</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Rozpocznij rysowanie prostokątów</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Rozpocznij rysowanie okręgów</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Rozpocznij rysowanie linii</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Rozpocznij rysowanie punktów</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Rozpocznij rysowanie polilinii. Ctrl+Klik lewy kończy tworzenie.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Edytuj kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Przesuń i edytuj zaznaczone kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Usuń kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Usuń zaznaczone kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Duplikuj kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Utwórz duplikat zaznaczonych kształtów</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Kopiuj kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Kopiuj zaznaczone kształty do schowka</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Wklej kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Wklej skopiowane kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Cofnij ostatni punkt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Cofnij ostatnio narysowany punkt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Usuń zaznaczony punkt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Usuń zaznaczony punkt z wielokąta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Cofnij ostatnie dodanie i edycję kształtu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Ukryj kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Ukryj wszystkie kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>&amp;Pokaż kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Pokaż wszystkie kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Przełącz &amp;kształty</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Przełącz widoczność wszystkich kształtów</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Samouczek</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Pokaż stronę samouczka</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Powiększenie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+kółko</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>Powiększ (&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Zwiększ powiększenie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>Pomniejsz (&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Zmniejsz powiększenie</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>Oryginalny rozmiar (&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Powiększ do oryginalnego rozmiaru</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Dopasuj do okna (&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Powiększenie dopasowane do rozmiaru okna</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Dopasuj szerokość (&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Powiększenie dopasowane do szerokości okna</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>Jasność i kontrast (&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Dostosuj jasność i kontrast</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Edytuj etykietę</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Zmień etykietę zaznaczonego kształtu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Wypełnij rysowany wielokąt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Wypełniaj wielokąt podczas rysowania</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Plik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Edycja</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Widok</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Pomoc</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s uruchomiono.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Nieprawidłowa etykieta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Nieprawidłowa etykieta '{}' dla typu walidacji '{}'</translation>
+        <translation>Nieprawidłowa etykieta &apos;{}&apos; dla typu walidacji &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Błąd zapisu etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Błąd otwarcia pliku</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Brak pliku: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Wczytywanie %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Wczytano %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Pliki obrazów i etykiet (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s — Wybierz plik obrazu lub etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s — Zapisz/wczytaj adnotacje w folderze</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s. Adnotacje będą zapisywane/wczytywane w %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s — Wybierz plik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Pliki etykiet (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Wybierz plik</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Uwaga</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Zapisać adnotacje do &quot;{}&quot; przed zamknięciem?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Zapisać adnotacje?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s — Otwórz folder</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Przełącz tryb „zachowaj poprzednią adnotację”</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Zachowaj poprzednią jasność/kontrast</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Błędy konfiguracji</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Wystąpiły błędy podczas wczytywania konfiguracji. Sprawdź listę poniżej i przeładuj konfigurację lub zignoruj błędne wiersze.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Zresetuj układ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Wielokąt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Prostokąt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Okrąg</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Linia</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Łamana</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Kliknij punkty, aby segmentować obiekt. Ctrl+LeftClick kończy tworzenie.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Narysuj ramkę ograniczającą, aby segmentować obiekt.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points niedostępne</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s nie obsługuje poleceń punktowych.
 Wybierz inny model lub użyj trybu AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Lista plików jest wyłączona, gdy otwarty jest plik etykiet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Dodaj punkt do krawędzi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Wstaw nowy punkt na wskazywanej krawędzi wielokąta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Zachowaj poprzedni zoom (&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Trwale usunąć ten plik etykiet? Tej operacji nie można cofnąć.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Trwale usunąć {} kształtów? Tej operacji nie można cofnąć.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Powiększ lub pomniejsz obraz. Skróty {} i {} działają także na płótnie.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Dozwolone formaty: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Nie można otworzyć wybranego pliku etykiet: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Nie można otworzyć wybranego pliku obrazu: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Nie udało się wczytać: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Prostokąt Zorientowany</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Rozpocznij rysowanie prostokątów zorientowanych</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Wnioskowanie AI nie utworzyło nowej adnotacji.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Kształt nie ma obszaru; nic nie zostało utworzone.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Ustawienia…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Edytuj ustawienia</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Ustawienia są zarządzane przez --config w tej sesji</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Błąd konfiguracji</translation>
     </message>
@@ -897,82 +723,66 @@ Wybierz inny model lub użyj trybu AI-Box.</translation>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Etykiety</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Pokaż okno etykiety przy nowym kształcie</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Predefiniowane etykiety</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Walidacja etykiet</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Otwórz plik konfiguracji jako tekst…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Zmiany w pliku tekstowym zostaną zastosowane po ponownym uruchomieniu</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(brak)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>jeden element na wiersz</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Błąd konfiguracji</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Predefiniowane etykiety nie mogą być puste, gdy walidacja etykiet jest ustawiona na „exact”. Najpierw wyłącz walidację „exact”.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Język</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Zmiana zostanie zastosowana po ponownym uruchomieniu.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Domyślny systemu</translation>
     </message>

--- a/labelme/translate/pt_BR.ts
+++ b/labelme/translate/pt_BR.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Anotação Assistida por IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>A IA sugere anotações nos modos 'AI-Points' e 'AI-Box'</translation>
+        <translation>A IA sugere anotações nos modos &apos;AI-Points&apos; e &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Selecione o modo 'AI-Points' ou 'AI-Box' para habilitar a Anotação Assistida por IA</translation>
+        <translation>Selecione o modo &apos;AI-Points&apos; ou &apos;AI-Box&apos; para habilitar a Anotação Assistida por IA</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>Texto para Anotação IA</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>IA cria anotações a partir do prompt de texto</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>ex.: cachorro, gato, pássaro</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Executar</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Pontuação</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Selecione o modo 'Polygon', 'Rectangle' ou 'AI-Points' para ativar</translation>
+        <translation>Selecione o modo &apos;Polygon&apos;, &apos;Rectangle&apos; ou &apos;AI-Points&apos; para ativar</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Brilho/Contraste</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Clique e arraste para mover o ponto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Clique e arraste para mover a forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Criando %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC para cancelar</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter ou Espaço para finalizar</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Editando formas</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Clique no ponto inicial da linha</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Clique no ponto final da linha</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Clique no ponto inicial da linha contínua</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Clique no próximo ponto ou Ctrl/Cmd+Clique para finalizar (linha contínua)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Clique no ponto central do círculo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Clique em um ponto da circunferência do círculo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Clique na primeira esquina do retângulo</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Clique para adicionar um ponto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Clique para excluir o ponto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Clique para criar um ponto na forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Clique com o botão direito e arraste para copiar a forma</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Clique na esquina oposta do retângulo (Shift para quadrado)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Clique em pontos para incluir ou Shift+Click para excluir. Ctrl+LeftClick finaliza a criação.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Clique no primeiro canto do bbox para segmentação com IA</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Clique no canto oposto para segmentar o objeto</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Clique na primeira esquina do retângulo orientado</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Clique na segunda esquina para definir a orientação</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Clique na terceira esquina para fechar o retângulo orientado</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Clique e arraste para girar a forma</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Marcadores</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Lista de Anotações</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Selecione um rótulo para começar a anotar. Pressione 'Esc' para desmarcar.</translation>
+        <translation>Selecione um rótulo para começar a anotar. Pressione &apos;Esc&apos; para desmarcar.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Lista de Rótulos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Buscar Nome do Arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Lista de Arquivos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Sair</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Sair do aplicativo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Abrir arquivo de imagem ou rótulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Abrir Diretório</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Imagem &amp;Seguinte</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Abrir seguinte (mantenha Ctrl+Shift para copiar rótulos)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Imagem &amp;Anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Abrir anterior (mantenha Ctrl+Shift para copiar rótulos)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Salvar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Salvar rótulos no arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Salvar &amp;Como</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Salvar rótulos em um arquivo diferente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Excluir Arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Excluir arquivo de rótulo atual</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Alterar Diretório de &amp;Saída</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Alterar onde as anotações são carregadas/salvas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Salvar &amp;Automaticamente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Salvar automaticamente</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Salvar com Dados da Imagem</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Salvar dados da imagem no arquivo de rótulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Fechar arquivo atual</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Manter Anotação Anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Começar a desenhar polígonos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Começar a desenhar retângulos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Começar a desenhar círculos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Começar a desenhar linhas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Começar a desenhar pontos</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Começar a desenhar linha contínua. Ctrl+Clique esquerdo finaliza a criação.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Editar Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Mover e editar as formas selecionadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Excluir Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Excluir as formas selecionadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Duplicar Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Criar uma cópia das formas selecionadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Copiar Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Copiar formas selecionados para a área de transferência</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Colar Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Colar formas copiadas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Desfazer último ponto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Desfazer último ponto desenhado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Remover Ponto Selecionado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Remover ponto selecionado do polígono</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Desfazer</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Desfazer última adição e edição de forma</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Ocultar &amp;Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Ocultar todas as formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Mostrar &amp;Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Mostrar todas as formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Alternar &amp;Formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Alternar todas as formas</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Mostrar página do tutorial</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Roda</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Aproximar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Aumentar nível de zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Afastar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Diminuir nível de zoom</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>Tamanho &amp;Original</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Zoom para o tamanho original</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Ajustar à &amp;Janela</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>O zoom segue o tamanho da janela</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Ajustar à &amp;Largura</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>O zoom segue a largura da janela</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>Brilho e &amp;Contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Ajustar brilho e contraste</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Editar Rótulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Modificar o rótulo da forma selecionada</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Preencher Polígono ao Desenhar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Preencher polígono enquanto desenha</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Visualizar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Ajuda</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s iniciado.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Rótulo inválido</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Rótulo inválido '{}' com tipo de validação '{}'</translation>
+        <translation>Rótulo inválido &apos;{}&apos; com tipo de validação &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Erro ao salvar dados do rótulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Erro ao abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Arquivo não encontrado: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Carregando %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Carregado %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Arquivos de Imagem e Rótulo (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Escolher Arquivo de Imagem ou Rótulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Salvar/Carregar Anotações no Diretório</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . As anotações serão salvas/carregadas em %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Escolher Arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Arquivos de rótulo (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Escolher Arquivo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Atenção</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Salvar anotações em &quot;{}&quot; antes de fechar?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Salvar anotações?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Abrir Diretório</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Alternar modo &quot;manter anotação anterior&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Manter Brilho/Contraste Anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Erros de Configuração</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Foram encontrados erros ao carregar a configuração. Por favor, revise os erros abaixo e recarregue sua configuração ou ignore as linhas com erro.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Redefinir layout</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Polígono</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Retângulo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Círculo</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Linha</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Ponto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Linha Contínua</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Clique em pontos para segmentar o objeto. Ctrl+LeftClick finaliza a criação.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Desenhe uma caixa delimitadora para segmentar o objeto.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points indisponível</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s não suporta prompts de pontos.
 Selecione um modelo diferente ou use o modo AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>A lista de arquivos está desativada quando um arquivo de rótulos é aberto</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Adicionar ponto à aresta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Inserir um novo ponto na aresta do polígono em foco</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Manter Zoom &amp;Anterior</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Excluir permanentemente este arquivo de rótulo? Esta ação não pode ser desfeita.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Excluir permanentemente {} formas? Esta ação não pode ser desfeita.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Aproximar ou afastar a imagem. Os atalhos {} e {} também funcionam sobre a tela.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Formatos permitidos: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Não foi possível abrir o arquivo de rótulo selecionado: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Não foi possível abrir o arquivo de imagem selecionado: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Falha ao carregar: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Retângulo Orientado</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Começar a desenhar retângulos orientados</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>A inferência de IA não produziu nenhuma nova anotação.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>A forma não tinha área; nenhum objeto criado.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Configurações…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Editar configurações</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>As configurações desta sessão são gerenciadas via --config</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Erro de Configuração</translation>
     </message>
@@ -897,82 +723,66 @@ Selecione um modelo diferente ou use o modo AI-Box.</translation>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Rótulos</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Mostrar popup de rótulo ao criar nova forma</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Rótulos predefinidos</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Validação de rótulo</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Abrir arquivo de configuração como texto…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Edições no arquivo de texto são aplicadas após reiniciar</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(nenhum)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>um item por linha</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Erro de Configuração</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Os rótulos predefinidos não podem ficar vazios enquanto a validação de rótulo estiver definida como «exact». Desative primeiro a validação «exact».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Aplicado após reiniciar o aplicativo.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Padrão do sistema</translation>
     </message>

--- a/labelme/translate/ru_RU.ts
+++ b/labelme/translate/ru_RU.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Разметка с помощью ИИ</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>ИИ предлагает аннотацию в режимах 'AI-Points' и 'AI-Box'</translation>
+        <translation>ИИ предлагает аннотацию в режимах &apos;AI-Points&apos; и &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Выберите режим 'AI-Points' или 'AI-Box', чтобы включить аннотацию с помощью ИИ</translation>
+        <translation>Выберите режим &apos;AI-Points&apos; или &apos;AI-Box&apos;, чтобы включить аннотацию с помощью ИИ</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>ИИ: текст → разметка</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>например: собака,кот,птица</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Выполнить</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Оценка</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>ИИ создаёт разметку по текстовому запросу</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Выберите режим 'Polygon', 'Rectangle' или 'AI-Points', чтобы включить</translation>
+        <translation>Выберите режим &apos;Polygon&apos;, &apos;Rectangle&apos; или &apos;AI-Points&apos;, чтобы включить</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Яркость/Контраст</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Нажмите и перетащите, чтобы переместить точку</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Нажмите и перетащите, чтобы переместить фигуру</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Создание %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC — отмена</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter или Space — завершить</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Редактирование фигур</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Нажмите начальную точку для линии</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Нажмите конечную точку для линии</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Нажмите начальную точку для ломаной</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Нажмите следующую точку или завершите Ctrl/Cmd+нажатие для ломаной</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Нажмите центр окружности</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Нажмите точку на окружности для круга</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Нажмите первый угол для прямоугольника</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Нажмите, чтобы добавить точку</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + нажатие — удалить точку</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + нажатие — создать точку на фигуре</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Правый клик и перетаскивание — копировать фигуру</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Нажмите противоположный угол для прямоугольника (Shift — квадрат)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Нажмите точки для включения или Shift+Click для исключения. Ctrl+LeftClick завершает создание.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Нажмите на первый угол bbox для сегментации ИИ</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Нажмите на противоположный угол для сегментации объекта</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Нажмите первый угол для ориентированного прямоугольника</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Нажмите второй угол для задания ориентации</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Нажмите третий угол для замыкания ориентированного прямоугольника</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Нажмите и перетащите, чтобы повернуть фигуру</translation>
     </message>
@@ -196,703 +160,565 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Флаги</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Список разметки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Выберите метку, чтобы начать разметку. Нажмите 'Esc', чтобы снять выбор.</translation>
+        <translation>Выберите метку, чтобы начать разметку. Нажмите &apos;Esc&apos;, чтобы снять выбор.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Список меток</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Поиск по имени файла</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Список файлов</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Выйти из приложения</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Открыть изображение или файл разметки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Открыть папку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Следующее изображение (&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Открыть следующее (удерживайте Ctrl+Shift, чтобы копировать метки)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Предыдущее изображение (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Открыть предыдущее (удерживайте Ctrl+Shift, чтобы копировать метки)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Сохранить метки в файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Сохранить метки в другой файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>Удалить файл (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Удалить текущий файл меток</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Изменить папку вывода (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Изменить место загрузки/сохранения аннотаций</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Сохранять &amp;автоматически</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Сохранять автоматически</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Сохранять вместе с данными изображения</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Сохранять данные изображения в файле разметки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Закрыть</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Закрыть текущий файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Сохранять предыдущую разметку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Начать рисовать полигоны</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Начать рисовать прямоугольники</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Начать рисовать окружности</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Начать рисовать линии</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Начать рисовать точки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Начать рисовать ломаную. Ctrl+ЛКМ завершает.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Редактировать фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Перемещать и редактировать выбранные фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Удалить фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Удалить выбранные фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Дублировать фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Создать копию выбранных фигур</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Копировать фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Копировать выбранные фигуры в буфер обмена</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Вставить фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Вставить скопированные фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Отменить последнюю точку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Отменить последнюю нарисованную точку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Удалить выбранную точку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Удалить выбранную точку из полигона</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Отменить последнее добавление и редактирование фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Скрыть фигуры (&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Скрыть все фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>&amp;Показать фигуры (&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Показать все фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>&amp;Переключить фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Переключить все фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Руководство</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Показать страницу руководства</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Масштаб</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Колесо</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>Увеличить (&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Увеличить уровень масштаба</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>Уменьшить (&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Уменьшить уровень масштаба</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp;Исходный размер</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Вернуть исходный размер</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>По размеру окна</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Масштаб подстраивается под размер окна</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>По &amp;ширине</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Масштаб подстраивается под ширину окна</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Яркость/Контраст</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Настроить яркость и контраст</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Редактировать метку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Изменить метку выбранной фигуры</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Заполнить нарисованный полигон</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Заполнять полигон во время рисования</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Правка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Вид</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Справка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s запущен.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Неверная метка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Неверная метка '{}' с типом проверки '{}'</translation>
+        <translation>Неверная метка &apos;{}&apos; с типом проверки &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Ошибка при сохранении данных разметки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Ошибка при открытии файла</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Файл не найден: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Загрузка %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s загружен</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Файлы изображения и меток (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s — выберите файл изображения или меток</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s — сохранять/загружать разметку в папке</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s. Разметка будет сохраняться/загружаться в %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s — выбрать файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Файлы меток (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Выбрать файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Сохранить аннотации в &quot;{}&quot; перед закрытием?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Сохранить аннотации?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s — открыть папку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Переключить режим &quot;сохранять предыдущую разметку&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Сохранять яркость/контраст предыдущего изображения</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Ошибки конфигурации</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Были найдены ошибки при загрузке конфигурации. Пожалуйста, просмотрите ошибки ниже и перезагрузите конфигурацию или игнорируйте ошибочные строки.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Сбросить компоновку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>Сохранить (&amp;S)
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Открыть
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Отменить
 </translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Полигон</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Прямоугольник</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Окружность</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Ломаная</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Нажмите точки для сегментации объекта. Ctrl+LeftClick завершает создание.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Нарисуйте ограничивающую рамку для сегментации объекта.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points недоступен</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s не поддерживает точечные запросы.
 Выберите другую модель или используйте режим AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Список файлов отключён при открытии файла меток</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Добавить точку на ребро</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Вставить новую точку на ребре полигона под курсором</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Сохранять предыдущий масштаб</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Безвозвратно удалить этот файл меток? Это действие нельзя отменить.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Безвозвратно удалить {} фигур? Это действие нельзя отменить.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Увеличить или уменьшить изображение. Также доступно с {} и {} на холсте.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Допустимые форматы: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Не удалось открыть выбранный файл меток: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Не удалось открыть выбранный файл изображения: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Не удалось загрузить: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Ориентированный прямоугольник</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Начать рисовать ориентированные прямоугольники</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Инференс ИИ не создал новой аннотации.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Фигура не имеет площади; ничего не создано.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Настройки…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Редактировать настройки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Настройки управляются через --config для этого сеанса</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Ошибка конфигурации</translation>
     </message>
@@ -900,82 +726,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Метки</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Показывать всплывающее окно метки для новой фигуры</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Предустановленные метки</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Проверка меток</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Открыть файл конфигурации как текст…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Изменения в текстовом файле применяются после перезапуска</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(нет)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>по одному элементу на строку</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Ошибка конфигурации</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Предустановленные метки не могут быть пустыми, пока проверка меток установлена в «exact». Сначала отключите проверку «exact».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Вступает в силу после перезапуска.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Системный язык</translation>
     </message>

--- a/labelme/translate/th_TH.ts
+++ b/labelme/translate/th_TH.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>แอนโนเทชันด้วย AI</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI แนะนำแอนโนเทชันในโหมด 'AI-Points' และ 'AI-Box'</translation>
+        <translation>AI แนะนำแอนโนเทชันในโหมด &apos;AI-Points&apos; และ &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>เลือกโหมด 'AI-Points' หรือ 'AI-Box' เพื่อเปิดใช้งานแอนโนเทชันด้วย AI</translation>
+        <translation>เลือกโหมด &apos;AI-Points&apos; หรือ &apos;AI-Box&apos; เพื่อเปิดใช้งานแอนโนเทชันด้วย AI</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI ข้อความสู่แอนโนเทชัน</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>เช่น สุนัข, แมว, นก</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>รัน</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>คะแนน</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI สร้างแอนโนเทชันจากข้อความที่ป้อน</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>เลือกโหมด 'Polygon', 'Rectangle' หรือ 'AI-Points' เพื่อเปิดใช้งาน</translation>
+        <translation>เลือกโหมด &apos;Polygon&apos;, &apos;Rectangle&apos; หรือ &apos;AI-Points&apos; เพื่อเปิดใช้งาน</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>ความสว่าง/คอนทราสต์</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>คลิกและลากเพื่อย้ายจุด</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>คลิกและลากเพื่อย้ายรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>กำลังสร้าง %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>กด ESC เพื่อยกเลิก</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>กด Enter หรือ Space เพื่อยืนยัน</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>แก้ไขรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>คลิกจุดเริ่มต้นของเส้น</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>คลิกจุดสิ้นสุดของเส้น</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>คลิกจุดเริ่มต้นของเส้นต่อเนื่อง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>คลิกจุดถัดไป หรือ Ctrl/Cmd+คลิกเพื่อจบเส้นต่อเนื่อง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>คลิกจุดศูนย์กลางของวงกลม</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>คลิกจุดบนเส้นรอบวงของวงกลม</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>คลิกมุมแรกของสี่เหลี่ยม</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>คลิกเพื่อเพิ่มจุด</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + คลิกเพื่อลบจุด</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + คลิกเพื่อสร้างจุดบนรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>คลิกขวาและลากเพื่อคัดลอกรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>คลิกมุมตรงข้ามของสี่เหลี่ยม (Shift สำหรับสี่เหลี่ยมจัตุรัส)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>คลิกจุดเพื่อรวม หรือ Shift+Click เพื่อยกเว้น Ctrl+LeftClick เพื่อจบการสร้าง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>คลิกมุมแรกของ bbox สำหรับ AI segmentation</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>คลิกมุมตรงข้ามเพื่อแบ่งส่วนวัตถุ</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>คลิกมุมแรกของสี่เหลี่ยมมีทิศทาง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>คลิกมุมที่สองเพื่อกำหนดทิศทาง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>คลิกมุมที่สามเพื่อปิดสี่เหลี่ยมมีทิศทาง</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>คลิกและลากเพื่อหมุนรูปร่าง</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>แฟล็ก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>รายการแอนโนเทชัน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>เลือกเลเบลเพื่อเริ่มกำกับข้อมูล กด 'Esc' เพื่อยกเลิกการเลือก</translation>
+        <translation>เลือกเลเบลเพื่อเริ่มกำกับข้อมูล กด &apos;Esc&apos; เพื่อยกเลิกการเลือก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>รายการเลเบล</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>ค้นหาชื่อไฟล์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>รายการไฟล์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>ออก (&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>ปิดแอป</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>เปิด (&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>เปิดรูปหรือไฟล์เลเบล</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>เปิดโฟลเดอร์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>รูปถัดไป (&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>เปิดรูปถัดไป (กด Ctrl+Shift เพื่อคัดลอกเลเบล)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>รูปก่อนหน้า (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>เปิดรูปก่อนหน้า (กด Ctrl+Shift เพื่อคัดลอกเลเบล)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>บันทึก (&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>บันทึกเลเบลลงไฟล์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>บันทึกเป็น (&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>บันทึกเลเบลไปยังไฟล์อื่น</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>ลบไฟล์ (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>ลบไฟล์เลเบลปัจจุบัน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>เปลี่ยนโฟลเดอร์ผลลัพธ์ (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>เปลี่ยนโฟลเดอร์สำหรับโหลด/บันทึกแอนโนเทชัน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>บันทึกอัตโนมัติ (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>บันทึกอัตโนมัติ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>บันทึกพร้อมข้อมูลรูป</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>บันทึกข้อมูลรูปในไฟล์เลเบล</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>ปิด (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>ปิดไฟล์ปัจจุบัน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>คงแอนโนเทชันก่อนหน้า</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>เริ่มวาดหลายเหลี่ยม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>เริ่มวาดสี่เหลี่ยม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>เริ่มวาดวงกลม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>เริ่มวาดเส้น</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>เริ่มวาดจุด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>เริ่มวาดเส้นต่อเนื่อง Ctrl+คลิกซ้ายเพื่อจบ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>แก้ไขรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>ย้ายและแก้ไขรูปร่างที่เลือก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>ลบรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>ลบรูปร่างที่เลือก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>ทำซ้ำรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>สร้างสำเนารูปร่างที่เลือก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>คัดลอกรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>คัดลอกรูปร่างที่เลือกไปคลิปบอร์ด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>วางรูปร่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>วางรูปร่างที่คัดลอก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>ยกเลิกจุดล่าสุด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>ยกเลิกจุดที่วาดล่าสุด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>ลบจุดที่เลือก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>ลบจุดที่เลือกออกจากหลายเหลี่ยม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>ยกเลิก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>ยกเลิกการเพิ่มและแก้ไขรูปร่างล่าสุด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>ซ่อนรูปร่าง (&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>ซ่อนรูปร่างทั้งหมด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>แสดงรูปร่าง (&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>แสดงรูปร่างทั้งหมด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>สลับรูปร่าง (&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>สลับรูปร่างทั้งหมด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>บทแนะนำ (&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>แสดงหน้าบทแนะนำ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>ซูม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+ล้อเลื่อน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>ซูมเข้า (&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>เพิ่มระดับซูม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>ซูมออก (&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>ลดระดับซูม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>ขนาดจริง (&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>ซูมเป็นขนาดจริง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>พอดีหน้าต่าง (&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>ซูมตามขนาดหน้าต่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>พอดีความกว้าง (&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>ซูมตามความกว้างหน้าต่าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>ความสว่าง คอนทราสต์ (&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>ปรับความสว่างและคอนทราสต์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>แก้ไขเลเบล (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>แก้ไขเลเบลของรูปร่างที่เลือก</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>เติมสีหลายเหลี่ยมที่วาด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>เติมสีหลายเหลี่ยมขณะวาด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>ไฟล์ (&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>แก้ไข (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>มุมมอง (&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>ช่วยเหลือ (&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s เริ่มทำงานแล้ว</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>เลเบลไม่ถูกต้อง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>เลเบล '{}' ไม่ถูกต้อง ประเภทการตรวจ '{}'</translation>
+        <translation>เลเบล &apos;{}&apos; ไม่ถูกต้อง ประเภทการตรวจ &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>เกิดข้อผิดพลาดในการบันทึกข้อมูลเลเบล</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>เกิดข้อผิดพลาดในการเปิดไฟล์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>ไม่มีไฟล์: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>กำลังโหลด %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>โหลด %s แล้ว</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>ไฟล์รูปและเลเบล (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - เลือกรูปหรือไฟล์เลเบล</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - บันทึก/โหลดแอนโนเทชันในโฟลเดอร์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s แอนโนเทชันจะถูกบันทึก/โหลดใน %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - เลือกไฟล์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>ไฟล์เลเบล (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>เลือกไฟล์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>คำเตือน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>บันทึกแอนโนเทชันไปที่ &quot;{}&quot; ก่อนปิดหรือไม่?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>บันทึกแอนโนเทชันหรือไม่?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - เปิดโฟลเดอร์</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>สลับโหมด &quot;คงแอนโนเทชันก่อนหน้า&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>คงความสว่าง/คอนทราสต์ก่อนหน้า</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>ข้อผิดพลาดการตั้งค่า</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>พบข้อผิดพลาดขณะโหลดการตั้งค่า กรุณาตรวจสอบด้านล่าง แล้วโหลดการตั้งค่าใหม่หรือข้ามบรรทัดที่มีข้อผิดพลาด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>รีเซ็ตเค้าโครง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>หลายเหลี่ยม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>สี่เหลี่ยม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>วงกลม</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>เส้น</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>จุด</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>เส้นต่อเนื่อง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>คลิกจุดเพื่อแบ่งส่วนวัตถุ Ctrl+LeftClick เพื่อจบการสร้าง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>วาดกรอบสี่เหลี่ยมเพื่อแบ่งส่วนวัตถุ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points ไม่พร้อมใช้งาน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s ไม่รองรับการกำหนดจุด
 กรุณาเลือกโมเดลอื่นหรือใช้โหมด AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>รายการไฟล์ถูกปิดใช้งานเมื่อเปิดไฟล์ป้ายกำกับ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>เพิ่มจุดบนขอบ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>แทรกจุดใหม่บนขอบของรูปหลายเหลี่ยมที่เคอร์เซอร์ชี้อยู่</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>คงระดับซูมก่อนหน้า (&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>ลบไฟล์เลเบลนี้อย่างถาวร? การกระทำนี้ไม่สามารถยกเลิกได้</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>ลบรูปร่าง {} รายการอย่างถาวร? การกระทำนี้ไม่สามารถยกเลิกได้</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>ซูมเข้า-ออกของรูป ใช้ทางลัด {} และ {} ที่แคนวาสได้เช่นกัน</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>รูปแบบที่อนุญาต: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>ไม่สามารถเปิดไฟล์ป้ายกำกับที่เลือก: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>ไม่สามารถเปิดไฟล์ภาพที่เลือก: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>โหลดไม่สำเร็จ: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>สี่เหลี่ยมมีทิศทาง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>เริ่มวาดสี่เหลี่ยมมีทิศทาง</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>การอนุมานของ AI ไม่ได้สร้างคำอธิบายประกอบใหม่</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>รูปร่างไม่มีพื้นที่ จึงไม่มีการสร้างใดๆ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>การตั้งค่า…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>แก้ไขการตั้งค่า</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>การตั้งค่าถูกจัดการผ่าน --config สำหรับเซสชันนี้</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>ข้อผิดพลาดการตั้งค่า</translation>
     </message>
@@ -897,82 +723,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>ทั่วไป</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>เลเบล</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>แสดงป๊อปอัปเลเบลเมื่อสร้างรูปร่างใหม่</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>เลเบลที่กำหนดไว้ล่วงหน้า</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>การตรวจสอบเลเบล</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>การตั้งค่า</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>เปิดไฟล์ตั้งค่าเป็นข้อความ…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>การแก้ไขในไฟล์ข้อความจะมีผลหลังรีสตาร์ท</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>ปิด</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(ไม่มี)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>หนึ่งรายการต่อบรรทัด</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>ข้อผิดพลาดการตั้งค่า</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
-        <translation>เลเบลที่กำหนดไว้ล่วงหน้าต้องไม่ว่างเปล่าขณะที่การตรวจสอบเลเบลถูกตั้งค่าเป็น 'exact' โปรดปิดการตรวจสอบ 'exact' ก่อน</translation>
+        <translation>เลเบลที่กำหนดไว้ล่วงหน้าต้องไม่ว่างเปล่าขณะที่การตรวจสอบเลเบลถูกตั้งค่าเป็น &apos;exact&apos; โปรดปิดการตรวจสอบ &apos;exact&apos; ก่อน</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>ภาษา</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>จะมีผลหลังรีสตาร์ท</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>ค่าเริ่มต้นของระบบ</translation>
     </message>

--- a/labelme/translate/tr_TR.ts
+++ b/labelme/translate/tr_TR.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Yapay Zeka Destekli Açıklama</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>Yapay zeka, 'AI-Points' ve 'AI-Box' modlarında açıklama önerir</translation>
+        <translation>Yapay zeka, &apos;AI-Points&apos; ve &apos;AI-Box&apos; modlarında açıklama önerir</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Yapay Zeka Destekli Açıklamayı etkinleştirmek için 'AI-Points' veya 'AI-Box' modunu seçin</translation>
+        <translation>Yapay Zeka Destekli Açıklamayı etkinleştirmek için &apos;AI-Points&apos; veya &apos;AI-Box&apos; modunu seçin</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>Yapay Zeka Metinden Açıklama</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>ör. köpek, kedi, kuş</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Çalıştır</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Puan</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>Yapay zeka, metin isteminden açıklamalar üretir</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Etkinleştirmek için 'Polygon', 'Rectangle' veya 'AI-Points' modunu seçin</translation>
+        <translation>Etkinleştirmek için &apos;Polygon&apos;, &apos;Rectangle&apos; veya &apos;AI-Points&apos; modunu seçin</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Parlaklık/Kontrast</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Noktayı taşımak için tıklayıp sürükleyin</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Şekli taşımak için tıklayıp sürükleyin</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>%r oluşturuluyor</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>İptal etmek için ESC</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Tamamlamak için Enter veya Space</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Şekiller düzenleniyor</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Çizginin başlangıç noktasına tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Çizginin bitiş noktasına tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Çizgi şeridinin başlangıç noktasına tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Çizgi şeridi için sonraki noktaya tıklayın veya Ctrl/Cmd+Tıklama ile tamamlayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Dairenin merkezine tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Dairenin çevresi üzerindeki bir noktaya tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Dikdörtgenin ilk köşesine tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Nokta eklemek için tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>Noktayı silmek için ALT + SHIFT + Tıklama</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>Şekil üzerinde nokta oluşturmak için ALT + Tıklama</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Şekli kopyalamak için sağ tıklayıp sürükleyin</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Dikdörtgenin karşı köşesine tıklayın (kare için Shift)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Dahil etmek için noktalara tıklayın, dışlamak için Shift+Tıklama. Ctrl+Sol Tıklama oluşturmayı sonlandırır.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Yapay zeka bölütlemesi için sınır kutusunun ilk köşesine tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Nesneyi bölütlemek için karşı köşeye tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Yönlü dikdörtgenin ilk köşesine tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Yönü belirlemek için ikinci köşeye tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Yönlü dikdörtgeni kapatmak için üçüncü köşeye tıklayın</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Şekli döndürmek için tıklayıp sürükleyin</translation>
     </message>
@@ -196,703 +160,565 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Bayraklar</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Açıklama Listesi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Açıklama eklemek için bir etiket seçin. Seçimi kaldırmak için 'Esc' tuşuna basın.</translation>
+        <translation>Açıklama eklemek için bir etiket seçin. Seçimi kaldırmak için &apos;Esc&apos; tuşuna basın.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Etiket Listesi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Dosya Adında Ara</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Dosya Listesi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Çıkış</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Uygulamadan çık</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Aç</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Görüntü veya etiket dosyasını aç</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Klasörü Aç</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>&amp;Sonraki Görüntü</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
-        <translation>Sonrakini aç (etiketleri kopyalamak için Ctrl+Shift'i basılı tutun)</translation>
+        <translation>Sonrakini aç (etiketleri kopyalamak için Ctrl+Shift&apos;i basılı tutun)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>&amp;Önceki Görüntü</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
-        <translation>Öncekini aç (etiketleri kopyalamak için Ctrl+Shift'i basılı tutun)</translation>
+        <translation>Öncekini aç (etiketleri kopyalamak için Ctrl+Shift&apos;i basılı tutun)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Etiketleri dosyaya kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>&amp;Farklı Kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Etiketleri başka bir dosyaya kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>Dosyayı &amp;Sil</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Açık olan etiket dosyasını sil</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Çıktı Klasörünü &amp;Değiştir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Açıklamaların yüklendiği/kaydedildiği konumu değiştir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>&amp;Otomatik Kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Otomatik olarak kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Görüntü Verisiyle Kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Görüntü verisini etiket dosyasına kaydet</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Kapat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Açık olan dosyayı kapat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Önceki Açıklamayı Koru</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Çokgen çizmeye başla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Dikdörtgen çizmeye başla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Daire çizmeye başla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Çizgi çizmeye başla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Nokta çizmeye başla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Çizgi şeridi çizmeye başla. Ctrl+Sol Tıklama oluşturmayı sonlandırır.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Şekilleri Düzenle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Seçili şekilleri taşı ve düzenle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Şekilleri Sil</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Seçili şekilleri sil</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Şekilleri Çoğalt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Seçili şekillerin bir kopyasını oluştur</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Şekilleri Kopyala</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Seçili şekilleri panoya kopyala</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Şekilleri Yapıştır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Kopyalanmış şekilleri yapıştır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Son noktayı geri al</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Çizilen son noktayı geri al</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Seçili Noktayı Kaldır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Seçili noktayı çokgenden kaldır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Geri Al</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Şekle yapılan son ekleme ve düzenlemeyi geri al</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Şekilleri
 &amp;Gizle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Tüm şekilleri gizle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Şekilleri
 &amp;Göster</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Tüm şekilleri göster</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Şekilleri
 &amp;Aç/Kapat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Tüm şekilleri aç/kapat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Öğretici</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Öğretici sayfasını göster</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Yakınlaştırma</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Tekerlek</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Yakınlaştır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Yakınlaştırma düzeyini artır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Uzaklaştır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Yakınlaştırma düzeyini azalt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp;Orijinal Boyut</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Orijinal boyuta getir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Pencereye &amp;Sığdır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Yakınlaştırma pencere boyutunu izler</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>&amp;Genişliğe Sığdır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Yakınlaştırma pencere genişliğini izler</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Parlaklık ve Kontrast</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Parlaklığı ve kontrastı ayarla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>Etiketi &amp;Düzenle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Seçili şeklin etiketini değiştir</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Çizerken Çokgeni Doldur</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Çizim sırasında çokgeni doldur</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Dosya</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Düzenle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Görünüm</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Yardım</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s başlatıldı.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Geçersiz etiket</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>'{}' doğrulama türü için '{}' etiketi geçersiz</translation>
+        <translation>&apos;{}&apos; doğrulama türü için &apos;{}&apos; etiketi geçersiz</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Etiket verisi kaydedilirken hata oluştu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Dosya açılırken hata oluştu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Belirtilen dosya bulunamadı: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>%s yükleniyor…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>%s yüklendi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Görüntü ve Etiket dosyaları (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Görüntü veya Etiket dosyası seçin</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Klasördeki Açıklamaları Kaydet/Yükle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Açıklamalar %s konumunda kaydedilecek/yüklenecek</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Dosya Seçin</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Etiket dosyaları (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Dosya Seçin</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Dikkat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Kapatmadan önce açıklamalar &quot;{}&quot; konumuna kaydedilsin mi?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Açıklamalar kaydedilsin mi?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Klasörü Aç</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>&quot;önceki açıklamayı koru&quot; modunu aç/kapat</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Önceki Parlaklık/Kontrastı Koru</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Yapılandırma Hataları</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Yapılandırma yüklenirken hatalar bulundu. Lütfen aşağıdaki hataları gözden geçirip yapılandırmayı yeniden yükleyin veya hatalı satırları yok sayın.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Düzeni Sıfırla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Çokgen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Dikdörtgen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Daire</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Çizgi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Nokta</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Çizgi Şeridi</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Nesneyi bölütlemek için noktalara tıklayın. Ctrl+Sol Tıklama oluşturmayı sonlandırır.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Nesneyi bölütlemek için bir sınır kutusu çizin.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points Kullanılamıyor</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s nokta istemlerini desteklemiyor.
 Lütfen farklı bir model seçin veya AI-Box modunu kullanın.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Bir etiket dosyası açıkken dosya listesi devre dışı kalır</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Kenara nokta ekle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Üzerinde durulan poligon kenarına yeni bir nokta ekle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Önceki &amp;Yakınlaştırmayı Koru</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Bu etiket dosyası kalıcı olarak silinsin mi? Bu işlem geri alınamaz.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>{} şekil kalıcı olarak silinsin mi? Bu işlem geri alınamaz.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Görüntüyü yakınlaştırın veya uzaklaştırın. {} ve {} kısayolları tuvalde de çalışır.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>İzin verilen biçimler: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Seçilen etiket dosyası açılamadı: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Seçilen görüntü dosyası açılamadı: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Yükleme başarısız: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Yönlü Dikdörtgen</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Yönlü dikdörtgen çizmeye başla</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Yapay zeka çıkarımı yeni bir açıklama oluşturmadı.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Şeklin alanı yoktu; hiçbir şey oluşturulmadı.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Ayarlar…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Ayarları düzenle</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Bu oturumda ayarlar --config ile yönetiliyor</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Yapılandırma Hatası</translation>
     </message>
@@ -900,82 +726,66 @@ Lütfen farklı bir model seçin veya AI-Box modunu kullanın.</translation>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Genel</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Etiketler</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Yeni şekilde etiket penceresi göster</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Önceden tanımlı etiketler</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Etiket doğrulama</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Yapılandırma dosyasını metin olarak aç…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Metin dosyasındaki değişiklikler yeniden başlatma sonrasında geçerli olur</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(yok)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>her satıra bir öğe</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Yapılandırma Hatası</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
-        <translation>Etiket doğrulama 'exact' olarak ayarlıyken önceden tanımlı etiketler boş olamaz. Önce 'exact' doğrulamasını devre dışı bırakın.</translation>
+        <translation>Etiket doğrulama &apos;exact&apos; olarak ayarlıyken önceden tanımlı etiketler boş olamaz. Önce &apos;exact&apos; doğrulamasını devre dışı bırakın.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Dil</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Yeniden başlatma sonrasında geçerli olur.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Sistem varsayılanı</translation>
     </message>

--- a/labelme/translate/uk_UA.ts
+++ b/labelme/translate/uk_UA.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>AI-анотація</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>ШІ пропонує анотацію в режимах 'AI-Points' та 'AI-Box'</translation>
+        <translation>ШІ пропонує анотацію в режимах &apos;AI-Points&apos; та &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Виберіть режим 'AI-Points' або 'AI-Box', щоб увімкнути анотацію за допомогою ШІ</translation>
+        <translation>Виберіть режим &apos;AI-Points&apos; або &apos;AI-Box&apos;, щоб увімкнути анотацію за допомогою ШІ</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI: текст в анотацію</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI створює анотації з текстової підказки</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>наприклад, собака, кішка, птах</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Запустити</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Оцінка</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Виберіть режим 'Polygon', 'Rectangle' або 'AI-Points', щоб увімкнути</translation>
+        <translation>Виберіть режим &apos;Polygon&apos;, &apos;Rectangle&apos; або &apos;AI-Points&apos;, щоб увімкнути</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Яскравість/Контраст</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Створення %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>ESC для скасування</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Enter або пробіл для завершення</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Редагування фігур</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Натисніть початкову точку лінії</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Натисніть кінцеву точку лінії</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Натисніть початкову точку для лінії</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Натисніть наступну точку або завершіть через Ctrl/Cmd+Click для linestrip</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Натисніть центральну точку для кола</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Натисніть точку на окружності для кола</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Натисніть перший кут для прямокутника</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Натисніть протилежний кут для прямокутника (Shift для квадрата)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Натисніть, щоб додати точку</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Натисніть і перетягніть, щоб перемістити точку</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Натисніть, щоб видалити точку</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Натисніть, щоб створити точку на фігурі</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Натисніть і перетягніть, щоб перемістити фігуру</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Натисніть правою кнопкою миші та перетягніть, щоб скопіювати фігуру</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Натисніть точки для включення або Shift+Click для виключення. Ctrl+LeftClick завершує створення.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Натисніть на перший кут bbox для сегментації ШІ</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
-        <translation>Натисніть на протилежний кут для сегментації об'єкта</translation>
+        <translation>Натисніть на протилежний кут для сегментації об&apos;єкта</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Натисніть перший кут для орієнтованого прямокутника</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Натисніть другий кут для задання орієнтації</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Натисніть третій кут для замикання орієнтованого прямокутника</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Натисніть і перетягніть, щоб обертати фігуру</translation>
     </message>
@@ -196,703 +160,565 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>&amp;Зберегти</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Зберегти мітки у файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>&amp;Зберегти як</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Зберегти мітки в інший файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>&amp;Автоматично зберегти</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Зберегти автоматично</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Зберегти з даними зображення</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Зберегти дані зображення у файлі мітки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>&amp;Змінити каталог виводу</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Змінити місце завантаження/збереження анотацій</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>&amp;Відкрити</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Відкрити файл зображення або мітки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Відкрити каталог</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>&amp;Закрити</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Закрити поточний файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>&amp;Видалити файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Видалити поточний файл мітки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Зберегти попередню анотацію</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Увімкнути режим «зберегти попередню анотацію»</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Зберегти попередню яскравість/контраст</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Видалити фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Видалити вибрані фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>&amp;Редагувати мітку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Змінити мітку вибраної фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Дублювати фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Створити дублікат вибраних фігур</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Копіювати фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Копіювати вибрані фігури в буфер обміну</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Вставити фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Вставити скопійовані фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Скасувати останній пункт</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Скасувати останню намальовану точку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Скасувати останнє додавання та редагування фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Видалити вибрану точку</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Видалити вибрану точку з багатокутника</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Почніть малювати багатокутники</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Редагувати фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Перемістити і відредагувати вибрані фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Почніть малювати прямокутники</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Почніть малювати кола</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Почніть малювати лінії</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Почніть малювати точки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Почніть малювати лінію. Ctrl+Лівий клік завершує створення.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>&amp;Наступне зображення</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Відкрити далі (утримуйте Ctrl+Shift, щоб скопіювати мітки)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>&amp;Попереднє зображення</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Відкрити попередній (утримуйте Ctrl+Shift, щоб скопіювати мітки)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>&amp;Припасувати вікно</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Масштаб відповідає розміру вікна</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>За &amp;шириною</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Масштаб відповідає ширині вікна</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>&amp;Яскравість Контраст</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Відрегулювати яскравість і контраст</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>&amp;Збільшити</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Збільшити масштаб</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>&amp;Зменшити</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Зменшити масштаб</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>&amp;Оригінальний розмір</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Збільшити до оригінального розміру</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Скинути макет</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Заливка багатокутника при малюванні</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Заповнювати багатокутник під час малювання</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>&amp;Приховати
 фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Приховати всі фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>&amp;Показати
 фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Показати всі фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>&amp;Переключити
 фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Переключити всі фігури</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Збільшити</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+колесо</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>&amp;Вийти</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Вийти з програми</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>&amp;Посібник</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Показати сторінку підручника</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>&amp;Редагувати</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>&amp;Переглянути</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s розпочато.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Прапори</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Список анотацій</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
         <translation>Виберіть мітку, щоб розпочати анотування для неї. Натисніть «Esc», щоб скасувати вибір.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Список міток</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Пошук імені файлу</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Список файлів</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Помилки конфігурації</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Під час завантаження конфігурації виявлено помилки. Перегляньте наведені нижче помилки та перезавантажте свою конфігурацію або проігноруйте помилкові рядки.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Недійсна мітка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
         <translation>Недійсна мітка &quot;{}&quot; з типом перевірки &quot;{}&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Помилка збереження даних мітки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Помилка відкриття файлу</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Такого файлу немає: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Завантаження %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Завантажено %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Файли зображень і міток (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Виберіть файл зображення або мітки</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Зберегти/завантажити анотації в каталозі</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Анотації будуть збережені/завантажені в %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Виберіть файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Файли міток (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Виберіть файл</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Увага</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Зберегти анотації до &quot;{}&quot; перед закриттям?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Зберегти анотації?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Відкрити каталог</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Багатокутник</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Прямокутник</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Коло</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Лінія</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>LineStrip</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
-        <translation>Натисніть точки для сегментації об'єкта. Ctrl+LeftClick завершує створення.</translation>
+        <translation>Натисніть точки для сегментації об&apos;єкта. Ctrl+LeftClick завершує створення.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
-        <translation>Намалюйте обмежувальну рамку для сегментації об'єкта.</translation>
+        <translation>Намалюйте обмежувальну рамку для сегментації об&apos;єкта.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points недоступний</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s не підтримує точкові запити.
 Будь ласка, виберіть іншу модель або використовуйте режим AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Список файлів вимкнено, коли відкрито файл міток</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Додати точку на ребро</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Вставити нову точку на ребрі полігона під курсором</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>&amp;Зберегти попередній масштаб</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Остаточно видалити цей файл мітки? Цю дію неможливо скасувати.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Остаточно видалити {} фігур? Цю дію неможливо скасувати.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Збільшення або зменшення зображення. Також доступно за допомогою {} і {} на полотні.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Дозволені формати: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Не вдалося відкрити вибраний файл міток: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Не вдалося відкрити вибраний файл зображення: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Не вдалося завантажити: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Орієнтований прямокутник</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Почніть малювати орієнтовані прямокутники</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Інференс ШІ не створив нової анотації.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Фігура не має площі; нічого не створено.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Параметри…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Редагувати параметри</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Параметри керуються через --config для цього сеансу</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Помилка конфігурації</translation>
     </message>
@@ -900,82 +726,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Загальні</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Мітки</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Показувати спливаюче вікно мітки для нової фігури</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Попередньо визначені мітки</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Перевірка мітки</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Відкрити файл конфігурації як текст…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Зміни в текстовому файлі застосуються після перезапуску</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(немає)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>по одному елементу на рядок</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Помилка конфігурації</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>Попередньо визначені мітки не можуть бути порожніми, коли перевірка мітки встановлена на «exact». Спочатку вимкніть перевірку «exact».</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Набуде чинності після перезапуску.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Мова системи</translation>
     </message>

--- a/labelme/translate/vi_VN.ts
+++ b/labelme/translate/vi_VN.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>Chú thích dữ liệu với sự hỗ trợ của AI</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI gợi ý chú thích trong các chế độ 'AI-Points' và 'AI-Box'</translation>
+        <translation>AI gợi ý chú thích trong các chế độ &apos;AI-Points&apos; và &apos;AI-Box&apos;</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>Chọn chế độ 'AI-Points' hoặc 'AI-Box' để bật Chú thích Hỗ trợ AI</translation>
+        <translation>Chọn chế độ &apos;AI-Points&apos; hoặc &apos;AI-Box&apos; để bật Chú thích Hỗ trợ AI</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI Văn bản sang Chú thích</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>ví dụ: chó,mèo,chim</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>Chạy</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>Điểm số</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI tạo chú thích từ lời nhắc văn bản</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>Chọn chế độ 'Polygon', 'Rectangle' hoặc 'AI-Points' để bật</translation>
+        <translation>Chọn chế độ &apos;Polygon&apos;, &apos;Rectangle&apos; hoặc &apos;AI-Points&apos; để bật</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>Độ sáng/Độ tương phản</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>Nhấn và kéo để di chuyển điểm</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>Nhấn và kéo để di chuyển hình dạng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>Đang tạo %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>Nhấn ESC để hủy</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>Nhấn Enter hoặc Space để hoàn tất</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>Chỉnh sửa hình dạng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>Nhấn điểm bắt đầu cho đường thẳng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>Nhấn điểm kết thúc cho đường thẳng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>Nhấn điểm bắt đầu cho đường gấp khúc</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>Nhấn điểm tiếp theo hoặc hoàn tất bằng Ctrl/Cmd+Nhấn cho đường gấp khúc</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>Nhấn điểm trung tâm cho hình tròn</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>Nhấn điểm trên chu vi cho hình tròn</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>Nhấn góc đầu tiên cho hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>Nhấn để thêm điểm</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + Nhấn để xóa điểm</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + Nhấn để tạo điểm trên hình dạng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>Nhấn chuột phải và kéo để sao chép hình dạng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>Nhấn góc đối diện cho hình chữ nhật (Shift để tạo hình vuông)</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>Nhấp điểm để bao gồm hoặc Shift+Click để loại trừ. Ctrl+LeftClick kết thúc tạo.</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>Nhấp vào góc đầu tiên của bbox để phân đoạn AI</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>Nhấp vào góc đối diện để phân đoạn đối tượng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>Nhấn góc đầu tiên cho hình chữ nhật có hướng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>Nhấn góc thứ hai để đặt hướng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>Nhấn góc thứ ba để đóng hình chữ nhật có hướng</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>Nhấn và kéo để xoay hình dạng</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>Cờ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>Danh sách Chú thích</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>Chọn nhãn để bắt đầu chú thích. Nhấn 'Esc' để bỏ chọn.</translation>
+        <translation>Chọn nhãn để bắt đầu chú thích. Nhấn &apos;Esc&apos; để bỏ chọn.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>Danh sách Nhãn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>Tìm kiếm Tên tệp</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>Danh sách Tệp</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>Thoát(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>Thoát ứng dụng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>Mở(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>Mở tệp hình ảnh hoặc nhãn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>Mở Thư mục</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>Hình ảnh Tiếp theo(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>Mở tiếp theo (giữ Ctl+Shift để sao chép nhãn)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>Hình ảnh Trước(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>Mở trước đó (giữ Ctl+Shift để sao chép nhãn)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>Lưu(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>Lưu nhãn vào tệp</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>Lưu thành(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>Lưu nhãn vào tệp khác</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>Xóa(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>Xóa tệp nhãn hiện tại</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>Thay đổi Thư mục Đầu ra(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>Thay đổi nơi chú thích được tải/lưu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>Tự động lưu (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>Tự động lưu</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>Lưu với Dữ liệu Hình ảnh</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>Lưu dữ liệu hình ảnh trong tệp nhãn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>Đóng(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>Đóng tệp hiện tại</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>Giữ Chú thích Trước đó</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>Bắt đầu vẽ đa giác</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>Bắt đầu vẽ hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>Bắt đầu vẽ hình tròn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>Bắt đầu vẽ đường thẳng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>Bắt đầu vẽ điểm</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>Bắt đầu vẽ đường gấp khúc. Ctrl+Nhấn chuột trái để kết thúc tạo.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>Chỉnh sửa Hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>Di chuyển và chỉnh sửa các hình dạng đã chọn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>Xóa Hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>Xóa các hình dạng đã chọn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>Nhân đôi Hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>Tạo bản sao của các hình dạng đã chọn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>Sao chép Hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>Sao chép các hình dạng đã chọn vào clipboard</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>Dán Hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>Dán các hình dạng đã sao chép</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>Hoàn tác điểm cuối cùng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>Hoàn tác điểm vẽ cuối cùng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>Xóa Điểm đã Chọn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>Xóa điểm đã chọn khỏi đa giác</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>Hoàn tác</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>Hoàn tác lần thêm và chỉnh sửa hình dạng cuối cùng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>Ẩn Hình dạng(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>Ẩn tất cả hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>Hiển thị Hình dạng(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>Hiển thị tất cả hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>Bật/tắt Hình dạng(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>Bật/tắt tất cả hình dạng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>Hướng dẫn(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>Hiển thị trang hướng dẫn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>Thu phóng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+Bánh xe</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>Phóng to(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>Tăng mức thu phóng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>Thu nhỏ(&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>Giảm mức thu phóng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>Kích thước Gốc(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>Thu phóng về kích thước gốc</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>Vừa Cửa sổ(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>Thu phóng theo kích thước cửa sổ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>Vừa Chiều rộng(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>Thu phóng theo chiều rộng cửa sổ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>Độ sáng Độ tương phản(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>Điều chỉnh độ sáng và độ tương phản</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>Chỉnh sửa Nhãn(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>Sửa đổi nhãn của hình dạng đã chọn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>Tô Đa giác Vẽ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>Tô đa giác khi vẽ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>Tệp(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>Chỉnh sửa(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>Xem(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>Trợ giúp(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s đã khởi động.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>Nhãn không hợp lệ</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>Nhãn không hợp lệ '{}' với loại xác thực '{}'</translation>
+        <translation>Nhãn không hợp lệ &apos;{}&apos; với loại xác thực &apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>Lỗi khi lưu dữ liệu nhãn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>Lỗi khi mở tệp</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>Không có tệp như vậy: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>Đang tải %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>Đã tải %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>Tệp Hình ảnh &amp; Nhãn (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - Chọn tệp Hình ảnh hoặc Nhãn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - Lưu/Tải Chú thích trong Thư mục</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . Chú thích sẽ được lưu/tải trong %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - Chọn Tệp</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>Tệp nhãn (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>Chọn Tệp</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>Chú ý</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>Lưu chú thích vào &quot;{}&quot; trước khi đóng?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>Lưu chú thích?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - Mở Thư mục</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>Bật/tắt chế độ &quot;giữ chú thích trước đó&quot;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>Giữ Độ sáng/Độ tương phản Trước đó</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>Lỗi Cấu hình</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>Đã tìm thấy lỗi khi tải cấu hình. Vui lòng xem lại các lỗi bên dưới và tải lại cấu hình hoặc bỏ qua các dòng bị lỗi.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>Đặt lại bố cục</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>Đa giác</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>Hình chữ nhật</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>Hình tròn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>Đường thẳng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>Điểm</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>Đường gấp khúc</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>Nhấp điểm để phân đoạn đối tượng. Ctrl+LeftClick kết thúc tạo.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>Vẽ một hộp giới hạn để phân đoạn đối tượng.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points không khả dụng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s không hỗ trợ gợi ý điểm.
 Vui lòng chọn mô hình khác hoặc sử dụng chế độ AI-Box.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>Danh sách tệp bị tắt khi mở tệp nhãn</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>Thêm điểm vào cạnh</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>Chèn điểm mới vào cạnh đa giác đang trỏ tới</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>Giữ &amp;Mức Phóng to Trước đó</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>Xóa vĩnh viễn tệp nhãn này? Hành động này không thể hoàn tác.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>Xóa vĩnh viễn {} hình dạng? Hành động này không thể hoàn tác.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>Phóng to hoặc thu nhỏ hình ảnh. Các phím tắt {} và {} cũng hoạt động trên canvas.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>Định dạng cho phép: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>Không thể mở tệp nhãn đã chọn: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>Không thể mở tệp ảnh đã chọn: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>Không thể tải: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>Hình chữ nhật có hướng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>Bắt đầu vẽ hình chữ nhật có hướng</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>Suy luận AI không tạo ra chú thích mới nào.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>Hình không có diện tích; không có gì được tạo.</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>Cài đặt…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>Chỉnh sửa cài đặt</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>Cài đặt được quản lý qua --config trong phiên này</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Lỗi Cấu hình</translation>
     </message>
@@ -897,82 +723,66 @@ Vui lòng chọn mô hình khác hoặc sử dụng chế độ AI-Box.</transla
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>Chung</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>Nhãn</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>Hiển thị cửa sổ nhãn khi tạo hình dạng mới</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>Nhãn định sẵn</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>Kiểm tra nhãn</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>Cài đặt</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>Mở tệp cấu hình dưới dạng văn bản…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>Chỉnh sửa trong tệp văn bản sẽ áp dụng sau khi khởi động lại</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>Đóng</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>(không có)</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>mỗi dòng một mục</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>Lỗi Cấu hình</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
-        <translation>Nhãn định sẵn không được để trống khi kiểm tra nhãn được đặt thành 'exact'. Vui lòng tắt kiểm tra 'exact' trước.</translation>
+        <translation>Nhãn định sẵn không được để trống khi kiểm tra nhãn được đặt thành &apos;exact&apos;. Vui lòng tắt kiểm tra &apos;exact&apos; trước.</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>Ngôn ngữ</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>Có hiệu lực sau khi khởi động lại.</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>Mặc định của hệ thống</translation>
     </message>

--- a/labelme/translate/zh_CN.ts
+++ b/labelme/translate/zh_CN.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>AI 辅助标注</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>在 'AI-Points' 和 'AI-Box' 模式下，AI 会提供标注建议</translation>
+        <translation>在 &apos;AI-Points&apos; 和 &apos;AI-Box&apos; 模式下，AI 会提供标注建议</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>请选择 'AI-Points' 或 'AI-Box' 模式以启用 AI 辅助标注</translation>
+        <translation>请选择 &apos;AI-Points&apos; 或 &apos;AI-Box&apos; 模式以启用 AI 辅助标注</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI 文本转标注</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>例如：dog,cat,bird</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>得分</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI 将根据文本提示生成标注</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>请选择 'Polygon'、'Rectangle' 或 'AI-Points' 模式以启用</translation>
+        <translation>请选择 &apos;Polygon&apos;、&apos;Rectangle&apos; 或 &apos;AI-Points&apos; 模式以启用</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>亮度/对比度</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>按住鼠标拖动以移动顶点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>按住鼠标拖动以移动形状</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>正在创建 %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>按 ESC 键取消</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>按 Enter 或空格键确认</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>正在编辑形状</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>单击确定直线起点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>单击确定直线终点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>单击确定折线起点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>单击添加下一个顶点；按住 Ctrl/Cmd 并单击以结束折线</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>单击确定圆心</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>单击圆周上的点以确定圆形</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>单击确定矩形的第一个角</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>单击以添加顶点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>按住 ALT + SHIFT 并单击以删除顶点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>按住 ALT 并单击以在形状上添加顶点</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>按住鼠标右键拖动以复制形状</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>单击对角以确定矩形（按住 Shift 绘制正方形）</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>单击添加包含点；按住 Shift 并单击添加排除点；按住 Ctrl 并单击结束创建。</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>单击确定 AI 分割边界框的第一个角</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>单击对角以分割对象</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>单击确定有向矩形的第一个角</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>单击第二个角以设定方向</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>单击第三个角以闭合有向矩形</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>按住鼠标左键拖动以旋转形状</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>标记</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>标注列表</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>选择标签以开始标注；按 'Esc' 取消选择。</translation>
+        <translation>选择标签以开始标注；按 &apos;Esc&apos; 取消选择。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>标签列表</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>搜索文件名</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>文件列表</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>退出应用</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>打开(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>打开图像或标签文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>打开目录</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>下一张图像(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>打开下一张（按住 Ctrl+Shift 可复制标签）</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>上一张图像(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>打开上一张（按住 Ctrl+Shift 可复制标签）</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>保存(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>保存标签至文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>另存为(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>将标签另存至其他文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>删除文件(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>删除当前的标签文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>更改输出目录(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>更改标注的加载与保存位置</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>自动保存(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>自动保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>连同图像数据一并保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>将图像数据写入标签文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>关闭(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>关闭当前文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>保留上一次的标注</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>开始绘制多边形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>开始绘制矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>开始绘制圆形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>开始绘制直线</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>开始绘制点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>开始绘制折线；按住 Ctrl 并单击结束创建。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>编辑形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>移动并编辑所选形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>删除形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>删除所选形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>创建形状副本</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>为所选形状创建副本</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>复制形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>将所选形状复制至剪贴板</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>粘贴形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>粘贴已复制的形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>撤销上一个顶点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>撤销上一次绘制的顶点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>移除所选顶点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>从多边形中移除所选顶点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>撤销</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>撤销对形状的最近一次添加或编辑</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>隐藏形状(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>隐藏全部形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>显示形状(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>显示全部形状</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>切换形状显示(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>切换全部形状的显示状态</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>教程(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>打开教程页面</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>缩放</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+滚轮</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>放大(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>提高缩放级别</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>缩小(&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>降低缩放级别</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>原始尺寸(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>缩放至原始尺寸</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>适合窗口(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>随窗口大小自动缩放</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>适合宽度(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>随窗口宽度自动缩放</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>亮度与对比度(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>调整亮度与对比度</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>编辑标签(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>修改所选形状的标签</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>填充正在绘制的多边形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>绘制过程中填充多边形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>编辑(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>视图(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>帮助(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s 已启动。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>标签无效</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>标签 '{}' 无效（验证类型为 '{}'）</translation>
+        <translation>标签 &apos;{}&apos; 无效（验证类型为 &apos;{}&apos;）</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>保存标签数据时出错</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>打开文件时出错</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>文件未找到：&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>正在加载 %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>已加载 %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>图像与标签文件 (%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - 选择图像或标签文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - 在目录中加载与保存标注</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s。标注将在 %s 中加载与保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - 选择文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>标签文件 (*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>选择文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>关闭前是否将标注保存至 &quot;{}&quot;？</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>是否保存标注？</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - 打开目录</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>切换“保留上一次的标注”模式</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>保留上一次的亮度/对比度</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>配置错误</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>加载配置时发现错误。请查看下方的错误信息，并重新加载配置或忽略有误的行。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>重置布局</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>多边形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>圆形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>直线</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>折线</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>单击添加点以分割对象；按住 Ctrl 并单击结束创建。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>绘制边界框以分割对象。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points 不可用</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s 不支持点提示。
 请另选模型，或改用 AI-Box 模式。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>打开标签文件时，文件列表不可用</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>在边上添加顶点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>在悬停的多边形边上插入新顶点</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>保留上一次的缩放(&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>永久删除该标签文件？此操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>永久删除 {} 个形状？此操作无法撤销。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>放大或缩小图像；也可在画布上使用 {} 与 {}。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>支持的格式: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>无法打开所选标签文件: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>无法打开所选图像文件: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>加载失败：{path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>有向矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>开始绘制有向矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>AI 推理未生成新标注。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>形状面积为零，未创建。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>设置…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>编辑设置</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>本次会话的设置通过 --config 管理</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>配置错误</translation>
     </message>
@@ -897,82 +723,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>通用</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>新建形状时显示标签弹窗</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>预定义标签</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>标签验证</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>以文本方式打开配置文件…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>在文本文件中所做的修改将在重启后生效</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>（无）</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>每行一项</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>配置错误</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>当标签验证设置为“exact”时，预定义标签不能为空。请先禁用“exact”验证。</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>重新启动后生效。</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>系统默认</translation>
     </message>

--- a/labelme/translate/zh_TW.ts
+++ b/labelme/translate/zh_TW.ts
@@ -4,63 +4,52 @@
 <context>
     <name>AiAssistedAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI-Assisted Annotation</source>
         <translation>AI輔助標註</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>AI suggests annotation in &apos;AI-Points&apos; and &apos;AI-Box&apos; modes</source>
-        <translation>AI在'AI-Points'和'AI-Box'模式下建議標註</translation>
+        <translation>AI在&apos;AI-Points&apos;和&apos;AI-Box&apos;模式下建議標註</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_assisted_annotation_widget.py" line="0"/>
         <source>Select &apos;AI-Points&apos; or &apos;AI-Box&apos; mode to enable AI-Assisted Annotation</source>
-        <translation>選擇'AI-Points'或'AI-Box'模式以啟用AI輔助標註</translation>
+        <translation>選擇&apos;AI-Points&apos;或&apos;AI-Box&apos;模式以啟用AI輔助標註</translation>
     </message>
 </context>
 <context>
     <name>AiTextToAnnotationWidget</name>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI Text-to-Annotation</source>
         <translation>AI提示</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>e.g., dog,cat,bird</source>
         <translation>例如：狗,貓,鳥</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Run</source>
         <translation>執行</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Score</source>
         <translation>分數</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>IoU</source>
         <translation>IoU</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>AI creates annotations from the text prompt</source>
         <translation>AI根據文字提示創建標註</translation>
     </message>
     <message>
-        <location filename="../widgets/_ai_text_to_annotation_widget.py" line="0"/>
         <source>Select &apos;Polygon&apos;, &apos;Rectangle&apos;, or &apos;AI-Points&apos; mode to enable</source>
-        <translation>選擇'Polygon'、'Rectangle'或'AI-Points'模式以啟用</translation>
+        <translation>選擇&apos;Polygon&apos;、&apos;Rectangle&apos;或&apos;AI-Points&apos;模式以啟用</translation>
     </message>
 </context>
 <context>
     <name>BrightnessContrastDialog</name>
     <message>
-        <location filename="../widgets/brightness_contrast_dialog.py" line="0"/>
         <source>Brightness/Contrast</source>
         <translation>亮度/對比度</translation>
     </message>
@@ -68,127 +57,102 @@
 <context>
     <name>Canvas</name>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move point</source>
         <translation>點擊並拖拽以移動控制點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to move shape</source>
         <translation>點擊並拖拽以移動形狀</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Creating %r</source>
         <translation>正在創建 %r</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ESC to cancel</source>
         <translation>按 ESC 取消</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Enter or Space to finalize</source>
         <translation>按 Enter 或空格鍵完成</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Editing shapes</source>
         <translation>編輯形狀</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for line</source>
         <translation>點擊線段起點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click end point for line</source>
         <translation>點擊線段終點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click start point for linestrip</source>
         <translation>點擊折線起點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click next point or finish by Ctrl/Cmd+Click for linestrip</source>
         <translation>點擊下一個點或 Ctrl/Cmd+點擊完成折線</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click center point for circle</source>
         <translation>點擊圓形中心點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click point on circumference for circle</source>
         <translation>點擊圓周上的點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for rectangle</source>
         <translation>點擊矩形第一個角</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click to add point</source>
         <translation>點擊以添加點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + SHIFT + Click to delete point</source>
         <translation>ALT + SHIFT + 點擊以刪除點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>ALT + Click to create point on shape</source>
         <translation>ALT + 點擊在形狀上創建點</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Right-click &amp; drag to copy shape</source>
         <translation>右鍵點擊並拖拽以複製形狀</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner for rectangle (Shift for square)</source>
         <translation>點擊矩形對角（Shift繪製正方形）</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click points to include or Shift+Click to exclude. Ctrl+LeftClick ends creation.</source>
         <translation>點擊添加包含點或Shift+Click添加排除點。Ctrl+LeftClick結束創建。</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner of bbox for AI segmentation</source>
         <translation>點擊bbox的第一個角進行AI分割</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click opposite corner to segment object</source>
         <translation>點擊對角以分割物件</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click first corner for oriented rectangle</source>
         <translation>點擊有向矩形的第一個角</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click second corner to set orientation</source>
         <translation>點擊第二個角以設定方向</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click third corner to close oriented rectangle</source>
         <translation>點擊第三個角以閉合有向矩形</translation>
     </message>
     <message>
-        <location filename="../widgets/canvas.py" line="0"/>
         <source>Click &amp; drag to rotate the shape</source>
         <translation>點擊並拖拽以旋轉形狀</translation>
     </message>
@@ -196,700 +160,562 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Flags</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Annotation List</source>
         <translation>批註列表</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Select label to start annotating for it. Press &apos;Esc&apos; to deselect.</source>
-        <translation>選擇標籤類型並開始以其標註。按'Esc'取消選擇。</translation>
+        <translation>選擇標籤類型並開始以其標註。按&apos;Esc&apos;取消選擇。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label List</source>
         <translation>標籤列表</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Search Filename</source>
         <translation>按文件名檢索</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File List</source>
         <translation>文件列表</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Quit application</source>
         <translation>退出應用</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Open
 </source>
         <translation>打開(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open image or label file</source>
         <translation>打開圖像或標籤文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open Dir</source>
         <translation>打開目錄</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Next Image</source>
         <translation>下一幅(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open next (hold Ctl+Shift to copy labels)</source>
         <translation>打開下一幅（按 Ctrl+Shift 複製標籤）</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Prev Image</source>
         <translation>上一幅(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Open prev (hold Ctl+Shift to copy labels)</source>
         <translation>打開上一幅（按 Ctrl+Shift 複製標籤）</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save
 </source>
         <translation>保存(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to file</source>
         <translation>保存標籤到文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Save As</source>
         <translation>另存為(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save labels to a different file</source>
         <translation>保存標籤到不同的文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Delete File</source>
         <translation>刪除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete current label file</source>
         <translation>刪除當前標籤文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Change Output Dir</source>
         <translation>更改輸出路徑(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Change where annotations are loaded/saved</source>
         <translation>更改載入、保存標註的路徑</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save &amp;Automatically</source>
         <translation>自動保存(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save automatically</source>
         <translation>自動保存</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save With Image Data</source>
         <translation>同時保存圖像數據</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save image data in label file</source>
         <translation>將圖像數據保存到標籤文件中</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Close</source>
         <translation>關閉(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Close current file</source>
         <translation>關閉當前文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Annotation</source>
         <translation>保留上一個標註</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing polygons</source>
         <translation>開始繪製多邊形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing rectangles</source>
         <translation>開始繪製矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing circles</source>
         <translation>開始繪製圓形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing lines</source>
         <translation>開始繪製直線</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing points</source>
         <translation>開始繪製控制點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing linestrip. Ctrl+LeftClick ends creation.</source>
         <translation>開始繪製折線。Ctrl+單擊左鍵結束繪製。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit Shapes</source>
         <translation>編輯圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Move and edit the selected shapes</source>
         <translation>移動、編輯選中的圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete Shapes</source>
         <translation>刪除圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Delete the selected shapes</source>
         <translation>刪除選中的圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Duplicate Shapes</source>
         <translation>複製圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Create a duplicate of the selected shapes</source>
         <translation>為選中的圖形創建副本</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy Shapes</source>
         <translation>複製圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Copy selected shapes to clipboard</source>
         <translation>複製選中圖形到剪貼板</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste Shapes</source>
         <translation>粘貼圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Paste copied shapes</source>
         <translation>粘貼已複製的圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last point</source>
         <translation>撤銷最後的控制點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last drawn point</source>
         <translation>撤銷最後一次繪製的控制點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove Selected Point</source>
         <translation>移除選中的控制點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Remove selected point from polygon</source>
         <translation>從多邊形中移除選中的控制點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo
 </source>
         <translation>撤銷</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Undo last add and edit of shape</source>
         <translation>撤銷最近一次添加和編輯</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Hide
 Shapes</source>
         <translation>隱藏圖形(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Hide all shapes</source>
         <translation>隱藏所有圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Show
 Shapes</source>
         <translation>顯示圖形(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show all shapes</source>
         <translation>顯示所有圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Toggle
 Shapes</source>
         <translation>開關圖形(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle all shapes</source>
         <translation>開關所有圖形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Tutorial</source>
         <translation>教程[&amp;T]</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Show tutorial page</source>
         <translation>顯示教程網頁</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom</source>
         <translation>縮放</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Ctrl+Wheel</source>
         <translation>Ctrl+滾輪</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom &amp;In</source>
         <translation>放大(&amp;I)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Increase zoom level</source>
         <translation>增加縮放水平</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Zoom Out</source>
         <translation>縮小(&amp;Z)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Decrease zoom level</source>
         <translation>減小縮放水平</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Original size</source>
         <translation>原始大小(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom to original size</source>
         <translation>縮放至原始大小</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Fit Window</source>
         <translation>適應窗口(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window size</source>
         <translation>跟隨窗口大小縮放</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fit &amp;Width</source>
         <translation>適應寬度(&amp;W)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom follows window width</source>
         <translation>跟隨窗口寬度縮放</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Brightness Contrast</source>
         <translation>亮度 對比度(&amp;B)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Adjust brightness and contrast</source>
         <translation>調節亮度和對比度</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit Label</source>
         <translation>編輯標籤(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Modify the label of the selected shape</source>
         <translation>修改選中圖形的標籤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill Drawing Polygon</source>
         <translation>填充所繪多邊形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Fill polygon while drawing</source>
         <translation>繪製時填充多邊形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Edit</source>
         <translation>編輯(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;View</source>
         <translation>視圖(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Help</source>
         <translation>幫助(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s started.</source>
         <translation>%s 已啟動</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label</source>
         <translation>無效的標籤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Invalid label &apos;{}&apos; with validation type &apos;{}&apos;</source>
-        <translation>無效的標籤'{}'，驗證類型'{}'</translation>
+        <translation>無效的標籤&apos;{}&apos;，驗證類型&apos;{}&apos;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error saving label data</source>
         <translation>保存標籤發生錯誤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&lt;b&gt;%s&lt;/b&gt;</source>
         <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Error opening file</source>
         <translation>打開文件發生錯誤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>No such file: &lt;b&gt;%s&lt;/b&gt;</source>
         <translation>文件不存在: &lt;b&gt;%s&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loading %s...</source>
         <translation>正在載入 %s...</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Loaded %s</source>
         <translation>已載入 %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Image &amp; Label files (%s)</source>
         <translation>圖像和標籤文件(%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose Image or Label file</source>
         <translation>%s - 選擇圖像或標籤文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Save/Load Annotations in Directory</source>
         <translation>%s - 保存和載入批註的路徑</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s . Annotations will be saved/loaded in %s</source>
         <translation>%s . 批註會被載入和保存在 %s</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Choose File</source>
         <translation>%s - 選擇文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Label files (*%s)</source>
         <translation>標籤文件(*%s)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Choose File</source>
         <translation>選擇文件</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Attention</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations to &quot;{}&quot; before closing?</source>
         <translation>關閉前保存批註到&quot;{}&quot;嗎?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Save annotations?</source>
         <translation>保存批註嗎?</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s - Open Directory</source>
         <translation>%s - 打開目錄</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Toggle &quot;keep previous annotation&quot; mode</source>
         <translation>開關「保留上一個標註」模式</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Keep Previous Brightness/Contrast</source>
         <translation>保留之前的亮度/對比度</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Errors</source>
         <translation>設定錯誤</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Errors were found while loading the configuration. Please review the errors below and reload your configuration or ignore the erroneous lines.</source>
         <translation>載入設定時發現錯誤。請檢查以下錯誤並重新載入設定，或忽略錯誤的行。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Reset Layout</source>
         <translation>重置佈局</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Polygon</source>
         <translation>多邊形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Rectangle</source>
         <translation>矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Circle</source>
         <translation>圓形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Line</source>
         <translation>直線</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Point</source>
         <translation>控制點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>LineStrip</source>
         <translation>折線</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points</source>
         <translation>AI-Points</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Click points to segment object. Ctrl+LeftClick ends creation.</source>
         <translation>點擊添加點以分割對象。Ctrl+LeftClick結束創建。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Box</source>
         <translation>AI-Box</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Draw a bounding box to segment object.</source>
         <translation>繪製邊界框以分割物件。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI-Points Unavailable</source>
         <translation>AI-Points 無法使用</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>%s does not support point prompts.
 Please select a different model or use AI-Box mode.</source>
         <translation>%s 不支援點提示。
 請選擇其他模型或使用 AI-Box 模式。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>File list is disabled when a label file is opened</source>
         <translation>開啟標籤檔案時，檔案列表已停用</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Add Point to Edge</source>
         <translation>在邊上新增頂點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Insert a new point at the hovered polygon edge</source>
         <translation>在游標所在的多邊形邊上插入新頂點</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>&amp;Keep Previous Zoom</source>
         <translation>保留上一個縮放(&amp;K)</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete this label file? This action cannot be undone.</source>
         <translation>永久刪除此標籤文件？此操作無法復原。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Permanently delete {} shapes? This action cannot be undone.</source>
         <translation>永久刪除{}個圖形？此操作無法復原。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Zoom the image in or out. The shortcuts {} and {} also work on the canvas.</source>
         <translation>縮放圖像。快捷鍵{}和{}亦可在畫布上使用。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Allowed formats: {formats}</source>
         <translation>支援的格式: {formats}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected label file could not be opened: {path}</source>
         <translation>無法開啟所選標籤檔案: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>The selected image file could not be opened: {path}</source>
         <translation>無法開啟所選影像檔案: {path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Failed to load: {path}</source>
         <translation>載入失敗：{path}</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Oriented Rectangle</source>
         <translation>有向矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Start drawing oriented rectangles</source>
         <translation>開始繪製有向矩形</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>AI inference produced no new annotation.</source>
         <translation>AI 推理未產生新標註。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Shape had no area; nothing created.</source>
         <translation>形狀面積為零，未建立。</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings…</source>
         <translation>設定…</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Edit settings</source>
         <translation>編輯設定</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Settings are managed via --config for this session</source>
         <translation>本次工作階段的設定由 --config 管理</translation>
     </message>
     <message>
-        <location filename="../app.py" line="0"/>
         <source>Configuration Error</source>
         <translation>設定錯誤</translation>
     </message>
@@ -897,82 +723,66 @@ Please select a different model or use AI-Box mode.</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Labels</source>
         <translation>標籤</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Show label popup on new shape</source>
         <translation>建立新形狀時顯示標籤快顯視窗</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Predefined labels</source>
         <translation>預定義標籤</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Label validation</source>
         <translation>標籤驗證</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Open config file as text…</source>
         <translation>以純文字開啟設定檔…</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Edits made in the text file apply after restart</source>
         <translation>文字檔案中的變更將在重新啟動後生效</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>(none)</source>
         <translation>（無）</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>one item per line</source>
         <translation>每行一個項目</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Configuration Error</source>
         <translation>設定錯誤</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>Predefined labels cannot be empty while Label validation is set to exact. Disable exact validation first.</source>
         <translation>當標籤驗證設定為「exact」時，預定義標籤不能為空。請先停用「exact」驗證。</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Language</source>
         <translation>語言</translation>
     </message>
     <message>
-        <location filename="../_config/_schema.py" line="0"/>
         <source>Takes effect after restart.</source>
         <translation>重新啟動後生效。</translation>
     </message>
     <message>
-        <location filename="../widgets/settings_dialog.py" line="0"/>
         <source>System default</source>
         <translation>系統預設</translation>
     </message>

--- a/tools/update_translate.py
+++ b/tools/update_translate.py
@@ -1,4 +1,3 @@
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -25,32 +24,31 @@ def main() -> None:
 
     labelme_translate_path: Path = labelme_path / "translate"
 
-    pylupdate_version: str = (
-        subprocess.check_output(["pylupdate5", "-version"], stderr=subprocess.STDOUT)
+    lupdate_version: str = (
+        subprocess.check_output(
+            ["pyside6-lupdate", "-version"], stderr=subprocess.STDOUT
+        )
         .decode()
         .split()[-1]
-        .lstrip("v")
     )
-    logger.info("using pylupdate5 version: {}", pylupdate_version)
-    if pylupdate_version.split(".")[:2] != ["5", "15"]:
-        logger.warning("pylupdate5 version is not 5.15.x, skipping .ts generation")
-        return
+    logger.info("using pyside6-lupdate version: {}", lupdate_version)
 
     lrelease_version: str = (
-        subprocess.check_output(["lrelease", "-version"]).decode().split()[-1]
+        subprocess.check_output(["pyside6-lrelease", "-version"]).decode().split()[-1]
     )
-    logger.info("using lrelease version: {}", lrelease_version)
-    if lrelease_version.split(".")[:2] != ["5", "15"]:
-        logger.warning("lrelease version is not 5.15.x, skipping .qm generation")
-        return
+    logger.info("using pyside6-lrelease version: {}", lrelease_version)
 
     ts_paths: list[Path] = sorted(labelme_translate_path.glob("*.ts"))
 
-    # Batch all languages into a single pylupdate5 call (~10x faster)
+    # Batch all languages into a single pyside6-lupdate call (~10x faster).
+    # -locations none keeps diffs stable across code edits by omitting source
+    # file/line references that would otherwise churn on every change.
     subprocess.check_call(
         [
-            "pylupdate5",
-            "-noobsolete",
+            "pyside6-lupdate",
+            "-no-obsolete",
+            "-locations",
+            "none",
             *labelme_files,
             "-ts",
             *ts_paths,
@@ -58,20 +56,14 @@ def main() -> None:
     )
 
     for ts_path in ts_paths:
-        ts_content: str = ts_path.read_text()
-        new_ts_content: str = re.sub(r'line="\d+"', 'line="0"', ts_content)
-        if ts_content == new_ts_content:
-            raise RuntimeError(f"no line numbers found in {ts_path}")
-        ts_path.write_text(new_ts_content)
-
         qm_path: Path = ts_path.with_suffix(".qm")
         subprocess.check_call(
-            ["lrelease", ts_path, "-qm", qm_path],
+            ["pyside6-lrelease", ts_path, "-qm", qm_path],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
         if not qm_path.exists():
-            raise RuntimeError(f"lrelease did not produce {qm_path}")
+            raise RuntimeError(f"pyside6-lrelease did not produce {qm_path}")
 
     logger.info("updated {} languages", len(ts_paths))
 


### PR DESCRIPTION
## Summary

- Switch `tools/update_translate.py` from PyQt5's `pylupdate5`/`lrelease` to PySide6's `pyside6-lupdate`/`pyside6-lrelease`, which ship with the already-pinned `pyside6` dependency, so no external Qt5 tools are needed.
- Pass `-locations none` so `.ts` files omit source file/line references natively. This replaces the regex pass that rewrote `line="N"` to `line="0"` to keep diffs stable across code edits.
- Drop the `5.15.x` version gate: the bundled tools track the pinned `pyside6`, so the version is now informational only (still logged).
- Regenerate all 20 `labelme/translate/*.ts`; `<location>` elements are gone and apostrophes are normalized to `&apos;`. Compiled `.qm` output is byte-identical.

## Test plan

- [x] `uv run tools/update_translate.py` regenerates all 20 languages with 0 unfinished strings
- [x] `make lint` (ruff format/check, ty)

## Note

CI still installs the Qt5 `qttools5-dev` apt package in `lint.yml`, but `lint` stopped invoking the translation tools in `db6b2bcc`, so it is already orphaned and unrelated to this change. Left out to keep this PR surgical; can be removed separately.
