### PR TITLE
fix: keep flag checkboxes disabled across textChanged rebuild

### DIFF
--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -52,6 +52,7 @@ class LabelDialog(QtWidgets.QDialog):
         self._sort_labels = sort_labels
         self._flags_spec: dict[str, list[str]] = flags or {}
         self._label_history: list[str] = []
+        self._flags_disabled = False
 
         if fit_to_content is None:
             fit_to_content = {"row": False, "column": True}
@@ -212,6 +213,7 @@ class LabelDialog(QtWidgets.QDialog):
                     checkbox = QtWidgets.QCheckBox(key)
                     if key in current_states:
                         checkbox.setChecked(current_states[key])
+                    checkbox.setEnabled(not self._flags_disabled)
                     self._flags_layout.addWidget(checkbox)
 
     def add_label_history(self, label: str) -> None:
@@ -254,6 +256,7 @@ class LabelDialog(QtWidgets.QDialog):
         else:
             self.edit_group_id.setText(str(group_id))
 
+        self._flags_disabled = flags_disabled
         if flags is not None:
             self._show_popup_flags(flags)
         else:
@@ -264,10 +267,6 @@ class LabelDialog(QtWidgets.QDialog):
         )
         if matches:
             self.label_list.setCurrentItem(matches[0])
-
-        if flags_disabled:
-            for checkbox in self._flag_checkboxes():
-                checkbox.setEnabled(False)
 
         self._fit_label_list_to_content()
         self.edit.setFocus(QtCore.Qt.FocusReason.PopupFocusReason)
@@ -293,6 +292,7 @@ class LabelDialog(QtWidgets.QDialog):
         for key, checked in flags.items():
             checkbox = QtWidgets.QCheckBox(key)
             checkbox.setChecked(checked)
+            checkbox.setEnabled(not self._flags_disabled)
             self._flags_layout.addWidget(checkbox)
 
     def _collect_flags(self) -> dict[str, bool]:

--- a/tests/unit/widgets/label_dialog_characterize_test.py
+++ b/tests/unit/widgets/label_dialog_characterize_test.py
@@ -575,3 +575,22 @@ def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
     )
     assert seen["enabled"]
     assert all(seen["enabled"])
+
+
+def test_flags_disabled_survives_text_edit_rebuild(qtbot: QtBot) -> None:
+    seen: dict[str, list[bool]] = {}
+
+    def edit_then_inspect(d: LabelDialog) -> None:
+        d.edit.setText("cattle")
+        seen.update(enabled=[cb.isEnabled() for cb in _checkboxes(d)])
+
+    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        flags_disabled=True,
+        at_show=edit_then_inspect,
+    )
+    assert seen["enabled"]
+    assert not any(seen["enabled"])


### PR DESCRIPTION
`LabelDialog.popup(..., flags_disabled=True)` disabled the flag checkboxes once after building them, but editing the label text fires `textChanged`, which runs `_update_flags` and rebuilds the checkboxes enabled, re-enabling read-only flags. The original fix (#2240) covered the initial render but not this rebuild path, which the issue flagged as a residual gap.

This tracks the disabled state on the dialog and applies it in both flag-building paths (`_show_popup_flags` and `_update_flags`), so any rebuild preserves it. The now-redundant post-build loop in `popup()` is removed.

## Test plan
- [x] new `test_flags_disabled_survives_text_edit_rebuild` (edits text mid-popup, asserts checkboxes stay disabled); confirmed it fails without the `_update_flags` change
- [x] `uv run pytest tests/unit/widgets/label_dialog_characterize_test.py` (53 passed)
- [x] `uv run ruff check` / `uv run ty check` clean
