### PR TITLE
docs: state v7 no-public-API contract and bound v6.3.x maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,24 @@ On some Linux distributions, labelme is also packaged in the system's native rep
 | Qt     | Qt6 (PySide6)                  | Qt5                  |
 | OS     | 64-bit macOS / Windows / Linux | older OSes           |
 
-labelme follows [SPEC 0](https://scientific-python.org/specs/spec-0000/) (the successor to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)) for dropping Python versions, in step with its core scientific dependencies (numpy, scipy, scikit-image). v6.3.x is the maintenance line for Qt5 and Python 3.10 stragglers and receives critical fixes only.
+labelme follows [SPEC 0](https://scientific-python.org/specs/spec-0000/) (the successor to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)) for dropping Python versions, in step with its core scientific dependencies (numpy, scipy, scikit-image). v6.3.x is the maintenance line for Qt5 and Python 3.10 stragglers.
+
+v6.3.x receives critical fixes only, on a best-effort basis with no release cadence or SLA. "Critical" is limited to:
+
+- security vulnerabilities,
+- data-loss or annotation-corruption bugs,
+- install or launch breakage caused by upstream dependency drift.
+
+Feature backports and non-critical bugs are out of scope; all new development happens on v7.x.
 
 ### Upgrading from v6.x to v7
 
 v7.0.0 raises the platform floor:
 
-- **Qt binding:** the GUI moved from PyQt5 (Qt5) to PySide6 (Qt6). `pip install labelme` now pulls PySide6 instead of PyQt5. If you import labelme as a library, note that internal Qt imports are PySide6.
+- **Qt binding:** the GUI moved from PyQt5 (Qt5) to PySide6 (Qt6). `pip install labelme` now pulls PySide6 instead of PyQt5.
 - **Python:** the minimum is now Python 3.11 (3.10 is dropped).
 - **OS:** Qt6 requires a 64-bit macOS, Windows, or Linux; older OSes that only Qt5 supported are no longer covered.
+- **No public Python API:** labelme is an application, not a library, and exposes no stable Python API. Its internal modules were privatized in v7 (renamed to underscore-prefixed names), so `import labelme.app`, `labelme.utils`, `labelme.widgets`, and similar imports no longer work. If you previously imported labelme internals, pin `labelme<7` and vendor the code you need; see [`examples/utils.py`](examples/utils.py) for copy-and-adapt reference code that reads the JSON annotation format without depending on labelme.
 
 If you need to stay on PyQt5/Qt5, Python 3.10, or an older OS, pin to the v6.3.x maintenance line:
 
@@ -117,6 +126,16 @@ All previous releases remain installable from [PyPI](https://pypi.org/project/la
 v7.0.0 also changes config parsing:
 
 - **Config booleans:** `~/.labelmerc` is now parsed with ruamel.yaml (YAML 1.2), so the boolean spellings `yes`/`no`/`on`/`off` (in any capitalization) are read as strings rather than booleans. If you set any boolean option this way, switch it to `true`/`false`.
+
+### Public interface
+
+labelme is an application. The interfaces you can build on and that we keep stable are:
+
+- the **command-line interface** (`labelme ...`),
+- the **on-disk JSON annotation format**, and
+- the **`~/.labelmerc` config format**.
+
+Everything else, including the Python import surface, is internal and may change or be renamed without notice. To consume annotations from your own code, read the JSON format directly (see [`examples/utils.py`](examples/utils.py)).
 
 ## Usage
 


### PR DESCRIPTION
Now that the import surface is privatized (#2234 / PR #2253, merged), the README can state the v7 contract.

- Replaces the old "internal Qt imports are PySide6" library note with a clear statement that labelme is an application with **no stable Python API**, tells internal-importers to pin `labelme<7`, and points to `examples/utils.py` as copy-and-adapt reference for reading the JSON format.
- Adds a **Public interface** section framing the three contracts that DO stay stable: the CLI, the on-disk JSON annotation format, and the `~/.labelmerc` config format.
- Bounds the v6.3.x maintenance promise to security vulnerabilities, data-loss/annotation-corruption bugs, and install/launch breakage from upstream dependency drift, best-effort with no cadence/SLA, excluding feature backports and non-critical bugs.

Closes #2235

## Test plan
- [x] README renders; all four acceptance criteria in #2235 satisfied (no-public-API note, `examples/utils.py` pointer, bounded v6.3.x section, privatization already merged)
