### PR TITLE
ci: publish to PyPI on GitHub release instead of tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 ---
 name: Publish to PyPI
 on:
-  push:
-    tags: [v*]
+  release:
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -11,6 +11,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
       - run: make check_translate
       - run: uv build


### PR DESCRIPTION
## What

Switch the PyPI publish workflow trigger from a raw tag push (`on: push: tags: [v*]`) to a published GitHub release (`on: release: types: [published]`), mirroring the [imgviz](https://github.com/wkentaro/imgviz/blob/main/.github/workflows/publish.yml) setup.

## Why

- Releases are cut through the GitHub Releases UI/API (with release notes), and the tag + published package stay in lockstep — no more "tag pushed but forgot the release notes" drift.
- The publish only fires on an intentional *published* release, not on any `v*` tag that happens to be pushed.

## Notes

- Added `fetch-depth: 0` to the checkout so `hatch-vcs` can see the release tag and derive the version (matches imgviz).
- Kept the labelme-specific `make check_translate` release gate and the pinned `checkout@v4` / `setup-uv@v6` versions (consistent with the rest of labelme's workflows; not bumped to imgviz's newer pins).

## Release-process impact

To cut v7.0.0 now: create a GitHub release for tag `v7.0.0` (creating the tag as part of it) and publish it → this workflow runs `make check_translate` → `uv build` → PyPI via OIDC.