### PR TITLE
ci: bump checkout and setup-uv off deprecated Node 20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
       - run: make setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: make check_translate
       - name: Extract release notes from CHANGELOG.md
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true


### PR DESCRIPTION
The v7.0.2 release run warned that `actions/checkout@v4` and `astral-sh/setup-uv@v6` target Node.js 20, which GitHub Actions runners now force onto Node.js 24 ([deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Bump both to their latest moving-major tags, which run on Node 24 natively, across `release.yml`, `test.yml`, and `lint.yml`:

- `actions/checkout` v4 → v7
- `astral-sh/setup-uv` v6 → v7

setup-uv has v8.x releases, but astral publishes no moving `v8` tag (only `v1`–`v7`), so `@v7` is the latest tag consistent with this repo's moving-major convention. The inputs in use (`python-version`, `activate-environment`, `fetch-depth`) are unchanged in the new majors.

## Test plan
- [x] The lint and test workflows on this PR exercise the bumped `checkout` / `setup-uv` steps; green CI confirms the bump.
