### PR TITLE
fix: align compute_polygon_from_mask coordinates with image space

### DIFF
--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Final
 from typing import NamedTuple
 
 import numpy as np
@@ -142,20 +143,27 @@ def _get_contour_length(contour: NDArray[np.float32]) -> float:
 
 
 def compute_polygon_from_mask(mask: NDArray[np.bool_]) -> NDArray[np.float32]:
+    # Pad so a region touching the image border still has a background ring to
+    # close its contour against; the resulting offset is removed below.
+    PAD: Final[int] = 1
     contours: NDArray[np.float32] = skimage.measure.find_contours(
-        np.pad(mask, pad_width=1)
+        np.pad(mask, pad_width=PAD)
     )
     if len(contours) == 0:
         logger.warning("No contour found, so returning empty polygon.")
         return np.empty((0, 2), dtype=np.float32)
 
     contour: NDArray[np.float32] = max(contours, key=_get_contour_length)
-    POLYGON_APPROX_TOLERANCE: float = 0.004
+    contour = contour - PAD  # undo the pad shift: back to image-space coords
+    POLYGON_APPROX_TOLERANCE: Final[float] = 0.004
     polygon: NDArray[np.float32] = skimage.measure.approximate_polygon(
         coords=contour,
         tolerance=np.ptp(contour, axis=0).max() * POLYGON_APPROX_TOLERANCE,
     )
-    polygon = np.clip(polygon, (0, 0), (mask.shape[0] - 1, mask.shape[1] - 1))
+    # np.clip is inclusive and a half-pixel boundary can reach shape - 0.5, so
+    # the ceiling is mask.shape (not mask.shape - 1) to keep edge-touching
+    # contours from being pulled inward by a pixel.
+    polygon = np.clip(polygon, (0, 0), (mask.shape[0], mask.shape[1]))
     polygon = polygon[:-1]  # drop last point that is duplicate of first point
 
     return polygon[:, ::-1]  # yx -> xy

--- a/tests/unit/_automation/_geometry_test.py
+++ b/tests/unit/_automation/_geometry_test.py
@@ -165,16 +165,16 @@ def test_compute_polygon_from_mask_returns_empty_for_empty_mask() -> None:
 
 def test_compute_polygon_from_mask_traces_rectangle_extent_in_xy_order() -> None:
     # Rows 1-3, cols 1-7 set. The result is xy-ordered, so the max extent is
-    # x=8.0, y=4.0 (a yx result would swap them, which the max assertion catches).
-    # The lower bound is the contour's half-pixel offset; the upper bound is
-    # clamped to mask size minus 1.
+    # x=7.5, y=3.5 (a yx result would swap them, which the max assertion catches).
+    # The coordinates are the region's half-pixel boundary in image space:
+    # x in [0.5, 7.5], y in [0.5, 3.5].
     mask = np.zeros((5, 9), dtype=bool)
     mask[1:4, 1:8] = True
 
     polygon = compute_polygon_from_mask(mask=mask)
 
-    assert polygon.min(axis=0) == pytest.approx([1.5, 1.5])
-    assert polygon.max(axis=0) == pytest.approx([8.0, 4.0])
+    assert polygon.min(axis=0) == pytest.approx([0.5, 0.5])
+    assert polygon.max(axis=0) == pytest.approx([7.5, 3.5])
 
 
 def test_compute_polygon_from_mask_picks_largest_contour() -> None:
@@ -188,8 +188,22 @@ def test_compute_polygon_from_mask_picks_largest_contour() -> None:
 
     polygon = compute_polygon_from_mask(mask=mask)
 
-    assert polygon.min(axis=0) == pytest.approx([1.5, 1.5])
-    assert polygon.max(axis=0) == pytest.approx([7.5, 5.5])
+    assert polygon.min(axis=0) == pytest.approx([0.5, 0.5])
+    assert polygon.max(axis=0) == pytest.approx([6.5, 4.5])
+
+
+def test_compute_polygon_from_mask_keeps_half_pixel_boundary_at_image_edge() -> None:
+    # A fully-set mask has no background border, so its contour is the outer
+    # half-pixel boundary: x in [-0.5, W-0.5], y in [-0.5, H-0.5]. The near side
+    # clips to 0, while the far side must clamp to mask size (W=9, H=5), not
+    # size-1, so it keeps its half-pixel offset (8.5, 4.5) instead of being
+    # pulled in by a pixel.
+    mask = np.ones((5, 9), dtype=bool)
+
+    polygon = compute_polygon_from_mask(mask=mask)
+
+    assert polygon.min(axis=0) == pytest.approx([0.0, 0.0])
+    assert polygon.max(axis=0) == pytest.approx([8.5, 4.5])
 
 
 def test_compute_oriented_rectangle_from_mask_l_shape_is_axis_aligned() -> None:


### PR DESCRIPTION
Closes #2224

`compute_polygon_from_mask` pads the mask by 1px before `find_contours` (so a
region touching the image border still has a background ring to close its
contour against), but the resulting contour coordinates were never shifted back.
Every returned polygon therefore carried a systematic ~1px diagonal offset. The
clip ceiling compounded it: it used `mask.shape - 1` in that padded space,
pulling the far edge in by another pixel.

This affects polygons produced by AI-assisted / automation annotation
(`_shape_builders` consumes this helper).

## Summary
- Subtract the pad width after contouring to return coordinates to image space.
- Clamp to `mask.shape` (not `mask.shape - 1`): `np.clip` is inclusive and a
  half-pixel boundary can reach `shape - 0.5`, so the old ceiling pulled
  edge-touching contours inward by a pixel.
- Update the #2219 characterization tests (which pinned the offset behavior) to
  the corrected expectations, and add an edge-touching regression test.

For the issue's worked example (a `(5, 9)` mask with `mask[1:4, 1:8]`), the
function now returns `min=[0.5, 0.5]`, `max=[7.5, 3.5]` (xy) — the region's true
half-pixel boundary in image space — instead of the previous `[1.5, 1.5]` /
`[8.0, 4.0]`.

## Test plan
- [x] updated characterization tests + new edge-touching case in
  `tests/unit/_automation/_geometry_test.py`
- [x] empirical check: worked example -> `[0.5,0.5]..[7.5,3.5]`; fully-set mask
  keeps far-edge boundary `..[8.5,4.5]`
- [x] full suite: `uv run pytest tests/` (564 passed)
- [x] `make lint`
