### PR TITLE
fix(logging): substitute values in loguru warnings via brace-style placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed two warning log messages rendering literal `%r`/`%d` placeholders instead of their values (the no-op point-removal warning and the empty save-path warning); loguru formats with brace-style placeholders, so the diagnostic values were silently dropped ([#2293](https://github.com/wkentaro/labelme/pull/2293))
 - Fixed noisy Qt log lines flooding the terminal (notably the macOS per-keypress `qt.qpa.keymapper: Mismatch between Cocoa and Carbon` warning); Qt logging is now routed through the app logger with these harmless lines filtered out while genuine Qt warnings still surface ([#2292](https://github.com/wkentaro/labelme/pull/2292))
 
 ## [7.0.2] - 2026-07-03

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2374,7 +2374,7 @@ class MainWindow(QtWidgets.QMainWindow):
             label_path = self.prompt_save_file_path()
 
         if not label_path:
-            logger.warning("label_path=%r is empty, so cannot save", label_path)
+            logger.warning("label_path={!r} is empty, so cannot save", label_path)
             return
 
         if self.save_labels(label_path=label_path):

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -73,7 +73,7 @@ class Shape:
     def remove_point(self, i: int) -> None:
         if not self.can_remove_point():
             logger.warning(
-                "Cannot remove point from: shape_type=%r, len(points)=%d",
+                "Cannot remove point from: shape_type={!r}, len(points)={:d}",
                 self.shape_type,
                 len(self.points),
             )

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -4,6 +4,7 @@ import math
 
 import numpy as np
 import pytest
+from loguru import logger
 
 from labelme import _shape
 from labelme._shape import Shape
@@ -241,6 +242,26 @@ def test_remove_point_is_noop_for_non_polyline() -> None:
 
     assert len(shape.points) == 2
     assert len(shape.point_labels) == 2
+
+
+def test_remove_point_noop_logs_substituted_values() -> None:
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array([(0.0, 0.0), (10.0, 10.0)], dtype=np.float64),
+    )
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda m: messages.append(m.record["message"]), level="WARNING"
+    )
+
+    try:
+        shape.remove_point(i=0)
+    finally:
+        logger.remove(sink_id)
+
+    assert messages == [
+        "Cannot remove point from: shape_type='rectangle', len(points)=2"
+    ]
 
 
 def test_move_vertex_replaces_only_target_point() -> None:


### PR DESCRIPTION
Two `logger.warning` calls used printf-style `%r`/`%d` placeholders, but loguru
renders messages with `str.format`, which silently ignores unreferenced
positional args. So the no-op point-removal warning (`Shape.remove_point`) and
the empty save-path warning both logged their literal placeholder text with the
diagnostic values dropped. Both are switched to loguru's brace-style
placeholders, matching every other `logger.*` call in the codebase.

A grep across `labelme/` confirms these were the only two remaining printf-style
logger placeholders.

## Test plan
- [x] Added `test_remove_point_noop_logs_substituted_values`, which captures the
  rendered message via a loguru sink and asserts the substituted values appear
- [x] `uv run pytest tests/unit -q` (556 passed)
- [x] `uv run ruff check` / `uv run ty check --no-progress` clean
