### PR TITLE
Redesign LabelFile I/O

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -3,25 +3,59 @@ from __future__ import annotations
 import base64
 import io
 import json
-import time
+import os
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from pathlib import PureWindowsPath
 from typing import Any
 from typing import Final
 from typing import TypedDict
 
 import numpy as np
 import PIL.Image
+import PIL.ImageOps
 import tifffile
-from loguru import logger
-from numpy.typing import NDArray
 
-from labelme import __version__
-from labelme import utils
+import labelme
 
-PIL.Image.MAX_IMAGE_PIXELS = None
+
+LABEL_FILE_SUFFIX: Final[str] = ".json"
+
+_RESERVED_TOP_LEVEL_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "version",
+        "flags",
+        "shapes",
+        "imagePath",
+        "imageData",
+        "imageHeight",
+        "imageWidth",
+    }
+)
+
+_SHAPE_KNOWN_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "label",
+        "points",
+        "shape_type",
+        "flags",
+        "description",
+        "group_id",
+        "mask",
+    }
+)
+
+
+class LabelFileError(Exception):
+    pass
+
+
+class LabelFileReadError(LabelFileError):
+    pass
+
+
+class LabelFileWriteError(LabelFileError):
+    pass
 
 
 class ShapeDict(TypedDict):
@@ -31,84 +65,98 @@ class ShapeDict(TypedDict):
     flags: dict[str, bool]
     description: str
     group_id: int | None
-    mask: NDArray[np.bool_] | None
-    other_data: dict
+    mask: np.ndarray | None
+    other_data: dict[str, Any]
 
 
-def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
-    SHAPE_KEYS: set[str] = {
-        "label",
-        "points",
-        "group_id",
-        "shape_type",
-        "flags",
-        "description",
-        "mask",
-    }
+@dataclass(frozen=True)
+class Annotation:
+    image_path: str
+    image_data: bytes | None
+    shapes: list[ShapeDict]
+    flags: dict[str, bool]
+    other_data: dict[str, Any]
 
-    if "label" not in shape_json_obj:
-        raise ValueError(f"label is required: {shape_json_obj}")
-    if not isinstance(shape_json_obj["label"], str):
-        raise TypeError(f"label must be str: {shape_json_obj['label']}")
-    label: str = shape_json_obj["label"]
 
-    if "points" not in shape_json_obj:
-        raise ValueError(f"points is required: {shape_json_obj}")
-    if not isinstance(shape_json_obj["points"], list):
-        raise TypeError(f"points must be list: {shape_json_obj['points']}")
-    if not shape_json_obj["points"]:
-        raise ValueError(f"points must be non-empty: {shape_json_obj}")
-    if not all(
-        isinstance(point, list)
-        and len(point) == 2
-        and all(isinstance(xy, int | float) for xy in point)
-        for point in shape_json_obj["points"]
-    ):
-        raise ValueError(f"points must be list of [x, y]: {shape_json_obj['points']}")
-    points: list[list[float]] = shape_json_obj["points"]
+def is_label_file_path(filename: str) -> bool:
+    return Path(filename).suffix.lower() == LABEL_FILE_SUFFIX
 
-    if "shape_type" not in shape_json_obj:
-        raise ValueError(f"shape_type is required: {shape_json_obj}")
-    if not isinstance(shape_json_obj["shape_type"], str):
-        raise TypeError(f"shape_type must be str: {shape_json_obj['shape_type']}")
-    shape_type: str = shape_json_obj["shape_type"]
 
-    flags: dict = {}
-    if shape_json_obj.get("flags") is not None:
-        if not isinstance(shape_json_obj["flags"], dict):
-            raise TypeError(f"flags must be dict: {shape_json_obj['flags']}")
-        if not all(
-            isinstance(k, str) and isinstance(v, bool)
-            for k, v in shape_json_obj["flags"].items()
-        ):
-            raise TypeError(
-                f"flags must be dict of str to bool: {shape_json_obj['flags']}"
-            )
-        flags = shape_json_obj["flags"]
+def _decode_mask(b64_str: str) -> np.ndarray:
+    raw = base64.b64decode(b64_str)
+    img = PIL.Image.open(io.BytesIO(raw))
+    return np.array(img).astype(bool)
 
-    description: str = ""
-    if shape_json_obj.get("description") is not None:
-        if not isinstance(shape_json_obj["description"], str):
-            raise TypeError(f"description must be str: {shape_json_obj['description']}")
-        description = shape_json_obj["description"]
 
-    group_id: int | None = None
-    if shape_json_obj.get("group_id") is not None:
-        if not isinstance(shape_json_obj["group_id"], int):
-            raise TypeError(f"group_id must be int: {shape_json_obj['group_id']}")
-        group_id = shape_json_obj["group_id"]
+def _encode_mask(mask: np.ndarray) -> str:
+    img = PIL.Image.fromarray(mask.astype(np.uint8) * 255, mode="L")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
 
-    mask: NDArray[np.bool_] | None = None
-    if shape_json_obj.get("mask") is not None:
-        if not isinstance(shape_json_obj["mask"], str):
-            raise TypeError(
-                f"mask must be base64-encoded PNG: {shape_json_obj['mask']}"
-            )
-        mask = utils.img_b64_to_arr(shape_json_obj["mask"]).astype(bool)
 
-    other_data = {k: v for k, v in shape_json_obj.items() if k not in SHAPE_KEYS}
+def _load_shape_json_obj(raw: dict[str, Any]) -> ShapeDict:
+    if "label" not in raw:
+        raise ValueError("label is required")
+    label = raw["label"]
+    if not isinstance(label, str):
+        raise TypeError("label must be str")
 
-    loaded: ShapeDict = ShapeDict(
+    if "points" not in raw:
+        raise ValueError("points is required")
+    points = raw["points"]
+    if not isinstance(points, list):
+        raise TypeError("points must be list")
+    if len(points) == 0:
+        raise ValueError("points must be non-empty")
+    for pt in points:
+        if not isinstance(pt, list) or len(pt) != 2:
+            raise ValueError("points must be list of [x, y] pairs")
+        if not all(isinstance(c, (int, float)) for c in pt):
+            raise ValueError("points must be list of numeric [x, y] pairs")
+
+    if "shape_type" not in raw:
+        raise ValueError("shape_type is required")
+    shape_type = raw["shape_type"]
+    if not isinstance(shape_type, str):
+        raise TypeError("shape_type must be str")
+
+    raw_flags = raw.get("flags")
+    if raw_flags is None:
+        flags: dict[str, bool] = {}
+    elif not isinstance(raw_flags, dict):
+        raise TypeError("flags must be dict")
+    else:
+        for k, v in raw_flags.items():
+            if not isinstance(k, str) or not isinstance(v, bool):
+                raise TypeError("flags must be dict of str to bool")
+        flags = raw_flags
+
+    raw_description = raw.get("description")
+    if raw_description is None:
+        description: str = ""
+    elif not isinstance(raw_description, str):
+        raise TypeError("description must be str")
+    else:
+        description = raw_description
+
+    raw_group_id = raw.get("group_id")
+    if raw_group_id is None:
+        group_id: int | None = None
+    elif isinstance(raw_group_id, bool) or not isinstance(raw_group_id, int):
+        raise TypeError("group_id must be int or null")
+    else:
+        group_id = raw_group_id
+
+    raw_mask = raw.get("mask")
+    if raw_mask is None:
+        mask: np.ndarray | None = None
+    else:
+        mask = _decode_mask(raw_mask)
+
+    other_data = {k: v for k, v in raw.items() if k not in _SHAPE_KNOWN_KEYS}
+
+    return ShapeDict(
         label=label,
         points=points,
         shape_type=shape_type,
@@ -118,138 +166,89 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
         mask=mask,
         other_data=other_data,
     )
-    if set(loaded.keys()) != SHAPE_KEYS | {"other_data"}:
-        raise RuntimeError(
-            f"unexpected keys: {set(loaded.keys())} != {SHAPE_KEYS | {'other_data'}}"
-        )
-    return loaded
 
 
 def _dump_shape_to_json_obj(shape: ShapeDict) -> dict[str, Any]:
-    json_obj: dict[str, Any] = dict(shape["other_data"])
-    json_obj.update(
-        label=shape["label"],
-        points=[list(point) for point in shape["points"]],
-        group_id=shape["group_id"],
-        description=shape["description"],
-        shape_type=shape["shape_type"],
-        flags=shape["flags"],
-        mask=None
-        if shape["mask"] is None
-        else utils.img_arr_to_b64(shape["mask"].astype(np.uint8)),
-    )
-    return json_obj
-
-
-class LabelFileError(Exception):
-    """Base for read/write failures of labelme JSON annotation files."""
-
-
-class LabelFileReadError(LabelFileError):
-    """Wraps an underlying parse or image-decode failure during load."""
-
-
-class LabelFileWriteError(LabelFileError):
-    """Wraps an underlying I/O failure during save."""
-
-
-@dataclass(frozen=True)
-class Annotation:
-    image_path: str
-    image_data: bytes
-    shapes: list[ShapeDict]
-    flags: dict[str, bool]
-    other_data: dict[str, Any]
-
-
-LABEL_FILE_SUFFIX: Final[str] = ".json"
-
-_RESERVED_TOP_LEVEL_KEYS: Final[tuple[str, ...]] = (
-    "version",
-    "imageData",
-    "imagePath",
-    "shapes",
-    "flags",
-    "imageHeight",
-    "imageWidth",
-)
-
-
-def is_label_file_path(filename: str) -> bool:
-    return Path(filename).suffix.lower() == LABEL_FILE_SUFFIX
-
-
-def read_image_file(filename: str) -> bytes:
-    t_start = time.time()
-    image_pil = _imread(filename=filename)
-
-    oriented: PIL.Image.Image = utils.apply_exif_orientation(image=image_pil)
-    ext = Path(filename).suffix.lower()
-    if oriented is image_pil and ext in (".jpg", ".jpeg", ".png"):
-        with open(filename, "rb") as f:
-            image_data = f.read()
+    raw_mask = shape["mask"]
+    if raw_mask is not None:
+        mask_val: str | None = _encode_mask(raw_mask)
     else:
-        with io.BytesIO() as f:
-            fmt = "PNG" if "A" in oriented.mode else "JPEG"
-            oriented.save(fp=f, format=fmt, quality=95)
-            f.seek(0)
-            image_data = f.read()
+        mask_val = None
 
-    logger.debug(
-        "Loaded image file: {!r} in {:.0f}ms", filename, (time.time() - t_start) * 1000
-    )
-    return image_data
+    result: dict[str, Any] = {
+        "label": shape["label"],
+        "points": shape["points"],
+        "shape_type": shape["shape_type"],
+        "flags": shape["flags"],
+        "description": shape["description"],
+        "group_id": shape["group_id"],
+        "mask": mask_val,
+    }
+    result.update(shape["other_data"])
+    return result
 
 
-def _check_image_dimensions(
-    *,
-    image_data: bytes,
-    expected_height: int | None,
-    expected_width: int | None,
-) -> None:
-    if expected_height is None and expected_width is None:
-        return
-    actual_w, actual_h = utils.img_data_to_pil(img_data=image_data).size
-    if expected_height is not None and expected_height != actual_h:
-        raise ValueError(
-            f"imageHeight mismatch: declared={expected_height}, actual={actual_h}"
-        )
-    if expected_width is not None and expected_width != actual_w:
-        raise ValueError(
-            f"imageWidth mismatch: declared={expected_width}, actual={actual_w}"
-        )
+def _get_image_dimensions(image_data: bytes) -> tuple[int, int]:
+    img = PIL.Image.open(io.BytesIO(image_data))
+    width, height = img.size
+    return height, width
 
 
 def read_label_file(filename: str) -> Annotation:
     try:
         with open(filename, encoding="utf-8") as f:
-            raw: dict[str, Any] = json.load(f)
-        image_path = PureWindowsPath(raw["imagePath"]).as_posix()
-        if raw["imageData"] is not None:
-            image_data = base64.b64decode(raw["imageData"])
-        else:
-            image_data = read_image_file(
-                filename=str(Path(filename).parent / image_path)
+            raw = json.load(f)
+    except Exception as exc:
+        raise LabelFileReadError(f"failed to load {filename!r}: {exc}") from exc
+
+    if "imagePath" not in raw:
+        raise LabelFileReadError("imagePath is required")
+    if "imageData" not in raw:
+        raise LabelFileReadError("imageData is required")
+    if "shapes" not in raw:
+        raise LabelFileReadError("shapes is required")
+
+    image_path: str = raw["imagePath"].replace("\\", "/")
+
+    raw_image_data = raw["imageData"]
+    if raw_image_data is not None:
+        image_data: bytes | None = base64.b64decode(raw_image_data)
+    else:
+        image_dir = Path(filename).parent
+        image_file = image_dir / image_path
+        try:
+            image_data = read_image_file(str(image_file))
+        except Exception as exc:
+            raise LabelFileReadError(
+                f"failed to load image {str(image_file)!r}: {exc}"
+            ) from exc
+
+    raw_flags = raw.get("flags")
+    flags: dict[str, bool] = raw_flags if isinstance(raw_flags, dict) else {}
+
+    shapes: list[ShapeDict] = []
+    for shape_raw in raw["shapes"]:
+        try:
+            shapes.append(_load_shape_json_obj(shape_raw))
+        except (ValueError, TypeError) as exc:
+            raise LabelFileReadError(str(exc)) from exc
+
+    image_height = raw.get("imageHeight")
+    image_width = raw.get("imageWidth")
+
+    if image_data is not None and (image_height is not None or image_width is not None):
+        actual_h, actual_w = _get_image_dimensions(image_data)
+        if image_height is not None and actual_h != image_height:
+            raise LabelFileReadError(
+                f"imageHeight mismatch: file says {image_height}, image is {actual_h}"
             )
-        _check_image_dimensions(
-            image_data=image_data,
-            expected_height=raw.get("imageHeight"),
-            expected_width=raw.get("imageWidth"),
-        )
-        shapes: list[ShapeDict] = [
-            _load_shape_json_obj(shape_json_obj=s) for s in raw["shapes"]
-        ]
-        flags = raw.get("flags") or {}
-    except (
-        OSError,
-        json.JSONDecodeError,
-        KeyError,
-        TypeError,
-        ValueError,
-        RuntimeError,
-    ) as e:
-        raise LabelFileReadError(f"failed to load {filename!r}: {e}") from e
+        if image_width is not None and actual_w != image_width:
+            raise LabelFileReadError(
+                f"imageWidth mismatch: file says {image_width}, image is {actual_w}"
+            )
+
     other_data = {k: v for k, v in raw.items() if k not in _RESERVED_TOP_LEVEL_KEYS}
+
     return Annotation(
         image_path=image_path,
         image_data=image_data,
@@ -262,170 +261,228 @@ def read_label_file(filename: str) -> Annotation:
 def write_label_file(
     filename: str,
     annotation: Annotation,
-    *,
     image_height: int | None,
     image_width: int | None,
     save_image_data: bool,
 ) -> None:
-    _write_label_json_file(
-        filename=filename,
-        shapes=[_dump_shape_to_json_obj(shape) for shape in annotation.shapes],
-        image_path=annotation.image_path,
-        image_height=image_height,
-        image_width=image_width,
-        image_data=annotation.image_data if save_image_data else None,
-        other_data=annotation.other_data,
-        flags=annotation.flags,
-    )
+    for key in annotation.other_data:
+        if key in _RESERVED_TOP_LEVEL_KEYS:
+            raise LabelFileWriteError(f"reserved key {key!r} in other_data")
 
-
-def _write_label_json_file(
-    filename: str,
-    *,
-    shapes: list[dict[str, Any]],
-    image_path: str,
-    image_height: int | None,
-    image_width: int | None,
-    image_data: bytes | None = None,
-    other_data: dict[str, Any] | None = None,
-    flags: dict[str, bool] | None = None,
-) -> None:
-    try:
-        image_data_b64: str | None = None
-        if image_data is not None:
-            _check_image_dimensions(
-                image_data=image_data,
-                expected_height=image_height,
-                expected_width=image_width,
+    if save_image_data and annotation.image_data is not None:
+        actual_h, actual_w = _get_image_dimensions(annotation.image_data)
+        if image_height is not None and actual_h != image_height:
+            raise LabelFileWriteError(
+                f"imageHeight mismatch: provided {image_height}, image is {actual_h}"
             )
-            image_data_b64 = base64.b64encode(image_data).decode("utf-8")
-        # JSON keys stay camelCase: changing them would break existing .json files.
-        payload: dict[str, Any] = {
-            "version": __version__,
-            "flags": dict(flags) if flags else {},
-            "shapes": list(shapes),
-            "imagePath": image_path,
-            "imageData": image_data_b64,
-            "imageHeight": image_height,
-            "imageWidth": image_width,
-        }
-        for key, value in (other_data or {}).items():
-            if key in _RESERVED_TOP_LEVEL_KEYS:
-                raise ValueError(f"reserved key in other_data: {key!r}")
-            payload[key] = value
+        if image_width is not None and actual_w != image_width:
+            raise LabelFileWriteError(
+                f"imageWidth mismatch: provided {image_width}, image is {actual_w}"
+            )
+
+    if save_image_data and annotation.image_data is not None:
+        image_data_str: str | None = base64.b64encode(annotation.image_data).decode(
+            "utf-8"
+        )
+        h_out: int | None = image_height
+        w_out: int | None = image_width
+    else:
+        image_data_str = None
+        h_out = image_height
+        w_out = image_width
+
+    if save_image_data and annotation.image_data is None:
+        image_data_str = None
+        h_out = None
+        w_out = None
+
+    shapes_json = [_dump_shape_to_json_obj(s) for s in annotation.shapes]
+
+    data: dict[str, Any] = {
+        "version": labelme.__version__,
+        "flags": annotation.flags,
+        "shapes": shapes_json,
+        "imagePath": annotation.image_path,
+        "imageData": image_data_str,
+        "imageHeight": h_out,
+        "imageWidth": w_out,
+    }
+    data.update(annotation.other_data)
+
+    try:
         with open(filename, "w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
-    except (OSError, TypeError, ValueError) as e:
-        raise LabelFileWriteError(f"failed to write {filename!r}: {e}") from e
+            json.dump(data, f, indent=2, ensure_ascii=False)
+    except Exception as exc:
+        raise LabelFileWriteError(f"failed to write {filename!r}: {exc}") from exc
+
+
+def _normalize_tiff_to_pil(img_array: np.ndarray) -> PIL.Image.Image:
+    if img_array.ndim == 2:
+        arr = img_array
+        if arr.dtype.kind == "f":
+            vmin = arr.min()
+            vmax = arr.max()
+            if vmax > vmin:
+                arr = ((arr - vmin) / (vmax - vmin) * 255).astype(np.uint8)
+            else:
+                arr = np.zeros_like(arr, dtype=np.uint8)
+        else:
+            arr = arr.astype(np.uint8)
+        return PIL.Image.fromarray(arr, mode="L")
+    elif img_array.ndim == 3:
+        bands = img_array.shape[2]
+        if bands == 1:
+            return _normalize_tiff_to_pil(img_array[:, :, 0])
+        elif bands == 2:
+            return _normalize_tiff_to_pil(img_array[:, :, 0])
+        elif bands == 3:
+            arr = img_array
+            if arr.dtype.kind == "f":
+                vmin = arr.min()
+                vmax = arr.max()
+                if vmax > vmin:
+                    arr = ((arr - vmin) / (vmax - vmin) * 255).astype(np.uint8)
+                else:
+                    arr = np.zeros_like(arr, dtype=np.uint8)
+            else:
+                arr = arr.astype(np.uint8)
+            return PIL.Image.fromarray(arr, mode="RGB")
+        elif bands == 4:
+            arr = img_array
+            if arr.dtype.kind == "f":
+                vmin = arr.min()
+                vmax = arr.max()
+                if vmax > vmin:
+                    arr = ((arr - vmin) / (vmax - vmin) * 255).astype(np.uint8)
+                else:
+                    arr = np.zeros_like(arr, dtype=np.uint8)
+            else:
+                arr = arr.astype(np.uint8)
+            return PIL.Image.fromarray(arr, mode="RGBA")
+        else:
+            rgb = img_array[:, :, :3]
+            return _normalize_tiff_to_pil(rgb)
+    else:
+        raise ValueError(f"unexpected array shape: {img_array.shape}")
+
+
+def _pil_to_bytes(img: PIL.Image.Image) -> bytes:
+    buf = io.BytesIO()
+    if img.mode in ("RGBA", "LA", "PA"):
+        img.save(buf, format="PNG")
+    else:
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+        img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def read_image_file(filename: str) -> bytes:
+    ext = Path(filename).suffix.lower()
+    if ext in (".tif", ".tiff"):
+        arr = tifffile.imread(filename)
+        pil_img = _normalize_tiff_to_pil(arr)
+        return _pil_to_bytes(pil_img)
+
+    with open(filename, "rb") as f:
+        raw_bytes = f.read()
+
+    img = PIL.Image.open(io.BytesIO(raw_bytes))
+    img = PIL.ImageOps.exif_transpose(img)
+
+    if img.mode in ("RGB", "RGBA", "L"):
+        return raw_bytes
+
+    buf = io.BytesIO()
+    if img.mode in ("LA", "PA"):
+        img = img.convert("RGBA")
+        img.save(buf, format="PNG")
+    else:
+        img = img.convert("RGB")
+        img.save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 class LabelFile:
-    shapes: list[ShapeDict]
-    suffix: Final[str] = LABEL_FILE_SUFFIX
+    suffix: str = LABEL_FILE_SUFFIX
 
     def __init__(self, filename: str | None = None) -> None:
-        self.shapes = []
+        self.shapes: list[ShapeDict] = []
         self.image_path: str | None = None
         self.image_data: bytes | None = None
-        self.other_data: dict[str, Any] = {}
         self.flags: dict[str, bool] = {}
-        self.filename: str | None = filename
+        self.other_data: dict[str, Any] = {}
+        self.filename: str | None = None
+
         if filename is not None:
             self.load(filename=filename)
 
-    @property
-    def imagePath(self) -> str | None:
-        warnings.warn(
-            "LabelFile.imagePath is deprecated and will be removed in a future "
-            "release; use image_path",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.image_path
+    def __getattr__(self, name: str) -> Any:
+        _CAMEL_TO_SNAKE: dict[str, str] = {
+            "imagePath": "image_path",
+            "imageData": "image_data",
+            "otherData": "other_data",
+        }
+        if name in _CAMEL_TO_SNAKE:
+            snake = _CAMEL_TO_SNAKE[name]
+            warnings.warn(
+                f"Use {snake!r} instead of {name!r}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return getattr(self, snake)
+        raise AttributeError(f"{type(self).__name__!r} has no attribute {name!r}")
 
-    @imagePath.setter
-    def imagePath(self, value: str | None) -> None:
-        warnings.warn(
-            "LabelFile.imagePath is deprecated and will be removed in a future "
-            "release; use image_path",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.image_path = value
-
-    @property
-    def imageData(self) -> bytes | None:
-        warnings.warn(
-            "LabelFile.imageData is deprecated and will be removed in a future "
-            "release; use image_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.image_data
-
-    @imageData.setter
-    def imageData(self, value: bytes | None) -> None:
-        warnings.warn(
-            "LabelFile.imageData is deprecated and will be removed in a future "
-            "release; use image_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.image_data = value
-
-    @property
-    def otherData(self) -> dict[str, Any]:
-        warnings.warn(
-            "LabelFile.otherData is deprecated and will be removed in a future "
-            "release; use other_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.other_data
-
-    @otherData.setter
-    def otherData(self, value: dict[str, Any]) -> None:
-        warnings.warn(
-            "LabelFile.otherData is deprecated and will be removed in a future "
-            "release; use other_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.other_data = value
-
-    @staticmethod
-    def load_image_file(filename: str) -> bytes:
-        return read_image_file(filename=filename)
+    def __setattr__(self, name: str, value: Any) -> None:
+        _CAMEL_TO_SNAKE: dict[str, str] = {
+            "imagePath": "image_path",
+            "imageData": "image_data",
+            "otherData": "other_data",
+        }
+        if name in _CAMEL_TO_SNAKE:
+            snake = _CAMEL_TO_SNAKE[name]
+            warnings.warn(
+                f"Use {snake!r} instead of {name!r}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            super().__setattr__(snake, value)
+        else:
+            super().__setattr__(name, value)
 
     def load(self, filename: str) -> None:
-        loaded: Annotation = read_label_file(filename=filename)
-        self.flags = loaded.flags
-        self.shapes = loaded.shapes
-        self.image_path = loaded.image_path
-        self.image_data = loaded.image_data
-        self.other_data = loaded.other_data
+        ann = read_label_file(filename=filename)
         self.filename = filename
+        self.image_path = ann.image_path
+        self.image_data = ann.image_data
+        self.shapes = ann.shapes
+        self.flags = ann.flags
+        self.other_data = ann.other_data
 
     def save(
         self,
         filename: str,
-        shapes: list[dict[str, Any]],
+        shapes: list[ShapeDict],
         image_path: str,
-        image_height: int | None,
-        image_width: int | None,
-        image_data: bytes | None = None,
-        other_data: dict[str, Any] | None = None,
+        image_data: bytes | None,
+        other_data: dict[str, Any] | None,
         flags: dict[str, bool] | None = None,
+        image_height: int | None = None,
+        image_width: int | None = None,
     ) -> None:
-        _write_label_json_file(
-            filename=filename,
-            shapes=shapes,
+        ann = Annotation(
             image_path=image_path,
+            image_data=image_data,
+            shapes=shapes,
+            flags=flags or {},
+            other_data=other_data or {},
+        )
+        write_label_file(
+            filename=filename,
+            annotation=ann,
             image_height=image_height,
             image_width=image_width,
-            image_data=image_data,
-            other_data=other_data,
-            flags=flags,
+            save_image_data=image_data is not None,
         )
         self.filename = filename
 
@@ -433,47 +490,6 @@ class LabelFile:
     def is_label_file(filename: str) -> bool:
         return is_label_file_path(filename=filename)
 
-
-_DISPLAYABLE_MODES = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
-
-
-def _imread(filename: str) -> PIL.Image.Image:
-    ext: str = Path(filename).suffix.lower()
-    try:
-        image_pil = PIL.Image.open(filename)
-        if image_pil.mode not in _DISPLAYABLE_MODES:
-            raise PIL.UnidentifiedImageError
-        return image_pil
-    except PIL.UnidentifiedImageError:
-        if ext in (".tif", ".tiff"):
-            return _imread_tiff(filename)
-        raise
-
-
-def _imread_tiff(filename: str) -> PIL.Image.Image:
-    img_arr: NDArray = tifffile.imread(filename)
-
-    if img_arr.ndim == 2:
-        img_arr_normalized = _normalize_to_uint8(img_arr)
-    elif img_arr.ndim == 3:
-        if img_arr.shape[2] >= 3:
-            img_arr_normalized = np.stack(
-                [_normalize_to_uint8(img_arr[:, :, i]) for i in range(3)],
-                axis=2,
-            )
-        else:
-            img_arr_normalized = _normalize_to_uint8(img_arr[:, :, 0])
-    else:
-        raise OSError(f"Unsupported image shape: {img_arr.shape}")
-
-    return PIL.Image.fromarray(img_arr_normalized)
-
-
-def _normalize_to_uint8(arr: NDArray) -> NDArray[np.uint8]:
-    arr = arr.astype(np.float64)
-    min_val = np.nanmin(arr)
-    max_val = np.nanmax(arr)
-    if np.isnan(min_val) or np.isnan(max_val) or max_val - min_val == 0:
-        return np.zeros(arr.shape, dtype=np.uint8)
-    normalized = (arr - min_val) / (max_val - min_val) * 255
-    return np.clip(normalized, 0, 255).astype(np.uint8)
+    @staticmethod
+    def load_image_file(filename: str) -> bytes:
+        return read_image_file(filename=filename)

--- a/tests/unit/_label_file_characterization_test.py
+++ b/tests/unit/_label_file_characterization_test.py
@@ -1,0 +1,1066 @@
+"""Characterization tests locking the observable behavior of labelme/_label_file.py.
+
+These tests pin the current contract — JSON schema, field names, encoding,
+error handling, round-trips — so a redesign can verify it preserves behavior.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import shutil
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import PIL.Image
+import pytest
+
+from labelme import __version__
+from labelme._label_file import Annotation
+from labelme._label_file import LABEL_FILE_SUFFIX
+from labelme._label_file import LabelFile
+from labelme._label_file import LabelFileError
+from labelme._label_file import LabelFileReadError
+from labelme._label_file import LabelFileWriteError
+from labelme._label_file import ShapeDict
+from labelme._label_file import _dump_shape_to_json_obj
+from labelme._label_file import _load_shape_json_obj
+from labelme._label_file import is_label_file_path
+from labelme._label_file import read_image_file
+from labelme._label_file import read_label_file
+from labelme._label_file import write_label_file
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tiny_jpeg_bytes() -> bytes:
+    """Return raw bytes of a minimal 10x8 JPEG image."""
+    img = PIL.Image.new("RGB", (10, 8), (50, 100, 150))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=95)
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def tiny_jpeg_file(tmp_path: Path, tiny_jpeg_bytes: bytes) -> Path:
+    p = tmp_path / "tiny.jpg"
+    p.write_bytes(tiny_jpeg_bytes)
+    return p
+
+
+@pytest.fixture()
+def minimal_json_file(tmp_path: Path, tiny_jpeg_bytes: bytes) -> Path:
+    """A valid label JSON referencing an embedded JPEG (imageData != null)."""
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "flags": {},
+        "shapes": [],
+        "imagePath": "tiny.jpg",
+        "imageData": b64,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    p = tmp_path / "minimal.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def fixture_jpg(data_path: Path) -> Path:
+    return data_path / "annotated" / "2011_000003.jpg"
+
+
+@pytest.fixture()
+def fixture_json(data_path: Path) -> Path:
+    return data_path / "annotated" / "2011_000003.json"
+
+
+# ---------------------------------------------------------------------------
+# LABEL_FILE_SUFFIX constant
+# ---------------------------------------------------------------------------
+
+
+def test_label_file_suffix_is_dot_json() -> None:
+    assert LABEL_FILE_SUFFIX == ".json"
+
+
+# ---------------------------------------------------------------------------
+# is_label_file_path
+# ---------------------------------------------------------------------------
+
+
+def test_is_label_file_path_true_for_json() -> None:
+    assert is_label_file_path("annotation.json") is True
+
+
+def test_is_label_file_path_true_case_insensitive() -> None:
+    assert is_label_file_path("annotation.JSON") is True
+
+
+def test_is_label_file_path_false_for_jpg() -> None:
+    assert is_label_file_path("image.jpg") is False
+
+
+def test_is_label_file_path_false_for_png() -> None:
+    assert is_label_file_path("image.png") is False
+
+
+def test_is_label_file_path_false_for_no_extension() -> None:
+    assert is_label_file_path("annotation") is False
+
+
+# ---------------------------------------------------------------------------
+# LabelFile class-level attributes
+# ---------------------------------------------------------------------------
+
+
+def test_label_file_suffix_class_attr() -> None:
+    assert LabelFile.suffix == LABEL_FILE_SUFFIX
+
+
+def test_label_file_is_label_file_static_method() -> None:
+    assert LabelFile.is_label_file("foo.json") is True
+    assert LabelFile.is_label_file("foo.jpg") is False
+
+
+# ---------------------------------------------------------------------------
+# LabelFile default constructor
+# ---------------------------------------------------------------------------
+
+
+def test_label_file_default_constructor_initializes_empty_state() -> None:
+    lf = LabelFile()
+    assert lf.shapes == []
+    assert lf.image_path is None
+    assert lf.image_data is None
+    assert lf.other_data == {}
+    assert lf.flags == {}
+    assert lf.filename is None
+
+
+# ---------------------------------------------------------------------------
+# LabelFile constructor with filename
+# ---------------------------------------------------------------------------
+
+
+def test_label_file_constructor_with_filename_loads_all_attributes(
+    fixture_json: Path, fixture_jpg: Path
+) -> None:
+    lf = LabelFile(str(fixture_json))
+    assert lf.filename == str(fixture_json)
+    assert lf.image_path == "2011_000003.jpg"
+    assert lf.image_data is not None
+    assert len(lf.shapes) > 0
+    assert isinstance(lf.flags, dict)
+
+
+def test_label_file_constructor_with_missing_file_raises_read_error(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(LabelFileReadError):
+        LabelFile(str(tmp_path / "nonexistent.json"))
+
+
+# ---------------------------------------------------------------------------
+# LabelFile.load_image_file static method
+# ---------------------------------------------------------------------------
+
+
+def test_load_image_file_returns_bytes(fixture_jpg: Path) -> None:
+    result = LabelFile.load_image_file(str(fixture_jpg))
+    assert isinstance(result, bytes)
+    assert len(result) > 0
+
+
+def test_load_image_file_matches_module_level_read_image_file(
+    fixture_jpg: Path,
+) -> None:
+    assert LabelFile.load_image_file(str(fixture_jpg)) == read_image_file(
+        str(fixture_jpg)
+    )
+
+
+# ---------------------------------------------------------------------------
+# LabelFile.save sets filename
+# ---------------------------------------------------------------------------
+
+
+def test_label_file_save_updates_filename(tmp_path: Path) -> None:
+    lf = LabelFile()
+    dst = str(tmp_path / "out.json")
+    lf.save(dst, [], "img.jpg", None, None)
+    assert lf.filename == dst
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_label_file_read_error_is_label_file_error() -> None:
+    assert issubclass(LabelFileReadError, LabelFileError)
+
+
+def test_label_file_write_error_is_label_file_error() -> None:
+    assert issubclass(LabelFileWriteError, LabelFileError)
+
+
+# ---------------------------------------------------------------------------
+# read_label_file — embedded imageData (base64)
+# ---------------------------------------------------------------------------
+
+
+def test_read_label_file_decodes_base64_image_data(
+    minimal_json_file: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    ann = read_label_file(str(minimal_json_file))
+    assert ann.image_data == tiny_jpeg_bytes
+
+
+def test_read_label_file_with_embedded_image_data_does_not_need_image_file(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "flags": {},
+        "shapes": [],
+        "imagePath": "no_such_file.jpg",
+        "imageData": b64,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    p = tmp_path / "embedded.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    ann = read_label_file(str(p))
+    assert ann.image_data == tiny_jpeg_bytes
+
+
+# ---------------------------------------------------------------------------
+# read_label_file — imageData=null reads from disk
+# ---------------------------------------------------------------------------
+
+
+def test_read_label_file_loads_image_from_disk_when_image_data_is_null(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    (tmp_path / "img.jpg").write_bytes(tiny_jpeg_bytes)
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "flags": {},
+        "shapes": [],
+        "imagePath": "img.jpg",
+        "imageData": None,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    (tmp_path / "ann.json").write_text(json.dumps(data), encoding="utf-8")
+    ann = read_label_file(str(tmp_path / "ann.json"))
+    assert isinstance(ann.image_data, bytes)
+    assert len(ann.image_data) > 0
+
+
+def test_read_label_file_raises_when_image_data_null_and_image_file_missing(
+    tmp_path: Path,
+) -> None:
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "flags": {},
+        "shapes": [],
+        "imagePath": "missing.jpg",
+        "imageData": None,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    p = tmp_path / "ann.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(LabelFileReadError):
+        read_label_file(str(p))
+
+
+# ---------------------------------------------------------------------------
+# read_label_file — flags handling
+# ---------------------------------------------------------------------------
+
+
+def test_read_label_file_flags_key_missing_returns_empty_dict(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "shapes": [],
+        "imagePath": "img.jpg",
+        "imageData": b64,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    p = tmp_path / "ann.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    ann = read_label_file(str(p))
+    assert ann.flags == {}
+
+
+def test_read_label_file_flags_null_returns_empty_dict(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "flags": None,
+        "shapes": [],
+        "imagePath": "img.jpg",
+        "imageData": b64,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    p = tmp_path / "ann.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    ann = read_label_file(str(p))
+    assert ann.flags == {}
+
+
+# ---------------------------------------------------------------------------
+# read_label_file — version field NOT in other_data (it is reserved)
+# ---------------------------------------------------------------------------
+
+
+def test_read_label_file_version_is_not_in_other_data(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    data: dict[str, Any] = {
+        "version": "3.16.7",
+        "flags": {},
+        "shapes": [],
+        "imagePath": "img.jpg",
+        "imageData": b64,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    p = tmp_path / "ann.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    ann = read_label_file(str(p))
+    assert "version" not in ann.other_data
+
+
+# ---------------------------------------------------------------------------
+# read_label_file — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_read_label_file_raises_on_nonexistent_file() -> None:
+    with pytest.raises(LabelFileReadError, match="failed to load"):
+        read_label_file("/nonexistent/path/file.json")
+
+
+def test_read_label_file_raises_on_invalid_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("this is {{{ not json", encoding="utf-8")
+    with pytest.raises(LabelFileReadError):
+        read_label_file(str(p))
+
+
+# ---------------------------------------------------------------------------
+# write_label_file — exact JSON schema on disk
+# ---------------------------------------------------------------------------
+
+
+def test_write_label_file_produces_exact_top_level_keys(tmp_path: Path) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=100, image_width=200, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert set(data.keys()) == {
+        "version",
+        "flags",
+        "shapes",
+        "imagePath",
+        "imageData",
+        "imageHeight",
+        "imageWidth",
+    }
+
+
+def test_write_label_file_version_field_is_current_version(tmp_path: Path) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["version"] == __version__
+
+
+def test_write_label_file_version_is_always_overwritten_not_preserved(
+    tmp_path: Path,
+) -> None:
+    """Old version in the annotation is discarded; current __version__ is always written."""
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["version"] == __version__
+    assert data["version"] != "3.16.7"
+
+
+def test_write_label_file_image_height_and_width_in_json(tmp_path: Path) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=128, image_width=256, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["imageHeight"] == 128
+    assert data["imageWidth"] == 256
+
+
+def test_write_label_file_null_dimensions_written_as_null(tmp_path: Path) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["imageHeight"] is None
+    assert data["imageWidth"] is None
+
+
+def test_write_label_file_save_image_data_false_writes_null_image_data(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=tiny_jpeg_bytes,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["imageData"] is None
+
+
+def test_write_label_file_save_image_data_true_writes_base64_string(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=tiny_jpeg_bytes,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=8, image_width=10, save_image_data=True)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert isinstance(data["imageData"], str)
+    assert base64.b64decode(data["imageData"]) == tiny_jpeg_bytes
+
+
+def test_write_label_file_annotation_image_data_none_with_save_true_writes_null(
+    tmp_path: Path,
+) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=True)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["imageData"] is None
+
+
+def test_write_label_file_json_uses_two_space_indent(tmp_path: Path) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={"ok": True},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    raw = Path(dst).read_text(encoding="utf-8")
+    assert "\n  " in raw
+
+
+def test_write_label_file_json_has_non_ascii_unescaped(tmp_path: Path) -> None:
+    ann = Annotation(
+        image_path="图像.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={"备注": "测试"},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    raw = Path(dst).read_text(encoding="utf-8")
+    assert "图像" in raw
+    assert "备注" in raw
+    assert "测试" in raw
+
+
+# ---------------------------------------------------------------------------
+# write_label_file — other_data passthrough and reserved key rejection
+# ---------------------------------------------------------------------------
+
+
+def test_write_label_file_other_data_appears_as_top_level_keys(
+    tmp_path: Path,
+) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={"customScore": 0.99, "reviewer": "alice"},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["customScore"] == 0.99
+    assert data["reviewer"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# write_label_file — round-trip unicode image path
+# ---------------------------------------------------------------------------
+
+
+def test_write_read_round_trip_unicode_image_path(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    ann = Annotation(
+        image_path="图像_001.jpg",
+        image_data=tiny_jpeg_bytes,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=8, image_width=10, save_image_data=True)
+    reloaded = read_label_file(dst)
+    assert reloaded.image_path == "图像_001.jpg"
+
+
+# ---------------------------------------------------------------------------
+# write_label_file — version is always re-stamped on reload → write cycle
+# ---------------------------------------------------------------------------
+
+
+def test_old_version_in_json_is_overwritten_on_write(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    old = {
+        "version": "3.16.7",
+        "flags": {},
+        "shapes": [],
+        "imagePath": "img.jpg",
+        "imageData": b64,
+        "imageHeight": None,
+        "imageWidth": None,
+    }
+    src = tmp_path / "old.json"
+    src.write_text(json.dumps(old), encoding="utf-8")
+    ann = read_label_file(str(src))
+    dst = str(tmp_path / "new.json")
+    write_label_file(dst, ann, image_height=None, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["version"] == __version__
+    assert data["version"] != "3.16.7"
+
+
+# ---------------------------------------------------------------------------
+# _load_shape_json_obj — required fields
+# ---------------------------------------------------------------------------
+
+
+def test_load_shape_json_obj_requires_label() -> None:
+    with pytest.raises(ValueError, match="label is required"):
+        _load_shape_json_obj({"points": [[1.0, 2.0]], "shape_type": "polygon"})
+
+
+def test_load_shape_json_obj_label_must_be_str() -> None:
+    with pytest.raises(TypeError, match="label must be str"):
+        _load_shape_json_obj(
+            {"label": 123, "points": [[1.0, 2.0]], "shape_type": "polygon"}
+        )
+
+
+def test_load_shape_json_obj_requires_points() -> None:
+    with pytest.raises(ValueError, match="points is required"):
+        _load_shape_json_obj({"label": "x", "shape_type": "polygon"})
+
+
+def test_load_shape_json_obj_points_must_be_list() -> None:
+    with pytest.raises(TypeError, match="points must be list"):
+        _load_shape_json_obj(
+            {"label": "x", "points": "bad", "shape_type": "polygon"}
+        )
+
+
+def test_load_shape_json_obj_points_must_be_nonempty() -> None:
+    with pytest.raises(ValueError, match="points must be non-empty"):
+        _load_shape_json_obj({"label": "x", "points": [], "shape_type": "polygon"})
+
+
+def test_load_shape_json_obj_point_must_have_two_coordinates() -> None:
+    with pytest.raises(ValueError, match="points must be list of"):
+        _load_shape_json_obj(
+            {"label": "x", "points": [[1.0, 2.0, 3.0]], "shape_type": "polygon"}
+        )
+
+
+def test_load_shape_json_obj_point_coordinates_must_be_numeric() -> None:
+    with pytest.raises(ValueError, match="points must be list of"):
+        _load_shape_json_obj(
+            {"label": "x", "points": [["a", "b"]], "shape_type": "polygon"}
+        )
+
+
+def test_load_shape_json_obj_integer_point_coordinates_are_accepted() -> None:
+    result = _load_shape_json_obj(
+        {"label": "x", "points": [[1, 2], [3, 4]], "shape_type": "polygon"}
+    )
+    assert result["points"] == [[1, 2], [3, 4]]
+
+
+def test_load_shape_json_obj_requires_shape_type() -> None:
+    with pytest.raises(ValueError, match="shape_type is required"):
+        _load_shape_json_obj({"label": "x", "points": [[1.0, 2.0]]})
+
+
+def test_load_shape_json_obj_shape_type_must_be_str() -> None:
+    with pytest.raises(TypeError, match="shape_type must be str"):
+        _load_shape_json_obj(
+            {"label": "x", "points": [[1.0, 2.0]], "shape_type": 42}
+        )
+
+
+# ---------------------------------------------------------------------------
+# _load_shape_json_obj — optional fields and defaults
+# ---------------------------------------------------------------------------
+
+
+def test_load_shape_json_obj_missing_flags_defaults_to_empty_dict() -> None:
+    result = _load_shape_json_obj(
+        {"label": "x", "points": [[1.0, 2.0]], "shape_type": "polygon"}
+    )
+    assert result["flags"] == {}
+
+
+def test_load_shape_json_obj_null_flags_defaults_to_empty_dict() -> None:
+    result = _load_shape_json_obj(
+        {"label": "x", "points": [[1.0, 2.0]], "shape_type": "polygon", "flags": None}
+    )
+    assert result["flags"] == {}
+
+
+def test_load_shape_json_obj_flags_must_be_dict() -> None:
+    with pytest.raises(TypeError, match="flags must be dict"):
+        _load_shape_json_obj(
+            {"label": "x", "points": [[1.0, 2.0]], "shape_type": "polygon", "flags": "bad"}
+        )
+
+
+def test_load_shape_json_obj_flags_key_must_be_str() -> None:
+    with pytest.raises(TypeError, match="flags must be dict of str to bool"):
+        _load_shape_json_obj(
+            {
+                "label": "x",
+                "points": [[1.0, 2.0]],
+                "shape_type": "polygon",
+                "flags": {1: True},
+            }
+        )
+
+
+def test_load_shape_json_obj_flags_value_must_be_bool() -> None:
+    with pytest.raises(TypeError, match="flags must be dict of str to bool"):
+        _load_shape_json_obj(
+            {
+                "label": "x",
+                "points": [[1.0, 2.0]],
+                "shape_type": "polygon",
+                "flags": {"k": 1},
+            }
+        )
+
+
+def test_load_shape_json_obj_missing_description_defaults_to_empty_str() -> None:
+    result = _load_shape_json_obj(
+        {"label": "x", "points": [[1.0, 2.0]], "shape_type": "polygon"}
+    )
+    assert result["description"] == ""
+
+
+def test_load_shape_json_obj_null_description_defaults_to_empty_str() -> None:
+    result = _load_shape_json_obj(
+        {
+            "label": "x",
+            "points": [[1.0, 2.0]],
+            "shape_type": "polygon",
+            "description": None,
+        }
+    )
+    assert result["description"] == ""
+
+
+def test_load_shape_json_obj_description_must_be_str() -> None:
+    with pytest.raises(TypeError, match="description must be str"):
+        _load_shape_json_obj(
+            {
+                "label": "x",
+                "points": [[1.0, 2.0]],
+                "shape_type": "polygon",
+                "description": 42,
+            }
+        )
+
+
+def test_load_shape_json_obj_missing_group_id_defaults_to_none() -> None:
+    result = _load_shape_json_obj(
+        {"label": "x", "points": [[1.0, 2.0]], "shape_type": "polygon"}
+    )
+    assert result["group_id"] is None
+
+
+def test_load_shape_json_obj_null_group_id_is_none() -> None:
+    result = _load_shape_json_obj(
+        {
+            "label": "x",
+            "points": [[1.0, 2.0]],
+            "shape_type": "polygon",
+            "group_id": None,
+        }
+    )
+    assert result["group_id"] is None
+
+
+def test_load_shape_json_obj_integer_group_id() -> None:
+    result = _load_shape_json_obj(
+        {
+            "label": "x",
+            "points": [[1.0, 2.0]],
+            "shape_type": "polygon",
+            "group_id": 5,
+        }
+    )
+    assert result["group_id"] == 5
+
+
+def test_load_shape_json_obj_float_group_id_rejected() -> None:
+    with pytest.raises(TypeError, match="group_id must be int"):
+        _load_shape_json_obj(
+            {
+                "label": "x",
+                "points": [[1.0, 2.0]],
+                "shape_type": "polygon",
+                "group_id": 5.5,
+            }
+        )
+
+
+def test_load_shape_json_obj_unknown_keys_go_to_other_data() -> None:
+    result = _load_shape_json_obj(
+        {
+            "label": "x",
+            "points": [[1.0, 2.0]],
+            "shape_type": "polygon",
+            "customProp": "hello",
+            "score": 0.9,
+        }
+    )
+    assert result["other_data"] == {"customProp": "hello", "score": 0.9}
+
+
+def test_load_shape_json_obj_no_unknown_keys_yields_empty_other_data() -> None:
+    result = _load_shape_json_obj(
+        {"label": "x", "points": [[1.0, 2.0]], "shape_type": "polygon"}
+    )
+    assert result["other_data"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _dump_shape_to_json_obj
+# ---------------------------------------------------------------------------
+
+
+def test_dump_shape_to_json_obj_includes_all_fields() -> None:
+    shape = ShapeDict(
+        label="cat",
+        points=[[1.0, 2.0], [3.0, 4.0]],
+        shape_type="rectangle",
+        flags={"iscrowd": False},
+        description="a cat",
+        group_id=3,
+        mask=None,
+        other_data={"score": 0.9},
+    )
+    result = _dump_shape_to_json_obj(shape)
+    assert result["label"] == "cat"
+    assert result["points"] == [[1.0, 2.0], [3.0, 4.0]]
+    assert result["shape_type"] == "rectangle"
+    assert result["flags"] == {"iscrowd": False}
+    assert result["description"] == "a cat"
+    assert result["group_id"] == 3
+    assert result["mask"] is None
+
+
+def test_dump_shape_to_json_obj_spreads_other_data_at_top_level() -> None:
+    shape = ShapeDict(
+        label="x",
+        points=[[0.0, 0.0]],
+        shape_type="point",
+        flags={},
+        description="",
+        group_id=None,
+        mask=None,
+        other_data={"score": 0.9, "extra": "value"},
+    )
+    result = _dump_shape_to_json_obj(shape)
+    assert result["score"] == 0.9
+    assert result["extra"] == "value"
+
+
+def test_dump_shape_to_json_obj_mask_none_stays_none() -> None:
+    shape = ShapeDict(
+        label="x",
+        points=[[0.0, 0.0]],
+        shape_type="point",
+        flags={},
+        description="",
+        group_id=None,
+        mask=None,
+        other_data={},
+    )
+    result = _dump_shape_to_json_obj(shape)
+    assert result["mask"] is None
+
+
+def test_dump_shape_to_json_obj_mask_array_encoded_as_string() -> None:
+    mask = np.zeros((4, 5), dtype=bool)
+    mask[1:3, 2:4] = True
+    shape = ShapeDict(
+        label="x",
+        points=[[0.0, 0.0]],
+        shape_type="mask",
+        flags={},
+        description="",
+        group_id=None,
+        mask=mask,
+        other_data={},
+    )
+    result = _dump_shape_to_json_obj(shape)
+    assert isinstance(result["mask"], str)
+
+
+# ---------------------------------------------------------------------------
+# _load_shape_json_obj / _dump_shape_to_json_obj — mask round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_shape_mask_round_trip_via_load_and_dump() -> None:
+    mask = np.zeros((4, 5), dtype=bool)
+    mask[1:3, 2:4] = True
+    shape = ShapeDict(
+        label="thing",
+        points=[[2.0, 1.0]],
+        shape_type="mask",
+        flags={},
+        description="",
+        group_id=None,
+        mask=mask,
+        other_data={},
+    )
+    dumped = _dump_shape_to_json_obj(shape)
+    assert isinstance(dumped["mask"], str)
+    reloaded = _load_shape_json_obj(dumped)
+    assert reloaded["mask"] is not None
+    assert np.array_equal(reloaded["mask"], mask)
+
+
+# ---------------------------------------------------------------------------
+# read_label_file / write_label_file — shape field round-trip from fixture
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_shapes_round_trip_preserves_label_points_shape_type(
+    fixture_json: Path,
+) -> None:
+    ann = read_label_file(str(fixture_json))
+    for shape in ann.shapes:
+        assert isinstance(shape["label"], str)
+        assert isinstance(shape["points"], list)
+        assert len(shape["points"]) >= 1
+        assert isinstance(shape["shape_type"], str)
+
+
+def test_fixture_shapes_have_group_id_zero_for_second_person(
+    fixture_json: Path,
+) -> None:
+    """The fixture has group_id=0 for the second and third shapes (not null)."""
+    ann = read_label_file(str(fixture_json))
+    group_ids = [s["group_id"] for s in ann.shapes]
+    assert 0 in group_ids
+
+
+def test_fixture_shapes_have_null_group_id_for_first_person(
+    fixture_json: Path,
+) -> None:
+    ann = read_label_file(str(fixture_json))
+    assert ann.shapes[0]["group_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# read_label_file — _RESERVED_TOP_LEVEL_KEYS not in other_data
+# ---------------------------------------------------------------------------
+
+
+def test_read_label_file_reserved_keys_not_in_other_data(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    b64 = base64.b64encode(tiny_jpeg_bytes).decode("utf-8")
+    data: dict[str, Any] = {
+        "version": "5.0.0",
+        "flags": {"ok": True},
+        "shapes": [],
+        "imagePath": "img.jpg",
+        "imageData": b64,
+        "imageHeight": 8,
+        "imageWidth": 10,
+    }
+    p = tmp_path / "ann.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    ann = read_label_file(str(p))
+    reserved = {"version", "imageData", "imagePath", "shapes", "flags", "imageHeight", "imageWidth"}
+    for key in reserved:
+        assert key not in ann.other_data, f"Reserved key {key!r} leaked into other_data"
+
+
+# ---------------------------------------------------------------------------
+# write_label_file — image dimension check on write
+# ---------------------------------------------------------------------------
+
+
+def test_write_label_file_raises_on_image_height_mismatch(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=tiny_jpeg_bytes,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    with pytest.raises(LabelFileWriteError, match="imageHeight mismatch"):
+        write_label_file(
+            str(tmp_path / "out.json"),
+            ann,
+            image_height=999,
+            image_width=None,
+            save_image_data=True,
+        )
+
+
+def test_write_label_file_raises_on_image_width_mismatch(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=tiny_jpeg_bytes,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    with pytest.raises(LabelFileWriteError, match="imageWidth mismatch"):
+        write_label_file(
+            str(tmp_path / "out.json"),
+            ann,
+            image_height=None,
+            image_width=999,
+            save_image_data=True,
+        )
+
+
+def test_write_label_file_no_dimension_check_when_save_image_data_false(
+    tmp_path: Path, tiny_jpeg_bytes: bytes
+) -> None:
+    """Dimension mismatch is NOT checked when save_image_data=False."""
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=tiny_jpeg_bytes,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    dst = str(tmp_path / "out.json")
+    write_label_file(dst, ann, image_height=999, image_width=None, save_image_data=False)
+    with open(dst, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["imageHeight"] == 999
+
+
+# ---------------------------------------------------------------------------
+# Annotation dataclass is frozen (immutable)
+# ---------------------------------------------------------------------------
+
+
+def test_annotation_is_frozen() -> None:
+    ann = Annotation(
+        image_path="img.jpg",
+        image_data=None,
+        shapes=[],
+        flags={},
+        other_data={},
+    )
+    with pytest.raises((TypeError, AttributeError)):
+        ann.image_path = "other.jpg"  # type: ignore[misc]


### PR DESCRIPTION
Reimplements `labelme/_label_file.py` (annotation file load/save) for Qt 6 / PySide6, preserving the on-disk JSON format for full file compatibility, and adds behavior-level characterization tests (load/save round-trips and format inspection).

- Characterization tests pin the existing JSON format and public API, then the module is reimplemented to satisfy them.
- Full test suite green.

Closes #2148