### PR TITLE
fix(config): report non-mapping config sections instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed two warning log messages rendering literal `%r`/`%d` placeholders instead of their values (the no-op point-removal warning and the empty save-path warning); loguru formats with brace-style placeholders, so the diagnostic values were silently dropped ([#2293](https://github.com/wkentaro/labelme/pull/2293))
 - Fixed a startup crash when the config file contains an empty section such as a bare `shortcuts:` or `ai:`; empty sections now keep their defaults instead of raising an uncaught `AttributeError` ([#2295](https://github.com/wkentaro/labelme/pull/2295))
+- Fixed a startup crash when a config section is set to a non-mapping value such as `shortcuts: oops`; the malformed section now surfaces in the configuration-error dialog (with an Ignore-and-use-defaults option) instead of crashing ([#2300](https://github.com/wkentaro/labelme/pull/2300))
 - Fixed noisy Qt log lines flooding the terminal (notably the macOS per-keypress `qt.qpa.keymapper: Mismatch between Cocoa and Carbon` warning); Qt logging is now routed through the app logger with these harmless lines filtered out while genuine Qt warnings still surface ([#2292](https://github.com/wkentaro/labelme/pull/2292))
 
 ## [7.0.2] - 2026-07-03

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -24,19 +24,28 @@ def _update_dict(
             validate_item(key, value)
         if key not in target_dict:
             raise ValueError(f"Unexpected key in config: {key}")
-        target_is_section = isinstance(target_dict[key], dict)
-        if target_is_section and value is None:
-            # An empty section (e.g. a bare `shortcuts:`) parses as None; keep the
-            # defaults instead of wiping the whole section.
-            continue
-        if target_is_section and isinstance(value, dict):
-            _update_dict(
-                cast(dict[str, object], target_dict[key]),
-                cast(dict[str, object], value),
-                validate_item=validate_item,
-            )
-        else:
+        if not isinstance(target_dict[key], dict):
             target_dict[key] = value
+            continue
+
+        # target_dict[key] is a section, so the override must be a mapping.
+        if value is None:
+            # An empty section (e.g. a bare `shortcuts:`) keeps its defaults
+            # instead of wiping the whole section.
+            continue
+        if not isinstance(value, dict):
+            # A non-mapping override (e.g. `shortcuts: oops`) would wipe the
+            # section with a scalar and crash the app downstream; surface it as
+            # a config error instead.
+            raise ValueError(
+                f"Config section {key!r} must be a mapping, "
+                f"but got {type(value).__name__}: {value!r}"
+            )
+        _update_dict(
+            cast(dict[str, object], target_dict[key]),
+            cast(dict[str, object], value),
+            validate_item=validate_item,
+        )
 
 
 def _validate_config_item(key: str, value: object) -> None:
@@ -68,12 +77,19 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         logger.info("Migrating old config: store_data -> with_image_data")
         config_from_yaml["with_image_data"] = config_from_yaml.pop("store_data")
 
-    shortcuts = config_from_yaml.get("shortcuts") or {}
+    # A malformed section (e.g. `shortcuts: oops`) is left untouched here so the
+    # merge in _update_dict reports it as a config error instead of crashing.
+    shortcuts = config_from_yaml.get("shortcuts")
+    if not isinstance(shortcuts, dict):
+        shortcuts = {}
     if shortcuts.pop("add_point_to_edge", None):
         logger.info("Migrating old config: removing shortcuts.add_point_to_edge")
 
-    if (model_name := (config_from_yaml.get("ai") or {}).get("default")) and (
-        m := re.match(r"^SegmentAnything \((.*)\)$", model_name)
+    ai = config_from_yaml.get("ai")
+    if (
+        isinstance(ai, dict)
+        and (model_name := ai.get("default"))
+        and (m := re.match(r"^SegmentAnything \((.*)\)$", model_name))
     ):
         model_name_new: str = f"Sam ({m.group(1)})"
         logger.info(
@@ -81,7 +97,7 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
             model_name,
             model_name_new,
         )
-        config_from_yaml["ai"]["default"] = model_name_new
+        ai["default"] = model_name_new
 
     # Migrate polygon shortcut keys to shape
     _POLYGON_TO_SHAPE_RENAMES = {

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -111,6 +111,23 @@ def test_load_config_empty_section_keeps_defaults(
     assert config[section][key] == value
 
 
+@pytest.mark.parametrize("section", ["shortcuts", "ai"])
+def test_migrate_leaves_malformed_section_for_merge_to_report(section: str) -> None:
+    config = {section: "oops"}
+    _config._migrate_config_from_file(config)
+    assert config[section] == "oops"
+
+
+@pytest.mark.parametrize("section", ["shortcuts", "ai"])
+def test_load_config_malformed_section_raises(tmp_path: Path, section: str) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(f"{section}: oops\n")
+    with pytest.raises(
+        ValueError, match=f"Config section {section!r} must be a mapping"
+    ):
+        _config.load_config(config_file=config_file, config_overrides={})
+
+
 def test_migrate_polygon_shortcut_skips_when_new_key_exists() -> None:
     config = {"shortcuts": {"edit_polygon": "Ctrl+X", "edit_shape": "Ctrl+Y"}}
     _config._migrate_config_from_file(config)


### PR DESCRIPTION
Follow-up to #2295, which made an *empty* config section (a bare `shortcuts:` / `ai:`, parsed as `None`) keep its defaults. This handles the sibling case that #2295 explicitly left out of scope: a section set to a *non-mapping* value, e.g. `shortcuts: oops`.

That case crashed the app at startup with an uncaught `AttributeError` — `_migrate_config_from_file` called `.pop()`/`.get()` on the scalar, and only `ValueError` reaches the config-error dialog. Even past migration, `_update_dict` would overwrite the default section dict with the scalar, moving the crash downstream where sections are indexed as dicts (`config["shortcuts"][...]`).

## Approach

Make the merge the single validation gate:

- `_migrate_config_from_file` skips non-dict sections (via `isinstance` guards), leaving the malformed value in place instead of crashing on it.
- `_update_dict` raises a `ValueError` naming the offending section when a dict-typed section gets a non-`None`, non-mapping override. That flows into the existing "Configuration Errors" dialog (`_app.py` `_load_config`, already the handler for `validate_label`/`shape_color`/`labels` errors), which offers Ignore-and-use-defaults.

Empty sections keep the tolerate-and-default behavior from #2295; only non-`None`, non-mapping overrides are rejected.

## Test plan

- [x] `tests/unit/_config_test.py`: added `test_migrate_leaves_malformed_section_for_merge_to_report` and `test_load_config_malformed_section_raises` (both parametrized over `shortcuts` / `ai`); both fail on the pre-fix code (`AttributeError` in migration; silent overwrite in the merge).
- [x] `make lint` and the full `pytest` suite (730) pass.

Stacked on #2295 (base branch `fix/config-empty-section-crash`); GitHub will retarget this to `main` once #2295 merges.
