### PR TITLE
refactor: build ToolBar actions via the shared add_actions helper

### DIFF
--- a/labelme/_widgets/tool_bar.py
+++ b/labelme/_widgets/tool_bar.py
@@ -6,6 +6,8 @@ from PySide6 import QtGui
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 
+from .._utils import add_actions
+
 _OBJECT_NAME_SUFFIX: Final = "ToolBar"
 _FONT_SCALE_FACTOR: Final = 0.8
 _VERTICAL_SEPARATOR_STYLE: Final = (
@@ -43,11 +45,7 @@ class ToolBar(QtWidgets.QToolBar):
         if orientation == Qt.Orientation.Vertical:
             self.setStyleSheet(_VERTICAL_SEPARATOR_STYLE)
 
-        for action in actions:
-            if action is None:
-                self.addSeparator()
-            else:
-                self.addAction(action)
+        add_actions(self, actions)
 
         if orientation == Qt.Orientation.Vertical:
             self._equalize_button_widths()


### PR DESCRIPTION
`ToolBar.__init__` hand-rolled the same `None → addSeparator / else → addAction`
dispatch that `labelme._utils.add_actions` already provides and that the rest of
the app uses for every menu and toolbar. This was the one place left reinventing
it. Route `ToolBar` through the canonical helper so the dispatch lives in one
place.

`ToolBar.addAction` stays overridden, so `add_actions` still wraps each `QAction`
in a `QToolButton` exactly as before, and the `QWidgetAction` bypass is preserved.
The helper's extra `QMenu` branch is unreachable here (`actions` is typed
`list[QAction | None]`), so behavior is unchanged.

## Test plan
- [x] Drove the real `ToolBar` under `QT_QPA_PLATFORM=offscreen` in both
      orientations; the rendered tool buttons, labels, and separators are
      byte-identical to `main`.
- [x] `tests/unit/widgets/tool_bar_test.py` (21) and the full suite (709) pass
- [x] `ruff check`, `ruff format --check`, `ty check` clean
