### PR TITLE
build: make translation optional per-PR, gate it at release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,5 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
+      - run: make check_translate
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq ($(OS),Windows_NT)
 	SHELL := bash
 endif
 
-.PHONY: help setup format lint test coverage update_translate
+.PHONY: help setup format lint test coverage update_translate check_translate
 .DEFAULT_GOAL := help
 
 PYTEST_ARGS ?= --numprocesses=auto
@@ -40,6 +40,12 @@ test:  # Run tests
 
 update_translate:
 	$(call exec,uv run tools/update_translate.py)
+
+check_translate:  # Fail if any translation is unfinished (release gate)
+	@if grep -rl 'type="unfinished"' labelme/translate/*.ts; then \
+		printf '\033[1;31mError: unfinished translations found; releases require complete translations\033[0m\n'; \
+		exit 1; \
+	fi
 
 coverage:  # Run tests with coverage
 	$(MAKE) test PYTEST_ARGS="--cov=labelme --cov-report=term-missing"

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,6 @@ lint: update_translate  # Lint code
 	$(call exec,git ls-files "*.yml" "*.yaml" | xargs uv run yamlfix --check)
 	$(call exec,uv run typos)
 	$(call exec,git diff --exit-code labelme/translate)
-	@if grep -r 'type="unfinished"' labelme/translate/*.ts; then \
-		printf '\033[1;31mError: unfinished translations found\033[0m\n'; \
-		exit 1; \
-	fi
 
 format:  # Format code
 	$(call exec,uv run ruff format)


### PR DESCRIPTION
## Summary
- Drop the `make lint` gate that failed on `type="unfinished"` translations. New UI strings can now ship in English and be translated out of band, instead of forcing a contributor to hand-translate one string into all ~20 locales before a PR can merge.
- Qt already omits unfinished translations from the compiled `.qm`, so an untranslated string falls back to its source English text at runtime. The removed gate added no runtime guarantee, only per-PR friction (and a quality risk: translations landing without native-speaker review).
- The existing `git diff --exit-code labelme/translate` check stays, so new strings are still captured into the committed `.ts`/`.qm` as `unfinished` entries for translators to pick up later.
- Relocate the completeness check to the release boundary: a new `make check_translate` target runs in `publish.yml` before build, so a `v*` tag will not publish while any string is unfinished. This preserves the current "ship only fully-translated builds" bar without paying it per PR.

## Test plan
- [x] `make check_translate` exits 0 on the current tree (all locales finished)
- [x] `make check_translate` exits non-zero when a string is made `unfinished` (verified by injecting one into `ja_JP.ts`)
- [x] Confirmed a newly-added source string lands as `type="unfinished"` and is absent from the compiled `.qm` (English fallback at runtime)

Closes #2171
