### PR TITLE
test(label-file): cover malformed shape-field validation branches

### DIFF
--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -91,7 +91,6 @@ def test_read_label_file_extracts_other_data(
         (lambda raw: raw.pop("imagePath"), "imagePath"),
         (lambda raw: raw.pop("imageData"), "imageData"),
         (lambda raw: raw.pop("shapes"), "shapes"),
-        (lambda raw: raw["shapes"].append({"label": "x"}), "points is required"),
         (lambda raw: raw.update({"imageHeight": 1}), "imageHeight mismatch"),
         (lambda raw: raw.update({"imageWidth": 1}), "imageWidth mismatch"),
     ],
@@ -99,7 +98,6 @@ def test_read_label_file_extracts_other_data(
         "missing_imagePath",
         "missing_imageData",
         "missing_shapes",
-        "invalid_shape",
         "imageHeight_mismatch",
         "imageWidth_mismatch",
     ],
@@ -111,6 +109,64 @@ def test_read_label_file_raises_read_error_on_malformed(
     error_match: str,
 ) -> None:
     mutator(annotated_raw)
+    _dump_json(path=annotated_dst, raw=annotated_raw)
+
+    with pytest.raises(LabelFileReadError, match=error_match):
+        read_label_file(filename=str(annotated_dst))
+
+
+@pytest.mark.parametrize(
+    ("break_shape", "error_match"),
+    [
+        (lambda shape: shape.pop("label"), "label is required"),
+        (lambda shape: shape.update(label=1), "label must be str"),
+        (lambda shape: shape.pop("points"), "points is required"),
+        (lambda shape: shape.update(points="nope"), "points must be list:"),
+        (lambda shape: shape.update(points=[]), "points must be non-empty"),
+        (
+            lambda shape: shape.update(points=[[0.0, 0.0, 0.0]]),
+            "points must be list of",
+        ),
+        (lambda shape: shape.pop("shape_type"), "shape_type is required"),
+        (lambda shape: shape.update(shape_type=5), "shape_type must be str"),
+        (lambda shape: shape.update(flags="no"), "flags must be dict:"),
+        (
+            lambda shape: shape.update(flags={"a": 1}),
+            "flags must be dict of str to bool",
+        ),
+        (lambda shape: shape.update(description=1), "description must be str"),
+        (lambda shape: shape.update(group_id="1"), "group_id must be int"),
+        (lambda shape: shape.update(mask=123), "mask must be base64-encoded PNG"),
+    ],
+    ids=[
+        "label_missing",
+        "label_not_str",
+        "points_missing",
+        "points_not_list",
+        "points_empty",
+        "points_bad_entry",
+        "shape_type_missing",
+        "shape_type_not_str",
+        "flags_not_dict",
+        "flags_value_not_bool",
+        "description_not_str",
+        "group_id_not_int",
+        "mask_not_str",
+    ],
+)
+def test_read_label_file_raises_on_malformed_shape_field(
+    annotated_raw: dict[str, Any],
+    annotated_dst: Path,
+    break_shape: Callable[[dict[str, Any]], Any],
+    error_match: str,
+) -> None:
+    shape: dict[str, Any] = {
+        "label": "x",
+        "points": [[0.0, 0.0]],
+        "shape_type": "point",
+    }
+    break_shape(shape)
+    annotated_raw["shapes"].append(shape)
     _dump_json(path=annotated_dst, raw=annotated_raw)
 
     with pytest.raises(LabelFileReadError, match=error_match):


### PR DESCRIPTION
`_load_shape_json_obj` in `labelme/_label_file.py` guards `read_label_file`
against malformed hand-edited annotation files, raising a specific
`TypeError`/`ValueError` per bad field. Only the `points is required` branch was
exercised; the label / shape_type / flags / description / group_id / mask checks
and the individual `points` sub-checks had no regression coverage.

This adds a dedicated parametrized `test_read_label_file_raises_on_malformed_shape_field`
that breaks exactly one field of an otherwise-valid shape per case (via the same
mutator-lambda idiom the sibling malformed-document test already uses), and moves
the one pre-existing shape-level case out of `test_read_label_file_raises_read_error_on_malformed`
so the two tests split cleanly: document-level keys vs. per-shape fields.

Test-only; no production code changes.

## Test plan
- [x] `uv run pytest tests/unit/_label_file_test.py -q` (36 passed)
- [x] `uv run pytest tests/unit -q` (567 passed)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` clean on the touched file
