### PR TITLE
fix: undo after Delete File no longer restores the deleted annotations

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2455,7 +2455,12 @@ class MainWindow(QtWidgets.QMainWindow):
         # Only the label file was deleted, not the image: clear the annotations
         # but keep the image on the canvas.
         self._docks.label_list.clear()
+        # Drop the pre-delete backups first so undo cannot resurrect the
+        # annotations of the file we just removed; load_shapes then re-seeds the
+        # stack with the empty state, keeping "top mirrors current" intact.
+        self._canvas_widgets.canvas.shape_backups.clear()
         self._canvas_widgets.canvas.load_shapes(shapes=[], replace=True)
+        self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
         self.mark_clean()
 
     @property

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -10,6 +10,7 @@ from labelme._app import MainWindow
 
 from ..conftest import close_or_pause
 from .conftest import MainWinFactory
+from .conftest import select_shape
 from .conftest import show_window_and_wait_for_imagedata
 
 
@@ -94,5 +95,43 @@ def test_delete_label_file_keeps_image(
     assert len(win._docks.label_list) == 0
     assert win._image_path is not None
     assert win._annotation is not None
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_undo_after_delete_file_does_not_restore_shapes(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / "annotated"),
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    monkeypatch.setattr(win, "_confirm_deletion", lambda *args, **kwargs: True)
+
+    # A prior shape edit in the same session enables the undo action.
+    win._switch_canvas_mode(edit=True)
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
+    win.delete_selected_shapes()
+    qtbot.wait(50)
+    assert canvas.can_restore_shape
+    assert win._actions.undo.isEnabled()
+
+    win.delete_file()
+    qtbot.wait(50)
+    assert canvas.shapes == []
+
+    # Undo must not resurrect the annotations of the file removed from disk.
+    assert not canvas.can_restore_shape
+    assert not win._actions.undo.isEnabled()
+    win.undo_shape_edit()
+    assert canvas.shapes == []
+    assert len(win._docks.label_list) == 0
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)


### PR DESCRIPTION
Follow-up to #2138. After "Delete File", the annotations were cleared via `load_shapes([])`, but the pre-delete snapshots were left on the canvas undo stack and the Undo action was never re-synced. If Undo had been enabled by a prior edit, Ctrl+Z after Delete File popped the empty state and restored the just-deleted annotations — and re-saving recreated the JSON removed from disk, contradicting the dialog's "This action cannot be undone."

`delete_file()` now clears `shape_backups` *before* `load_shapes([])`, so the trailing `backup_shapes()` re-seeds the stack with the empty state (keeping Canvas's "top of stack mirrors current state" invariant), then disables the Undo action.

## Test plan
- [x] Added regression test `test_undo_after_delete_file_does_not_restore_shapes` (fails on `main`, passes here)
- [x] `uv run pytest tests/e2e/file_operations_test.py tests/e2e/last_label_and_restore_test.py`
- [x] `uv run ruff check` / `uv run ty check`

Closes #2166
