### PR TITLE
Modernize LabelDialog for Qt 6

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -260,7 +260,7 @@ class LabelDialog(QtWidgets.QDialog):
             self._update_flags(self.edit.text())
 
         matches = self.label_list.findItems(
-            self.edit.text(), QtCore.Qt.MatchFlag.MatchExactly
+            self.edit.text(), QtCore.Qt.MatchFlag.MatchFixedString
         )
         if matches:
             self.label_list.setCurrentItem(matches[0])

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -1,34 +1,44 @@
 from __future__ import annotations
 
 import re
-from typing import cast
+from typing import Final
 
-from loguru import logger
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-import labelme.utils
+from labelme.utils import label_validator
 
-# TODO(unknown):
-# - Calculate optimal position so as not to go out of screen area.
+_PLACEHOLDER_TEXT: Final[str] = "Enter object label"
+_GROUP_ID_PLACEHOLDER: Final[str] = "Group ID"
+_DESCRIPTION_PLACEHOLDER: Final[str] = "Description"
 
 
 class LabelQLineEdit(QtWidgets.QLineEdit):
+    """QLineEdit that forwards Up/Down key events to a paired list widget."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.list_widget: QtWidgets.QListWidget | None = None
+
     def set_list_widget(self, list_widget: QtWidgets.QListWidget) -> None:
         self.list_widget = list_widget
 
-    def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:
-        if a0.key() in [QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down]:
-            self.list_widget.keyPressEvent(a0)
-        else:
-            super().keyPressEvent(a0)
+    def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
+        key = event.key()
+        if key in (QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down):
+            if self.list_widget is not None:
+                QtWidgets.QApplication.sendEvent(self.list_widget, event)
+            return
+        super().keyPressEvent(event)
 
 
 class LabelDialog(QtWidgets.QDialog):
+    """Dialog for entering label, group id, description, and flags."""
+
     def __init__(
         self,
-        text: str = "Enter object label",
+        text: str = _PLACEHOLDER_TEXT,
         parent: QtWidgets.QWidget | None = None,
         labels: list[str] | None = None,
         sort_labels: bool = True,
@@ -39,201 +49,188 @@ class LabelDialog(QtWidgets.QDialog):
     ) -> None:
         super().__init__(parent)
 
+        self._sort_labels = sort_labels
+        self._flags_spec: dict[str, list[str]] = flags or {}
+        self._label_history: list[str] = []
+
         if fit_to_content is None:
             fit_to_content = {"row": False, "column": True}
         self._fit_to_content = fit_to_content
-        self._sort_labels = sort_labels
-        self._flags = flags or {}
-        self._label_history: list[str] = []
 
-        self.edit = self._build_label_edit(placeholder=text, has_flags=bool(flags))
-        self.edit_group_id = self._build_group_id_edit()
-        self.label_list = self._build_label_list(labels=labels)
-        self.edit.set_list_widget(self.label_list)
-        self._flags_layout = QtWidgets.QVBoxLayout()
-        self._reset_flags()
-        self.edit_description = self._build_description_edit()
-        button_box = self._build_button_box()
+        # Build widgets
+        self.edit = LabelQLineEdit()
+        self.edit.setPlaceholderText(text)
+        self.edit.setValidator(label_validator())
 
-        root = QtWidgets.QVBoxLayout(self)
-        if show_text_field:
-            edit_row = QtWidgets.QHBoxLayout()
-            edit_row.addWidget(self.edit, stretch=6)
-            edit_row.addWidget(self.edit_group_id, stretch=2)
-            root.addLayout(edit_row)
-        root.addWidget(button_box)
-        root.addWidget(self.label_list)
-        root.addItem(self._flags_layout)
-        root.addWidget(self.edit_description)
-
-        self.edit.setCompleter(self._build_completer(mode=completion))
-
-    def _build_label_edit(self, placeholder: str, has_flags: bool) -> LabelQLineEdit:
-        edit = LabelQLineEdit()
-        edit.setPlaceholderText(placeholder)
-        edit.setValidator(labelme.utils.label_validator())
-        edit.editingFinished.connect(self._on_editing_finished)
-        if has_flags:
-            edit.textChanged.connect(self._on_text_changed)
-        return edit
-
-    def _build_group_id_edit(self) -> QtWidgets.QLineEdit:
-        edit_group_id = QtWidgets.QLineEdit()
-        edit_group_id.setPlaceholderText("Group ID")
-        edit_group_id.setValidator(
-            QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"\d*"))
+        self.edit_group_id = QtWidgets.QLineEdit()
+        self.edit_group_id.setPlaceholderText(_GROUP_ID_PLACEHOLDER)
+        self.edit_group_id.setValidator(
+            QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"[0-9]*"))
         )
-        return edit_group_id
 
-    def _build_label_list(self, labels: list[str] | None) -> QtWidgets.QListWidget:
-        label_list = QtWidgets.QListWidget()
-        if self._fit_to_content["row"]:
-            label_list.setHorizontalScrollBarPolicy(
-                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        self.edit_description = QtWidgets.QTextEdit()
+        self.edit_description.setPlaceholderText(_DESCRIPTION_PLACEHOLDER)
+        self.edit_description.setFixedHeight(50)
+
+        self.label_list = QtWidgets.QListWidget()
+        self.label_list.setFixedHeight(150)
+
+        # Configure label list
+        if sort_labels:
+            self.label_list.setDragDropMode(
+                QtWidgets.QAbstractItemView.DragDropMode.NoDragDrop
             )
-        if self._fit_to_content["column"]:
-            label_list.setVerticalScrollBarPolicy(
-                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-            )
-        if labels:
-            label_list.addItems(labels)
-        if self._sort_labels:
-            label_list.sortItems()
         else:
-            label_list.setDragDropMode(
+            self.label_list.setDragDropMode(
                 QtWidgets.QAbstractItemView.DragDropMode.InternalMove
             )
-        label_list.currentItemChanged.connect(self._on_label_selected)
-        label_list.itemDoubleClicked.connect(self._on_label_double_clicked)
-        label_list.setFixedHeight(150)
-        return label_list
 
-    def _build_description_edit(self) -> QtWidgets.QTextEdit:
-        description = QtWidgets.QTextEdit()
-        description.setPlaceholderText("Label description")
-        description.setFixedHeight(50)
-        return description
+        if fit_to_content["row"]:
+            self.label_list.setHorizontalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
+        if fit_to_content["column"]:
+            self.label_list.setVerticalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
 
-    def _build_button_box(self) -> QtWidgets.QDialogButtonBox:
+        # Set up completer bound to label_list's model
+        completer = self._make_completer(completion=completion)
+        self.edit.setCompleter(completer)
+        self.edit.set_list_widget(self.label_list)
+
+        # Button box
         button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
-            orientation=QtCore.Qt.Orientation.Horizontal,
-            parent=self,
         )
-        button_box.accepted.connect(self._validate)
+        button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).clicked.connect(
+            self._on_ok_clicked
+        )
         button_box.rejected.connect(self.reject)
-        return button_box
 
-    def _build_completer(self, mode: str) -> QtWidgets.QCompleter:
-        completer = QtWidgets.QCompleter()
-        if mode == "startswith":
+        # Build layout
+        main_layout = QtWidgets.QVBoxLayout()
+        self.setLayout(main_layout)
+
+        if show_text_field:
+            top_row = QtWidgets.QHBoxLayout()
+            top_row.addWidget(self.edit, stretch=4)
+            top_row.addWidget(self.edit_group_id, stretch=1)
+            main_layout.addLayout(top_row)
+        else:
+            self.edit.setParent(None)
+
+        main_layout.addWidget(button_box)
+        main_layout.addWidget(self.label_list)
+
+        self._flags_container = QtWidgets.QWidget()
+        self._flags_layout = QtWidgets.QVBoxLayout()
+        self._flags_layout.setContentsMargins(0, 0, 0, 0)
+        self._flags_container.setLayout(self._flags_layout)
+        main_layout.addWidget(self._flags_container)
+
+        main_layout.addWidget(self.edit_description)
+
+        # Connect signals
+        self.edit.editingFinished.connect(self._strip_edit_text)
+        self.edit.textChanged.connect(self._update_flags)
+        self.label_list.currentItemChanged.connect(self._on_label_selected)
+        self.label_list.itemDoubleClicked.connect(self._on_item_double_clicked)
+
+        # Populate initial labels
+        if labels is not None:
+            for label in labels:
+                self.label_list.addItem(label)
+            if sort_labels:
+                self.label_list.sortItems()
+
+    def _make_completer(self, completion: str) -> QtWidgets.QCompleter:
+        if completion == "startswith":
+            completer = QtWidgets.QCompleter(self.label_list.model())
             completer.setCompletionMode(
                 QtWidgets.QCompleter.CompletionMode.InlineCompletion
             )
-        elif mode == "contains":
+            return completer
+        elif completion == "contains":
+            completer = QtWidgets.QCompleter(self.label_list.model())
             completer.setCompletionMode(
                 QtWidgets.QCompleter.CompletionMode.PopupCompletion
             )
             completer.setFilterMode(QtCore.Qt.MatchFlag.MatchContains)
+            return completer
         else:
-            raise ValueError(f"Unsupported completion: {mode}")
-        completer.setModel(self.label_list.model())
-        return completer
+            raise ValueError(f"Unknown completion mode: {completion!r}")
+
+    def _strip_edit_text(self) -> None:
+        self.edit.setText(self.edit.text().strip())
+
+    def _on_label_selected(
+        self,
+        current: QtWidgets.QListWidgetItem | None,
+        previous: QtWidgets.QListWidgetItem | None,
+    ) -> None:
+        if current is None:
+            return
+        self.edit.setText(current.text())
+
+    def _on_item_double_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
+        self.label_list.setCurrentItem(item)
+        self._on_ok_clicked()
+
+    def _on_ok_clicked(self) -> None:
+        if not self.edit.isEnabled() or self.edit.text().strip():
+            self.accept()
+
+    def _flag_checkboxes(self) -> list[QtWidgets.QCheckBox]:
+        checkboxes: list[QtWidgets.QCheckBox] = []
+        for i in range(self._flags_layout.count()):
+            item = self._flags_layout.itemAt(i)
+            widget = item.widget() if item is not None else None
+            if isinstance(widget, QtWidgets.QCheckBox):
+                checkboxes.append(widget)
+        return checkboxes
+
+    def _clear_flags_layout(self) -> None:
+        while self._flags_layout.count():
+            item = self._flags_layout.takeAt(0)
+            if item is None:
+                continue
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _update_flags(self, text: str) -> None:
+        current_states = {cb.text(): cb.isChecked() for cb in self._flag_checkboxes()}
+        self._clear_flags_layout()
+
+        for pattern, flag_keys in self._flags_spec.items():
+            if re.match(pattern, text):
+                for key in flag_keys:
+                    checkbox = QtWidgets.QCheckBox(key)
+                    if key in current_states:
+                        checkbox.setChecked(current_states[key])
+                    self._flags_layout.addWidget(checkbox)
 
     def add_label_history(self, label: str) -> None:
         if label not in self._label_history:
             self._label_history.append(label)
-        if self.label_list.findItems(label, QtCore.Qt.MatchFlag.MatchExactly):
-            return
-        self.label_list.addItem(label)
-        if self._sort_labels:
-            self.label_list.sortItems()
+
+        if not self.label_list.findItems(label, QtCore.Qt.MatchFlag.MatchExactly):
+            self.label_list.addItem(label)
+            if self._sort_labels:
+                self.label_list.sortItems()
 
     def set_predefined_labels(self, labels: list[str]) -> None:
-        merged = list(dict.fromkeys(labels + self._label_history))
-        # Mutate the existing list widget in place so the completer, which is
-        # bound to its model, keeps working without being rebuilt.
+        history_extras = [h for h in self._label_history if h not in labels]
+        all_labels = list(dict.fromkeys(labels)) + history_extras
+
         self.label_list.clear()
-        self.label_list.addItems(merged)
+        for label in all_labels:
+            self.label_list.addItem(label)
+
         if self._sort_labels:
             self.label_list.sortItems()
-
-    def _on_label_selected(self, item: QtWidgets.QListWidgetItem | None) -> None:
-        # Clearing the list (e.g. set_predefined_labels) fires this with None.
-        if item is None:
-            return
-        self.edit.setText(item.text())
-
-    def _validate(self) -> None:
-        if not self.edit.isEnabled():
-            self.accept()
-            return
-
-        if self.edit.text().strip():
-            self.accept()
-
-    def _on_label_double_clicked(self, _: QtWidgets.QListWidgetItem) -> None:
-        self._validate()
-
-    def _on_editing_finished(self) -> None:
-        self.edit.setText(self.edit.text().strip())
-
-    def _on_text_changed(self, label_new: str) -> None:
-        # keep state of shared flags
-        flags_old = self._current_flags()
-
-        flags_new = {}
-        for pattern, keys in self._flags.items():
-            if re.match(pattern, label_new):
-                for key in keys:
-                    flags_new[key] = flags_old.get(key, False)
-        self._set_flags(flags_new)
-
-    def _delete_flags(self) -> None:
-        while self._flags_layout.count() > 0:
-            item = self._flags_layout.takeAt(0)
-            if item is None:
-                break
-            widget = item.widget()
-            if widget is not None:
-                widget.setParent(QtWidgets.QWidget())
-
-    def _reset_flags(self, label: str = "") -> None:
-        flags = {}
-        for pattern, keys in self._flags.items():
-            if re.match(pattern, label):
-                for key in keys:
-                    flags[key] = False
-        self._set_flags(flags)
-
-    def _set_flags(self, flags: dict[str, bool]) -> None:
-        self._delete_flags()
-        for key, checked in flags.items():
-            item = QtWidgets.QCheckBox(key, self)
-            item.setChecked(checked)
-            self._flags_layout.addWidget(item)
-            item.show()
-
-    def _current_flags(self) -> dict[str, bool]:
-        return {
-            cb.text(): cb.isChecked()
-            for i in range(self._flags_layout.count())
-            if (item := self._flags_layout.itemAt(i)) is not None
-            and (cb := cast(QtWidgets.QCheckBox, item.widget())) is not None
-        }
-
-    def _current_group_id(self) -> int | None:
-        group_id = self.edit_group_id.text()
-        if group_id:
-            return int(group_id)
-        return None
-
-    def _restore_or_reset_flags(self, text: str, flags: dict[str, bool] | None) -> None:
-        if flags:
-            self._set_flags(flags)
-        else:
-            self._reset_flags(text)
 
     def popup(
         self,
@@ -244,25 +241,56 @@ class LabelDialog(QtWidgets.QDialog):
         description: str | None = None,
         flags_disabled: bool = False,
     ) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
-        # text=None preserves whatever was previously typed in the edit field.
-        if text is None:
-            text = self.edit.text()
+        if text is not None:
+            self.edit.setText(text)
+            self.edit.selectAll()
+
+        self.edit_description.setPlainText(description or "")
+
+        if group_id is None:
+            self.edit_group_id.setText("")
+        else:
+            self.edit_group_id.setText(str(group_id))
+
+        if flags is not None:
+            self._show_popup_flags(flags)
+        else:
+            self._update_flags(self.edit.text())
+
+        matches = self.label_list.findItems(
+            self.edit.text(), QtCore.Qt.MatchFlag.MatchExactly
+        )
+        if matches:
+            self.label_list.setCurrentItem(matches[0])
 
         self._fit_label_list_to_content()
-        self._apply_dialog_state(
-            text=text,
-            group_id=group_id,
-            description=description or "",
-            flags=flags,
-            flags_disabled=flags_disabled,
-        )
         self.edit.setFocus(QtCore.Qt.FocusReason.PopupFocusReason)
-        if move:
-            self.move(QtGui.QCursor.pos())
 
-        if not self.exec():
-            return None, None, None, None
-        return self._read_dialog_state()
+        if move:
+            cursor_pos = QtGui.QCursor.pos()
+            self.move(cursor_pos)
+
+        result = self.exec()
+
+        if result == QtWidgets.QDialog.DialogCode.Accepted:
+            label = self.edit.text()
+            returned_flags = self._collect_flags()
+            gid_text = self.edit_group_id.text()
+            returned_group_id: int | None = int(gid_text) if gid_text else None
+            returned_description = self.edit_description.toPlainText()
+            return label, returned_flags, returned_group_id, returned_description
+
+        return None, None, None, None
+
+    def _show_popup_flags(self, flags: dict[str, bool]) -> None:
+        self._clear_flags_layout()
+        for key, checked in flags.items():
+            checkbox = QtWidgets.QCheckBox(key)
+            checkbox.setChecked(checked)
+            self._flags_layout.addWidget(checkbox)
+
+    def _collect_flags(self) -> dict[str, bool]:
+        return {cb.text(): cb.isChecked() for cb in self._flag_checkboxes()}
 
     def _fit_label_list_to_content(self) -> None:
         if self._fit_to_content["row"]:
@@ -271,50 +299,3 @@ class LabelDialog(QtWidgets.QDialog):
             )
         if self._fit_to_content["column"]:
             self.label_list.setMinimumWidth(self.label_list.sizeHintForColumn(0) + 2)
-
-    def _apply_dialog_state(
-        self,
-        text: str,
-        group_id: int | None,
-        description: str,
-        flags: dict[str, bool] | None,
-        flags_disabled: bool,
-    ) -> None:
-        self.edit_description.setPlainText(description)
-        self._restore_or_reset_flags(text=text, flags=flags)
-        if flags_disabled:
-            for i in range(self._flags_layout.count()):
-                item = self._flags_layout.itemAt(i)
-                if item is not None:
-                    widget = item.widget()
-                    if widget is not None:
-                        widget.setDisabled(True)
-
-        self.edit.setText(text)
-        self.edit.selectAll()
-
-        if group_id is None:
-            self.edit_group_id.clear()
-        else:
-            self.edit_group_id.setText(str(group_id))
-
-        self._highlight_matching_label(text)
-
-    def _highlight_matching_label(self, text: str) -> None:
-        items = self.label_list.findItems(text, QtCore.Qt.MatchFlag.MatchFixedString)
-        if not items:
-            return
-        if len(items) != 1:
-            logger.warning(f"Label list has duplicate '{text}'")
-        self.label_list.setCurrentItem(items[0])
-        self.edit.completer().setCurrentRow(self.label_list.row(items[0]))
-
-    def _read_dialog_state(
-        self,
-    ) -> tuple[str, dict[str, bool], int | None, str]:
-        return (
-            self.edit.text(),
-            self._current_flags(),
-            self._current_group_id(),
-            self.edit_description.toPlainText(),
-        )

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -198,6 +198,7 @@ class LabelDialog(QtWidgets.QDialog):
                 continue
             widget = item.widget()
             if widget is not None:
+                widget.setParent(None)
                 widget.deleteLater()
 
     def _update_flags(self, text: str) -> None:
@@ -262,6 +263,10 @@ class LabelDialog(QtWidgets.QDialog):
         )
         if matches:
             self.label_list.setCurrentItem(matches[0])
+
+        if flags_disabled:
+            for checkbox in self._flag_checkboxes():
+                checkbox.setEnabled(False)
 
         self._fit_label_list_to_content()
         self.edit.setFocus(QtCore.Qt.FocusReason.PopupFocusReason)

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -127,6 +127,7 @@ class LabelDialog(QtWidgets.QDialog):
         self._flags_container = QtWidgets.QWidget()
         self._flags_layout = QtWidgets.QVBoxLayout()
         self._flags_layout.setContentsMargins(0, 0, 0, 0)
+        self._flags_layout.setSpacing(0)
         self._flags_container.setLayout(self._flags_layout)
         main_layout.addWidget(self._flags_container)
 

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -245,7 +245,7 @@ class LabelDialog(QtWidgets.QDialog):
     ) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
         if text is not None:
             self.edit.setText(text)
-            self.edit.selectAll()
+        self.edit.selectAll()
 
         self.edit_description.setPlainText(description or "")
 

--- a/tests/unit/widgets/label_dialog_characterize_test.py
+++ b/tests/unit/widgets/label_dialog_characterize_test.py
@@ -499,9 +499,7 @@ def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
     assert seen["desc"] == "hello world"
 
 
-def test_popup_flags_disabled_checkboxes_remain_enabled(qtbot: QtBot) -> None:
-    # Documented latent behavior: flags_disabled=True does NOT actually disable
-    # the checkboxes, because setText() during dialog setup rebuilds them.
+def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
     dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
     _run_popup(
@@ -510,6 +508,38 @@ def test_popup_flags_disabled_checkboxes_remain_enabled(qtbot: QtBot) -> None:
         text="cat",
         flags={"indoor": True},
         flags_disabled=True,
+        at_show=lambda d: seen.update(
+            enabled=[cb.isEnabled() for cb in _checkboxes(d)]
+        ),
+    )
+    assert seen["enabled"]
+    assert not any(seen["enabled"])
+
+
+def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
+    seen: dict[str, list[bool]] = {}
+    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        at_show=lambda d: seen.update(
+            enabled=[cb.isEnabled() for cb in _checkboxes(d)]
+        ),
+    )
+    assert seen["enabled"]
+    assert all(seen["enabled"])
+
+
+def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor"]})
+    _run_popup(dialog, accept=True, text="cat", flags_disabled=True)
+
+    seen: dict[str, list[bool]] = {}
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
         at_show=lambda d: seen.update(
             enabled=[cb.isEnabled() for cb in _checkboxes(d)]
         ),

--- a/tests/unit/widgets/label_dialog_characterize_test.py
+++ b/tests/unit/widgets/label_dialog_characterize_test.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from PySide6 import QtCore
+from PySide6 import QtWidgets
+from pytestqt.qtbot import QtBot
+
+from labelme.widgets.label_dialog import LabelDialog
+from labelme.widgets.label_dialog import LabelQLineEdit
+
+# Black-box characterization of LabelDialog: behavior is exercised only through
+# the public surface (popup(), public methods, public widgets edit/
+# edit_group_id/edit_description/label_list, and observable Qt state). No
+# private method or attribute is referenced, so a rewrite is free to restructure
+# internals while these tests keep pinning observable behavior.
+
+
+def _make_dialog(
+    qtbot: QtBot,
+    text: str = "Enter object label",
+    labels: list[str] | None = None,
+    sort_labels: bool = True,
+    show_text_field: bool = True,
+    completion: str = "startswith",
+    fit_to_content: dict[str, bool] | None = None,
+    flags: dict[str, list[str]] | None = None,
+) -> LabelDialog:
+    dialog = LabelDialog(
+        text=text,
+        labels=labels,
+        sort_labels=sort_labels,
+        show_text_field=show_text_field,
+        completion=completion,
+        fit_to_content=fit_to_content,
+        flags=flags,
+    )
+    qtbot.addWidget(dialog)
+    return dialog
+
+
+def _run_popup(
+    dialog: LabelDialog,
+    accept: bool = True,
+    at_show: Callable[[LabelDialog], None] | None = None,
+    text: str | None = None,
+    move: bool = False,
+    flags: dict[str, bool] | None = None,
+    group_id: int | None = None,
+    description: str | None = None,
+    flags_disabled: bool = False,
+) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
+    code = (
+        QtWidgets.QDialog.DialogCode.Accepted
+        if accept
+        else QtWidgets.QDialog.DialogCode.Rejected
+    )
+
+    def fake_exec() -> int:
+        if at_show is not None:
+            at_show(dialog)
+        return code
+
+    dialog.exec = fake_exec  # ty: ignore[invalid-assignment]
+    return dialog.popup(
+        text=text,
+        move=move,
+        flags=flags,
+        group_id=group_id,
+        description=description,
+        flags_disabled=flags_disabled,
+    )
+
+
+def _checkboxes(dialog: LabelDialog) -> list[QtWidgets.QCheckBox]:
+    return dialog.findChildren(QtWidgets.QCheckBox)
+
+
+def _ok_button(dialog: LabelDialog) -> QtWidgets.QPushButton:
+    box = dialog.findChild(QtWidgets.QDialogButtonBox)
+    assert box is not None
+    button = box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+    assert button is not None
+    return button
+
+
+# ---------------------------------------------------------------------------
+# LabelQLineEdit
+# ---------------------------------------------------------------------------
+
+
+def test_set_list_widget_stores_reference(qtbot: QtBot) -> None:
+    edit = LabelQLineEdit()
+    qtbot.addWidget(edit)
+    list_widget = QtWidgets.QListWidget()
+    qtbot.addWidget(list_widget)
+    edit.set_list_widget(list_widget)
+    assert edit.list_widget is list_widget
+
+
+def test_key_down_forwarded_to_list_widget(qtbot: QtBot) -> None:
+    edit = LabelQLineEdit()
+    qtbot.addWidget(edit)
+    list_widget = QtWidgets.QListWidget()
+    qtbot.addWidget(list_widget)
+    list_widget.addItems(["a", "b", "c"])
+    list_widget.setCurrentRow(0)
+    edit.set_list_widget(list_widget)
+    edit.show()
+    qtbot.keyClick(edit, QtCore.Qt.Key.Key_Down)
+    assert list_widget.currentRow() == 1
+
+
+def test_key_up_forwarded_to_list_widget(qtbot: QtBot) -> None:
+    edit = LabelQLineEdit()
+    qtbot.addWidget(edit)
+    list_widget = QtWidgets.QListWidget()
+    qtbot.addWidget(list_widget)
+    list_widget.addItems(["a", "b", "c"])
+    list_widget.setCurrentRow(2)
+    edit.set_list_widget(list_widget)
+    edit.show()
+    qtbot.keyClick(edit, QtCore.Qt.Key.Key_Up)
+    assert list_widget.currentRow() == 1
+
+
+def test_other_keys_edit_text_not_forwarded(qtbot: QtBot) -> None:
+    edit = LabelQLineEdit()
+    qtbot.addWidget(edit)
+    list_widget = QtWidgets.QListWidget()
+    qtbot.addWidget(list_widget)
+    list_widget.addItems(["a", "b", "c"])
+    list_widget.setCurrentRow(0)
+    edit.set_list_widget(list_widget)
+    edit.show()
+    qtbot.keyClicks(edit, "x")
+    assert edit.text() == "x"
+    assert list_widget.currentRow() == 0
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_widgets_exist(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    assert isinstance(dialog.edit, LabelQLineEdit)
+    assert isinstance(dialog.edit_group_id, QtWidgets.QLineEdit)
+    assert isinstance(dialog.edit_description, QtWidgets.QTextEdit)
+    assert isinstance(dialog.label_list, QtWidgets.QListWidget)
+
+
+def test_default_placeholder_is_non_empty(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    assert dialog.edit.placeholderText() != ""
+
+
+def test_custom_placeholder_text(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, text="Type here")
+    assert dialog.edit.placeholderText() == "Type here"
+
+
+def test_group_id_and_description_placeholders_non_empty(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    assert dialog.edit_group_id.placeholderText() != ""
+    assert dialog.edit_description.placeholderText() != ""
+
+
+def test_show_text_field_true_parents_edit_to_dialog(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, show_text_field=True)
+    assert dialog.edit.parent() is dialog
+
+
+def test_show_text_field_false_leaves_edit_parentless(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, show_text_field=False)
+    assert dialog.edit.parent() is None
+
+
+def test_initial_labels_listed(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["banana", "apple", "cherry"])
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert set(items) == {"apple", "banana", "cherry"}
+
+
+def test_sort_labels_true_sorts(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["banana", "apple", "cherry"], sort_labels=True)
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert items == ["apple", "banana", "cherry"]
+
+
+def test_sort_labels_false_preserves_order_and_enables_drag(qtbot: QtBot) -> None:
+    dialog = _make_dialog(
+        qtbot, labels=["banana", "apple", "cherry"], sort_labels=False
+    )
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert items == ["banana", "apple", "cherry"]
+    assert (
+        dialog.label_list.dragDropMode()
+        == QtWidgets.QAbstractItemView.DragDropMode.InternalMove
+    )
+
+
+@pytest.mark.parametrize("row_off", [True, False])
+@pytest.mark.parametrize("col_off", [True, False])
+def test_fit_to_content_scrollbar_policies(
+    qtbot: QtBot, row_off: bool, col_off: bool
+) -> None:
+    dialog = _make_dialog(qtbot, fit_to_content={"row": row_off, "column": col_off})
+    always_off = QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    if row_off:
+        assert dialog.label_list.horizontalScrollBarPolicy() == always_off
+    if col_off:
+        assert dialog.label_list.verticalScrollBarPolicy() == always_off
+
+
+# ---------------------------------------------------------------------------
+# Completion
+# ---------------------------------------------------------------------------
+
+
+def test_completion_startswith_inline(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, completion="startswith")
+    assert (
+        dialog.edit.completer().completionMode()
+        == QtWidgets.QCompleter.CompletionMode.InlineCompletion
+    )
+
+
+def test_completion_contains_popup_and_matchcontains(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, completion="contains")
+    completer = dialog.edit.completer()
+    assert (
+        completer.completionMode()
+        == QtWidgets.QCompleter.CompletionMode.PopupCompletion
+    )
+    assert completer.filterMode() == QtCore.Qt.MatchFlag.MatchContains
+
+
+def test_completion_invalid_raises(qtbot: QtBot) -> None:
+    with pytest.raises(ValueError):
+        LabelDialog(completion="fuzzy")
+
+
+def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["a", "b"])
+    assert dialog.edit.completer().model() is dialog.label_list.model()
+
+
+# ---------------------------------------------------------------------------
+# Label history / predefined labels
+# ---------------------------------------------------------------------------
+
+
+def test_add_label_history_appends_new(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=[])
+    dialog.add_label_history("dog")
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert "dog" in items
+
+
+def test_add_label_history_no_duplicate(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["dog"])
+    dialog.add_label_history("dog")
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert items.count("dog") == 1
+
+
+def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["banana", "apple"], sort_labels=True)
+    dialog.add_label_history("cherry")
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert items == ["apple", "banana", "cherry"]
+
+
+def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["a"], sort_labels=False)
+    dialog.add_label_history("b")
+    dialog.set_predefined_labels(["a", "c"])
+    items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
+    assert set(items) == {"a", "b", "c"}
+    assert len(items) == 3
+
+
+def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["a"])
+    dialog.set_predefined_labels(["a", "b", "c"])
+    assert dialog.edit.completer().model() is dialog.label_list.model()
+
+
+# ---------------------------------------------------------------------------
+# Editing behavior
+# ---------------------------------------------------------------------------
+
+
+def test_editing_finished_strips_whitespace(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("  hello  ")
+    dialog.edit.editingFinished.emit()
+    assert dialog.edit.text() == "hello"
+
+
+def test_selecting_label_sets_edit_text(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["cat", "dog"])
+    item = dialog.label_list.findItems("dog", QtCore.Qt.MatchFlag.MatchExactly)[0]
+    dialog.label_list.setCurrentItem(item)
+    assert dialog.edit.text() == "dog"
+
+
+def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["cat"])
+    dialog.label_list.setCurrentItem(
+        dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
+    )
+    dialog.label_list.clear()  # fires currentItemChanged(None)
+    assert dialog.edit.text() == "cat"
+
+
+# ---------------------------------------------------------------------------
+# Validation (via the OK button)
+# ---------------------------------------------------------------------------
+
+
+def test_ok_with_text_accepts(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("car")
+    _ok_button(dialog).click()
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+
+def test_ok_with_empty_text_does_not_accept(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("")
+    _ok_button(dialog).click()
+    assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+
+def test_ok_with_whitespace_text_does_not_accept(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("   ")
+    _ok_button(dialog).click()
+    assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+
+def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("")
+    dialog.edit.setEnabled(False)
+    _ok_button(dialog).click()
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+
+def test_double_click_label_accepts(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["cat"])
+    item = dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
+    dialog.label_list.setCurrentItem(item)  # selection sets the edit text
+    dialog.label_list.itemDoubleClicked.emit(item)
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+
+def test_flags_shown_for_matching_label(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor", "outdoor"]})
+    dialog.edit.setText("cat")
+    names = {cb.text() for cb in _checkboxes(dialog)}
+    assert names == {"indoor", "outdoor"}
+
+
+def test_flags_absent_for_non_matching_label(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor"]})
+    dialog.edit.setText("dog")
+    assert _checkboxes(dialog) == []
+
+
+def test_flags_shown_for_prefix_match(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flags={"car": ["fast"]})
+    dialog.edit.setText("car_red")
+    names = {cb.text() for cb in _checkboxes(dialog)}
+    assert names == {"fast"}
+
+
+def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor"]})
+    dialog.edit.setText("cat")
+    box = next(cb for cb in _checkboxes(dialog) if cb.text() == "indoor")
+    box.setChecked(True)
+    dialog.edit.setText("cat2")  # still matches "^cat"
+    box2 = next(cb for cb in _checkboxes(dialog) if cb.text() == "indoor")
+    assert box2.isChecked()
+
+
+# ---------------------------------------------------------------------------
+# popup() round-trips (exec stubbed)
+# ---------------------------------------------------------------------------
+
+
+def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, labels=["cat"])
+    text, flags, group_id, description = _run_popup(
+        dialog, accept=True, text="cat", group_id=3, description="a pet"
+    )
+    assert text == "cat"
+    assert group_id == 3
+    assert description == "a pet"
+    assert flags == {}
+
+
+def test_popup_preserves_html_like_description(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    _, _, _, description = _run_popup(
+        dialog, accept=True, text="cat", description="<b>bold</b>"
+    )
+    assert description == "<b>bold</b>"
+
+
+def test_popup_returns_all_none_on_reject(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    result = _run_popup(dialog, accept=False, text="cat")
+    assert result == (None, None, None, None)
+
+
+def test_popup_group_id_none_yields_empty_then_none(qtbot: QtBot) -> None:
+    seen: dict[str, str] = {}
+    dialog = _make_dialog(qtbot)
+    _, _, group_id, _ = _run_popup(
+        dialog,
+        accept=True,
+        text="x",
+        group_id=None,
+        at_show=lambda d: seen.update(gid=d.edit_group_id.text()),
+    )
+    assert seen["gid"] == ""
+    assert group_id is None
+
+
+def test_popup_group_id_zero_is_preserved(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot)
+    _, _, group_id, _ = _run_popup(dialog, accept=True, text="x", group_id=0)
+    assert group_id == 0
+
+
+def test_popup_sets_group_id_text_at_show(qtbot: QtBot) -> None:
+    seen: dict[str, str] = {}
+    dialog = _make_dialog(qtbot)
+    _run_popup(
+        dialog,
+        accept=True,
+        text="x",
+        group_id=7,
+        at_show=lambda d: seen.update(gid=d.edit_group_id.text()),
+    )
+    assert seen["gid"] == "7"
+
+
+def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
+    seen: dict[str, str] = {}
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("preexisting")
+    _run_popup(
+        dialog,
+        accept=True,
+        text=None,
+        at_show=lambda d: seen.update(t=d.edit.text()),
+    )
+    assert seen["t"] == "preexisting"
+
+
+def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
+    seen: dict[str, object] = {}
+    dialog = _make_dialog(qtbot, labels=["cat", "dog"])
+    _run_popup(
+        dialog,
+        accept=True,
+        text="dog",
+        at_show=lambda d: seen.update(
+            cur=d.label_list.currentItem().text()
+            if d.label_list.currentItem()
+            else None
+        ),
+    )
+    assert seen["cur"] == "dog"
+
+
+def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
+    seen: dict[str, str] = {}
+    dialog = _make_dialog(qtbot)
+    _run_popup(
+        dialog,
+        accept=True,
+        text="x",
+        description="hello world",
+        at_show=lambda d: seen.update(desc=d.edit_description.toPlainText()),
+    )
+    assert seen["desc"] == "hello world"
+
+
+def test_popup_flags_disabled_checkboxes_remain_enabled(qtbot: QtBot) -> None:
+    # Documented latent behavior: flags_disabled=True does NOT actually disable
+    # the checkboxes, because setText() during dialog setup rebuilds them.
+    seen: dict[str, list[bool]] = {}
+    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        flags={"indoor": True},
+        flags_disabled=True,
+        at_show=lambda d: seen.update(
+            enabled=[cb.isEnabled() for cb in _checkboxes(d)]
+        ),
+    )
+    assert seen["enabled"]
+    assert all(seen["enabled"])

--- a/tests/unit/widgets/label_dialog_characterize_test.py
+++ b/tests/unit/widgets/label_dialog_characterize_test.py
@@ -470,6 +470,19 @@ def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
     assert seen["t"] == "preexisting"
 
 
+def test_popup_text_none_selects_existing_edit_text(qtbot: QtBot) -> None:
+    seen: dict[str, str] = {}
+    dialog = _make_dialog(qtbot)
+    dialog.edit.setText("preexisting")
+    _run_popup(
+        dialog,
+        accept=True,
+        text=None,
+        at_show=lambda d: seen.update(sel=d.edit.selectedText()),
+    )
+    assert seen["sel"] == "preexisting"
+
+
 def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
     dialog = _make_dialog(qtbot, labels=["cat", "dog"])

--- a/tests/unit/widgets/label_dialog_characterize_test.py
+++ b/tests/unit/widgets/label_dialog_characterize_test.py
@@ -499,6 +499,22 @@ def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
     assert seen["cur"] == "dog"
 
 
+def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> None:
+    seen: dict[str, object] = {}
+    dialog = _make_dialog(qtbot, labels=["Cat", "Dog"])
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        at_show=lambda d: seen.update(
+            cur=d.label_list.currentItem().text()
+            if d.label_list.currentItem()
+            else None
+        ),
+    )
+    assert seen["cur"] == "Cat"
+
+
 def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _make_dialog(qtbot)


### PR DESCRIPTION
Reimplements the `LabelDialog` label-entry widget for Qt 6 / PySide6, and reworks its tests to behavior-level (black-box) characterization.

- Characterization tests pin observable behavior through the public API, then the widget is reimplemented to satisfy them.
- Full test suite green.

Closes #2147