### PR TITLE
docs: note the YAML 1.2 config boolean change in the v7 upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ pip install 'labelme<7'
 
 All previous releases remain installable from [PyPI](https://pypi.org/project/labelme/#history), so existing pins keep working.
 
+v7.0.0 also changes config parsing:
+
+- **Config booleans:** `~/.labelmerc` is now parsed with ruamel.yaml (YAML 1.2), so the boolean spellings `yes`/`no`/`on`/`off` (in any capitalization) are read as strings rather than booleans. If you set any boolean option this way, switch it to `true`/`false`.
+
 ## Usage
 
 Run `labelme --help` for detail.\


### PR DESCRIPTION
Closes #2226

The "Upgrading from v6.x to v7" README note covered only the platform floor
(Qt6/PySide6, Python, OS). v7 also switched config parsing from PyYAML to
ruamel.yaml (YAML 1.2, #2114), so `yes`/`no`/`on`/`off` in `~/.labelmerc` are now
read as strings rather than booleans — a silent surprise the upgrade guide should
pre-empt.

Add a short, scoped note to the v7 upgrade section telling users to use
`true`/`false` for boolean config values. Kept it as a separate bullet (the
config change is not a platform-floor item) and called out that the change
applies to those spellings in any capitalization.

## Test plan
- [x] `make lint` (mdformat)
- [x] rendered the upgrade section and confirmed wording/accuracy (config parsing
  uses ruamel.yaml `YAML(typ="safe")`, i.e. YAML 1.2)
