### PR TITLE
fix: make a shape hidden while hovered inert to the pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a hidden shape staying hover-interactive (highlight, cursor, click-to-select) when it was the hovered shape at the moment it was hidden ([#2276](https://github.com/wkentaro/labelme/pull/2276))
 - Fixed annotation label text being clipped or invisible in the label list on some desktop styles (e.g. GNOME/Adwaita) by widening the delegate's text clip rect to the rendered width ([#2273](https://github.com/wkentaro/labelme/pull/2273))
 - Fixed `line` and two-point `linestrip` shapes being unselectable by click ([#2107](https://github.com/wkentaro/labelme/pull/2107))
 - Fixed the canvas going blank after "Delete File" (Delete File now removes only the label JSON and keeps the image on screen) ([#2138](https://github.com/wkentaro/labelme/pull/2138))

--- a/labelme/_widgets/_canvas_interaction.py
+++ b/labelme/_widgets/_canvas_interaction.py
@@ -89,7 +89,7 @@ def _build_candidates(
     priority_shape: Shape | None,
 ) -> list[Shape]:
     candidates: list[Shape] = []
-    if priority_shape is not None:
+    if priority_shape is not None and priority_shape.visible:
         candidates.append(priority_shape)
     for shape in reversed(shapes):
         if not shape.visible:

--- a/tests/unit/widgets/canvas_interaction_characterization_test.py
+++ b/tests/unit/widgets/canvas_interaction_characterization_test.py
@@ -183,6 +183,44 @@ def test_cursor_is_open_hand_when_hovering_shape_body_in_edit_mode(
 
 
 # ---------------------------------------------------------------------------
+# Cursor shape -- edit mode, shape hidden while hovered (#2250)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_shape_hidden_while_hovered_stops_being_hover_interactive(
+    canvas: Canvas,
+) -> None:
+    # Regression for #2250: hiding the hovered shape must make it inert to the
+    # pointer. The hit-test used to keep the previously-hovered shape as a
+    # priority candidate without checking visibility, so a hidden shape stayed
+    # hover-highlighted and draggable until the pointer moved off it.
+    shape = Shape(
+        shape_type="polygon",
+        points=np.array([(10, 10), (40, 10), (40, 40), (10, 40)], dtype=np.float64),
+        closed=True,
+    )
+    canvas.load_shapes(shapes=[shape])
+    canvas.set_editing(value=True)
+    canvas.scale = 1.0
+
+    canvas.mouseMoveEvent(
+        _make_move_event(pos=_image_to_widget(canvas=canvas, img_x=25, img_y=25))
+    )
+    assert canvas.hovered_shape is shape
+
+    canvas.set_shape_visible(shape=shape, value=False)
+
+    # Move slightly while still over the now-hidden shape body.
+    canvas.mouseMoveEvent(
+        _make_move_event(pos=_image_to_widget(canvas=canvas, img_x=26, img_y=26))
+    )
+
+    assert canvas.hovered_shape is None
+    assert QtWidgets.QApplication.overrideCursor() is None
+
+
+# ---------------------------------------------------------------------------
 # Cursor shape -- edit mode, vertex hover
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The canvas hover hit-test (`find_hover_target` → `_build_candidates`) prepended the previously-hovered shape as a priority candidate **without** checking visibility, while every other shape was already visibility-filtered. So a shape hidden while it was the hovered shape stayed hover-interactive — its highlight, cursor change, and click-to-select kept working on the now-invisible shape until the pointer moved off it. The fix applies the same `.visible` check to the priority slot.

The regression test drives the real `Canvas` through actual mouse events (hover a shape body → hide it → move slightly) and asserts it becomes inert (no hovered shape, no override cursor). Verified red on `main`, green here.

Closes #2250

## Test plan
- [x] `tests/unit/widgets/canvas_interaction_characterization_test.py::test_shape_hidden_while_hovered_stops_being_hover_interactive` — new test, verified failing on `main` and passing here
- [x] `uv run pytest tests/` — 705 passed
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check` — clean

## Deferred to a follow-up

Scoped to the reported hover path. Review surfaced sibling cases where a hidden shape stays **movable** via *selection* rather than hover — all reachable only by hiding a shape through a keyboard shortcut while an interaction is active (the Polygon Labels checkbox path is covered here, since clicking the list forces a hit-test-refreshing mouse move):

1. A body drag continues to move the shape if it is hidden mid-drag (`_continue_left_button_drag` → `_drag_selected_shapes` is driven by `selected_shapes`, not hover).
2. A vertex press-drag with no intervening mouse move (stale `_hovered_vertex`).
3. Arrow-key nudging of a selected-but-hidden shape (`_move_by_keyboard` reads `selected_shapes` with no visibility check).

These are **selection**-inertness rather than hover, and fixing them cleanly needs a product decision (should hiding a shape also deselect it / cancel an in-progress drag?), so they are intentionally left out of this bugfix and warrant a separate tracking issue.
