### PR TITLE
fix(config): tolerate empty config sections instead of crashing at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed two warning log messages rendering literal `%r`/`%d` placeholders instead of their values (the no-op point-removal warning and the empty save-path warning); loguru formats with brace-style placeholders, so the diagnostic values were silently dropped ([#2293](https://github.com/wkentaro/labelme/pull/2293))
+- Fixed a startup crash when the config file contains an empty section such as a bare `shortcuts:` or `ai:`; empty sections now keep their defaults instead of raising an uncaught `AttributeError` ([#2295](https://github.com/wkentaro/labelme/pull/2295))
 - Fixed noisy Qt log lines flooding the terminal (notably the macOS per-keypress `qt.qpa.keymapper: Mismatch between Cocoa and Carbon` warning); Qt logging is now routed through the app logger with these harmless lines filtered out while genuine Qt warnings still surface ([#2292](https://github.com/wkentaro/labelme/pull/2292))
 
 ## [7.0.2] - 2026-07-03

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -24,7 +24,12 @@ def _update_dict(
             validate_item(key, value)
         if key not in target_dict:
             raise ValueError(f"Unexpected key in config: {key}")
-        if isinstance(target_dict[key], dict) and isinstance(value, dict):
+        target_is_section = isinstance(target_dict[key], dict)
+        if target_is_section and value is None:
+            # An empty section (e.g. a bare `shortcuts:`) parses as None; keep the
+            # defaults instead of wiping the whole section.
+            continue
+        if target_is_section and isinstance(value, dict):
             _update_dict(
                 cast(dict[str, object], target_dict[key]),
                 cast(dict[str, object], value),
@@ -63,10 +68,11 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         logger.info("Migrating old config: store_data -> with_image_data")
         config_from_yaml["with_image_data"] = config_from_yaml.pop("store_data")
 
-    if config_from_yaml.get("shortcuts", {}).pop("add_point_to_edge", None):
+    shortcuts = config_from_yaml.get("shortcuts") or {}
+    if shortcuts.pop("add_point_to_edge", None):
         logger.info("Migrating old config: removing shortcuts.add_point_to_edge")
 
-    if (model_name := config_from_yaml.get("ai", {}).get("default")) and (
+    if (model_name := (config_from_yaml.get("ai") or {}).get("default")) and (
         m := re.match(r"^SegmentAnything \((.*)\)$", model_name)
     ):
         model_name_new: str = f"Sam ({m.group(1)})"
@@ -88,7 +94,6 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         "hide_all_polygons": "hide_all_shapes",
         "toggle_all_polygons": "toggle_all_shapes",
     }
-    shortcuts = config_from_yaml.get("shortcuts", {})
     for old_key, new_key in _POLYGON_TO_SHAPE_RENAMES.items():
         if old_key in shortcuts and new_key not in shortcuts:
             logger.info(

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -89,6 +89,28 @@ def test_migrate_polygon_shortcuts_no_shortcuts_key() -> None:
     assert "shortcuts" not in config
 
 
+@pytest.mark.parametrize("section", ["shortcuts", "ai"])
+def test_migrate_tolerates_empty_section(section: str) -> None:
+    config = {section: None}
+    _config._migrate_config_from_file(config)
+    assert config[section] is None
+
+
+@pytest.mark.parametrize(
+    ("section", "probe"),
+    [("shortcuts", ("save", "Ctrl+S")), ("ai", ("default", "Sam2 (balanced)"))],
+    ids=["shortcuts", "ai"],
+)
+def test_load_config_empty_section_keeps_defaults(
+    tmp_path: Path, section: str, probe: tuple[str, str]
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(f"{section}:\n")
+    config = _config.load_config(config_file=config_file, config_overrides={})
+    key, value = probe
+    assert config[section][key] == value
+
+
 def test_migrate_polygon_shortcut_skips_when_new_key_exists() -> None:
     config = {"shortcuts": {"edit_polygon": "Ctrl+X", "edit_shape": "Ctrl+Y"}}
     _config._migrate_config_from_file(config)


### PR DESCRIPTION
A bare `shortcuts:` or `ai:` section in the config file parses as YAML `null`. `_migrate_config_from_file` then called `.pop()` / `.get()` on it, raising an uncaught `AttributeError` that crashed labelme at startup — `_load_config` only catches `ValueError`, so it never reached the config-error dialog. `_update_dict` also overwrote the default section with `None`, which would crash the app downstream where sections are indexed as plain dicts (`config["ai"]["default"]`, `config["shortcuts"][...]`).

Empty sections now keep their defaults: migration guards each section with `or {}`, and the merge skips a `None` override of a dict-typed section. The `_update_dict` guard is general — it covers every dict-typed section (`shape`, `ai`, `canvas`, the docks, `shortcuts`, ...), not just the two that triggered the report — and matches the existing `raw.get("flags") or {}` tolerance in `_label_file.py`.

## Out of scope

A non-`None`, non-dict override of a dict-typed section (e.g. `shortcuts: "oops"`) still fails uncaught, and crashes even earlier — inside `_migrate_config_from_file`, before the merge is reached. Handling that malformed-config class is a separate, larger change (harden both migration and merge, decide raise-vs-tolerate) and is left for a follow-up.

## Test plan

- [x] `tests/unit/_config_test.py`: added `test_migrate_tolerates_empty_section` and `test_load_config_empty_section_keeps_defaults` (parametrized over `shortcuts` / `ai`); both fail with the original `AttributeError` before the fix.
- [x] Verified end-to-end via the e2e harness: launching the app with a `shortcuts:`/`ai:` empty-section config crashes at startup before the fix, and boots keeping defaults after.
- [x] `make lint` (ruff format + ruff + ty) and the full `pytest` suite (713) pass.
