### PR TITLE
fix: reset label flags on each new-shape popup

### DIFF
--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -260,6 +260,9 @@ class LabelDialog(QtWidgets.QDialog):
         if flags is not None:
             self._show_popup_flags(flags)
         else:
+            # _update_flags keeps the checked state of boxes that already exist
+            # (wanted while typing); clear them so a fresh popup starts unchecked.
+            self._clear_flags_layout()
             self._update_flags(self.edit.text())
 
         matches = self.label_list.findItems(

--- a/tests/unit/widgets/label_dialog_characterize_test.py
+++ b/tests/unit/widgets/label_dialog_characterize_test.py
@@ -77,6 +77,12 @@ def _checkboxes(dialog: LabelDialog) -> list[QtWidgets.QCheckBox]:
     return dialog.findChildren(QtWidgets.QCheckBox)
 
 
+def _checkbox(dialog: LabelDialog, name: str) -> QtWidgets.QCheckBox:
+    matches = [cb for cb in _checkboxes(dialog) if cb.text() == name]
+    assert matches, f"no checkbox named {name!r}"
+    return matches[0]
+
+
 def _ok_button(dialog: LabelDialog) -> QtWidgets.QPushButton:
     box = dialog.findChild(QtWidgets.QDialogButtonBox)
     assert box is not None
@@ -575,6 +581,41 @@ def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
     )
     assert seen["enabled"]
     assert all(seen["enabled"])
+
+
+def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
+    qtbot: QtBot,
+) -> None:
+    seen: dict[str, bool] = {}
+    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor"]})
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        at_show=lambda d: _checkbox(d, "indoor").setChecked(True),
+    )
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        at_show=lambda d: seen.update(checked=_checkbox(d, "indoor").isChecked()),
+    )
+    assert seen["checked"] is False
+
+
+def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
+    qtbot: QtBot,
+) -> None:
+    seen: dict[str, bool] = {}
+    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor"]})
+    _run_popup(dialog, accept=True, text="cat", flags={"indoor": True})
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        at_show=lambda d: seen.update(checked=_checkbox(d, "indoor").isChecked()),
+    )
+    assert seen["checked"] is False
 
 
 def test_flags_disabled_survives_text_edit_rebuild(qtbot: QtBot) -> None:


### PR DESCRIPTION
Checking a flag on one shape left it checked when the label dialog reopened for the next new shape, until you manually unchecked it. The checkboxes from the previous popup were never cleared, and the no-explicit-flags path re-applies the checked state of whatever boxes still exist. On a fresh popup the dialog now clears the leftover flag checkboxes before rebuilding them, so each new shape starts with all flags unchecked. The carry-over that live typing relies on is unchanged.

## Test plan
- [x] `pytest tests/unit/widgets/label_dialog_characterize_test.py` — two new tests pin that checked flags (set interactively, and via an edited shape's flags dict) do not leak into the next new-shape popup; both fail without the fix
- [x] `ruff check` and `ty check` clean
