### PR TITLE
fix(label-file): validate image-level flags on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `read_label_file` silently accepting a non-dict image-level `flags` value in an annotation file; the top-level flags are now validated as a `dict[str, bool]` on load, exactly as per-shape flags already were, so a malformed file surfaces a clear read error instead of loading a bad value that crashes later ([#2305](https://github.com/wkentaro/labelme/pull/2305))
 - Fixed AI Assist / AI Text Prompt in polygon output mode emitting a degenerate 2-point "polygon" for thin, near-collinear detections; such a shape is not a valid polygon and later crashed mask conversion (`shape_to_mask` asserts more than 2 points), so it is now dropped like other empty detections ([#2298](https://github.com/wkentaro/labelme/pull/2298))
 - Fixed two warning log messages rendering literal `%r`/`%d` placeholders instead of their values (the no-op point-removal warning and the empty save-path warning); loguru formats with brace-style placeholders, so the diagnostic values were silently dropped ([#2293](https://github.com/wkentaro/labelme/pull/2293))
 - Fixed a startup crash when the config file contains an empty section such as a bare `shortcuts:` or `ai:`; empty sections now keep their defaults instead of raising an uncaught `AttributeError` ([#2295](https://github.com/wkentaro/labelme/pull/2295))

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
 from typing import Final
+from typing import cast
 
 import numpy as np
 import PIL.Image
@@ -22,6 +23,16 @@ from . import _utils
 from ._utils.shape import ShapeDict
 
 PIL.Image.MAX_IMAGE_PIXELS = None
+
+
+def _validate_flags(flags: object) -> dict[str, bool]:
+    if flags is None:
+        return {}
+    if not isinstance(flags, dict):
+        raise TypeError(f"flags must be dict: {flags}")
+    if not all(isinstance(k, str) and isinstance(v, bool) for k, v in flags.items()):
+        raise TypeError(f"flags must be dict of str to bool: {flags}")
+    return cast(dict[str, bool], flags)
 
 
 def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
@@ -62,18 +73,7 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
         raise TypeError(f"shape_type must be str: {shape_json_obj['shape_type']}")
     shape_type: str = shape_json_obj["shape_type"]
 
-    flags: dict = {}
-    if shape_json_obj.get("flags") is not None:
-        if not isinstance(shape_json_obj["flags"], dict):
-            raise TypeError(f"flags must be dict: {shape_json_obj['flags']}")
-        if not all(
-            isinstance(k, str) and isinstance(v, bool)
-            for k, v in shape_json_obj["flags"].items()
-        ):
-            raise TypeError(
-                f"flags must be dict of str to bool: {shape_json_obj['flags']}"
-            )
-        flags = shape_json_obj["flags"]
+    flags = _validate_flags(flags=shape_json_obj.get("flags"))
 
     description: str = ""
     if shape_json_obj.get("description") is not None:
@@ -228,7 +228,7 @@ def read_label_file(filename: str) -> Annotation:
         shapes: list[ShapeDict] = [
             _load_shape_json_obj(shape_json_obj=s) for s in raw["shapes"]
         ]
-        flags = raw.get("flags") or {}
+        flags = _validate_flags(flags=raw.get("flags"))
     except (
         OSError,
         json.JSONDecodeError,

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -93,6 +93,12 @@ def test_read_label_file_extracts_other_data(
         (lambda raw: raw.pop("shapes"), "shapes"),
         (lambda raw: raw.update({"imageHeight": 1}), "imageHeight mismatch"),
         (lambda raw: raw.update({"imageWidth": 1}), "imageWidth mismatch"),
+        (lambda raw: raw.update({"flags": "urgent"}), "flags must be dict:"),
+        (lambda raw: raw.update({"flags": False}), "flags must be dict:"),
+        (
+            lambda raw: raw.update({"flags": {"blurry": 1}}),
+            "flags must be dict of str to bool",
+        ),
     ],
     ids=[
         "missing_imagePath",
@@ -100,6 +106,9 @@ def test_read_label_file_extracts_other_data(
         "missing_shapes",
         "imageHeight_mismatch",
         "imageWidth_mismatch",
+        "flags_not_dict",
+        "flags_falsy_not_dict",
+        "flags_value_not_bool",
     ],
 )
 def test_read_label_file_raises_read_error_on_malformed(


### PR DESCRIPTION
`read_label_file` validated every field of an annotation file strictly except the image-level `flags`, which went through `raw.get("flags") or {}` with no type check. A non-dict `flags` (e.g. `"urgent"`, `[]`, `false`) was silently accepted into `Annotation.flags` — typed `dict[str, bool]` — and only surfaced later as a confusing crash on `.items()` or on re-save.

This extracts the existing per-shape flags validation into a shared `_validate_flags` helper and applies it at both the per-shape and image-level read sites, so a malformed `flags` now raises `LabelFileReadError` at load time, the same clean error every other malformed field already produced. `None` / absent / `{}` still yield `{}`; valid files are unaffected.

## Test plan
- [x] Added `flags_not_dict` / `flags_falsy_not_dict` / `flags_value_not_bool` cases to `tests/unit/_label_file_test.py` (39 passed)
- [x] `uv run ruff check` + `uv run ty check` clean
- [x] Drove `read_label_file` on real on-disk JSON: malformed flags raise `LabelFileReadError`; valid / empty / absent / null still load `{}`
