### PR TITLE
docs(changelog): promote Unreleased to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-07-01
+
 ### Added
 
 - Added a user-selectable color theme (System / Light / Dark) in the Settings dialog; System follows the OS appearance, and Dark mode is now supported where the app previously forced light mode ([#2260](https://github.com/wkentaro/labelme/pull/2260))
@@ -659,4 +661,5 @@ See the [GitHub Releases](https://github.com/wkentaro/labelme/releases) page for
 [6.2.0]: https://github.com/wkentaro/labelme/compare/v6.1.3...v6.2.0
 [6.3.0]: https://github.com/wkentaro/labelme/compare/v6.2.0...v6.3.0
 [6.3.1]: https://github.com/wkentaro/labelme/compare/v6.3.0...v6.3.1
-[unreleased]: https://github.com/wkentaro/labelme/compare/v6.3.1...HEAD
+[7.0.0]: https://github.com/wkentaro/labelme/compare/v6.3.1...v7.0.0
+[unreleased]: https://github.com/wkentaro/labelme/compare/v7.0.0...HEAD


### PR DESCRIPTION
Promotes the CHANGELOG `[Unreleased]` section to `## [7.0.0] - 2026-07-01` and opens a fresh empty `## [Unreleased]` above it, per Keep a Changelog convention. Adds the `[7.0.0]` compare link and repoints `[unreleased]` to compare from `v7.0.0`.

Part of #2272. The version string itself is derived from the git tag by hatch-vcs and is not touched here; the maintainer will push the `v7.0.0` tag separately after this and the translation-completion PR merge.

## Test plan
- [x] `uv run mdformat --check CHANGELOG.md` passes
- [x] diff limited to `CHANGELOG.md`