### PR TITLE
fix: keep AI Text-to-Annotation Score/IoU controls themed on live color-scheme switch

### DIFF
--- a/labelme/_widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/_widgets/_ai_text_to_annotation_widget.py
@@ -91,24 +91,34 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
         model_combo.setCurrentIndex(model_index)
         settings_layout.addWidget(model_combo, stretch=1)
 
-        score_label = QtWidgets.QLabel(self.tr("Score"))
-        score_label.setStyleSheet("color: gray; font-size: 10px;")
-        settings_layout.addWidget(score_label)
+        # Size and mute these via QFont and a palette role, never a stylesheet:
+        # a stylesheet switches the widget to QStyleSheetStyle, which pins its
+        # resolved colors at polish time and does not re-resolve them on a live
+        # color-scheme change, leaving the text faded after a mid-session theme
+        # switch.
+        small_font = self.font()
+        small_font.setPixelSize(10)
+
+        def make_threshold_label(text: str) -> QtWidgets.QLabel:
+            label = QtWidgets.QLabel(text)
+            label.setFont(small_font)
+            label.setForegroundRole(QtGui.QPalette.ColorRole.PlaceholderText)
+            return label
+
+        settings_layout.addWidget(make_threshold_label(self.tr("Score")))
         #
         self._score_spinbox = score_spinbox = QtWidgets.QDoubleSpinBox()
-        score_spinbox.setStyleSheet("font-size: 10px;")
+        score_spinbox.setFont(small_font)
         score_spinbox.setFixedWidth(50)
         score_spinbox.setRange(0, 1)
         score_spinbox.setSingleStep(0.05)
         score_spinbox.setValue(self._default_score_threshold)
         settings_layout.addWidget(score_spinbox)
 
-        iou_label = QtWidgets.QLabel(self.tr("IoU"))
-        iou_label.setStyleSheet("color: gray; font-size: 10px;")
-        settings_layout.addWidget(iou_label)
+        settings_layout.addWidget(make_threshold_label(self.tr("IoU")))
         #
         self._iou_spinbox = iou_spinbox = QtWidgets.QDoubleSpinBox()
-        iou_spinbox.setStyleSheet("font-size: 10px;")
+        iou_spinbox.setFont(small_font)
         iou_spinbox.setFixedWidth(50)
         iou_spinbox.setRange(0, 1)
         iou_spinbox.setSingleStep(0.05)


### PR DESCRIPTION
The AI Text-to-Annotation **Score** and **IoU** labels/spinboxes sized their font with a Qt stylesheet (`font-size` / `color`). Setting any stylesheet switches a widget to `QStyleSheetStyle`, which pins its resolved colors at polish time and does not re-resolve them when the color scheme changes live. So after switching the color theme mid-session these controls stayed on the old scheme and looked faded/inverted (the app's `_retheme` sweep only re-applies stylesheets that contain a `palette(...)` reference, which these did not).

Size the font via `QFont` and mute the labels via the `PlaceholderText` palette role instead, so both follow the palette live. This mirrors the existing `setForegroundRole(PlaceholderText)` idiom in `settings_dialog.py`.

No CHANGELOG entry: this widget is part of the unreleased v7 (PySide6) work, so the bug never shipped in a released version.

## Test plan
- [x] `ruff` + `ty` clean on the changed file
- [x] `pytest tests/e2e/ai_text_to_annotation_test.py` (8 passed)
- [x] Rebuilt the widget: labels/spinboxes render at 10px with an empty stylesheet and the labels carry the `PlaceholderText` role; thresholds unchanged (0.1 / 0.5)
- [x] Manual: open Settings, switch Color theme, confirm Score/IoU restyle in step with the rest of the UI
