### PR TITLE
fix: open Edit Label dialog at context-menu origin

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -216,6 +216,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._label_dialog = self._make_label_dialog()
 
         self._prev_opened_dir = None
+        self._label_list_menu_origin: QtCore.QPoint | None = None
         self._docks = self._setup_dock_widgets()
 
         self.setAcceptDrops(True)
@@ -1527,8 +1528,12 @@ class MainWindow(QtWidgets.QMainWindow):
                         widget.setStyleSheet(style)
 
     def show_label_list_menu(self, point: QtCore.QPoint) -> None:
-        # PySide6 type QMenu.exec() argument too narrowly
-        self._menus.label_list.exec(self._docks.label_list.mapToGlobal(point))  # ty: ignore[invalid-argument-type]
+        self._label_list_menu_origin = self._docks.label_list.mapToGlobal(point)
+        try:
+            # PySide6 type QMenu.exec() argument too narrowly
+            self._menus.label_list.exec(self._label_list_menu_origin)  # ty: ignore[invalid-argument-type]
+        finally:
+            self._label_list_menu_origin = None
 
     def validate_label(self, label: str) -> bool:
         policy = self._config["validate_label"]
@@ -1575,8 +1580,16 @@ class MainWindow(QtWidgets.QMainWindow):
         if not edit_description:
             self._label_dialog.edit_description.setDisabled(True)
 
+        canvas_menu_origin = self._canvas_widgets.canvas.context_menu_origin
+        menu_origin = (
+            canvas_menu_origin
+            if canvas_menu_origin is not None
+            else self._label_list_menu_origin
+        )
+
         text, flags, group_id, description = self._label_dialog.popup(
             text=first_shape.label if edit_text else "",
+            position=menu_origin,
             flags=first_shape.flags if edit_flags else None,
             group_id=first_shape.group_id if edit_group_id else None,
             description=first_shape.description if edit_description else None,

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -266,6 +266,7 @@ class Canvas(QtWidgets.QWidget):
             without_selection=QtWidgets.QMenu(),
             with_selection=QtWidgets.QMenu(),
         )
+        self.context_menu_origin: QtCore.QPoint | None = None
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
 
@@ -1131,7 +1132,12 @@ class Canvas(QtWidgets.QWidget):
             has_selection=len(self._selected_shapes_copy) > 0
         )
         self._release_cursor()
-        if menu.exec(self.mapToGlobal(event.position().toPoint())):  # type: ignore
+        self.context_menu_origin = self.mapToGlobal(event.position().toPoint())
+        try:
+            triggered = menu.exec(self.context_menu_origin)  # type: ignore
+        finally:
+            self.context_menu_origin = None
+        if triggered:
             return
         if not self._selected_shapes_copy:
             return

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -240,6 +240,7 @@ class LabelDialog(QtWidgets.QDialog):
         self,
         text: str | None = None,
         move: bool = True,
+        position: QtCore.QPoint | None = None,
         flags: dict[str, bool] | None = None,
         group_id: int | None = None,
         description: str | None = None,
@@ -275,8 +276,7 @@ class LabelDialog(QtWidgets.QDialog):
         self.edit.setFocus(QtCore.Qt.FocusReason.PopupFocusReason)
 
         if move:
-            cursor_pos = QtGui.QCursor.pos()
-            self.move(cursor_pos)
+            self.move(position if position is not None else QtGui.QCursor.pos())
 
         result = self.exec()
 


### PR DESCRIPTION
`LabelDialog.popup()` moved the dialog to the cursor position at popup time.
When Edit Label is chosen from a right-click context menu, the cursor sits
on the menu item, so the dialog opened far below where the menu itself was
opened (worse the lower the item sits in the menu).

The menu's origin (the right-click point) is now recorded while `menu.exec()`
runs and passed to `popup()` as the move target, so the dialog opens at the
menu's top-left corner. This covers both context menus that offer Edit Label:
the canvas right-click menu (origin recorded on the canvas) and the label list
menu (origin recorded on the main window). `menu.exec()` dispatches the action
slot synchronously, so the origin is valid when `_edit_label` reads it, and a
`try/finally` clears it afterward. The Ctrl+E, menubar, and double-click paths
leave the origin unset and keep falling back to the cursor position.

## Test plan
- [x] `uv run ruff check` + `uv run ty check` on the touched files
- [x] `uv run pytest tests/unit/widgets/label_dialog_*.py tests/e2e/canvas_interaction_test.py tests/e2e/annotation_test.py` (107 passed)
