### PR TITLE
fix: anchor label dialog popup at cursor and stop post-open jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the label dialog popup to anchor its content corner at the cursor; previously the window frame was anchored there, leaving the content a title-bar height below the pointer ([#2286](https://github.com/wkentaro/labelme/pull/2286))
+
+### Fixed
+
+- Fixed the label dialog visibly jumping right after opening; the post-show screen-edge correction now only nudges the dialog when it actually overflows the screen ([#2286](https://github.com/wkentaro/labelme/pull/2286))
+
 ## [7.0.0] - 2026-07-03
 
 ### Added

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -288,8 +288,10 @@ class LabelDialog(QtWidgets.QDialog):
             target = position if position is not None else QtGui.QCursor.pos()
             self._move_within_screen(target)
             # frameGeometry() lacks the window-manager decoration size until the
-            # dialog is mapped, so re-clamp once exec() has shown it.
-            QtCore.QTimer.singleShot(0, lambda: self._move_within_screen(target))
+            # dialog is mapped, so re-clamp once exec() has shown it. Clamp only
+            # (no re-anchor to target): a full re-move visibly jerks the already
+            # visible dialog, while the clamp is a no-op unless it overflows.
+            QtCore.QTimer.singleShot(0, lambda: self._clamp_within_screen(target))
 
         result = self.exec()
 
@@ -327,18 +329,23 @@ class LabelDialog(QtWidgets.QDialog):
 
     def _move_within_screen(self, target: QtCore.QPoint) -> None:
         self.adjustSize()
+        # setGeometry() anchors the client area, unlike move() which anchors the
+        # window frame: the content corner lands at target, not the title bar's.
+        self.setGeometry(QtCore.QRect(target, self.size()))
+        self._clamp_within_screen(target)
+
+    def _clamp_within_screen(self, target: QtCore.QPoint) -> None:
         screen = (
             QtGui.QGuiApplication.screenAt(target)
             or QtGui.QGuiApplication.primaryScreen()
         )
         if screen is None:
-            self.move(target)
             return
         available = screen.availableGeometry()
 
-        # move() positions the client area; nudge by the actual frame overflow so
-        # the window-manager decoration (title bar, borders) also stays on screen.
-        self.move(target)
+        # Nudge by the actual frame overflow (frameGeometry() includes the
+        # window-manager decoration) so the title bar and borders stay on screen,
+        # not just the content rect.
         frame = self.frameGeometry()
         dx = min(0, available.right() - frame.right())
         dx = max(dx, available.left() - frame.left())

--- a/tests/unit/widgets/label_dialog_screen_fit_test.py
+++ b/tests/unit/widgets/label_dialog_screen_fit_test.py
@@ -64,3 +64,29 @@ def test_move_keeps_dialog_within_screen(qtbot: QtBot, corner: str) -> None:
     dialog._move_within_screen(getattr(available, corner)())
 
     assert available.contains(dialog.frameGeometry())
+
+
+def test_move_anchors_content_corner_at_target(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flag_count=3)
+    dialog.show()
+    qtbot.waitExposed(dialog)
+
+    target = QtGui.QGuiApplication.primaryScreen().availableGeometry().center()
+    dialog._move_within_screen(target)
+
+    assert dialog.geometry().topLeft() == target
+
+
+def test_clamp_does_not_move_dialog_already_on_screen(qtbot: QtBot) -> None:
+    dialog = _make_dialog(qtbot, flag_count=3)
+    dialog.show()
+    qtbot.waitExposed(dialog)
+
+    available = QtGui.QGuiApplication.primaryScreen().availableGeometry()
+    target = available.center()
+    dialog._move_within_screen(target)
+    assert available.contains(dialog.frameGeometry())
+
+    pos_before = dialog.pos()
+    dialog._clamp_within_screen(target)
+    assert dialog.pos() == pos_before


### PR DESCRIPTION
The label dialog popup shipped in v7.0.0 anchoring its window *frame* at the cursor, so the content sat a title-bar height below the pointer. On top of that, the post-show screen-edge correction re-ran the full move on the already-visible dialog, making it visibly jump right after opening.

This splits the positioning into anchor + clamp:

- `_move_within_screen` now uses `setGeometry(QRect(target, size))` so the content corner lands at the cursor instead of the frame corner.
- The deferred post-`exec()` correction calls a new clamp-only `_clamp_within_screen`, which nudges the dialog only when it actually overflows the screen, so a dialog that already fits stays put.

## Test plan
- [x] new regression tests: `test_move_anchors_content_corner_at_target`, `test_clamp_does_not_move_dialog_already_on_screen`
- [x] `uv run pytest tests/unit/widgets/label_dialog_screen_fit_test.py` (9 passed)
- [x] `uv run ruff check` / `uv run ty check` clean
