### PR TITLE
fix(ai): drop degenerate 2-point polygon from thin detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed AI Assist / AI Text Prompt in polygon output mode emitting a degenerate 2-point "polygon" for thin, near-collinear detections; such a shape is not a valid polygon and later crashed mask conversion (`shape_to_mask` asserts more than 2 points), so it is now dropped like other empty detections ([#2298](https://github.com/wkentaro/labelme/pull/2298))
 - Fixed two warning log messages rendering literal `%r`/`%d` placeholders instead of their values (the no-op point-removal warning and the empty save-path warning); loguru formats with brace-style placeholders, so the diagnostic values were silently dropped ([#2293](https://github.com/wkentaro/labelme/pull/2293))
 - Fixed noisy Qt log lines flooding the terminal (notably the macOS per-keypress `qt.qpa.keymapper: Mismatch between Cocoa and Carbon` warning); Qt logging is now routed through the app logger with these harmless lines filtered out while genuine Qt warnings still surface ([#2292](https://github.com/wkentaro/labelme/pull/2292))
 

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -64,7 +64,7 @@ def _shape_from_detection(
             polygon = polygon + np.array(
                 [detection.bbox[0], detection.bbox[1]], dtype=np.float32
             )
-        if len(polygon) < 2:
+        if len(polygon) < 3:
             return None
         return _build_shape(
             shape_type="polygon",

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -151,6 +151,31 @@ def test_shapes_from_detections_oriented_rectangle_square_mask_no_bbox() -> None
         assert (shape.points[i][0], shape.points[i][1]) == pytest.approx((x, y))
 
 
+def test_shapes_from_detections_polygon_with_mask_traces_contour() -> None:
+    [shape] = shapes_from_detections(
+        detections=[Detection(mask=np.ones((20, 20), dtype=bool))],
+        shape_type="polygon",
+    )
+
+    assert shape.shape_type == "polygon"
+    assert len(shape.points) >= 3
+
+
+def test_shapes_from_detections_polygon_drops_degenerate_thin_mask() -> None:
+    # A near-collinear sliver mask collapses to fewer than 3 contour points,
+    # which is not a valid polygon; downstream consumers (e.g. shape_to_mask)
+    # assert len(points) > 2, so the builder must drop it rather than emit it.
+    mask = np.zeros((3, 400), dtype=bool)
+    mask[1, :] = True
+
+    shapes = shapes_from_detections(
+        detections=[Detection(mask=mask)],
+        shape_type="polygon",
+    )
+
+    assert shapes == []
+
+
 def test_shapes_from_detections_mask_drops_empty_mask() -> None:
     # OSAM occasionally returns a bbox whose segmentation mask is all-False;
     # without this guard the shape would render as bbox-only (no visible mask).


### PR DESCRIPTION
AI Assist / AI Text Prompt in polygon output mode built a Shape directly from `compute_polygon_from_mask`, which can legitimately collapse a thin, near-collinear detection (a wire, crack, or hairline object) to just 2 points. The builder only rejected results with fewer than 2 points, so a degenerate 2-point "polygon" was emitted. That is not a valid polygon: it has no area, and it later crashed mask conversion, since `shape_to_mask` asserts a polygon has more than 2 points.

This raises the guard to drop results with fewer than 3 points, matching the polygon minimum already enforced everywhere else in the codebase, and consistent with the file's existing silent-drop convention for degenerate detections (e.g. the all-False mask guard in the same function).

## Test plan
- [x] Added `test_shapes_from_detections_polygon_drops_degenerate_thin_mask` (regression: a 1px-thick sliver mask is dropped) and `test_shapes_from_detections_polygon_with_mask_traces_contour` (a normal mask still yields a valid polygon)
- [x] `uv run pytest tests/ -q` (724 passed under Xvfb)
- [x] `make lint` (ruff format + ruff check + ty) clean on the tracked source
