### PR TITLE
build: move update_translate from lint to the release gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 setup:  # Setup the development environment
 	$(call exec,uv sync)
 
-lint: update_translate  # Lint code
+lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
 	$(call exec,uv run ty check --no-progress)
@@ -26,7 +26,6 @@ lint: update_translate  # Lint code
 	$(call exec,git ls-files "*.md" | xargs uv run mdformat --check)
 	$(call exec,git ls-files "*.yml" "*.yaml" | xargs uv run yamlfix --check)
 	$(call exec,uv run typos)
-	$(call exec,git diff --exit-code labelme/translate)
 
 format:  # Format code
 	$(call exec,uv run ruff format)
@@ -41,7 +40,7 @@ test:  # Run tests
 update_translate:
 	$(call exec,uv run tools/update_translate.py)
 
-check_translate:  # Fail if any translation is unfinished (release gate)
+check_translate: update_translate  # Fail if any translation is unfinished (release gate)
 	@if grep -rl 'type="unfinished"' labelme/translate/*.ts; then \
 		printf '\033[1;31mError: unfinished translations found; releases require complete translations\033[0m\n'; \
 		exit 1; \


### PR DESCRIPTION
`make lint` ran `update_translate` on every PR, regenerating translations via `pyside6-lupdate`/`-lrelease` over every source file and all 22 languages, which is slow. Translations only need to be current at release, not on every lint, so this moves the regeneration into the release gate.

`update_translate` is now a prerequisite of `check_translate` (run in `publish.yml`) instead of `lint`. The now-redundant `git diff --exit-code labelme/translate` is dropped from lint since nothing regenerates there anymore.

Encoding it as a Make dependency keeps the regenerate-before-grep ordering in one place. As a bonus it closes a gap in the old release gate: `check_translate` greps committed `.ts` for `type="unfinished"`, so a brand-new untranslated string that was never run through `update_translate` was simply absent from `.ts` and slipped past. Now `check_translate` regenerates first, surfacing such strings as `unfinished` and blocking the release.

## Test plan
- [x] `make lint` no longer regenerates translations (no `pyside6-lupdate` invocation)
- [x] `make check_translate` regenerates `.ts`/`.qm` then fails on any `type="unfinished"`
