### PR TITLE
feat(examples): make examples/ self-contained with a vendored JSON reader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           labelme --help
           labelme --version
+          # examples/ must stay self-contained: no labelme imports (#2231)
+          ! grep -rnE "import labelme|from labelme" examples/
           (cd examples/primitives && ../tutorial/export_json.py primitives.json && rm -rf primitives)
           (cd examples/tutorial && rm -rf apc2016_obj3_json && ./export_json.py apc2016_obj3.json && python load_label_png.py && git checkout -- .)
           (cd examples/semantic_segmentation && rm -rf data_dataset_voc && ./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt && git checkout -- .)

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -7,14 +7,15 @@ from pathlib import Path
 
 import imgviz
 
-import labelme
-
 try:
     import lxml.builder  # type: ignore
     import lxml.etree  # type: ignore
 except ImportError:
     print("Please install lxml:\n\n    pip install lxml\n")
     sys.exit(1)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
 
 
 def main() -> None:
@@ -60,7 +61,7 @@ def main() -> None:
     for path in sorted(Path(args.input_dir).glob("*.json")):
         print("Generating dataset from:", path)
 
-        label_file = labelme.LabelFile(filename=str(path))
+        label_file = utils.load_label_file(str(path))
 
         base = path.stem
         out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
@@ -68,8 +69,7 @@ def main() -> None:
         if not args.noviz:
             out_viz_file = output_dir / "AnnotationsVisualization" / f"{base}.jpg"
 
-        assert label_file.image_data is not None
-        img = labelme.utils.img_data_to_arr(label_file.image_data)
+        img = utils.img_data_to_arr(label_file.image_data)
         imgviz.io.imsave(out_img_file, img)
 
         maker = lxml.builder.ElementMaker()

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -14,13 +14,14 @@ from typing import Final
 import imgviz
 import numpy as np
 
-import labelme
-
 try:
     import pycocotools.mask  # type: ignore
 except ImportError:
     print("Please install pycocotools:\n\n    pip install pycocotools\n")
     sys.exit(1)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
 
 
 def _circle_to_polygon_segmentation(
@@ -119,13 +120,12 @@ def main() -> None:
     for image_id, path in enumerate(label_files):
         print("Generating dataset from:", path)
 
-        label_file = labelme.LabelFile(filename=str(path))
+        label_file = utils.load_label_file(str(path))
 
         base = path.stem
         out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
 
-        assert label_file.image_data is not None
-        img = labelme.utils.img_data_to_arr(label_file.image_data)
+        img = utils.img_data_to_arr(label_file.image_data)
         if img.ndim == 3 and img.shape[2] == 4:
             img = imgviz.rgba2rgb(img)
         imgviz.io.imsave(out_img_file, img)
@@ -148,7 +148,7 @@ def main() -> None:
             label = shape["label"]
             group_id = shape.get("group_id")
             shape_type = shape.get("shape_type", "polygon")
-            mask = labelme.utils.shape_to_mask(img.shape[:2], points, shape_type)
+            mask = utils.shape_to_mask(img.shape[:2], points, shape_type)
 
             if group_id is None:
                 group_id = uuid.uuid1()

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import imgviz
 import numpy as np
 
-import labelme
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
 
 
 def main() -> None:
@@ -77,7 +78,7 @@ def main() -> None:
     for path in sorted(Path(args.input_dir).glob("*.json")):
         print("Generating dataset from:", path)
 
-        label_file = labelme.LabelFile(filename=str(path))
+        label_file = utils.load_label_file(str(path))
 
         base = path.stem
         out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
@@ -97,11 +98,10 @@ def main() -> None:
                     output_dir / "SegmentationObjectVisualization" / f"{base}.jpg"
                 )
 
-        assert label_file.image_data is not None
-        img = labelme.utils.img_data_to_arr(label_file.image_data)
+        img = utils.img_data_to_arr(label_file.image_data)
         imgviz.io.imsave(out_img_file, img)
 
-        cls, ins = labelme.utils.shapes_to_label(
+        cls, ins = utils.shapes_to_label(
             img_shape=img.shape,
             shapes=label_file.shapes,
             label_name_to_value=class_name_to_id,

--- a/examples/tutorial/draw_json.py
+++ b/examples/tutorial/draw_json.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 import argparse
+import sys
+from pathlib import Path
 
 import imgviz
 import matplotlib.pyplot as plt
 
-from labelme import utils
-from labelme._label_file import LabelFile
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
 
 
 def main() -> None:
@@ -14,8 +16,7 @@ def main() -> None:
     parser.add_argument("json_file")
     args = parser.parse_args()
 
-    label_file = LabelFile(args.json_file)
-    assert label_file.image_data is not None
+    label_file = utils.load_label_file(args.json_file)
     img = utils.img_data_to_arr(label_file.image_data)
 
     label_name_to_value = {"_background_": 0}

--- a/examples/tutorial/export_json.py
+++ b/examples/tutorial/export_json.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import sys
 from pathlib import Path
 
 import imgviz
@@ -9,8 +10,8 @@ import PIL.Image
 from loguru import logger
 from numpy.typing import NDArray
 
-from labelme import utils
-from labelme._label_file import LabelFile
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
 
 
 def main() -> None:
@@ -24,9 +25,8 @@ def main() -> None:
     out_dir = Path(json_file).with_suffix("") if args.out is None else Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    label_file: LabelFile = LabelFile(filename=json_file)
+    label_file = utils.load_label_file(json_file)
 
-    assert label_file.image_data is not None
     image: NDArray[np.uint8] = utils.img_data_to_arr(label_file.image_data)
 
     label_name_to_value: dict[str, int] = {"_background_": 0}

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Self-contained helpers for reading the labelme JSON annotation format.
+
+labelme is an application, not a Python library: the supported way to consume
+its output is to read the JSON format yourself, the way a PyTorch ``Dataset``
+reads whatever format its data lives in. This module is the worked reference for
+doing that. It depends only on the standard library, numpy, and PIL, never on
+``labelme``, so it keeps working regardless of how labelme's internals evolve.
+
+It deliberately re-implements the rasterization helpers (``shape_to_mask``,
+``shapes_to_label``, ``img_data_to_arr``) rather than importing them: this copy
+and labelme's internal copy have different owners and lifecycles. Copy this file
+next to your own scripts and adapt it.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import io
+import json
+import math
+import uuid
+from pathlib import Path
+from pathlib import PureWindowsPath
+from typing import Any
+
+import numpy as np
+import PIL.Image
+import PIL.ImageDraw
+from numpy.typing import NDArray
+
+
+@dataclasses.dataclass(frozen=True)
+class LabeledImage:
+    image_data: bytes
+    shapes: list[dict[str, Any]]
+
+
+def load_label_file(filename: str) -> LabeledImage:
+    with open(filename, encoding="utf-8") as f:
+        data = json.load(f)
+
+    if data.get("imageData") is not None:
+        image_data = base64.b64decode(data["imageData"])
+    else:
+        image_path = PureWindowsPath(data["imagePath"]).as_posix()
+        image_data = (Path(filename).parent / image_path).read_bytes()
+
+    shapes = [
+        {
+            "label": shape["label"],
+            "points": shape["points"],
+            "shape_type": shape.get("shape_type") or "polygon",
+            "group_id": shape.get("group_id"),
+            "flags": shape.get("flags") or {},
+            "mask": None
+            if shape.get("mask") is None
+            else img_b64_to_arr(shape["mask"]).astype(bool),
+        }
+        for shape in data["shapes"]
+    ]
+    return LabeledImage(image_data=image_data, shapes=shapes)
+
+
+def img_data_to_arr(img_data: bytes) -> NDArray[np.uint8]:
+    return np.array(PIL.Image.open(io.BytesIO(img_data)))
+
+
+def img_b64_to_arr(img_b64: str | bytes) -> NDArray[np.uint8]:
+    return img_data_to_arr(base64.b64decode(img_b64))
+
+
+def shape_to_mask(
+    img_shape: tuple[int, ...],
+    points: list[list[float]],
+    shape_type: str | None = None,
+    line_width: int = 10,
+    point_size: int = 5,
+) -> NDArray[np.bool_]:
+    mask = PIL.Image.fromarray(np.zeros(img_shape[:2], dtype=np.uint8))
+    draw = PIL.ImageDraw.Draw(mask)
+    xy = [tuple(point) for point in points]
+    if shape_type == "circle":
+        assert len(xy) == 2, "Shape of shape_type=circle must have 2 points"
+        (cx, cy), (px, py) = xy
+        d = math.sqrt((cx - px) ** 2 + (cy - py) ** 2)
+        draw.ellipse(((cx - d, cy - d), (cx + d, cy + d)), outline=1, fill=1)
+    elif shape_type == "rectangle":
+        assert len(xy) == 2, "Shape of shape_type=rectangle must have 2 points"
+        (x0, y0), (x1, y1) = xy
+        draw.rectangle(
+            ((min(x0, x1), min(y0, y1)), (max(x0, x1), max(y0, y1))),
+            outline=1,
+            fill=1,
+        )
+    elif shape_type == "line":
+        assert len(xy) == 2, "Shape of shape_type=line must have 2 points"
+        draw.line(xy=xy, fill=1, width=line_width)  # ty: ignore[invalid-argument-type]
+    elif shape_type == "linestrip":
+        # joint="curve" rounds the joints so wide lines have no notch at turns.
+        draw.line(xy=xy, fill=1, width=line_width, joint="curve")  # ty: ignore[invalid-argument-type]
+    elif shape_type == "point":
+        assert len(xy) == 1, "Shape of shape_type=point must have 1 points"
+        cx, cy = xy[0]
+        r = point_size
+        draw.ellipse(((cx - r, cy - r), (cx + r, cy + r)), outline=1, fill=1)
+    elif shape_type == "oriented_rectangle":
+        assert len(xy) == 4, "Shape of shape_type=oriented_rectangle must have 4 points"
+        draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
+    elif shape_type in [None, "polygon"]:
+        assert len(xy) > 2, "Polygon must have points more than 2"
+        draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
+    else:
+        raise ValueError(f"shape_type={shape_type!r} is not supported.")
+    return np.array(mask, dtype=bool)
+
+
+def shapes_to_label(
+    img_shape: tuple[int, ...],
+    shapes: list[dict[str, Any]],
+    label_name_to_value: dict[str, int],
+) -> tuple[NDArray[np.int32], NDArray[np.int32]]:
+    unknown = {s["label"] for s in shapes} - label_name_to_value.keys()
+    if unknown:
+        raise ValueError(
+            f"shape labels not in the provided labels: {sorted(unknown)!r}; "
+            f"add them so every shape label has a value"
+        )
+
+    cls = np.zeros(img_shape[:2], dtype=np.int32)
+    ins = np.zeros_like(cls)
+    instances: list[tuple[str, Any]] = []
+    for shape in shapes:
+        points = shape["points"]
+        label = shape["label"]
+        group_id = shape.get("group_id")
+        if group_id is None:
+            group_id = uuid.uuid1()
+        shape_type = shape.get("shape_type")
+
+        instance = (label, group_id)
+        if instance not in instances:
+            instances.append(instance)
+        ins_id = instances.index(instance) + 1
+        cls_id = label_name_to_value[label]
+
+        mask: NDArray[np.bool_]
+        if shape_type == "mask":
+            if not isinstance(shape["mask"], np.ndarray):
+                raise ValueError("shape['mask'] must be numpy.ndarray")
+            mask = np.zeros(img_shape[:2], dtype=bool)
+            (x1, y1), (x2, y2) = np.asarray(points).astype(int)
+            mask[y1 : y2 + 1, x1 : x2 + 1] = shape["mask"]
+        else:
+            mask = shape_to_mask(img_shape[:2], points, shape_type)
+
+        cls[mask] = cls_id
+        ins[mask] = ins_id
+
+    return cls, ins


### PR DESCRIPTION
Closes #2231

Part of the v7 effort to make labelme an application with no public Python API. The `examples/` scripts no longer import labelme internals; they read the labelme JSON format themselves via a vendored helper, the way a PyTorch `Dataset` reads whatever format its data lives in.

## Summary
- Add `examples/utils.py`: a self-contained reader for the labelme JSON format (`load_label_file`, `img_data_to_arr`, `shape_to_mask`, `shapes_to_label`) depending only on `json`/`numpy`/`PIL`, never on `labelme`. It deliberately carries its own copy of the rasterization helpers so the examples and labelme's internals can evolve independently.
- Repoint all five scripts (`instance_segmentation/labelme2coco.py`, `instance_segmentation/labelme2voc.py`, `bbox_detection/labelme2voc.py`, `tutorial/export_json.py`, `tutorial/draw_json.py`) onto `examples/utils.py`. `grep -rn "import labelme\|from labelme" examples/` now returns nothing.
- Guard it in CI: the existing "Run examples" job (which already runs every script end-to-end) now also fails if a `labelme` import is reintroduced into `examples/`.

## Test plan
- [x] every example script runs end-to-end via the CI "Run examples" job (incl. `primitives.json`, which exercises every shape type including `mask`)
- [x] vendored helpers produce byte-identical output to labelme's across all annotated fixtures
- [x] `grep -rnE "import labelme|from labelme" examples/` returns nothing
- [x] full suite green: `uv run pytest tests/` (617 passed)
- [x] `make lint` (ruff format/check, ty, taplo)
