### PR TITLE
refactor: break _label_file <-> _utils import cycle

### DIFF
--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
 from typing import Final
-from typing import TypedDict
 
 import numpy as np
 import PIL.Image
@@ -20,19 +19,9 @@ from numpy.typing import NDArray
 from labelme import __version__
 
 from . import _utils
+from ._utils.shape import ShapeDict
 
 PIL.Image.MAX_IMAGE_PIXELS = None
-
-
-class ShapeDict(TypedDict):
-    label: str
-    points: list[list[float]]
-    shape_type: str
-    flags: dict[str, bool]
-    description: str
-    group_id: int | None
-    mask: NDArray[np.bool_] | None
-    other_data: dict
 
 
 def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:

--- a/labelme/_utils/shape.py
+++ b/labelme/_utils/shape.py
@@ -5,19 +5,23 @@ from __future__ import annotations
 
 import math
 import uuid
-from typing import TYPE_CHECKING
+from typing import TypedDict
 
 import numpy as np
 import PIL.Image
 import PIL.ImageDraw
 from numpy.typing import NDArray
 
-# FIXME: guarded to break a runtime import cycle (_label_file imports
-# labelme._utils, which imports this module). Safe because ShapeDict is only used
-# in annotations, which `from __future__ import annotations` keeps unevaluated.
-# Drop the guard once _label_file no longer imports the whole utils package.
-if TYPE_CHECKING:
-    from labelme._label_file import ShapeDict
+
+class ShapeDict(TypedDict):
+    label: str
+    points: list[list[float]]
+    shape_type: str
+    flags: dict[str, bool]
+    description: str
+    group_id: int | None
+    mask: NDArray[np.bool_] | None
+    other_data: dict
 
 
 def shape_to_mask(


### PR DESCRIPTION
Breaks the `_label_file` <-> `labelme._utils` runtime import cycle so `_utils/shape.py` can drop its `TYPE_CHECKING` guard (Closes #2252).

The cycle was `_label_file` -> `labelme._utils` package -> `_utils/__init__` -> `shape.py` -> back to `_label_file` for `ShapeDict`. `shape.py` papered over it with a `TYPE_CHECKING` guard plus a FIXME.

The issue suggested importing the concrete `labelme._utils.image` submodule instead of the package, but that does not break the cycle: importing any submodule still runs `_utils/__init__.py`, which imports `shape.py`. Instead, this moves the shared `ShapeDict` TypedDict down into `_utils/shape.py` (the module whose `shapes_to_label` already consumes it). The dependency is now one-directional (`_label_file` imports `ShapeDict` from `_utils.shape`), the guard and FIXME are gone, and `_label_file` re-exposes `ShapeDict` so existing `from labelme._label_file import ShapeDict` call sites are unchanged.

## Test plan
- [x] `import labelme._label_file`, `labelme._utils`, `labelme._utils.shape`, and `labelme._app` all succeed in any entry order
- [x] `uv run pytest tests/` (685 passed)
- [x] `uv run ruff check` and `uv run ty check` clean
