### PR TITLE
refactor(canvas): extract hit-testing, cursor, and context-menu logic into a module

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -876,10 +876,11 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
         utils.add_actions(
-            self._canvas_widgets.canvas.menus[0], self._actions.context_menu
+            self._canvas_widgets.canvas.context_menus.without_selection,
+            self._actions.context_menu,
         )
         utils.add_actions(
-            self._canvas_widgets.canvas.menus[1],
+            self._canvas_widgets.canvas.context_menus.with_selection,
             (
                 action("&Copy here", self.copy_shape),
                 action("&Move here", self.move_shape),
@@ -1227,9 +1228,10 @@ class MainWindow(QtWidgets.QMainWindow):
         return not len(self._docks.label_list)
 
     def populate_mode_actions(self) -> None:
-        self._canvas_widgets.canvas.menus[0].clear()
+        self._canvas_widgets.canvas.context_menus.without_selection.clear()
         utils.add_actions(
-            self._canvas_widgets.canvas.menus[0], self._actions.context_menu
+            self._canvas_widgets.canvas.context_menus.without_selection,
+            self._actions.context_menu,
         )
         self._menus.edit.clear()
         actions = (

--- a/labelme/widgets/_canvas_interaction.py
+++ b/labelme/widgets/_canvas_interaction.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMenu
+
+from labelme._shape import Shape
+from labelme._shape import nearest_edge_index
+from labelme._shape import nearest_rotation_point_index
+from labelme._shape import nearest_vertex_index
+from labelme.widgets._shape_render import is_hit_by_point
+
+
+class HitKind(enum.Enum):
+    VERTEX = "vertex"
+    ROTATION_HANDLE = "rotation_handle"
+    EDGE = "edge"
+    BODY = "body"
+
+
+@dataclasses.dataclass(frozen=True)
+class HitTarget:
+    kind: HitKind
+    shape: Shape
+    index: int | None
+
+
+def find_hover_target(
+    *,
+    shapes: list[Shape],
+    point: npt.NDArray[np.float64],
+    scale: float,
+    epsilon: float,
+    point_size: int,
+    priority_shape: Shape | None,
+) -> HitTarget | None:
+    candidates = _build_candidates(
+        shapes=shapes,
+        priority_shape=priority_shape,
+    )
+
+    # Pass 1: vertex proximity
+    for shape in candidates:
+        idx = nearest_vertex_index(
+            shape=shape, point=point, scale=scale, epsilon=epsilon
+        )
+        if idx is not None:
+            return HitTarget(kind=HitKind.VERTEX, shape=shape, index=idx)
+
+    # Pass 2: rotation handle proximity
+    for shape in candidates:
+        idx = nearest_rotation_point_index(
+            shape=shape, point=point, scale=scale, epsilon=epsilon
+        )
+        if idx is not None:
+            return HitTarget(kind=HitKind.ROTATION_HANDLE, shape=shape, index=idx)
+
+    # Pass 3: edge proximity (only shapes that support adding a point)
+    for shape in candidates:
+        if not shape.can_add_point():
+            continue
+        idx = nearest_edge_index(shape=shape, point=point, scale=scale, epsilon=epsilon)
+        if idx is not None:
+            return HitTarget(kind=HitKind.EDGE, shape=shape, index=idx)
+
+    # Pass 4: body hit
+    for shape in candidates:
+        hit = is_hit_by_point(
+            shape=shape,
+            point=point,
+            scale=scale,
+            point_size=point_size,
+            epsilon=epsilon,
+        )
+        if hit:
+            return HitTarget(kind=HitKind.BODY, shape=shape, index=None)
+
+    return None
+
+
+def _build_candidates(
+    *,
+    shapes: list[Shape],
+    priority_shape: Shape | None,
+) -> list[Shape]:
+    candidates: list[Shape] = []
+    if priority_shape is not None:
+        candidates.append(priority_shape)
+    for shape in reversed(shapes):
+        if not shape.visible:
+            continue
+        if shape is priority_shape:
+            continue
+        candidates.append(shape)
+    return candidates
+
+
+def is_within_pick_threshold(
+    *,
+    a: npt.NDArray[np.float64],
+    b: npt.NDArray[np.float64],
+    scale: float,
+    epsilon: float,
+) -> bool:
+    return bool(np.linalg.norm(a - b) < epsilon / scale)
+
+
+class CursorRole(enum.Enum):
+    DEFAULT = "default"
+    DRAW = "draw"
+    HANDLE = "handle"
+    GRAB = "grab"
+    MOVE = "move"
+
+
+_CURSOR_SHAPE_MAP: Final[dict[CursorRole, Qt.CursorShape]] = {
+    CursorRole.DEFAULT: Qt.CursorShape.ArrowCursor,
+    CursorRole.DRAW: Qt.CursorShape.CrossCursor,
+    CursorRole.HANDLE: Qt.CursorShape.PointingHandCursor,
+    CursorRole.GRAB: Qt.CursorShape.OpenHandCursor,
+    CursorRole.MOVE: Qt.CursorShape.ClosedHandCursor,
+}
+assert set(_CURSOR_SHAPE_MAP) == set(CursorRole), (
+    f"_CURSOR_SHAPE_MAP missing roles: {set(CursorRole) - set(_CURSOR_SHAPE_MAP)}"
+)
+
+
+def cursor_shape_for(role: CursorRole) -> Qt.CursorShape:
+    return _CURSOR_SHAPE_MAP[role]
+
+
+@dataclasses.dataclass
+class ContextMenuPair:
+    without_selection: QMenu
+    with_selection: QMenu
+
+    def menu_for(self, *, has_selection: bool) -> QMenu:
+        if has_selection:
+            return self.with_selection
+        return self.without_selection

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -28,6 +28,9 @@ from labelme._shape import POLYLINE_SHAPE_TYPES
 from labelme._shape import Shape
 from labelme._shape import ShapeType
 
+from . import _canvas_interaction
+from ._canvas_interaction import CursorRole
+from ._canvas_interaction import HitKind
 from ._shape_render import Palette
 from ._shape_render import ShapeRenderContext
 from ._shape_render import VertexHighlight
@@ -96,12 +99,6 @@ def _shape_to_draft(shape: Shape) -> _DraftShape:
     )
 
 
-CURSOR_DEFAULT = Qt.CursorShape.ArrowCursor
-CURSOR_POINT = Qt.CursorShape.PointingHandCursor
-CURSOR_DRAW = Qt.CursorShape.CrossCursor
-CURSOR_MOVE = Qt.CursorShape.ClosedHandCursor
-CURSOR_GRAB = Qt.CursorShape.OpenHandCursor
-
 MOVE_SPEED: float = 5.0
 
 _CreateMode = Literal[
@@ -155,7 +152,7 @@ class _CanvasMode(enum.Enum):
 class Canvas(QtWidgets.QWidget):
     pixmap: QtGui.QPixmap
     _pixmap_hash: int | None
-    _cursor: QtCore.Qt.CursorShape
+    _cursor: CursorRole
     shapes: list[Shape]
     shape_backups: collections.deque[list[Shape]]
     _is_moving_shape: bool
@@ -238,7 +235,7 @@ class Canvas(QtWidgets.QWidget):
         )
         super().__init__(*args, **kwargs)
 
-        self._cursor = CURSOR_DEFAULT
+        self._cursor = CursorRole.DEFAULT
         self.reset_state()
 
         # self._line represents:
@@ -264,10 +261,10 @@ class Canvas(QtWidgets.QWidget):
         self._point_type: Literal["square", "round"] = "round"
         self._draft_palette = _DEFAULT_PALETTE
         self._palette_cache = {}
-        # Menus:
-        # 0: right-click without selection and dragging of shapes
-        # 1: right-click with selection and dragging of shapes
-        self.menus = (QtWidgets.QMenu(), QtWidgets.QMenu())
+        self.context_menus = _canvas_interaction.ContextMenuPair(
+            without_selection=QtWidgets.QMenu(),
+            with_selection=QtWidgets.QMenu(),
+        )
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
 
@@ -615,7 +612,7 @@ class Canvas(QtWidgets.QWidget):
             self._line = dataclasses.replace(
                 self._line, shape_type=desired_line_shape_type
             )
-        self._apply_cursor(CURSOR_DRAW)
+        self._apply_cursor(CursorRole.DRAW)
         if self._current is None:
             self.update()
             self._update_status()
@@ -652,7 +649,7 @@ class Canvas(QtWidgets.QWidget):
             )
         if not self._cursor_should_snap_to_polygon_origin(pos=pos):
             return pos
-        self._apply_cursor(CURSOR_POINT)
+        self._apply_cursor(CursorRole.HANDLE)
         self._highlight_vertex(index=0, mode="near")
         return current.points[0]
 
@@ -664,7 +661,13 @@ class Canvas(QtWidgets.QWidget):
         current = self._current
         if current is None or len(current.points) <= 1:
             return False
-        return self._is_close_enough(pos, current.points[0])
+        origin = current.points[0]
+        return _canvas_interaction.is_within_pick_threshold(
+            a=np.array([pos.x(), pos.y()]),
+            b=np.array([origin.x(), origin.y()]),
+            scale=self.scale,
+            epsilon=self._epsilon,
+        )
 
     def _refresh_hover_state(self, pos: QPointF) -> None:
         status_messages: list[str] = []
@@ -725,7 +728,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _continue_right_button_drag(self, pos: QPointF) -> None:
         if self._selected_shapes_copy:
-            self._apply_cursor(CURSOR_MOVE)
+            self._apply_cursor(CursorRole.MOVE)
             self._drag_shapes(shapes=self._selected_shapes_copy, cursor=pos)
             self.update()
         elif self.selected_shapes:
@@ -791,83 +794,78 @@ class Canvas(QtWidgets.QWidget):
         self._rotation_original_points = self.hovered_shape.points.copy()
 
     def _drag_selected_shapes(self, pos: QPointF) -> None:
-        self._apply_cursor(CURSOR_MOVE)
+        self._apply_cursor(CursorRole.MOVE)
         self._drag_shapes(shapes=self.selected_shapes, cursor=pos)
         self.update()
         self._is_moving_shape = True
 
     def _highlight_hover_shape(self, pos: QPointF, status_messages: list[str]) -> None:
-        ordered_shapes: list[Shape] = (
-            [self.hovered_shape] if self.hovered_shape else []
-        ) + [s for s in reversed(self.shapes) if s.visible and s != self.hovered_shape]
-        point = np.array([pos.x(), pos.y()])
+        target = _canvas_interaction.find_hover_target(
+            shapes=self.shapes,
+            point=np.array([pos.x(), pos.y()]),
+            scale=self.scale,
+            epsilon=self._epsilon,
+            point_size=self._point_size,
+            priority_shape=self.hovered_shape,
+        )
 
-        for shape in ordered_shapes:
-            index_vertex: int | None = _shape.nearest_vertex_index(
-                shape=shape, point=point, scale=self.scale, epsilon=self._epsilon
-            )
-            if index_vertex is None:
-                continue
-            self._set_highlight(
-                hovered_shape=shape,
+        if target is None:
+            self._release_cursor()
+            if self._set_highlight(
+                hovered_shape=None,
                 hovered_edge=None,
-                hovered_vertex=index_vertex,
+                hovered_vertex=None,
+                hovered_rotation=None,
+            ):
+                self.update()
+            return
+
+        if target.kind is HitKind.VERTEX:
+            assert target.index is not None
+            self._set_highlight(
+                hovered_shape=target.shape,
+                hovered_edge=None,
+                hovered_vertex=target.index,
                 hovered_rotation=None,
             )
-            self._highlight_vertex(index=index_vertex, mode="move")
-            self._apply_cursor(CURSOR_POINT)
+            self._highlight_vertex(index=target.index, mode="move")
+            self._apply_cursor(CursorRole.HANDLE)
             status_messages.append(self.tr("Click & drag to move point"))
-            if shape.can_remove_point():
+            if target.shape.can_remove_point():
                 status_messages.append(self.tr("ALT + SHIFT + Click to delete point"))
             self.update()
             return
 
-        for shape in ordered_shapes:
-            index_rotation: int | None = _shape.nearest_rotation_point_index(
-                shape=shape, point=point, scale=self.scale, epsilon=self._epsilon
-            )
-            if index_rotation is None:
-                continue
+        if target.kind is HitKind.ROTATION_HANDLE:
+            assert target.index is not None
             self._set_highlight(
-                hovered_shape=shape,
+                hovered_shape=target.shape,
                 hovered_edge=None,
                 hovered_vertex=None,
-                hovered_rotation=index_rotation,
+                hovered_rotation=target.index,
             )
-            self._highlight_rotation_point(index=index_rotation, mode="move")
-            self._apply_cursor(CURSOR_POINT)
+            self._highlight_rotation_point(index=target.index, mode="move")
+            self._apply_cursor(CursorRole.HANDLE)
             status_messages.append(self.tr("Click & drag to rotate the shape"))
             self.update()
             return
 
-        for shape in ordered_shapes:
-            index_edge: int | None = _shape.nearest_edge_index(
-                shape=shape, point=point, scale=self.scale, epsilon=self._epsilon
-            )
-            if index_edge is None or not shape.can_add_point():
-                continue
+        if target.kind is HitKind.EDGE:
+            assert target.index is not None
             self._set_highlight(
-                hovered_shape=shape,
-                hovered_edge=index_edge,
+                hovered_shape=target.shape,
+                hovered_edge=target.index,
                 hovered_vertex=None,
                 hovered_rotation=None,
             )
-            self._apply_cursor(CURSOR_POINT)
+            self._apply_cursor(CursorRole.HANDLE)
             status_messages.append(self.tr("ALT + Click to create point on shape"))
             self.update()
             return
 
-        for shape in ordered_shapes:
-            if not is_hit_by_point(
-                shape=shape,
-                point=point,
-                scale=self.scale,
-                point_size=self._point_size,
-                epsilon=self._epsilon,
-            ):
-                continue
+        if target.kind is HitKind.BODY:
             self._set_highlight(
-                hovered_shape=shape,
+                hovered_shape=target.shape,
                 hovered_edge=None,
                 hovered_vertex=None,
                 hovered_rotation=None,
@@ -878,18 +876,11 @@ class Canvas(QtWidgets.QWidget):
                     self.tr("Right-click & drag to copy shape"),
                 ]
             )
-            self._apply_cursor(CURSOR_GRAB)
+            self._apply_cursor(CursorRole.GRAB)
             self.update()
             return
 
-        self._release_cursor()
-        if self._set_highlight(
-            hovered_shape=None,
-            hovered_edge=None,
-            hovered_vertex=None,
-            hovered_rotation=None,
-        ):
-            self.update()
+        typing.assert_never(target.kind)
 
     def add_point_to_edge(self) -> None:
         shape = self._last_hovered_shape
@@ -1110,7 +1101,7 @@ class Canvas(QtWidgets.QWidget):
         self._prev_point = pos
 
     def _begin_pan(self, event: QtGui.QMouseEvent) -> None:
-        self._apply_cursor(CURSOR_GRAB)
+        self._apply_cursor(CursorRole.GRAB)
         self._pan_anchor = QPointF(self.mapToGlobal(event.position().toPoint()))
 
     def mouseReleaseEvent(self, a0: QtGui.QMouseEvent) -> None:
@@ -1130,7 +1121,9 @@ class Canvas(QtWidgets.QWidget):
             self._finish_pan()
 
     def _release_right(self, event: QtGui.QMouseEvent) -> None:
-        menu = self.menus[len(self._selected_shapes_copy) > 0]
+        menu = self.context_menus.menu_for(
+            has_selection=len(self._selected_shapes_copy) > 0
+        )
         self._release_cursor()
         if menu.exec(self.mapToGlobal(event.position().toPoint())):  # type: ignore
             return
@@ -1621,13 +1614,6 @@ class Canvas(QtWidgets.QWidget):
         self.drawing_polygon.emit(False)
         self.update()
 
-    def _is_close_enough(self, p1: QPointF, p2: QPointF) -> bool:
-        # d = distance(p1 - p2)
-        # m = (p1-p2).manhattanLength()
-        # print "d %.2f, m %d, %.2f" % (d, m, d - m)
-        threshold = self._epsilon / self.scale
-        return labelme.utils.distance(p1 - p2) < threshold
-
     # Required by QScrollArea: it queries these to compute the
     # scrollable viewport whenever adjustSize() is called.
     def _compute_canvas_size(self) -> QtCore.QSize:
@@ -1811,20 +1797,21 @@ class Canvas(QtWidgets.QWidget):
         shape.visible = value
         self.update()
 
-    def _apply_cursor(self, cursor: QtCore.Qt.CursorShape) -> None:
-        if cursor == self._cursor:
+    def _apply_cursor(self, role: CursorRole) -> None:
+        if role == self._cursor:
             return
+        shape = _canvas_interaction.cursor_shape_for(role=role)
         # Push on first apply; swap the top of the stack we already own afterwards.
-        if self._cursor == CURSOR_DEFAULT:
-            QtWidgets.QApplication.setOverrideCursor(cursor)
+        if self._cursor == CursorRole.DEFAULT:
+            QtWidgets.QApplication.setOverrideCursor(shape)
         else:
-            QtWidgets.QApplication.changeOverrideCursor(cursor)
-        self._cursor = cursor
+            QtWidgets.QApplication.changeOverrideCursor(shape)
+        self._cursor = role
 
     def _release_cursor(self) -> None:
-        if self._cursor == CURSOR_DEFAULT:
+        if self._cursor == CursorRole.DEFAULT:
             return
-        self._cursor = CURSOR_DEFAULT
+        self._cursor = CursorRole.DEFAULT
         QtWidgets.QApplication.restoreOverrideCursor()
 
     def reset_state(self) -> None:

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -762,16 +762,17 @@ def test_right_click_on_shape_opens_context_menu(
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
     # No prior right-drag has populated `_selected_shapes_copy`, so the bare
-    # right-click should open menus[0] (the no-clipboard variant). Stubbing
-    # both exec_ methods catches a regression that would route to menus[1].
+    # right-click should open the no-selection menu (the no-clipboard variant).
+    # Stubbing both exec methods catches a regression that would route to the
+    # selection menu.
     menu_opened: list[int] = []
     monkeypatch.setattr(
-        canvas.menus[0],
+        canvas.context_menus.without_selection,
         "exec",
         lambda *args, **kwargs: menu_opened.append(0) or None,
     )
     monkeypatch.setattr(
-        canvas.menus[1],
+        canvas.context_menus.with_selection,
         "exec",
         lambda *args, **kwargs: menu_opened.append(1) or None,
     )

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -208,13 +208,13 @@ def test_right_drag_copy_here_duplicates_shape(
 
     # The modal menu would block the test, so trigger "Copy here" directly
     # and return it truthy so the canvas treats the release as handled.
-    copy_here_action = canvas.menus[1].actions()[0]
+    copy_here_action = canvas.context_menus.with_selection.actions()[0]
 
     def trigger_copy_here(*args: object, **kwargs: object) -> object:
         copy_here_action.trigger()
         return copy_here_action
 
-    monkeypatch.setattr(canvas.menus[1], "exec", trigger_copy_here)
+    monkeypatch.setattr(canvas.context_menus.with_selection, "exec", trigger_copy_here)
 
     drag_canvas(
         qtbot=qtbot,

--- a/tests/unit/widgets/_canvas_interaction_test.py
+++ b/tests/unit/widgets/_canvas_interaction_test.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QMenu
+
+from labelme._shape import Shape
+from labelme.widgets._canvas_interaction import ContextMenuPair
+from labelme.widgets._canvas_interaction import CursorRole
+from labelme.widgets._canvas_interaction import HitKind
+from labelme.widgets._canvas_interaction import HitTarget
+from labelme.widgets._canvas_interaction import cursor_shape_for
+from labelme.widgets._canvas_interaction import find_hover_target
+from labelme.widgets._canvas_interaction import is_within_pick_threshold
+
+# Shared test constants
+_EPSILON: float = 10.0
+_SCALE: float = 1.0
+_POINT_SIZE: int = 8
+
+
+def _point(x: float, y: float) -> np.ndarray:
+    return np.array([x, y], dtype=np.float64)
+
+
+def _polygon(points: list[tuple[float, float]], *, visible: bool = True) -> Shape:
+    return Shape(
+        shape_type="polygon",
+        points=np.array(points, dtype=np.float64),
+        closed=True,
+        visible=visible,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HitTarget
+# ---------------------------------------------------------------------------
+
+
+def test_hit_target_frozen() -> None:
+    shape = _polygon([(0, 0), (10, 0), (10, 10)])
+    target = HitTarget(kind=HitKind.BODY, shape=shape, index=None)
+    with pytest.raises((AttributeError, TypeError)):
+        target.kind = HitKind.VERTEX  # ty: ignore[invalid-assignment]
+
+
+# ---------------------------------------------------------------------------
+# find_hover_target — empty shapes
+# ---------------------------------------------------------------------------
+
+
+def test_find_hover_target_empty_shapes_returns_none() -> None:
+    result = find_hover_target(
+        shapes=[],
+        point=_point(0.0, 0.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find_hover_target — visibility filtering
+# ---------------------------------------------------------------------------
+
+
+def test_invisible_shapes_are_excluded() -> None:
+    invisible = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=False)
+    result = find_hover_target(
+        shapes=[invisible],
+        point=_point(25.0, 25.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is None
+
+
+def test_visible_shape_body_hit() -> None:
+    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    result = find_hover_target(
+        shapes=[shape],
+        point=_point(25.0, 25.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is not None
+    assert result.kind == HitKind.BODY
+    assert result.shape is shape
+
+
+# ---------------------------------------------------------------------------
+# find_hover_target — category precedence: vertex > rotation > edge > body
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_match_beats_body() -> None:
+    # Shape with vertex at (10, 10); hover exactly on vertex -> VERTEX, not BODY.
+    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    result = find_hover_target(
+        shapes=[shape],
+        point=_point(10.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is not None
+    assert result.kind == HitKind.VERTEX
+    assert result.shape is shape
+    assert result.index == 0
+
+
+def test_vertex_on_last_candidate_beats_body_on_first_candidate() -> None:
+    # Two shapes: first (in list order) has a body at (25, 25) and its vertex
+    # far away; second (examined first in reverse order) has a vertex at (10, 10).
+    # Hover at (10, 10): the VERTEX on the second (topmost) shape must win.
+    body_shape = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    vertex_shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    # shapes=[body_shape, vertex_shape]: reverse order tries vertex_shape first.
+    result = find_hover_target(
+        shapes=[body_shape, vertex_shape],
+        point=_point(10.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is not None
+    assert result.kind == HitKind.VERTEX
+    assert result.shape is vertex_shape
+
+
+def test_category_precedence_vertex_over_body_across_shapes() -> None:
+    # Shape A (listed first, lower paint order): has body at center, vertex far.
+    # Shape B (listed second, higher paint order, examined first): vertex at (10,10).
+    # Hover at (10,10): vertex category dominates even though shape A is "first".
+    big = _polygon([(0, 0), (200, 0), (200, 200), (0, 200)])
+    small = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    result = find_hover_target(
+        shapes=[big, small],
+        point=_point(10.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is not None
+    assert result.kind == HitKind.VERTEX
+    assert result.shape is small
+
+
+# ---------------------------------------------------------------------------
+# find_hover_target — edge pass only for can_add_point shapes
+# ---------------------------------------------------------------------------
+
+
+def test_edge_hit_on_polygon() -> None:
+    # polygon: midpoint of top edge (10,10)-(90,10) is (50,10).
+    shape = _polygon([(10, 10), (90, 10), (90, 50), (10, 50)])
+    result = find_hover_target(
+        shapes=[shape],
+        point=_point(50.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    # Should be VERTEX or EDGE depending on distance to vertices.
+    # (50,10) is 40px from (10,10) and 40px from (90,10) — no vertex hit.
+    assert result is not None
+    assert result.kind == HitKind.EDGE
+    assert result.shape is shape
+
+
+def test_edge_not_tested_on_non_polyline_shape() -> None:
+    # A rectangle does not support can_add_point; an edge-only hover returns NONE
+    # (no vertex, no rotation, no edge pass, and body miss at far point).
+    rect = Shape(
+        shape_type="rectangle",
+        points=np.array([(10, 10), (50, 50)], dtype=np.float64),
+        closed=True,
+    )
+    # Hover at midpoint of top edge: (30, 10). For rectangle this should be BODY
+    # (inside path test), not EDGE.
+    result = find_hover_target(
+        shapes=[rect],
+        point=_point(30.0, 30.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    # rectangle is not a polyline, so edge pass is skipped; body hit for interior.
+    assert result is not None
+    assert result.kind == HitKind.BODY
+    assert result.shape is rect
+
+
+# ---------------------------------------------------------------------------
+# find_hover_target — priority_shape ordering
+# ---------------------------------------------------------------------------
+
+
+def test_priority_shape_is_checked_first() -> None:
+    # priority_shape is listed last in shapes but must be tried first.
+    # Two shapes overlap at (10,10). priority_shape has vertex at (10,10).
+    # The other shape also has vertex at (10,10).
+    # Without priority, reverse order tries shape_b first (it is last in list).
+    # With priority=shape_a, shape_a is tried first.
+    shape_a = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    shape_b = _polygon([(10, 10), (80, 10), (80, 80), (10, 80)])
+    result = find_hover_target(
+        shapes=[shape_b, shape_a],
+        point=_point(10.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=shape_a,
+    )
+    assert result is not None
+    assert result.kind == HitKind.VERTEX
+    assert result.shape is shape_a
+
+
+def test_priority_shape_not_in_shapes_is_still_checked() -> None:
+    # priority_shape need not be a member of shapes.
+    orphan = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    result = find_hover_target(
+        shapes=[],
+        point=_point(10.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=orphan,
+    )
+    assert result is not None
+    assert result.kind == HitKind.VERTEX
+    assert result.shape is orphan
+
+
+def test_priority_shape_not_duplicated_in_candidates() -> None:
+    # priority_shape appears in shapes; it must not be examined twice.
+    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    # Only one match expected: VERTEX at index 0.
+    result = find_hover_target(
+        shapes=[shape],
+        point=_point(10.0, 10.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=shape,
+    )
+    assert result is not None
+    assert result.kind == HitKind.VERTEX
+    assert result.shape is shape
+    assert result.index == 0
+
+
+# ---------------------------------------------------------------------------
+# find_hover_target — reverse paint order for non-priority shapes
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_paint_order_topmost_body_wins() -> None:
+    # Two overlapping body-only shapes. The second in the list (top paint layer)
+    # should be returned as the body hit.
+    shape_a = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    shape_b = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    result = find_hover_target(
+        shapes=[shape_a, shape_b],
+        point=_point(50.0, 50.0),
+        scale=_SCALE,
+        epsilon=_EPSILON,
+        point_size=_POINT_SIZE,
+        priority_shape=None,
+    )
+    assert result is not None
+    assert result.kind == HitKind.BODY
+    # shape_b is last in list, so first in reverse order — it should match first.
+    assert result.shape is shape_b
+
+
+# ---------------------------------------------------------------------------
+# is_within_pick_threshold
+# ---------------------------------------------------------------------------
+
+
+def test_is_within_pick_threshold_strictly_less_than() -> None:
+    a = _point(0.0, 0.0)
+    # Distance = epsilon/scale - small delta => True
+    b = _point(9.9, 0.0)
+    assert is_within_pick_threshold(a=a, b=b, scale=_SCALE, epsilon=_EPSILON) is True
+
+
+def test_is_within_pick_threshold_at_boundary_false() -> None:
+    # Exactly at epsilon/scale is NOT within (strictly less than).
+    a = _point(0.0, 0.0)
+    b = _point(10.0, 0.0)
+    assert is_within_pick_threshold(a=a, b=b, scale=_SCALE, epsilon=_EPSILON) is False
+
+
+def test_is_within_pick_threshold_beyond_boundary_false() -> None:
+    a = _point(0.0, 0.0)
+    b = _point(11.0, 0.0)
+    assert is_within_pick_threshold(a=a, b=b, scale=_SCALE, epsilon=_EPSILON) is False
+
+
+def test_is_within_pick_threshold_scale_shrinks_image_radius() -> None:
+    # At scale=2, the image-space threshold is epsilon/2 = 5.
+    # Distance of 6 in image space > 5, so False.
+    a = _point(0.0, 0.0)
+    b = _point(6.0, 0.0)
+    assert is_within_pick_threshold(a=a, b=b, scale=2.0, epsilon=_EPSILON) is False
+
+
+def test_is_within_pick_threshold_scale_shrinks_image_radius_hit() -> None:
+    # At scale=2, image threshold = 5. Distance of 4 < 5 => True.
+    a = _point(0.0, 0.0)
+    b = _point(4.0, 0.0)
+    assert is_within_pick_threshold(a=a, b=b, scale=2.0, epsilon=_EPSILON) is True
+
+
+def test_is_within_pick_threshold_larger_scale_smaller_image_radius() -> None:
+    # At scale=0.5, image threshold = 20. Distance 15 < 20 => True.
+    a = _point(0.0, 0.0)
+    b = _point(15.0, 0.0)
+    assert is_within_pick_threshold(a=a, b=b, scale=0.5, epsilon=_EPSILON) is True
+
+
+# ---------------------------------------------------------------------------
+# cursor_shape_for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [
+        (CursorRole.DEFAULT, Qt.CursorShape.ArrowCursor),
+        (CursorRole.DRAW, Qt.CursorShape.CrossCursor),
+        (CursorRole.HANDLE, Qt.CursorShape.PointingHandCursor),
+        (CursorRole.GRAB, Qt.CursorShape.OpenHandCursor),
+        (CursorRole.MOVE, Qt.CursorShape.ClosedHandCursor),
+    ],
+)
+def test_cursor_shape_for_all_roles(role: CursorRole, expected: Qt.CursorShape) -> None:
+    assert cursor_shape_for(role) == expected
+
+
+# ---------------------------------------------------------------------------
+# ContextMenuPair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_context_menu_pair_menu_for_no_selection(
+    qapp: QApplication,
+) -> None:
+    without = QMenu()
+    with_ = QMenu()
+    pair = ContextMenuPair(without_selection=without, with_selection=with_)
+    assert pair.menu_for(has_selection=False) is without
+
+
+@pytest.mark.gui
+def test_context_menu_pair_menu_for_with_selection(
+    qapp: QApplication,
+) -> None:
+    without = QMenu()
+    with_ = QMenu()
+    pair = ContextMenuPair(without_selection=without, with_selection=with_)
+    assert pair.menu_for(has_selection=True) is with_
+
+
+@pytest.mark.gui
+def test_context_menu_pair_stores_menus_as_named_attributes(
+    qapp: QApplication,
+) -> None:
+    without = QMenu()
+    with_ = QMenu()
+    pair = ContextMenuPair(without_selection=without, with_selection=with_)
+    assert pair.without_selection is without
+    assert pair.with_selection is with_

--- a/tests/unit/widgets/canvas_interaction_characterization_test.py
+++ b/tests/unit/widgets/canvas_interaction_characterization_test.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import numpy as np
+import pytest
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import QPointF
+from PySide6.QtCore import Qt
+from pytestqt.qtbot import QtBot
+
+from labelme._shape import Shape
+from labelme.widgets.canvas import Canvas
+from labelme.widgets.canvas import _DraftShape
+
+# Default epsilon in Canvas (screen-pixel hit radius).
+_EPSILON: float = 10.0
+
+# Pixmap dimensions used across all tests.
+_W: int = 200
+_H: int = 100
+
+
+@pytest.fixture(autouse=True)
+def _isolated_override_cursor_stack() -> Generator[None, None, None]:
+    # The override-cursor stack is process-global; an earlier GUI test can leave
+    # an override pushed. These tests assert on absolute override-cursor state,
+    # so drain the stack around each test to keep that state self-contained.
+    while QtWidgets.QApplication.overrideCursor() is not None:
+        QtWidgets.QApplication.restoreOverrideCursor()
+    yield
+    while QtWidgets.QApplication.overrideCursor() is not None:
+        QtWidgets.QApplication.restoreOverrideCursor()
+
+
+@pytest.fixture()
+def canvas(qtbot: QtBot) -> Canvas:
+    c = Canvas()
+    c.pixmap = QtGui.QPixmap(_W, _H)
+    # Resize to exactly the pixmap dimensions so the image-origin offset is
+    # zero and widget coordinates equal image coordinates at scale=1.0.
+    c.resize(_W, _H)
+    qtbot.addWidget(c)
+    return c
+
+
+def _make_move_event(pos: QPointF) -> QtGui.QMouseEvent:
+    return QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseMove,
+        pos,
+        pos,
+        Qt.MouseButton.NoButton,
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+
+
+def _make_press_event(
+    pos: QPointF,
+    button: Qt.MouseButton = Qt.MouseButton.RightButton,
+) -> QtGui.QMouseEvent:
+    return QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseButtonPress,
+        pos,
+        pos,
+        button,
+        button,
+        Qt.KeyboardModifier.NoModifier,
+    )
+
+
+def _make_release_event(
+    pos: QPointF,
+    button: Qt.MouseButton = Qt.MouseButton.RightButton,
+) -> QtGui.QMouseEvent:
+    return QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseButtonRelease,
+        pos,
+        pos,
+        button,
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+
+
+def _image_to_widget(canvas: Canvas, img_x: float, img_y: float) -> QPointF:
+    """Convert image-space coordinates to widget-space coordinates."""
+    origin = canvas._compute_image_origin_offset()
+    wx = (img_x + origin.x()) * canvas.scale
+    wy = (img_y + origin.y()) * canvas.scale
+    return QPointF(wx, wy)
+
+
+def _clear_cursor_override(canvas: Canvas) -> None:
+    """Remove any outstanding override cursor pushed by the canvas."""
+    canvas._release_cursor()
+
+
+# ---------------------------------------------------------------------------
+# Cursor shape -- create (drawing) mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_cursor_is_cross_when_hovering_in_create_mode(canvas: Canvas) -> None:
+    # Any mouse move in CREATE mode should engage CrossCursor.
+    canvas.set_editing(value=False)
+    canvas.create_mode = "rectangle"
+    pos = _image_to_widget(canvas=canvas, img_x=50, img_y=25)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None
+    assert override.shape() == Qt.CursorShape.CrossCursor
+    _clear_cursor_override(canvas=canvas)
+
+
+@pytest.mark.gui
+def test_cursor_reverts_to_no_override_after_cursor_cleared(canvas: Canvas) -> None:
+    # After _release_cursor the override stack is empty; callers treat that
+    # as ArrowCursor.
+    canvas.set_editing(value=False)
+    canvas.create_mode = "polygon"
+    pos = _image_to_widget(canvas=canvas, img_x=50, img_y=25)
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+    assert QtWidgets.QApplication.overrideCursor() is not None  # sanity
+
+    _clear_cursor_override(canvas=canvas)
+
+    assert QtWidgets.QApplication.overrideCursor() is None
+
+
+# ---------------------------------------------------------------------------
+# Cursor shape -- edit mode, empty canvas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_cursor_is_arrow_when_hovering_empty_canvas_in_edit_mode(
+    canvas: Canvas,
+) -> None:
+    # Moving over blank canvas area (no shapes) leaves no override cursor.
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+    pos = _image_to_widget(canvas=canvas, img_x=100, img_y=50)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    assert QtWidgets.QApplication.overrideCursor() is None
+
+
+# ---------------------------------------------------------------------------
+# Cursor shape -- edit mode, shape-body hover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_cursor_is_open_hand_when_hovering_shape_body_in_edit_mode(
+    canvas: Canvas,
+) -> None:
+    # Hovering the interior of a shape (not near a vertex or edge) uses
+    # OpenHandCursor to signal the shape is draggable.
+    shape = Shape(
+        shape_type="polygon",
+        points=np.array([(10, 10), (40, 10), (40, 40), (10, 40)], dtype=np.float64),
+        closed=True,
+    )
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+    # (25, 25) is the centroid, well away from every vertex and edge.
+    pos = _image_to_widget(canvas=canvas, img_x=25, img_y=25)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None
+    assert override.shape() == Qt.CursorShape.OpenHandCursor
+    _clear_cursor_override(canvas=canvas)
+
+
+# ---------------------------------------------------------------------------
+# Cursor shape -- edit mode, vertex hover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_cursor_is_pointing_hand_when_hovering_vertex_in_edit_mode(
+    canvas: Canvas,
+) -> None:
+    # Hovering a vertex in EDIT mode engages PointingHandCursor.
+    shape = Shape(
+        shape_type="polygon",
+        points=np.array([(10, 10), (40, 10), (40, 40), (10, 40)], dtype=np.float64),
+        closed=True,
+    )
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+    pos = _image_to_widget(canvas=canvas, img_x=10, img_y=10)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None
+    assert override.shape() == Qt.CursorShape.PointingHandCursor
+    _clear_cursor_override(canvas=canvas)
+
+
+# ---------------------------------------------------------------------------
+# Cursor shape -- edit mode, edge hover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_cursor_is_pointing_hand_when_hovering_edge_in_edit_mode(
+    canvas: Canvas,
+) -> None:
+    # Hovering an edge midpoint of a polygon (but not near a vertex) also
+    # uses PointingHandCursor because clicking inserts a vertex.
+    shape = Shape(
+        shape_type="polygon",
+        points=np.array([(10, 10), (90, 10), (90, 40), (10, 40)], dtype=np.float64),
+        closed=True,
+    )
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+    # (50, 10) is the midpoint of the top edge, not near any vertex.
+    pos = _image_to_widget(canvas=canvas, img_x=50, img_y=10)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None
+    assert override.shape() == Qt.CursorShape.PointingHandCursor
+    _clear_cursor_override(canvas=canvas)
+
+
+# ---------------------------------------------------------------------------
+# Cursor shape -- create mode, polygon-origin snap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_cursor_is_pointing_hand_when_snapping_to_polygon_origin(
+    canvas: Canvas,
+) -> None:
+    # While drawing a polygon with 3+ points, approaching the first point
+    # within epsilon switches from CrossCursor to PointingHandCursor.
+    canvas.set_editing(value=False)
+    canvas.create_mode = "polygon"
+    canvas.scale = 1.0
+    canvas._current = _DraftShape(
+        shape_type="polygon",
+        points=(QPointF(10, 10), QPointF(40, 10), QPointF(40, 40)),
+        point_labels=(1, 1, 1),
+    )
+    # Hover exactly on the polygon's first point (the snap target).
+    pos = _image_to_widget(canvas=canvas, img_x=10, img_y=10)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None
+    assert override.shape() == Qt.CursorShape.PointingHandCursor
+    _clear_cursor_override(canvas=canvas)
+
+
+@pytest.mark.gui
+def test_cursor_is_cross_when_far_from_polygon_origin(canvas: Canvas) -> None:
+    # When the cursor is more than epsilon/scale away from the polygon origin,
+    # CrossCursor is kept (no snap engagement).
+    canvas.set_editing(value=False)
+    canvas.create_mode = "polygon"
+    canvas.scale = 1.0
+    canvas._current = _DraftShape(
+        shape_type="polygon",
+        points=(QPointF(10, 10), QPointF(40, 10), QPointF(40, 40)),
+        point_labels=(1, 1, 1),
+    )
+    # (80, 50) is well beyond epsilon=10 from origin (10, 10).
+    pos = _image_to_widget(canvas=canvas, img_x=80, img_y=50)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None
+    assert override.shape() == Qt.CursorShape.CrossCursor
+    _clear_cursor_override(canvas=canvas)
+
+
+# ---------------------------------------------------------------------------
+# Context-menu selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_menus_tuple_has_exactly_two_entries(canvas: Canvas) -> None:
+    # The public menus attribute is a 2-tuple: (no-selection menu, selection menu).
+    assert len(canvas.menus) == 2
+    assert isinstance(canvas.menus[0], QtWidgets.QMenu)
+    assert isinstance(canvas.menus[1], QtWidgets.QMenu)
+
+
+@pytest.mark.gui
+def test_right_release_without_selection_copy_executes_menus_0(
+    canvas: Canvas,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Without a dragged copy (_selected_shapes_copy empty), the no-selection
+    # context menu (index 0) is executed.
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+    calls: list[int] = []
+    monkeypatch.setattr(canvas.menus[0], "exec", lambda pos=None: calls.append(0))
+    monkeypatch.setattr(canvas.menus[1], "exec", lambda pos=None: calls.append(1))
+    pos = _image_to_widget(canvas=canvas, img_x=50, img_y=25)
+
+    canvas.mousePressEvent(_make_press_event(pos=pos))
+    canvas.mouseReleaseEvent(_make_release_event(pos=pos))
+
+    assert calls == [0]
+
+
+@pytest.mark.gui
+def test_right_release_with_selection_copy_executes_menus_1(
+    canvas: Canvas,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # When selected shapes have been right-drag-copied (_selected_shapes_copy
+    # non-empty), the with-selection context menu (index 1) is executed.
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array([(10, 10), (50, 40)], dtype=np.float64),
+        closed=True,
+    )
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+    canvas.selected_shapes = [shape]
+    canvas._selected_shapes_copy = [shape.copy()]
+    calls: list[int] = []
+    monkeypatch.setattr(canvas.menus[0], "exec", lambda pos=None: calls.append(0))
+    monkeypatch.setattr(canvas.menus[1], "exec", lambda pos=None: calls.append(1))
+    pos = _image_to_widget(canvas=canvas, img_x=30, img_y=25)
+
+    canvas.mousePressEvent(_make_press_event(pos=pos))
+    canvas.mouseReleaseEvent(_make_release_event(pos=pos))
+
+    assert calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# Vertex hover-highlight + snapping parity across zoom (scale) levels
+#
+# Proximity formula (from _shape.nearest_vertex_index):
+#   screen_distance = euclidean_distance(image_point, vertex) * scale
+#   hit iff screen_distance <= epsilon          (epsilon default = 10.0)
+#
+# Equivalently: image_distance <= epsilon / scale
+#
+# The polygon below has a vertex at image-center (100, 50) and the other
+# vertices at the image periphery.  Test points are displaced along X only
+# from (100, 50) so no polygon edge passes through the test coordinate.
+# ---------------------------------------------------------------------------
+
+
+def _make_center_polygon() -> Shape:
+    """Polygon with a vertex at image-center (100, 50), others at corners."""
+    return Shape(
+        shape_type="polygon",
+        points=np.array(
+            [(100, 50), (30, 30), (170, 30), (170, 70), (30, 70)],
+            dtype=np.float64,
+        ),
+        closed=True,
+    )
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    "scale",
+    [0.5, 1.0, 2.0],
+    ids=["scale_0.5", "scale_1.0", "scale_2.0"],
+)
+def test_vertex_hover_within_epsilon_screen_pixels_gives_pointing_hand(
+    qtbot: QtBot,
+    scale: float,
+) -> None:
+    # A hover that is 7 SCREEN pixels from the vertex must always give
+    # PointingHandCursor regardless of zoom level because 7 < epsilon=10.
+    canvas = Canvas()
+    canvas.pixmap = QtGui.QPixmap(_W, _H)
+    canvas.resize(int(_W * scale), int(_H * scale))
+    canvas.scale = scale
+    qtbot.addWidget(canvas)
+
+    shape = _make_center_polygon()
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+
+    # 7 screen pixels at this scale equals 7/scale image pixels.
+    image_offset_px = 7.0 / scale
+    img_x = 100.0 + image_offset_px
+    pos = _image_to_widget(canvas=canvas, img_x=img_x, img_y=50.0)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    override = QtWidgets.QApplication.overrideCursor()
+    assert override is not None, (
+        f"scale={scale}: expected a cursor override (7 screen px from vertex)"
+    )
+    assert override.shape() == Qt.CursorShape.PointingHandCursor, (
+        f"scale={scale}: expected PointingHandCursor at 7 screen px from vertex"
+    )
+    _clear_cursor_override(canvas=canvas)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    "scale",
+    [0.5, 1.0, 2.0],
+    ids=["scale_0.5", "scale_1.0", "scale_2.0"],
+)
+def test_vertex_hover_beyond_epsilon_screen_pixels_does_not_select_vertex(
+    qtbot: QtBot,
+    scale: float,
+) -> None:
+    # A hover that is 12 SCREEN pixels from the vertex is outside epsilon=10
+    # and must NOT register as a vertex hit (_hovered_vertex stays None).
+    canvas = Canvas()
+    canvas.pixmap = QtGui.QPixmap(_W, _H)
+    canvas.resize(int(_W * scale), int(_H * scale))
+    canvas.scale = scale
+    qtbot.addWidget(canvas)
+
+    shape = _make_center_polygon()
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+
+    # 12 screen pixels at this scale equals 12/scale image pixels.
+    image_offset_px = 12.0 / scale
+    img_x = 100.0 + image_offset_px
+    pos = _image_to_widget(canvas=canvas, img_x=img_x, img_y=50.0)
+
+    canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+    assert canvas._hovered_vertex is None, (
+        f"scale={scale}: expected no vertex hit at 12 screen px from vertex "
+        f"(image_offset={image_offset_px:.2f}px, epsilon={_EPSILON})"
+    )
+    _clear_cursor_override(canvas=canvas)
+
+
+@pytest.mark.gui
+def test_screen_pixel_hit_radius_is_constant_across_scale_levels(
+    qtbot: QtBot,
+) -> None:
+    # Confirm parity: a fixed 7-screen-pixel offset from the vertex always
+    # triggers a vertex hit across three representative scale levels.
+    screen_offset_px: float = 7.0  # < epsilon=10, so always within hit range
+
+    for scale in (0.5, 1.0, 2.0):
+        canvas = Canvas()
+        canvas.pixmap = QtGui.QPixmap(_W, _H)
+        canvas.resize(int(_W * scale), int(_H * scale))
+        canvas.scale = scale
+        qtbot.addWidget(canvas)
+
+        shape = _make_center_polygon()
+        canvas.load_shapes(shapes=[shape])
+        canvas.set_editing(value=True)
+
+        image_offset_px = screen_offset_px / scale
+        img_x = 100.0 + image_offset_px
+        pos = _image_to_widget(canvas=canvas, img_x=img_x, img_y=50.0)
+
+        canvas.mouseMoveEvent(_make_move_event(pos=pos))
+
+        assert canvas._hovered_vertex is not None, (
+            f"scale={scale}: vertex should be hit at {screen_offset_px} screen px "
+            f"(image_offset={image_offset_px:.2f}px)"
+        )
+        override = QtWidgets.QApplication.overrideCursor()
+        assert override is not None, f"scale={scale}: expected cursor override"
+        assert override.shape() == Qt.CursorShape.PointingHandCursor, (
+            f"scale={scale}: expected PointingHandCursor"
+        )
+        _clear_cursor_override(canvas=canvas)

--- a/tests/unit/widgets/canvas_interaction_characterization_test.py
+++ b/tests/unit/widgets/canvas_interaction_characterization_test.py
@@ -299,11 +299,11 @@ def test_cursor_is_cross_when_far_from_polygon_origin(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_menus_tuple_has_exactly_two_entries(canvas: Canvas) -> None:
-    # The public menus attribute is a 2-tuple: (no-selection menu, selection menu).
-    assert len(canvas.menus) == 2
-    assert isinstance(canvas.menus[0], QtWidgets.QMenu)
-    assert isinstance(canvas.menus[1], QtWidgets.QMenu)
+def test_context_menus_pair_holds_two_menus(canvas: Canvas) -> None:
+    # The public context_menus pair exposes a no-selection menu and a
+    # selection menu as named QMenu attributes.
+    assert isinstance(canvas.context_menus.without_selection, QtWidgets.QMenu)
+    assert isinstance(canvas.context_menus.with_selection, QtWidgets.QMenu)
 
 
 @pytest.mark.gui
@@ -316,8 +316,12 @@ def test_right_release_without_selection_copy_executes_menus_0(
     canvas.set_editing(value=True)
     canvas.scale = 1.0
     calls: list[int] = []
-    monkeypatch.setattr(canvas.menus[0], "exec", lambda pos=None: calls.append(0))
-    monkeypatch.setattr(canvas.menus[1], "exec", lambda pos=None: calls.append(1))
+    monkeypatch.setattr(
+        canvas.context_menus.without_selection, "exec", lambda pos=None: calls.append(0)
+    )
+    monkeypatch.setattr(
+        canvas.context_menus.with_selection, "exec", lambda pos=None: calls.append(1)
+    )
     pos = _image_to_widget(canvas=canvas, img_x=50, img_y=25)
 
     canvas.mousePressEvent(_make_press_event(pos=pos))
@@ -344,8 +348,12 @@ def test_right_release_with_selection_copy_executes_menus_1(
     canvas.selected_shapes = [shape]
     canvas._selected_shapes_copy = [shape.copy()]
     calls: list[int] = []
-    monkeypatch.setattr(canvas.menus[0], "exec", lambda pos=None: calls.append(0))
-    monkeypatch.setattr(canvas.menus[1], "exec", lambda pos=None: calls.append(1))
+    monkeypatch.setattr(
+        canvas.context_menus.without_selection, "exec", lambda pos=None: calls.append(0)
+    )
+    monkeypatch.setattr(
+        canvas.context_menus.with_selection, "exec", lambda pos=None: calls.append(1)
+    )
     pos = _image_to_widget(canvas=canvas, img_x=30, img_y=25)
 
     canvas.mousePressEvent(_make_press_event(pos=pos))


### PR DESCRIPTION
## Summary
- Extract the Canvas interaction *decision* logic into a new `labelme/widgets/_canvas_interaction.py`, leaving `Canvas` to own widget state, painting, signals, and status text. The hover-resolution, cursor vocabulary, polygon-origin snap check, and context-menu selection were previously tangled inline in the ~2k-line `canvas.py`.
- `find_hover_target(...)` returns `HitTarget | None` (`HitKind` + shape + index, or `None` for a miss); `Canvas` dispatches highlight/cursor/status from it, with a `typing.assert_never` exhaustiveness guard. Per-shape geometry still delegates to the existing `_shape` / `_shape_render` primitives.
- `CursorRole` + `cursor_shape_for(...)` (backed by a dict with an import-time exhaustiveness assert) replace the bare cursor constants; `is_within_pick_threshold(...)` replaces the inline snap check; `ContextMenuPair` (named `without_selection` / `with_selection` menus + `menu_for`) replaces the two-element menu tuple indexed by a bool. `app.py` populates the named menus.
- Adds characterization tests for the observable interaction behavior (cursor per mode/hover via the override-cursor stack, context-menu selection, and screen-pixel snap parity across zoom levels) plus unit tests for the new module. Behavior is unchanged.

Three commits: characterize the existing behavior → add the module → switch `Canvas` over.

## Test plan
- [x] `uv run pytest` (670 passed)
- [x] `uv run ruff check` and `uv run ty check` clean
- [x] e2e canvas interaction green (right-click context menu, right-drag copy-here, hover/select)
- [x] each commit lints, type-checks, and passes its tests standalone

Closes #2150
