### PR TITLE
refactor: derive mask-required shape types from a single source

### DIFF
--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -1,6 +1,7 @@
 from ._ai_assist import AiAssistSession
 from ._geometry import shape_to_xyxy_bbox
 from ._osam_session import OsamSession
+from ._shape_builders import MASK_REQUIRED_SHAPE_TYPES
 from ._shape_builders import Detection
 from ._shape_builders import shapes_from_detections
 from ._suppression import suppress_detections_greedy

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Final
+from typing import get_args
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -151,6 +153,19 @@ def _circle_for_detection(detection: Detection) -> Circle | None:
         if radius > 0:
             return Circle(cx=(xmin + xmax) / 2, cy=(ymin + ymax) / 2, radius=radius)
     return None
+
+
+# Output formats that drop a bbox-only detection (the builder returns None when
+# the mask is absent). Derived from _shape_from_detection so it cannot drift; the
+# probe mirrors the runtime warning condition (a box but no mask).
+MASK_REQUIRED_SHAPE_TYPES: Final[frozenset[AiOutputFormat]] = frozenset(
+    shape_type
+    for shape_type in get_args(AiOutputFormat)
+    if _shape_from_detection(
+        detection=Detection(bbox=(0, 0, 1, 1), mask=None), shape_type=shape_type
+    )
+    is None
+)
 
 
 def shapes_from_detections(

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1312,8 +1312,11 @@ class MainWindow(QtWidgets.QMainWindow):
             texts=texts,
         )
 
-        MASK_REQUIRED_SHAPE_TYPES: Final[tuple[str, ...]] = ("polygon", "mask")
-        if masks is None and len(boxes) > 0 and shape_type in MASK_REQUIRED_SHAPE_TYPES:
+        if (
+            masks is None
+            and len(boxes) > 0
+            and shape_type in _automation.MASK_REQUIRED_SHAPE_TYPES
+        ):
             QtWidgets.QMessageBox.warning(
                 self,
                 self.tr("Mask Output Unavailable"),

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+from labelme._automation import MASK_REQUIRED_SHAPE_TYPES
 from labelme._automation import Detection
 from labelme._automation import shapes_from_detections
 
@@ -160,3 +161,7 @@ def test_shapes_from_detections_mask_drops_empty_mask() -> None:
         shape_type="mask",
     )
     assert shapes == []
+
+
+def test_mask_required_shape_types_is_polygon_and_mask() -> None:
+    assert MASK_REQUIRED_SHAPE_TYPES == {"polygon", "mask"}


### PR DESCRIPTION
The set of AI Text-to-Annotation output formats that require a mask was
encoded in two independent places: a local tuple in `_submit_ai_prompt`
gated the "Mask Output Unavailable" warning, while the shape builders
independently encoded the same set by returning `None` when a detection has
no mask. A new mask-only format added to the builders but not the warning
tuple would silently drop every detection with no user feedback (the failure
#2196 set out to prevent).

This derives `MASK_REQUIRED_SHAPE_TYPES` from `_shape_from_detection` itself,
exports it from the `_automation` package, and consumes it in the warning
path. The probe mirrors the runtime warning condition (a box but no mask), so
the set cannot drift from builder behavior.

## Test plan
- [x] Added `test_mask_required_shape_types_is_polygon_and_mask` pinning the
      derived set to `{"polygon", "mask"}`
- [x] `tests/e2e/ai_text_to_annotation_test.py` (exercises the warning path)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check`
- [x] Full suite: `uv run pytest tests/` (434 passed)

Closes #2198
