### PR TITLE
fix: silence noisy Qt log output on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed noisy Qt log lines flooding the terminal (notably the macOS per-keypress `qt.qpa.keymapper: Mismatch between Cocoa and Carbon` warning); Qt logging is now routed through the app logger with these harmless lines filtered out while genuine Qt warnings still surface ([#2292](https://github.com/wkentaro/labelme/pull/2292))
+
 ## [7.0.2] - 2026-07-03
 
 ### Fixed

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -10,6 +10,7 @@ import types
 import warnings
 from pathlib import Path
 from typing import AnyStr
+from typing import Final
 
 from loguru import logger
 from PySide6 import QtCore
@@ -75,6 +76,46 @@ def _setup_loguru(logger_level: str) -> None:
         backtrace=True,
         diagnose=True,
     )
+
+
+def _route_qt_logging_to_loguru() -> None:
+    # Qt logs through its own handler straight to the C stderr, bypassing loguru
+    # and the log file. Route it through loguru instead, dropping two harmless
+    # noise sources so genuine Qt warnings still surface. The macOS keymapper
+    # flood ("Mismatch between Cocoa and Carbon", one line per keypress) is
+    # dropped by category, since qt.qpa.keymapper carries only low-value keyboard
+    # diagnostics. The font-alias timing chatter is dropped by message text
+    # within its category, since qt.qpa.fonts also reports real font-loading
+    # failures worth keeping.
+    LEVELS: Final = {
+        QtCore.QtMsgType.QtDebugMsg: "DEBUG",
+        QtCore.QtMsgType.QtInfoMsg: "INFO",
+        QtCore.QtMsgType.QtWarningMsg: "WARNING",
+        QtCore.QtMsgType.QtCriticalMsg: "ERROR",
+        QtCore.QtMsgType.QtFatalMsg: "CRITICAL",
+    }
+
+    def handler(
+        mode: QtCore.QtMsgType, context: QtCore.QMessageLogContext, message: str
+    ) -> None:
+        if context.category == "qt.qpa.keymapper":
+            return
+        if (
+            context.category == "qt.qpa.fonts"
+            and "Populating font family alias" in message
+        ):
+            return
+        if context.category != "default":
+            # Keep the category prefix Qt's default handler would have printed.
+            message = f"{context.category}: {message}"
+        logger.log(LEVELS.get(mode, "INFO"), message)
+        if mode == QtCore.QtMsgType.QtFatalMsg:
+            # Qt calls abort() as soon as this handler returns, which skips the
+            # atexit drain of the enqueue=True file sink; flush it now so the
+            # line explaining the crash reaches the log file.
+            logger.complete()
+
+    QtCore.qInstallMessageHandler(handler)
 
 
 def _handle_exception(
@@ -227,6 +268,7 @@ def main() -> None:
         sys.exit(0)
 
     _setup_loguru(logger_level=args.logger_level.upper())
+    _route_qt_logging_to_loguru()
     logger.info("Starting {} {}", __appname__, __version__)
 
     sys.excepthook = _handle_exception

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import sys
+import types
 import warnings
+from collections.abc import Callable
+from typing import cast
 
 import pytest
+from loguru import logger
+from PySide6 import QtCore
 
+from labelme.__main__ import _route_qt_logging_to_loguru
 from labelme.__main__ import main
 
 
@@ -56,3 +62,51 @@ def test_canonical_flag_does_not_warn(
         with pytest.raises(SystemExit) as exc:
             main()
     assert exc.value.code == 0
+
+
+def test_route_qt_logging_drops_noise_and_forwards_the_rest() -> None:
+    _route_qt_logging_to_loguru()
+    handler = cast(
+        "Callable[[QtCore.QtMsgType, object, str], None]",
+        QtCore.qInstallMessageHandler(None),
+    )
+
+    forwarded: list[tuple[str, str]] = []
+    sink_id = logger.add(
+        lambda m: forwarded.append((m.record["level"].name, m.record["message"])),
+        level="DEBUG",
+    )
+    try:
+        keymapper = types.SimpleNamespace(category="qt.qpa.keymapper")
+        fonts = types.SimpleNamespace(category="qt.qpa.fonts")
+        default = types.SimpleNamespace(category="default")
+
+        handler(
+            QtCore.QtMsgType.QtWarningMsg,
+            keymapper,
+            "Mismatch between Cocoa and Carbon",
+        )
+        handler(
+            QtCore.QtMsgType.QtWarningMsg,
+            fonts,
+            "Populating font family aliases took 42 ms",
+        )
+        assert forwarded == []
+
+        handler(
+            QtCore.QtMsgType.QtWarningMsg, fonts, "Found no matching fonts for family"
+        )
+        handler(
+            QtCore.QtMsgType.QtWarningMsg,
+            default,
+            "Populating font family alias mentioned outside qt.qpa.fonts",
+        )
+        handler(QtCore.QtMsgType.QtCriticalMsg, default, "genuine failure")
+    finally:
+        logger.remove(sink_id)
+
+    assert forwarded == [
+        ("WARNING", "qt.qpa.fonts: Found no matching fonts for family"),
+        ("WARNING", "Populating font family alias mentioned outside qt.qpa.fonts"),
+        ("ERROR", "genuine failure"),
+    ]


### PR DESCRIPTION
Running Labelme on macOS floods the terminal with Qt's per-keypress `qt.qpa.keymapper: Mismatch between Cocoa and Carbon` warning (plus `qt.qpa.fonts` alias-timing chatter). Qt writes these straight to the C stderr, bypassing the app logger. This installs a Qt message handler that routes Qt logging through loguru and drops those two harmless sources: the keymapper flood by category, and the font chatter by message text so genuine `qt.qpa.fonts` load failures (e.g. "Found no matching fonts for family") still surface.

## Test plan
- [x] `pytest tests/unit/__main___test.py` — new test asserts the two noise lines are dropped while other messages forward at the mapped loguru level
- [x] Launched the app on macOS: no more `qt.qpa.*` spam in the terminal
