### PR TITLE
feat: mark preview features with a BETA badge in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a schema-driven Settings dialog (replaces the "open YAML in editor" preference), with immediate live-apply and comment-preserving writes to ~/.labelmerc ([#2120](https://github.com/wkentaro/labelme/pull/2120))
 - Added a Language picker to the Settings dialog so the UI language can be changed without editing the config file ([#2140](https://github.com/wkentaro/labelme/pull/2140))
 - Added a `show_labels` toggle in Settings to draw each shape's label text on the canvas at its top-left anchor, live-applied without restart ([#2182](https://github.com/wkentaro/labelme/pull/2182))
+- Added a BETA badge in the Settings dialog beside preview features (Show shape labels on canvas, Allow points outside the image boundary) to signal they are shipped for early use and to invite issue reports ([#2275](https://github.com/wkentaro/labelme/pull/2275))
 - Added image flags to the Settings dialog with live dock refresh — newly added flags appear without reloading the image ([#2169](https://github.com/wkentaro/labelme/pull/2169))
 - Added inline display of enabled shape flags in the annotation list (e.g. `car [occluded, truncated]`) so the full annotation state is visible at a glance ([#2134](https://github.com/wkentaro/labelme/pull/2134))
 - Added Indonesian (id_ID) localization ([#2143](https://github.com/wkentaro/labelme/pull/2143))

--- a/labelme/_config/_schema.py
+++ b/labelme/_config/_schema.py
@@ -37,6 +37,9 @@ class Setting:
     choice_labels: tuple[str, ...] | None = None
     # Optional muted caption rendered beneath the control.
     note: str | None = None
+    # Marks a feature shipped for early use: renders a "BETA" badge beside the
+    # label so users expect rough edges and report issues. Drop when it stabilizes.
+    beta: bool = False
 
 
 SETTINGS: Final[tuple[Setting, ...]] = (
@@ -67,6 +70,7 @@ SETTINGS: Final[tuple[Setting, ...]] = (
             str, QT_TRANSLATE_NOOP("SettingsDialog", "Show shape labels on canvas")
         ),
         kind="bool",
+        beta=True,
     ),
     Setting(
         key_path=("canvas", "allow_out_of_bounds_points"),
@@ -86,6 +90,7 @@ SETTINGS: Final[tuple[Setting, ...]] = (
                 "visible objects.",
             ),
         ),
+        beta=True,
     ),
     Setting(
         key_path=("language",),

--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -154,13 +154,28 @@ class SettingsDialog(QtWidgets.QDialog):
     def _build_label_cell(self, setting: schema.Setting) -> QtWidgets.QWidget:
         label = QtWidgets.QLabel(self.tr(setting.label))
         label.setWordWrap(True)
+        title: QtWidgets.QWidget = label
+        if setting.beta:
+            # Keep the label on one line so the badge hugs it instead of floating
+            # past a wrap; the dialog auto-widens to fit the row.
+            label.setWordWrap(False)
+            title = QtWidgets.QWidget()
+            title_layout = QtWidgets.QHBoxLayout(title)
+            title_layout.setContentsMargins(0, 0, 0, 0)
+            title_layout.setSpacing(6)
+            title_layout.addWidget(label)
+            title_layout.addWidget(
+                _build_beta_badge(text=self.tr("BETA")),
+                alignment=QtCore.Qt.AlignmentFlag.AlignVCenter,
+            )
+            title_layout.addStretch(1)
         if not setting.note:
-            return label
+            return title
         cell = QtWidgets.QWidget()
         cell_layout = QtWidgets.QVBoxLayout(cell)
         cell_layout.setContentsMargins(0, 0, 0, 0)
         cell_layout.setSpacing(2)
-        cell_layout.addWidget(label)
+        cell_layout.addWidget(title)
         note = QtWidgets.QLabel(self.tr(setting.note))
         note.setWordWrap(True)
         # Secondary text color, kept enabled: a disabled label would be announced
@@ -304,6 +319,27 @@ class SettingsDialog(QtWidgets.QDialog):
         model.item(exact_index).setEnabled(allowed)
         if not allowed and validate_combo.currentData() == "exact":
             validate_combo.setCurrentIndex(validate_combo.findData(None))
+
+
+def _build_beta_badge(*, text: str) -> QtWidgets.QLabel:
+    badge = QtWidgets.QLabel(text)
+    badge.setSizePolicy(
+        QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
+    )
+    # palette() refs (not literal hex) so the app's theme switch re-resolves them
+    # via _retheme; a muted outline reads as a status tag, not an accent-colored
+    # control, and text-on-window keeps the body-text contrast in both themes.
+    badge.setStyleSheet(
+        "QLabel {"
+        "  color: palette(text);"
+        "  border: 1px solid palette(mid);"
+        "  border-radius: 7px;"
+        "  padding: 0px 6px;"
+        "  font-size: 10px;"
+        "  font-weight: 600;"
+        "}"
+    )
+    return badge
 
 
 def _parse_str_list(*, edit: _PlainTextEdit) -> list[str] | None:

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -5,6 +5,7 @@ from PySide6 import QtGui
 from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
+from labelme._config import _schema as schema
 from labelme._config import load_config
 from labelme._widgets.settings_dialog import SettingsDialog
 from labelme._widgets.settings_dialog import _PlainTextEdit
@@ -42,6 +43,25 @@ def dialog(qtbot: QtBot, applied: Applied) -> SettingsDialog:
 
 def test_no_apply_on_construction(dialog: SettingsDialog, applied: Applied) -> None:
     assert applied == []
+
+
+def test_beta_settings_render_a_badge(dialog: SettingsDialog) -> None:
+    expected = {dialog.tr(setting.label) for setting in schema.SETTINGS if setting.beta}
+    assert expected, "no beta settings to verify"
+
+    badge_text = dialog.tr("BETA")
+    beta_labels: set[str] = set()
+    for badge in dialog.findChildren(QtWidgets.QLabel):
+        if badge.text() != badge_text:
+            continue
+        cell = badge.parentWidget()
+        assert cell is not None
+        beta_labels.update(
+            sibling.text()
+            for sibling in cell.findChildren(QtWidgets.QLabel)
+            if sibling is not badge
+        )
+    assert beta_labels == expected
 
 
 def test_accept_does_not_reapply_unchanged_str_list(


### PR DESCRIPTION
## Summary
- Adds a `beta` flag to `Setting` and renders a small "BETA" badge beside flagged features in the Settings dialog, signaling they are shipped for early use so users expect rough edges and report issues.
- Flags two features as beta: "Show shape labels on canvas" (#2182) and "Allow points outside the image boundary" (#2223).
- The badge is a muted outlined pill drawn from palette roles (`palette(text)` / `palette(mid)`), so it tracks light/dark theme switches via the existing `_retheme` path and reads as a status tag rather than an interactive control.

## Test plan
- [x] `test_beta_settings_render_a_badge` asserts a badge renders for exactly the schema's `beta=True` settings
- [x] `uv run pytest tests/unit/widgets/settings_dialog_test.py tests/unit/_config/_schema_test.py tests/e2e/settings_test.py` — 38 passed
- [x] ruff + ty clean
- [x] Rendered the dialog offscreen in light and dark to confirm the badge adapts and stays legible in both
