### PR TITLE
fix(discord-notify): stop at any trailing section, not just Test plan

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -30,11 +30,12 @@ jobs:
           fi
           TITLE_ESCAPED=$(printf '%s' "$PR_TITLE" | jq -Rs .)
           # Keep only the "## Summary" body: drop that heading and stop at the
-          # "## Test plan" section (per the PR template). Strip CRLF before awk
-          # so the heading anchors match. Cap well under Discord's 4096 limit.
+          # next heading of any kind, so trailing sections (Note for review,
+          # Test plan, etc.) are dropped. Strip CRLF before awk so the heading
+          # anchors match. Cap well under Discord's 4096 limit.
           BODY_ESCAPED=$(printf '%s' "$PR_BODY" | tr -d '\r' | awk '
-            /^#+ +[Tt]est +[Pp]lan/ { exit }
             /^#+ +[Ss]ummary *$/ { next }
+            /^#+ +/ { exit }
             { print }
           ' | jq -Rs '
             sub("^[[:space:]]+"; "") | sub("[[:space:]]+$"; "")


### PR DESCRIPTION
The Discord "new feature merged" notification only stopped extracting the PR
summary at a literal `## Test plan` heading, so any other H2 in between (e.g.
`## Note for review`, `## Scope`) leaked into the embed. It now stops at the
next heading of any kind, keeping just the summary body.

PRs without a `## Summary` heading (whose whole body up to the first section is
the summary) are unchanged: the leading prose is still kept.

## Test plan
- [x] Ran the awk against real merged feat PR bodies: #2120 (`## Summary` + `## Scope` + `## Test plan`) now drops `## Scope` onward; #2134 (no `## Summary`, has a code fence) keeps its full prose unchanged.
