### PR TITLE
fix: mark file dirty on undo so auto-save records it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Undo (Ctrl+Z) not triggering auto-save; undoing a shape edit now marks the file dirty, so with auto-save on the restored state is written to disk instead of leaving the previous edit saved ([#2288](https://github.com/wkentaro/labelme/pull/2288))
+
 ## [7.0.1] - 2026-07-03
 
 ### Changed

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1451,7 +1451,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.restore_last_shape()
         self._docks.label_list.clear()
         self._load_shapes(self._canvas_widgets.canvas.shapes)
-        self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
+        self.mark_dirty()
 
     def tutorial(self) -> None:
         url = "https://github.com/labelmeai/labelme/tree/main/examples/tutorial"  # NOQA

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Final
 
@@ -59,6 +60,42 @@ def test_auto_save_on_shape_move(
     assert abs((new_center.x() - original_center.x()) - 5.0) < 1.0
 
     assert label_file.exists()
+    assert_labelfile_sanity(str(label_file))
+
+    close_or_pause(qtbot=qtbot, widget=_auto_save_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_auto_save_on_undo(
+    qtbot: QtBot,
+    _auto_save_win: MainWindow,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    label_file = tmp_path / Path(_TEST_FILE_NAME).name
+
+    canvas = _auto_save_win._canvas_widgets.canvas
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
+    original_shape = canvas.selected_shapes[0]
+    original_center = QPointF(_shape_bounds(shape=original_shape).center())
+    original_points = [(float(x), float(y)) for x, y in original_shape.points]
+
+    qtbot.keyPress(canvas, Qt.Key.Key_Right)
+    qtbot.wait(50)
+    qtbot.keyRelease(canvas, Qt.Key.Key_Right)
+    qtbot.wait(50)
+    assert label_file.exists()
+
+    _auto_save_win.undo_shape_edit()
+    qtbot.wait(50)
+
+    restored_center = _shape_bounds(shape=canvas.shapes[0]).center()
+    assert abs(restored_center.x() - original_center.x()) < 1.0
+
+    with open(label_file) as f:
+        saved_xs = [x for x, _ in json.load(f)["shapes"][0]["points"]]
+    assert abs(min(saved_xs) - min(x for x, _ in original_points)) < 1.0
+
     assert_labelfile_sanity(str(label_file))
 
     close_or_pause(qtbot=qtbot, widget=_auto_save_win, pause=pause)


### PR DESCRIPTION
Fixes #2287. With auto-save on, moving a shape is saved to disk, but pressing Undo (Ctrl+Z) restored the shape only in memory: `undo_shape_edit` never marked the file dirty, so auto-save never wrote the reverted state back. Switching to another image and returning showed the pre-undo (offset) annotation.

`undo_shape_edit` now routes through `mark_dirty`, which already refreshes the undo action's enabled state and, with auto-save on, writes the restored shapes to disk (and otherwise flags the file dirty / enables Save). The bug predates v7 (present in v6.3.1), so it gets a CHANGELOG entry.

## Test plan
- [x] `test_auto_save_on_undo` added: move a shape (auto-saved), Undo, assert the on-disk label matches the original points. Fails on `main` (saved x off by 5.0), passes with the fix.
- [x] `uv run pytest tests/e2e/auto_save_test.py`
- [x] `uv run ruff check` / `uv run ty check`
