### PR TITLE
docs: drop stale numpy<2.0 pin from standalone-build instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a hidden shape staying hover-interactive (highlight, cursor, click-to-select) when it was the hovered shape at the moment it was hidden ([#2276](https://github.com/wkentaro/labelme/pull/2276))
+- Fixed the standalone-executable build instructions forcing `numpy<2.0` (a stale PyQt5-era PyInstaller workaround), which broke builds on Python 3.12+ where numpy 2.x is the default ([#2279](https://github.com/wkentaro/labelme/pull/2279))
 - Fixed annotation label text being clipped or invisible in the label list on some desktop styles (e.g. GNOME/Adwaita) by widening the delegate's text clip rect to the rendered width ([#2273](https://github.com/wkentaro/labelme/pull/2273))
 - Fixed `line` and two-point `linestrip` shapes being unselectable by click ([#2107](https://github.com/wkentaro/labelme/pull/2107))
 - Fixed the canvas going blank after "Delete File" (Delete File now removes only the label JSON and keeps the image on screen) ([#2138](https://github.com/wkentaro/labelme/pull/2138))

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ labelme data_annotated/ --labels labels.txt  # specify label list with a file
 ```bash
 LABELME_PATH=./labelme
 OSAM_PATH=$(python -c 'import os, osam; print(os.path.dirname(osam.__file__))')
-pip install 'numpy<2.0'  # numpy>=2.0 causes build errors (see #1532)
 pyinstaller labelme/labelme/__main__.py \
   --name=Labelme \
   --windowed \


### PR DESCRIPTION
The "How to build standalone executable" instructions told users to `pip install 'numpy<2.0'`, citing a PyInstaller build error (#1532). That was a PyQt5-era workaround that no longer applies under PySide6, and it breaks builds on Python 3.12+ where numpy 2.x is the default. This removes the stale pin.

Closes #2271

## Test plan
- [x] `numpy<2.0` line and its `#1532` reference removed from the README standalone-build section
- [x] No remaining `numpy<2.0` / `#1532` references anywhere (README, docs/, CI workflows, pyproject)
- [x] Remaining build block still valid; `pyproject.toml` already declares unpinned `numpy>=1.24`
