### PR TITLE
test: cover masks_to_bboxes happy path, guards, and empty mask

### DIFF
--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -111,3 +111,36 @@ def test_shape_to_mask_rectangle_reversed_coords() -> None:
     assert np.array_equal(mask_tl_br, mask_tr_bl)
     assert np.array_equal(mask_tl_br, mask_bl_tr)
     assert mask_tl_br.sum() > 0
+
+
+def test_masks_to_bboxes_returns_yxyx_bboxes() -> None:
+    masks = np.zeros((2, 10, 10), dtype=bool)
+    masks[0, 2:5, 3:7] = True
+    masks[1, 0:3, 0:4] = True
+    bboxes = shape_module.masks_to_bboxes(masks)
+    assert bboxes.shape == (2, 4)
+    assert bboxes.dtype == np.float32
+    # bboxes are returned in (y1, x1, y2, x2) order, not the more common xyxy.
+    assert np.array_equal(bboxes[0], [2, 3, 5, 7])
+    assert np.array_equal(bboxes[1], [0, 0, 3, 4])
+
+
+def test_masks_to_bboxes_raises_for_wrong_ndim() -> None:
+    masks = np.zeros((10, 10), dtype=bool)
+    with pytest.raises(ValueError, match=r"masks\.ndim must be 3"):
+        shape_module.masks_to_bboxes(masks)
+
+
+def test_masks_to_bboxes_raises_for_non_bool_dtype() -> None:
+    masks = np.zeros((1, 10, 10), dtype=np.uint8)
+    with pytest.raises(ValueError, match=r"masks\.dtype must be bool"):
+        shape_module.masks_to_bboxes(masks)
+
+
+def test_masks_to_bboxes_raises_for_all_false_mask() -> None:
+    # An all-False mask has no foreground pixels, so no bbox is defined: the
+    # implementation currently raises rather than returning a sentinel. Pin that
+    # behavior without depending on numpy's internal message.
+    masks = np.zeros((1, 10, 10), dtype=bool)
+    with pytest.raises(ValueError):
+        shape_module.masks_to_bboxes(masks)


### PR DESCRIPTION
`labelme.utils.masks_to_bboxes` is part of the public utils API but had no test
coverage. These tests pin its `(y1, x1, y2, x2)` return order, both input
validation guards (`ndim` and `dtype`), and the all-False-mask path.

The all-False case currently raises a numpy-internal `ValueError` (no foreground
pixels, so no bbox is defined); the test characterizes that behavior without
deciding whether an explicit guard or a sentinel return is preferable. That
contract is left for a follow-up.

## Test plan
- [x] `uv run pytest tests/unit/utils/shape_test.py` (11 passed)
- [x] `uv run ruff check` / `ruff format --check` clean
