### PR TITLE
test: cover keep_prev_brightness/contrast config migration

### DIFF
--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -97,6 +97,27 @@ def test_migrate_polygon_shortcut_skips_when_new_key_exists() -> None:
 
 
 @pytest.mark.parametrize(
+    ("old_config", "expected"),
+    [
+        ({"keep_prev_brightness": True}, {"keep_prev_brightness_contrast": True}),
+        ({"keep_prev_contrast": True}, {"keep_prev_brightness_contrast": True}),
+        (
+            {"keep_prev_brightness": True, "keep_prev_contrast": True},
+            {"keep_prev_brightness_contrast": True},
+        ),
+        ({"keep_prev_brightness": False, "keep_prev_contrast": False}, {}),
+    ],
+    ids=["brightness", "contrast", "both", "both_disabled"],
+)
+def test_migrate_keep_prev_brightness_contrast(
+    old_config: dict[str, bool], expected: dict[str, bool]
+) -> None:
+    config = old_config.copy()
+    _config._migrate_config_from_file(config)
+    assert config == expected
+
+
+@pytest.mark.parametrize(
     ("overrides", "message"),
     [
         (


### PR DESCRIPTION
`_config._migrate_config_from_file` folds the old `keep_prev_brightness` /
`keep_prev_contrast` flags into `keep_prev_brightness_contrast`, but that branch
had no test coverage. This parametrizes the four cases (brightness-only,
contrast-only, both, both-disabled), pinning that either flag triggers the
migration (and the old keys are dropped) while both-disabled leaves no flag.

## Test plan
- [x] `uv run pytest tests/unit/_config_test.py` (28 passed)
- [x] `uv run ruff check` / `ruff format --check` / `ty check` clean
