### PR TITLE
fix: guard AI inference so model errors surface instead of crashing

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1073,6 +1073,13 @@ class MainWindow(QtWidgets.QMainWindow):
         canvas.inference_produced_no_shapes.connect(
             self._on_inference_produced_no_shapes
         )
+        # The preview path emits this from inside paintEvent (an active
+        # QPainter); a queued connection defers the status-bar update until
+        # after the paint cycle so it never mutates UI mid-paint.
+        canvas.inference_failed.connect(
+            self._on_inference_failed,
+            Qt.ConnectionType.QueuedConnection,
+        )
         canvas.degenerate_shape_rejected.connect(
             lambda: self.show_status_message(
                 self.tr("Shape had no area; nothing created."), 5000
@@ -1308,12 +1315,17 @@ class MainWindow(QtWidgets.QMainWindow):
         ):
             self._text_osam_session = _automation.OsamSession(model_name=model_name)
 
-        boxes, scores, labels, masks = _automation.get_bboxes_from_texts(
-            session=self._text_osam_session,
-            image=utils.img_qt_to_arr(self._image)[:, :, :3],
-            image_id=str(hash(self._image_path)),
-            texts=texts,
-        )
+        try:
+            boxes, scores, labels, masks = _automation.get_bboxes_from_texts(
+                session=self._text_osam_session,
+                image=utils.img_qt_to_arr(self._image)[:, :, :3],
+                image_id=str(hash(self._image_path)),
+                texts=texts,
+            )
+        except Exception as e:
+            logger.opt(exception=e).error("AI text inference failed")
+            self._on_inference_failed(message=f"{type(e).__name__}: {e}")
+            return
 
         if (
             masks is None
@@ -1858,6 +1870,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.show_status_message(
             self.tr("AI inference produced no new annotation."), 5000
         )
+
+    def _on_inference_failed(self, message: str) -> None:
+        self.show_status_message(self.tr("AI inference failed: %s") % message, 10000)
 
     def _on_scroll_request(self, delta: int, orientation: Qt.Orientation) -> None:
         units = -delta * 0.1  # natural scroll

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -175,6 +175,7 @@ class Canvas(QtWidgets.QWidget):
     pan_request = QtCore.Signal(QPoint)
     new_shape = QtCore.Signal()
     inference_produced_no_shapes = QtCore.Signal()
+    inference_failed = QtCore.Signal(str)
     degenerate_shape_rejected = QtCore.Signal()
     selection_changed = QtCore.Signal(list)
     shape_moved = QtCore.Signal()
@@ -255,6 +256,7 @@ class Canvas(QtWidgets.QWidget):
         self._rotation_original_points = np.empty((0, 2))
         self.scale: float = 1.0
         self._ai_assist_session = _automation.AiAssistSession()
+        self._ai_inference_failed = False
         self._snapping = True
         self._hovered_shape_is_selected: bool = False
         self._painter = QtGui.QPainter()
@@ -418,6 +420,11 @@ class Canvas(QtWidgets.QWidget):
             point_labels=np.array(point_labels),
             existing_shapes=self.shapes,
         )
+
+    def _report_inference_failure(self, error: Exception) -> None:
+        self._ai_inference_failed = True
+        logger.opt(exception=error).error("AI inference failed")
+        self.inference_failed.emit(f"{type(error).__name__}: {error}")
 
     def backup_shapes(self) -> None:
         self.shape_backups.append([s.copy() for s in self.shapes])
@@ -1549,10 +1556,19 @@ class Canvas(QtWidgets.QWidget):
             point=self._line.points[1],
             label=self._line.point_labels[1],
         )
-        ai_shapes = self._shapes_from_ai_points(
-            points=preview.points,
-            point_labels=preview.point_labels,
-        )
+        try:
+            ai_shapes = self._shapes_from_ai_points(
+                points=preview.points,
+                point_labels=preview.point_labels,
+            )
+        except Exception as e:
+            # This runs inside paintEvent on every repaint, so a persistently
+            # failing model would report on every frame. Report once; a later
+            # success re-arms the report.
+            if not self._ai_inference_failed:
+                self._report_inference_failure(error=e)
+            return _draft_to_shape(preview)
+        self._ai_inference_failed = False
         if ai_shapes:
             return ai_shapes[0]
         return _draft_to_shape(preview)
@@ -1580,7 +1596,13 @@ class Canvas(QtWidgets.QWidget):
     def _finalize(self) -> None:
         assert self._current is not None
         if self.create_mode in _AI_CREATE_MODES:
-            new_shapes = self._build_new_shapes_from_ai_inference()
+            try:
+                new_shapes = self._build_new_shapes_from_ai_inference()
+            except Exception as e:
+                self._report_inference_failure(error=e)
+                self._cancel_current_shape()
+                return
+            self._ai_inference_failed = False
             if not new_shapes:
                 self.inference_produced_no_shapes.emit()
                 self._cancel_current_shape()
@@ -1795,6 +1817,9 @@ class Canvas(QtWidgets.QWidget):
         pixmap_arr = labelme.utils.img_qt_to_arr(img_qt=pixmap.toImage())
         self.pixmap = pixmap
         self._pixmap_hash = hash(pixmap_arr.tobytes())
+        # A new image is a fresh inference context that should surface its own
+        # first failure rather than staying muted by the prior image's latch.
+        self._ai_inference_failed = False
         if clear_shapes:
             self.shapes = []
         self.update()

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -288,3 +288,52 @@ def test_score_threshold_filters_detections(
     assert high_threshold_count == 1
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_text_prompt_inference_error_surfaces_without_crashing(
+    main_win: MainWinFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    # A model error during text-to-annotation inference must not crash the app:
+    # it surfaces as a non-fatal status message and the window stays alive.
+    win = main_win(file_or_dir=str(data_path / "raw/2011_000003.jpg"))
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+
+    def _raise(**_: object) -> osam.types.GenerateResponse:
+        raise RuntimeError("boom")
+
+    _install_mock_session(win=win, monkeypatch=monkeypatch, response_fn=_raise)
+    _run_text_prompt(win=win, qtbot=qtbot, text="person", create_mode="rectangle")
+
+    assert win.isVisible()
+    assert canvas.shapes == []
+    assert "AI inference failed" in win.statusBar().currentMessage()
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_canvas_inference_failed_signal_surfaces_status_message(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    # The hover-preview path emits inference_failed from inside paintEvent, so
+    # the signal is wired with a queued connection. Emitting it must still
+    # surface the status message once the event loop runs.
+    win = main_win(file_or_dir=str(data_path / "raw/2011_000003.jpg"))
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    win._canvas_widgets.canvas.inference_failed.emit("RuntimeError: boom")
+    qtbot.waitUntil(
+        lambda: "AI inference failed" in win.statusBar().currentMessage(),
+        timeout=1000,
+    )
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -302,6 +302,89 @@ def test_finalize_with_empty_inference_resets_state_and_notifies(
 
 
 @pytest.mark.gui
+@pytest.mark.parametrize("create_mode", ["ai_box_to_shape", "ai_points_to_shape"])
+def test_finalize_reports_inference_error_and_cancels(
+    canvas: Canvas,
+    monkeypatch: pytest.MonkeyPatch,
+    create_mode: str,
+) -> None:
+    # A model error while committing an AI shape must not crash _finalize: it
+    # surfaces a non-fatal inference_failed signal, cancels the in-progress
+    # shape, and does not masquerade as an empty-inference result.
+    def _raise(**_: object) -> list[Shape]:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(canvas, "_shapes_from_ai_points", _raise)
+    canvas.create_mode = create_mode
+    canvas._current = _DraftShape(
+        shape_type="rectangle",
+        points=(QPointF(0, 0), QPointF(10, 10)),
+        point_labels=(1, 1),
+    )
+    failed: list[str] = []
+    no_shapes: list[None] = []
+    canvas.inference_failed.connect(failed.append)
+    canvas.inference_produced_no_shapes.connect(lambda: no_shapes.append(None))
+
+    canvas._finalize()
+
+    assert failed == ["RuntimeError: boom"]
+    assert no_shapes == []
+    assert canvas._current is None
+    assert canvas.shapes == []
+
+
+@pytest.mark.gui
+def test_points_preview_throttles_inference_errors_until_recovery(
+    canvas: Canvas,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The points preview re-runs inference on every repaint, so a persistently
+    # failing model must report once, not once per frame. A later success
+    # re-arms the report so a fresh failure surfaces again.
+    behavior = {"fail": True}
+
+    def _maybe_raise(**_: object) -> list[Shape]:
+        if behavior["fail"]:
+            raise RuntimeError("boom")
+        return []
+
+    monkeypatch.setattr(canvas, "_shapes_from_ai_points", _maybe_raise)
+    canvas.create_mode = "ai_points_to_shape"
+    canvas._line = _DraftShape(
+        shape_type="rectangle",
+        points=(QPointF(0, 0), QPointF(5, 5)),
+        point_labels=(1, 1),
+    )
+    current = _DraftShape(
+        shape_type="rectangle",
+        points=(QPointF(0, 0),),
+        point_labels=(1,),
+    )
+    failed: list[str] = []
+    canvas.inference_failed.connect(failed.append)
+
+    canvas._build_ai_points_preview(current=current)
+    canvas._build_ai_points_preview(current=current)
+    assert failed == ["RuntimeError: boom"]
+
+    behavior["fail"] = False
+    canvas._build_ai_points_preview(current=current)
+    behavior["fail"] = True
+    canvas._build_ai_points_preview(current=current)
+    assert failed == ["RuntimeError: boom", "RuntimeError: boom"]
+
+
+@pytest.mark.gui
+def test_load_pixmap_rearms_inference_failure_report(canvas: Canvas) -> None:
+    # A new image is a fresh inference context: a previous image's latched
+    # failure must not mute the first failure report on the new image.
+    canvas._ai_inference_failed = True
+    canvas.load_pixmap(QtGui.QPixmap(_WIDTH, _HEIGHT))
+    assert canvas._ai_inference_failed is False
+
+
+@pytest.mark.gui
 def test_create_mode_switch_retypes_one_point_partial(canvas: Canvas) -> None:
     # Retype must update _current.shape_type and _line.shape_type, but must
     # NOT re-seed _line.points (which would alias both slots and break the


### PR DESCRIPTION
Closes #2202

AI-assisted inference (AI-Points / AI-Box / Text-to-Annotation) could throw on
model load, frozen-exe DLL issues, or malformed model output, and the exception
was unhandled. The points preview path runs inference inside `paintEvent` on
every repaint, so a failure there killed the process silently — the long-standing
"click Create AI-Polygon, window flashes back, no error" symptom.

## Summary
- Catch the exception at each inference call site (hover preview, commit, and the
  text-prompt path), log the traceback, and surface a non-fatal
  `AI inference failed: …` status message instead of crashing.
- Throttle the hover/preview path: a persistently failing model reports once and
  stays quiet until a later inference succeeds or a new image loads, so it can't
  spam from `paintEvent`. A commit click reports directly.
- The preview path emits its signal from inside `paintEvent`, so the
  `inference_failed` → status-bar connection is queued to avoid mutating UI
  mid-paint.

## Test plan
- [x] tests added: `tests/unit/widgets/canvas_test.py` (hover throttle + recovery,
  finalize reports-and-cancels, latch re-arm on new image) and
  `tests/e2e/ai_text_to_annotation_test.py` (text-path error surfaces without
  crashing, queued signal surfaces the status message)
- [x] real-app smoke: emitting `inference_failed` on a live window surfaces the
  status message and the window stays alive
- [x] `uv run pytest tests/` (634 passed) + `make lint`
