### PR TITLE
refactor: remove the deprecated public LabelFile class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated predefined labels in the label dialog in place when changed via Settings, preserving labels typed during the current session ([#2164](https://github.com/wkentaro/labelme/pull/2164))
 - Changed point shapes to be selected by clicking the marker as a whole rather than grabbing its single vertex ([#2158](https://github.com/wkentaro/labelme/pull/2158))
 
+### Removed
+
+- **Breaking:** Removed the public `LabelFile` class (`labelme.LabelFile`); use the `read_label_file` / `write_label_file` functions and the `LabelFileError` hierarchy in `labelme._label_file` instead ([#2246](https://github.com/wkentaro/labelme/pull/2246))
+
 ### Fixed
 
 - Fixed `line` and two-point `linestrip` shapes being unselectable by click ([#2107](https://github.com/wkentaro/labelme/pull/2107))

--- a/docs/adr/0002-annotation-round-trip.md
+++ b/docs/adr/0002-annotation-round-trip.md
@@ -60,3 +60,12 @@ headless consumers — they would import a numpy-only `Shape`. That collapse
 is retained for now so this refactor stayed scoped to making `Shape` Qt-free.
 Pushing `Shape` into `_label_file.py` remains inadvisable only for layering
 reasons, not Qt ones.
+
+## Amendment (2026-06): the `LabelFile` shim is removed
+
+The second rejected option above kept the public `LabelFile` class "untouched as
+a deprecated shim". It is now removed outright: nothing in the app or examples
+consumed it once `examples/` became self-contained, so the deprecated camelCase
+properties and the incoherent `save()` are gone. `read_label_file` /
+`write_label_file` and the `LabelFileError` hierarchy remain the only persistence
+entry points, which is the model that option already endorsed.

--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -14,4 +14,3 @@ __version__ = importlib.metadata.version("labelme")
 import onnxruntime
 
 from labelme import utils
-from labelme._label_file import LabelFile

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -4,7 +4,6 @@ import base64
 import io
 import json
 import time
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from pathlib import PureWindowsPath
@@ -317,121 +316,6 @@ def _write_label_json_file(
             json.dump(payload, f, ensure_ascii=False, indent=2)
     except (OSError, TypeError, ValueError) as e:
         raise LabelFileWriteError(f"failed to write {filename!r}: {e}") from e
-
-
-class LabelFile:
-    shapes: list[ShapeDict]
-    suffix: Final[str] = LABEL_FILE_SUFFIX
-
-    def __init__(self, filename: str | None = None) -> None:
-        self.shapes = []
-        self.image_path: str | None = None
-        self.image_data: bytes | None = None
-        self.other_data: dict[str, Any] = {}
-        self.flags: dict[str, bool] = {}
-        self.filename: str | None = filename
-        if filename is not None:
-            self.load(filename=filename)
-
-    @property
-    def imagePath(self) -> str | None:
-        warnings.warn(
-            "LabelFile.imagePath is deprecated and will be removed in a future "
-            "release; use image_path",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.image_path
-
-    @imagePath.setter
-    def imagePath(self, value: str | None) -> None:
-        warnings.warn(
-            "LabelFile.imagePath is deprecated and will be removed in a future "
-            "release; use image_path",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.image_path = value
-
-    @property
-    def imageData(self) -> bytes | None:
-        warnings.warn(
-            "LabelFile.imageData is deprecated and will be removed in a future "
-            "release; use image_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.image_data
-
-    @imageData.setter
-    def imageData(self, value: bytes | None) -> None:
-        warnings.warn(
-            "LabelFile.imageData is deprecated and will be removed in a future "
-            "release; use image_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.image_data = value
-
-    @property
-    def otherData(self) -> dict[str, Any]:
-        warnings.warn(
-            "LabelFile.otherData is deprecated and will be removed in a future "
-            "release; use other_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.other_data
-
-    @otherData.setter
-    def otherData(self, value: dict[str, Any]) -> None:
-        warnings.warn(
-            "LabelFile.otherData is deprecated and will be removed in a future "
-            "release; use other_data",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.other_data = value
-
-    @staticmethod
-    def load_image_file(filename: str) -> bytes:
-        return read_image_file(filename=filename)
-
-    def load(self, filename: str) -> None:
-        loaded: Annotation = read_label_file(filename=filename)
-        self.flags = loaded.flags
-        self.shapes = loaded.shapes
-        self.image_path = loaded.image_path
-        self.image_data = loaded.image_data
-        self.other_data = loaded.other_data
-        self.filename = filename
-
-    def save(
-        self,
-        filename: str,
-        shapes: list[dict[str, Any]],
-        image_path: str,
-        image_height: int | None,
-        image_width: int | None,
-        image_data: bytes | None = None,
-        other_data: dict[str, Any] | None = None,
-        flags: dict[str, bool] | None = None,
-    ) -> None:
-        _write_label_json_file(
-            filename=filename,
-            shapes=shapes,
-            image_path=image_path,
-            image_height=image_height,
-            image_width=image_width,
-            image_data=image_data,
-            other_data=other_data,
-            flags=flags,
-        )
-        self.filename = filename
-
-    @staticmethod
-    def is_label_file(filename: str) -> bool:
-        return is_label_file_path(filename=filename)
 
 
 _DISPLAYABLE_MODES = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 from labelme._label_file import Annotation
-from labelme._label_file import LabelFile
 from labelme._label_file import LabelFileReadError
 from labelme._label_file import LabelFileWriteError
 from labelme._label_file import ShapeDict
@@ -18,8 +17,8 @@ from labelme._label_file import read_label_file
 from labelme._label_file import write_label_file
 
 
-def test_LabelFile_load_windows_path(data_path: Path, tmp_path: Path) -> None:
-    """Test that LabelFile can load JSON with Windows-style backslash paths.
+def test_read_label_file_load_windows_path(data_path: Path, tmp_path: Path) -> None:
+    """Test that read_label_file loads JSON with Windows-style backslash paths.
 
     Regression test for https://github.com/wkentaro/labelme/issues/1725
     """
@@ -37,34 +36,9 @@ def test_LabelFile_load_windows_path(data_path: Path, tmp_path: Path) -> None:
     with open(json_file, "w") as f:
         json.dump(json_data, f)
 
-    label_file = LabelFile(str(json_file))
-    assert label_file.image_path == "../images/2011_000003.jpg"
-    assert label_file.image_data is not None
-
-
-@pytest.mark.parametrize(
-    ("snake_attr", "camel_attr", "initial", "updated"),
-    [
-        ("image_path", "imagePath", "foo.jpg", "bar.jpg"),
-        ("image_data", "imageData", b"foo", b"bar"),
-        ("other_data", "otherData", {"foo": 1}, {"bar": 2}),
-    ],
-)
-def test_LabelFile_camelCase_attribute_is_deprecated(
-    snake_attr: str,
-    camel_attr: str,
-    initial: object,
-    updated: object,
-) -> None:
-    label_file = LabelFile()
-    setattr(label_file, snake_attr, initial)
-
-    with pytest.warns(DeprecationWarning, match=snake_attr):
-        assert getattr(label_file, camel_attr) == initial
-
-    with pytest.warns(DeprecationWarning, match=snake_attr):
-        setattr(label_file, camel_attr, updated)
-    assert getattr(label_file, snake_attr) == updated
+    annotation = read_label_file(filename=str(json_file))
+    assert annotation.image_path == "../images/2011_000003.jpg"
+    assert annotation.image_data is not None
 
 
 @pytest.fixture()

--- a/tests/unit/read_image_file_test.py
+++ b/tests/unit/read_image_file_test.py
@@ -7,7 +7,7 @@ import numpy as np
 import PIL.Image
 import tifffile
 
-from labelme._label_file import LabelFile
+from labelme._label_file import read_image_file
 
 
 def _make_image(
@@ -22,25 +22,25 @@ def _make_image(
 
 def test_tiff_without_alpha_encoded_as_jpeg(tmp_path: Path) -> None:
     path = _make_image(tmp_path, "test.tiff")
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     assert data[:2] == b"\xff\xd8"
 
 
 def test_tiff_with_alpha_encoded_as_png(tmp_path: Path) -> None:
     path = _make_image(tmp_path, "test.tiff", mode="RGBA")
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     assert data[:4] == b"\x89PNG"
 
 
 def test_jpeg_returns_raw_bytes(tmp_path: Path) -> None:
     path = _make_image(tmp_path, "test.jpg")
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 
 
 def test_png_returns_raw_bytes(tmp_path: Path) -> None:
     path = _make_image(tmp_path, "test.png")
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 
 
@@ -49,7 +49,7 @@ def test_multispectral_tiff_float32(tmp_path: Path) -> None:
     path = tmp_path / "multispectral.tif"
     tifffile.imwrite(str(path), arr)
 
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     assert data[:2] == b"\xff\xd8"
 
     img = PIL.Image.open(io.BytesIO(data))
@@ -62,7 +62,7 @@ def test_grayscale_tiff_float32(tmp_path: Path) -> None:
     path = tmp_path / "grayscale.tif"
     tifffile.imwrite(str(path), arr)
 
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     img = PIL.Image.open(io.BytesIO(data))
     assert img.size == (64, 64)
 
@@ -72,7 +72,7 @@ def test_constant_value_tiff_returns_black(tmp_path: Path) -> None:
     path = tmp_path / "constant.tif"
     tifffile.imwrite(str(path), arr)
 
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     img = PIL.Image.open(io.BytesIO(data))
     assert img.size == (64, 64)
     assert np.array(img).max() == 0
@@ -83,6 +83,6 @@ def test_two_band_tiff_falls_back_to_first_band(tmp_path: Path) -> None:
     path = tmp_path / "twoband.tif"
     tifffile.imwrite(str(path), arr)
 
-    data = LabelFile.load_image_file(str(path))
+    data = read_image_file(filename=str(path))
     img = PIL.Image.open(io.BytesIO(data))
     assert img.size == (64, 64)


### PR DESCRIPTION
## Summary
- Remove the public `LabelFile` class and its re-export from `labelme/__init__.py`. It was a thin wrapper over `read_label_file` / `write_label_file`, carrying deprecated camelCase properties (`imagePath`/`imageData`/`otherData`) and a `save()` that ignored its own instance state.
- `read_label_file` / `write_label_file` and the `LabelFileError` / `LabelFileReadError` / `LabelFileWriteError` hierarchy remain the persistence API; nothing in the app or `examples/` used the class once `examples/` became self-contained.
- Re-point the still-relevant tests to the functional API: the #1725 Windows-path regression now drives `read_label_file`, and `load_image_file_test.py` is renamed to `read_image_file_test.py` calling `read_image_file`. The `LabelFile`-only camelCase-deprecation test is dropped.
- Record the shim's removal as an amendment to ADR 0002 (it had kept `LabelFile` "untouched as a deprecated shim").

## Test plan
- [x] `uv run pytest` (625 passed)
- [x] `uv run ruff check` / `uv run ty check` clean

Closes #2148
