### PR TITLE
fix: keep annotation label text visible on styles that collapse the text sub-rect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed annotation label text being clipped or invisible in the label list on some desktop styles (e.g. GNOME/Adwaita) by widening the delegate's text clip rect to the rendered width ([#2273](https://github.com/wkentaro/labelme/pull/2273))
 - Fixed `line` and two-point `linestrip` shapes being unselectable by click ([#2107](https://github.com/wkentaro/labelme/pull/2107))
 - Fixed the canvas going blank after "Delete File" (Delete File now removes only the label JSON and keeps the image on screen) ([#2138](https://github.com/wkentaro/labelme/pull/2138))
 - Fixed notch artifacts at interior vertices of linestrip masks by using PIL's `joint="curve"` rasterization ([#2163](https://github.com/wkentaro/labelme/pull/2163))

--- a/labelme/_widgets/label_list_widget.py
+++ b/labelme/_widgets/label_list_widget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+import math
 from collections.abc import Iterator
 from typing import NamedTuple
 from typing import cast
@@ -69,6 +70,11 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
         )
         if index.column() != 0:
             text_rect.adjust(5, 0, 0, 0)
+
+        # opt.text was emptied above, so some styles (e.g. Adwaita) return a
+        # text sub-rect too narrow for the rendered HTML and clip the label.
+        # Widen it to the document's ideal width so the text stays visible.
+        text_rect.setWidth(max(text_rect.width(), math.ceil(doc.idealWidth())))
 
         VERT_FUDGE = 4
         margin = (option.rect.height() - opt.fontMetrics.height()) // 2 - VERT_FUDGE

--- a/tests/unit/widgets/label_list_widget_test.py
+++ b/tests/unit/widgets/label_list_widget_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPalette
+from pytestqt.qtbot import QtBot
+
+from labelme._widgets.label_list_widget import HTMLDelegate
+
+
+def _has_ink_from(image: QtGui.QImage, start_x: int) -> bool:
+    for x in range(start_x, image.width()):
+        for y in range(image.height()):
+            if image.pixelColor(x, y) != QtGui.QColor(Qt.GlobalColor.white):
+                return True
+    return False
+
+
+def test_html_delegate_does_not_clip_label_when_text_subrect_collapses(
+    qtbot: QtBot,
+) -> None:
+    model = QtGui.QStandardItemModel()
+    model.appendRow(QtGui.QStandardItem("LabelText " * 8))
+    index = model.index(0, 0)
+
+    delegate = HTMLDelegate()
+
+    image = QtGui.QImage(400, 24, QtGui.QImage.Format.Format_ARGB32)
+    image.fill(Qt.GlobalColor.white)
+    painter = QtGui.QPainter(image)
+
+    option = QtWidgets.QStyleOptionViewItem()
+    # A narrow item rect emulates the styles (e.g. Adwaita) whose text sub-rect
+    # collapses because the delegate empties opt.text before measuring it.
+    option.rect = QtCore.QRect(0, 0, 6, 24)
+    option.palette.setColor(
+        QPalette.ColorGroup.Active, QPalette.ColorRole.Text, QtGui.QColor("black")
+    )
+    delegate.paint(painter, option, index)
+    painter.end()
+
+    # The collapsed sub-rect is only 6px wide; ink well past it (x >= 20) proves
+    # the widened clip rect let the label render instead of clipping it away.
+    assert _has_ink_from(image, start_x=20)


### PR DESCRIPTION
`HTMLDelegate.paint` empties `opt.text` before asking the style for the text sub-rect via `subElementRect(SE_ItemViewItemText, ...)`, so some desktop styles (e.g. GNOME/Adwaita) return a rect too narrow for the rendered HTML and clip the annotation label — on some setups making the text practically invisible. The fix widens the clip rect to the document's ideal width (`max(width, ceil(doc.idealWidth()))`), so it can only grow, never shrink a rect a well-behaved style already sized correctly.

The bug is style-dependent and can't be reproduced on this platform, so the regression test forces the same condition deterministically: it renders the delegate with a collapsed text sub-rect and asserts the label ink is drawn past the collapsed width instead of being clipped away (red on `main`, green here).

Closes #1228

## Test plan
- [x] `tests/unit/widgets/label_list_widget_test.py` — new test, verified failing on `main` and passing here
- [x] `uv run pytest tests/` — full suite green (703 passed)
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check` — clean
- [x] Real-widget render smoke: `LabelListWidget` populated with real shape labels renders without clipping or crash
