### PR TITLE
test(shape): cover move_vertex and translate mutation methods

### DIFF
--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -243,6 +243,29 @@ def test_remove_point_is_noop_for_non_polyline() -> None:
     assert len(shape.point_labels) == 2
 
 
+def test_move_vertex_replaces_only_target_point() -> None:
+    shape = _make_square_polygon()
+
+    shape.move_vertex(i=1, pos=(3.5, -1.25))
+
+    assert len(shape.points) == 4
+    assert shape.points[1] == pytest.approx((3.5, -1.25))
+    assert shape.points[0] == pytest.approx((0.0, 0.0))
+    assert shape.points[2] == pytest.approx((10.0, 10.0))
+    assert shape.points[3] == pytest.approx((0.0, 10.0))
+
+
+def test_translate_shifts_all_points_by_offset() -> None:
+    shape = _make_square_polygon()
+
+    shape.translate(offset=(2.5, -0.75))
+
+    assert len(shape.points) == 4
+    expected = [(2.5, -0.75), (12.5, -0.75), (12.5, 9.25), (2.5, 9.25)]
+    for i, (x, y) in enumerate(expected):
+        assert shape.points[i] == pytest.approx((x, y))
+
+
 # Edge i is the segment from points[i-1] to points[i] (roll-by-1 convention),
 # so for the square below edge 1 is the bottom and edge 0 is the left side.
 @pytest.mark.parametrize(


### PR DESCRIPTION
`Shape.insert_point` and `remove_point` are unit-tested, but their sibling
mutation methods `move_vertex` (drag a vertex) and `translate` (drag a whole
shape) had no direct coverage despite being core editing primitives. These tests
close that gap: they pin sub-pixel float precision, assert `move_vertex` changes
only the target vertex, and assert `translate` shifts every point by the offset
without changing the point count.

## Test plan
- [x] `uv run pytest tests/unit/_shape_test.py -q` (49 passed)
- [x] `uv run ruff check` / `uv run ty check` on the changed file
