### PR TITLE
refactor: import internal private modules relatively

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -17,10 +17,10 @@ from PySide6 import QtWidgets
 
 from labelme import __appname__
 from labelme import __version__
-from labelme import _config
-from labelme import _locale
-from labelme import _yaml
 
+from . import _config
+from . import _locale
+from . import _yaml
 from ._app import MainWindow
 from ._utils import new_icon
 

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -31,21 +31,21 @@ from PySide6.QtWidgets import QMessageBox
 
 from labelme import __appname__
 from labelme import __version__
-from labelme import _automation
-from labelme import _config
-from labelme._label_file import LABEL_FILE_SUFFIX
-from labelme._label_file import Annotation
-from labelme._label_file import LabelFileError
-from labelme._label_file import ShapeDict
-from labelme._label_file import is_label_file_path
-from labelme._label_file import read_image_file
-from labelme._label_file import read_label_file
-from labelme._label_file import write_label_file
-from labelme._shape import Shape
-from labelme._shape import ShapeType
-from labelme._shape_clipboard import ShapeClipboard
 
+from . import _automation
+from . import _config
 from . import _utils
+from ._label_file import LABEL_FILE_SUFFIX
+from ._label_file import Annotation
+from ._label_file import LabelFileError
+from ._label_file import ShapeDict
+from ._label_file import is_label_file_path
+from ._label_file import read_image_file
+from ._label_file import read_label_file
+from ._label_file import write_label_file
+from ._shape import Shape
+from ._shape import ShapeType
+from ._shape_clipboard import ShapeClipboard
 from ._widgets import AiAssistedAnnotationWidget
 from ._widgets import AiTextToAnnotationWidget
 from ._widgets import BrightnessContrastDialog

--- a/labelme/_automation/_ai_assist.py
+++ b/labelme/_automation/_ai_assist.py
@@ -5,8 +5,7 @@ import osam
 from loguru import logger
 from numpy.typing import NDArray
 
-from labelme._shape import Shape
-
+from .._shape import Shape
 from ._osam_session import OsamSession
 from ._shape_builders import Detection
 from ._shape_builders import shapes_from_detections

--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -9,7 +9,7 @@ import skimage
 from loguru import logger
 from numpy.typing import NDArray
 
-from labelme._shape import Shape
+from .._shape import Shape
 
 
 class Circle(NamedTuple):

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -8,8 +8,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
-from labelme._shape import Shape
-
+from .._shape import Shape
 from ._geometry import Circle
 from ._geometry import compute_circle_from_mask
 from ._geometry import compute_oriented_rectangle_from_mask

--- a/labelme/_automation/_suppression.py
+++ b/labelme/_automation/_suppression.py
@@ -8,8 +8,7 @@ import PIL.Image
 import PIL.ImageDraw
 from numpy.typing import NDArray
 
-from labelme._shape import Shape
-
+from .._shape import Shape
 from ._geometry import shape_to_xyxy_bbox
 from ._shape_builders import Detection
 

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -8,8 +8,8 @@ from typing import cast
 
 from loguru import logger
 
-from labelme import _yaml
-from labelme._config._writer import set_override
+from .. import _yaml
+from ._writer import set_override
 
 here = Path(__file__).resolve().parent
 

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -11,7 +11,7 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.comments import CommentedSeq
 
-from labelme import _yaml
+from .. import _yaml
 
 here = Path(__file__).resolve().parent
 

--- a/labelme/_shape_clipboard.py
+++ b/labelme/_shape_clipboard.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 from PySide6 import QtCore
 
-from labelme._shape import Shape
+from ._shape import Shape
 
 
 class ShapeClipboard(QtCore.QObject):

--- a/labelme/_widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/_widgets/_ai_assisted_annotation_widget.py
@@ -9,8 +9,7 @@ from PySide6 import QtGui
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 
-from labelme._automation import AiOutputFormat
-
+from .._automation import AiOutputFormat
 from ._info_button import InfoButton
 
 

--- a/labelme/_widgets/_canvas_interaction.py
+++ b/labelme/_widgets/_canvas_interaction.py
@@ -9,11 +9,10 @@ import numpy.typing as npt
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QMenu
 
-from labelme._shape import Shape
-from labelme._shape import nearest_edge_index
-from labelme._shape import nearest_rotation_point_index
-from labelme._shape import nearest_vertex_index
-
+from .._shape import Shape
+from .._shape import nearest_edge_index
+from .._shape import nearest_rotation_point_index
+from .._shape import nearest_vertex_index
 from ._shape_render import is_hit_by_point
 
 

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -11,12 +11,11 @@ import skimage.measure
 from PySide6 import QtCore
 from PySide6 import QtGui
 
-from labelme._shape import Shape
-from labelme._shape import get_rotation_handle
-from labelme._shape import nearest_edge_index
-from labelme._shape import oriented_rectangle_arrow_points
-
 from .. import _utils
+from .._shape import Shape
+from .._shape import get_rotation_handle
+from .._shape import nearest_edge_index
+from .._shape import oriented_rectangle_arrow_points
 
 PEN_WIDTH: Final[int] = 2
 

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -21,13 +21,12 @@ from PySide6.QtCore import QPointF
 from PySide6.QtCore import QRectF
 from PySide6.QtCore import Qt
 
-from labelme import _automation
-from labelme import _shape
-from labelme._shape import POLYLINE_SHAPE_TYPES
-from labelme._shape import Shape
-from labelme._shape import ShapeType
-
+from .. import _automation
+from .. import _shape
 from .. import _utils
+from .._shape import POLYLINE_SHAPE_TYPES
+from .._shape import Shape
+from .._shape import ShapeType
 from . import _canvas_interaction
 from ._canvas_interaction import CursorRole
 from ._canvas_interaction import HitKind

--- a/labelme/_widgets/label_list_widget.py
+++ b/labelme/_widgets/label_list_widget.py
@@ -12,7 +12,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QPalette
 from PySide6.QtWidgets import QStyle
 
-from labelme._shape import Shape
+from .._shape import Shape
 
 
 def format_label_with_color_dot(text: str, color: tuple[int, int, int]) -> str:

--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -8,8 +8,8 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from labelme import _locale
-from labelme._config import _schema as schema
+from .. import _locale
+from .._config import _schema as schema
 
 ApplySetting = Callable[[tuple[str, ...], object], bool]
 


### PR DESCRIPTION
## Summary

- Converts the 41 remaining absolute imports of internal private modules to relative imports, so every importable module under `labelme/` is private *and* imported as such, never through the package's public path (`from labelme._shape import Shape` -> `from .._shape import Shape`).
- Covers `_shape`, `_label_file`, `_config`, `_automation`, `_locale`, `_yaml`, `_shape_clipboard`. Single-dot for top-level modules, double-dot from subpackages, and the one intra-`_config` import shortened to `from ._writer import set_override`.
- Leaves the public package attributes `__appname__` and `__version__` imported as `from labelme import ...` on purpose: they are public package API, not private modules.

After this, the only `from labelme import ...` lines left in production are those two dunders.

## Stacking

Based on `feat/2234-privatize-import-surface` (#2253), not `main`, because it edits the same files that #2253 renames (`_app.py`, `_widgets/*`). Stacking keeps this diff to set-U lines only and avoids a rename-vs-edit conflict. **Retarget the base to `main` once #2253 merges.**

## Test plan

- [x] `uv run pytest tests/` (676 passed)
- [x] `make lint` clean (ruff format + check, ty, taplo, mdformat, yamlfix, typos)
- [x] imports resolve; `labelme --version` works
