### PR TITLE
fix(tiff): normalize TIFF display over finite pixels only

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -333,9 +333,13 @@ def _imread_tiff(filename: str) -> PIL.Image.Image:
 
 def _normalize_to_uint8(arr: NDArray) -> NDArray[np.uint8]:
     arr = arr.astype(np.float64)
-    min_val = np.nanmin(arr)
-    max_val = np.nanmax(arr)
-    if np.isnan(min_val) or np.isnan(max_val) or max_val - min_val == 0:
+    finite = arr[np.isfinite(arr)]
+    if finite.size == 0:
+        return np.zeros(arr.shape, dtype=np.uint8)
+    min_val = finite.min()
+    max_val = finite.max()
+    if max_val - min_val == 0:
         return np.zeros(arr.shape, dtype=np.uint8)
     normalized = (arr - min_val) / (max_val - min_val) * 255
-    return np.clip(normalized, 0, 255).astype(np.uint8)
+    bounded = np.nan_to_num(np.clip(normalized, 0, 255), nan=0.0)
+    return bounded.astype(np.uint8)

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -13,6 +13,7 @@ from labelme._label_file import Annotation
 from labelme._label_file import LabelFileReadError
 from labelme._label_file import LabelFileWriteError
 from labelme._label_file import ShapeDict
+from labelme._label_file import _normalize_to_uint8
 from labelme._label_file import read_label_file
 from labelme._label_file import write_label_file
 
@@ -258,3 +259,30 @@ def test_write_label_file_raises_write_error_on_io_failure(tmp_path: Path) -> No
             image_width=None,
             save_image_data=False,
         )
+
+
+def test_normalize_to_uint8_scales_finite_range() -> None:
+    result = _normalize_to_uint8(np.array([[0.0, 50.0, 100.0]]))
+    assert result.dtype == np.uint8
+    np.testing.assert_array_equal(result, [[0, 127, 255]])
+
+
+def test_normalize_to_uint8_constant_array_returns_zeros() -> None:
+    result = _normalize_to_uint8(np.full((2, 2), 42.0))
+    np.testing.assert_array_equal(result, np.zeros((2, 2), dtype=np.uint8))
+
+
+def test_normalize_to_uint8_all_non_finite_returns_zeros() -> None:
+    result = _normalize_to_uint8(np.full((2, 2), np.nan))
+    np.testing.assert_array_equal(result, np.zeros((2, 2), dtype=np.uint8))
+
+
+def test_normalize_to_uint8_maps_non_finite_pixels_deterministically() -> None:
+    """Regression: an inf pixel made the max inf, so finite/inf == 0 turned every
+    finite pixel black. Non-finite pixels must saturate instead: +inf -> 255,
+    -inf -> 0, nan -> 0, leaving finite pixels scaled over the finite range.
+    """
+    result = _normalize_to_uint8(
+        np.array([[0.0, 50.0, 100.0, np.inf, -np.inf, np.nan]])
+    )
+    np.testing.assert_array_equal(result, [[0, 127, 255, 255, 0, 0]])


### PR DESCRIPTION
A float TIFF with a single non-finite pixel loaded as an all-black image: `np.nanmax` returned `inf`, so every finite pixel divided by `inf` and collapsed to 0. The existing NaN guard shows the function already meant to handle non-finite TIFFs, but `inf` slipped through.

`_normalize_to_uint8` now computes the min/max over finite pixels only, and saturates non-finite pixels deterministically: `+inf -> 255`, `-inf -> 0`, `nan -> 0` (previously the `nan` path also hit an undefined `astype(uint8)` cast and a `RuntimeWarning`).

## Test plan
- [x] Added unit tests for `_normalize_to_uint8` (finite range, constant, all-non-finite, and the mixed `+inf`/`-inf`/`nan` regression): `tests/unit/_label_file_test.py`
- [x] Smoke: a float TIFF with an `inf` pixel now renders a full 0-255 gradient through the real `_imread` path instead of black
- [x] `uv run pytest tests/` (680 passed), `ruff check`, `ruff format --check`, `ty check`
