### PR TITLE
refactor: use typing.get_args instead of importing get_args

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -8,6 +8,7 @@ import platform
 import re
 import subprocess
 import time
+import typing
 import webbrowser
 from pathlib import Path
 from typing import Final
@@ -15,7 +16,6 @@ from typing import Literal
 from typing import NamedTuple
 from typing import TypeAlias
 from typing import cast
-from typing import get_args
 
 import imgviz
 import natsort
@@ -1497,7 +1497,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._ai_text.setEnabled(
             not edit
             and create_mode
-            in (*get_args(_TextToAnnotationCreateMode), *_AI_CREATE_MODES)
+            in (*typing.get_args(_TextToAnnotationCreateMode), *_AI_CREATE_MODES)
         )
         self._ai_annotation.setEnabled(not edit and create_mode in _AI_CREATE_MODES)
         if create_mode == "ai_points_to_shape":
@@ -2850,7 +2850,7 @@ def _resolve_text_annotation_shape_type(
 ) -> _automation.AiOutputFormat | None:
     if create_mode in _AI_CREATE_MODES:
         return ai_output_format
-    if create_mode in get_args(_TextToAnnotationCreateMode):
+    if create_mode in typing.get_args(_TextToAnnotationCreateMode):
         return cast(_TextToAnnotationCreateMode, create_mode)
     return None
 

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass
 from typing import Final
-from typing import get_args
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -159,7 +159,7 @@ def _circle_for_detection(detection: Detection) -> Circle | None:
 # probe mirrors the runtime warning condition (a box but no mask).
 MASK_REQUIRED_SHAPE_TYPES: Final[frozenset[AiOutputFormat]] = frozenset(
     shape_type
-    for shape_type in get_args(AiOutputFormat)
+    for shape_type in typing.get_args(AiOutputFormat)
     if _shape_from_detection(
         detection=Detection(bbox=(0, 0, 1, 1), mask=None), shape_type=shape_type
     )

--- a/labelme/_config/_schema.py
+++ b/labelme/_config/_schema.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
+import typing
 from typing import Final
 from typing import Literal
 from typing import cast
-from typing import get_args
 
 from PySide6.QtCore import QT_TRANSLATE_NOOP
 
@@ -20,7 +20,7 @@ _TRANSLATABLE_SECTIONS: Final = (
     QT_TRANSLATE_NOOP("SettingsDialog", "General"),
     QT_TRANSLATE_NOOP("SettingsDialog", "Labels"),
 )
-assert set(_TRANSLATABLE_SECTIONS) == set(get_args(Section))
+assert set(_TRANSLATABLE_SECTIONS) == set(typing.get_args(Section))
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Replaces `from typing import get_args` with `import typing` and `typing.get_args` call sites across `_app.py`, `_automation/_shape_builders.py`, and `_config/_schema.py`, matching the module-qualified `typing.get_args` already used elsewhere in the codebase (`_shape.py`, `_widgets/canvas.py`, `_widgets/settings_dialog.py`).

## Test plan
- [x] `uv run ruff check` passes (imports sorted, no unused)