### PR TITLE
refactor(make): run coverage through the test target via PYTEST_ARGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ update_translate:
 	$(call exec,uv run tools/update_translate.py)
 
 coverage:  # Run tests with coverage
-	$(call exec,uv run pytest -v tests/ --numprocesses=auto --cov=labelme --cov-report=term-missing)
+	$(MAKE) test PYTEST_ARGS="--cov=labelme --cov-report=term-missing"


### PR DESCRIPTION
Make the `coverage` target reuse the `test` target instead of duplicating the pytest invocation:

```make
coverage:  # Run tests with coverage
	$(MAKE) test PYTEST_ARGS="--cov=labelme --cov-report=term-missing"
```

Output stays colored (the `test` target's `exec` wrapper prints the command), and the pytest call now lives in one place. This matches the modern Makefile style in git-hunk and ihq.

Note: this drops `--numprocesses=auto` during coverage (PYTEST_ARGS is overridden), same as git-hunk/ihq.

## Test plan
- [x] `make -n coverage` expands to `make test PYTEST_ARGS=...` then `uv run pytest -v tests/ --cov=labelme --cov-report=term-missing`