### PR TITLE
test(_config): cover the unknown-key rejection path of load_config

### DIFF
--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -165,8 +165,19 @@ def test_migrate_keep_prev_brightness_contrast(
         ),
         ({"shape_color": "random"}, "Unexpected value for config key 'shape_color'"),
         ({"labels": ["cat", "cat"]}, "Duplicates are detected for config key 'labels'"),
+        ({"not_a_real_key": True}, "Unexpected key in config: not_a_real_key"),
+        (
+            {"shortcuts": {"not_a_real_shortcut": "Ctrl+Z"}},
+            "Unexpected key in config: not_a_real_shortcut",
+        ),
     ],
-    ids=["validate_label", "shape_color", "labels"],
+    ids=[
+        "validate_label",
+        "shape_color",
+        "labels",
+        "unknown_key",
+        "unknown_key_nested",
+    ],
 )
 def test_load_config_rejects_invalid_override(overrides: dict, message: str) -> None:
     with pytest.raises(ValueError, match=message):


### PR DESCRIPTION
`_update_dict` raises `Unexpected key in config: <key>` when a config override
carries a key absent from the default config, but no test exercised it. Extend
`test_load_config_rejects_invalid_override` with a top-level and a nested
(recursive) unknown key, each asserting the offending key by name so a
regression that reports the wrong key is caught.

## Test plan
- [x] `uv run pytest tests/unit/_config_test.py` (38 passed)
- [x] `uv run ruff check` / `ruff format --check` / `ty check` on the file
