### PR TITLE
test: cover oriented_rectangle_center geometry and guards

### DIFF
--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -34,6 +34,50 @@ def test_rotate_oriented_rectangle_around_origin() -> None:
         assert (shape.points[i][0], shape.points[i][1]) == pytest.approx((x, y))
 
 
+def test_oriented_rectangle_center_of_axis_aligned() -> None:
+    shape = _make_axis_aligned_oriented_rectangle()
+
+    center = _shape.oriented_rectangle_center(shape=shape)
+
+    assert (center[0], center[1]) == pytest.approx((5.0, 2.0))
+
+
+def test_oriented_rectangle_center_of_rotated_rectangle() -> None:
+    # A non-axis-aligned (45 deg) rectangle, so the center is exercised on a
+    # rotated shape rather than only the trivial axis-aligned case.
+    shape = Shape(
+        shape_type="oriented_rectangle",
+        points=np.array(
+            [(5.0, 0.0), (10.0, 5.0), (5.0, 10.0), (0.0, 5.0)], dtype=np.float64
+        ),
+        closed=True,
+    )
+
+    center = _shape.oriented_rectangle_center(shape=shape)
+
+    assert (center[0], center[1]) == pytest.approx((5.0, 5.0))
+
+
+def test_oriented_rectangle_center_raises_for_wrong_shape_type() -> None:
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array([(0.0, 0.0), (10.0, 4.0)], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match="only defined for oriented rectangles"):
+        _shape.oriented_rectangle_center(shape=shape)
+
+
+def test_oriented_rectangle_center_raises_for_wrong_point_count() -> None:
+    shape = Shape(
+        shape_type="oriented_rectangle",
+        points=np.array([(0.0, 0.0), (10.0, 0.0), (10.0, 4.0)], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match="requires 4 points"):
+        _shape.oriented_rectangle_center(shape=shape)
+
+
 def test_rotate_non_oriented_rectangle_raises() -> None:
     shape = Shape(
         shape_type="rectangle",


### PR DESCRIPTION
`labelme._shape.oriented_rectangle_center` computes the pivot used by all
oriented-rectangle rotation logic (canvas rotation, arrow overlay) but had no
unit coverage. This pins the diagonal-midpoint contract on an axis-aligned and a
rotated rectangle, plus both `ValueError` guards (wrong `shape_type`, wrong point
count). Pure numpy, no Qt.

## Test plan
- [x] `uv run pytest tests/unit/_shape_test.py` (35 passed)
- [x] `uv run ruff check` / `ruff format --check` / `ty check` clean
