### PR TITLE
refactor(api)!: remove public Python API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **Breaking:** Removed the public `LabelFile` class (`labelme.LabelFile`); use the `read_label_file` / `write_label_file` functions and the `LabelFileError` hierarchy in `labelme._label_file` instead ([#2246](https://github.com/wkentaro/labelme/pull/2246))
+- **Breaking:** Removed the deprecated `labelme.utils` compatibility shims: `labelme.utils.lblsave` (use `imgviz.io.lblsave`) and the camelCase aliases `addActions`, `distancetoline`, `fmtShortcut`, `labelValidator`, `newAction`, `newButton`, `newIcon` (use their snake_case names). The `from labelme import utils` top-level re-export is also dropped; import `labelme.utils` directly ([#2249](https://github.com/wkentaro/labelme/pull/2249))
 
 ### Fixed
 

--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -12,5 +12,3 @@ __version__ = importlib.metadata.version("labelme")
 # XXX: has to be imported before PySide6 to load dlls in order on Windows
 # https://github.com/wkentaro/labelme/issues/1564
 import onnxruntime
-
-from labelme import utils

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -266,49 +266,26 @@ def write_label_file(
     image_width: int | None,
     save_image_data: bool,
 ) -> None:
-    _write_label_json_file(
-        filename=filename,
-        shapes=[_dump_shape_to_json_obj(shape) for shape in annotation.shapes],
-        image_path=annotation.image_path,
-        image_height=image_height,
-        image_width=image_width,
-        image_data=annotation.image_data if save_image_data else None,
-        other_data=annotation.other_data,
-        flags=annotation.flags,
-    )
-
-
-def _write_label_json_file(
-    filename: str,
-    *,
-    shapes: list[dict[str, Any]],
-    image_path: str,
-    image_height: int | None,
-    image_width: int | None,
-    image_data: bytes | None = None,
-    other_data: dict[str, Any] | None = None,
-    flags: dict[str, bool] | None = None,
-) -> None:
     try:
         image_data_b64: str | None = None
-        if image_data is not None:
+        if save_image_data:
             _check_image_dimensions(
-                image_data=image_data,
+                image_data=annotation.image_data,
                 expected_height=image_height,
                 expected_width=image_width,
             )
-            image_data_b64 = base64.b64encode(image_data).decode("utf-8")
+            image_data_b64 = base64.b64encode(annotation.image_data).decode("utf-8")
         # JSON keys stay camelCase: changing them would break existing .json files.
         payload: dict[str, Any] = {
             "version": __version__,
-            "flags": dict(flags) if flags else {},
-            "shapes": list(shapes),
-            "imagePath": image_path,
+            "flags": dict(annotation.flags) if annotation.flags else {},
+            "shapes": [_dump_shape_to_json_obj(shape) for shape in annotation.shapes],
+            "imagePath": annotation.image_path,
             "imageData": image_data_b64,
             "imageHeight": image_height,
             "imageWidth": image_width,
         }
-        for key, value in (other_data or {}).items():
+        for key, value in annotation.other_data.items():
             if key in _RESERVED_TOP_LEVEL_KEYS:
                 raise ValueError(f"reserved key in other_data: {key!r}")
             payload[key] = value

--- a/labelme/utils/__init__.py
+++ b/labelme/utils/__init__.py
@@ -1,8 +1,3 @@
-import warnings
-
-import imgviz.io
-import numpy
-
 from .image import apply_exif_orientation
 from .image import img_arr_to_b64
 from .image import img_arr_to_data
@@ -26,35 +21,3 @@ from .qt import project_point_on_perpendicular_line
 from .shape import masks_to_bboxes
 from .shape import shape_to_mask
 from .shape import shapes_to_label
-
-
-def lblsave(filename: str, lbl: numpy.ndarray) -> None:
-    warnings.warn(
-        "labelme.utils.lblsave is deprecated; use imgviz.io.lblsave",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    imgviz.io.lblsave(filename, lbl)
-
-
-_DEPRECATED_ALIASES = {
-    "addActions": add_actions,
-    "distancetoline": distance_to_line,
-    "fmtShortcut": format_shortcut,
-    "labelValidator": label_validator,
-    "newAction": new_action,
-    "newButton": new_button,
-    "newIcon": new_icon,
-}
-
-
-def __getattr__(name: str) -> object:
-    target = _DEPRECATED_ALIASES.get(name)
-    if target is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    warnings.warn(
-        f"labelme.utils.{name} is deprecated; use labelme.utils.{target.__name__}",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return target

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 
 import math
 import uuid
+from typing import TYPE_CHECKING
 
 import numpy as np
 import PIL.Image
 import PIL.ImageDraw
 from numpy.typing import NDArray
 
-from labelme._label_file import ShapeDict
+# FIXME: guarded to break a runtime import cycle (_label_file imports
+# labelme.utils, which imports this module). Safe because ShapeDict is only used
+# in annotations, which `from __future__ import annotations` keeps unevaluated.
+# Drop the guard once _label_file no longer imports the whole utils package.
+if TYPE_CHECKING:
+    from labelme._label_file import ShapeDict
 
 
 def shape_to_mask(


### PR DESCRIPTION
## Summary
- Deletes the `LabelFile` class, its camelCase property shims (`imagePath`/`imageData`/`otherData`), and its duplicate static methods (`is_label_file`, `load_image_file`, `suffix`).
- Drops the `labelme.utils` deprecation machinery (`__getattr__`/`_DEPRECATED_ALIASES`) and `lblsave`.
- Strips `labelme/__init__.py` to package metadata only: `__appname__`, `__version__`, and the `onnxruntime` import (kept in `__init__` for Windows DLL ordering, #1564).
- The functional core (`Annotation`, `read_label_file`, `write_label_file`, `read_image_file`, `LabelFileError` and subclasses) stays; it is just no longer re-exported from the top level.

## Why
Part of the v7 effort to make labelme an application with no public Python API. The GUI already runs entirely on the functional core, so the `LabelFile` facade and the deprecation shims were dead weight serving a contract v7 abolishes. Blocked-by #2231 (examples self-contained) is already merged.

Stripping the top-level re-exports removed the `from labelme import utils` line that was incidentally masking a latent `_label_file` <-> `utils.shape` import cycle. `shape.py`'s `ShapeDict` import is annotation-only, so it now sits behind `TYPE_CHECKING`; a cold `import labelme.app` and the CLI load regardless of import order.

## Test plan
- [x] `import labelme; dir(labelme)` exposes no `utils` or `LabelFile` attribute
- [x] Cold `import labelme.app` and `labelme --help` work (regression caught pre-merge: the stripped `__init__` had exposed the import cycle)
- [x] Migrated `LabelFile`-based regression/image tests onto `read_label_file`/`read_image_file`; dropped the dead camelCase deprecation test
- [x] `uv run pytest tests/` (625 passed), `uv run ruff check`, `uv run ty check`

Closes #2233
