### PR TITLE
fix(shape): ignore linestrip's unrendered closing edge in hit-testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed clicking or hovering near a linestrip's unrendered "closing" line (the straight path from its last point back to its first) being treated as a hit on the shape; edge hover, add-point-to-edge, and body selection now ignore that phantom segment, since a linestrip is an open polyline and never draws it ([#2307](https://github.com/wkentaro/labelme/pull/2307))
 - Fixed the `--output` guard rejecting only lowercase `.json` paths; an upper- or mixed-case file path such as `--output notes.JSON` slipped past the "expects a directory" check and was treated as an output directory. The guard now reuses the canonical case-insensitive `is_label_file_path` helper ([#2317](https://github.com/wkentaro/labelme/pull/2317))
 
 ## [7.0.4] - 2026-07-12

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -135,6 +135,11 @@ def nearest_edge_index(
     )
     projections = starts + t[:, None] * segments
     distances = np.linalg.norm(scaled_point - projections, axis=1)
+    if shape.shape_type == "linestrip":
+        # A linestrip is an open polyline: the wrap-around segment np.roll builds
+        # at index 0 (last point back to the first) is never rendered, so it must
+        # not be a hit target.
+        distances[0] = np.inf
     return _nearest_index_within_epsilon(distances=distances, epsilon=epsilon)
 
 

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -177,6 +177,13 @@ def _make_square_polygon() -> Shape:
     )
 
 
+def _make_open_linestrip() -> Shape:
+    return Shape(
+        shape_type="linestrip",
+        points=np.array([(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)], dtype=np.float64),
+    )
+
+
 @pytest.mark.parametrize(
     # One row per ShapeType member; changing an existing type's membership in
     # POLYLINE_SHAPE_TYPES flips can_add_point and fails its row here.
@@ -381,6 +388,29 @@ def test_nearest_edge_index_returns_none_for_empty_shape() -> None:
     )
 
     assert index is None
+
+
+def test_nearest_edge_index_ignores_phantom_closing_edge_for_linestrip() -> None:
+    # A linestrip is open, so the segment from the last point back to the first
+    # is never rendered and must not register as a hit. (5, 5) lies exactly on
+    # that phantom diagonal but far from every drawn segment.
+    shape = _make_open_linestrip()
+
+    index = _shape.nearest_edge_index(
+        shape=shape, point=np.array([5.0, 5.0]), scale=1.0, epsilon=2.0
+    )
+
+    assert index is None
+
+
+def test_nearest_edge_index_matches_drawn_edge_for_linestrip() -> None:
+    shape = _make_open_linestrip()
+
+    index = _shape.nearest_edge_index(
+        shape=shape, point=np.array([5.0, 0.0]), scale=1.0, epsilon=1.0
+    )
+
+    assert index == 1
 
 
 def test_nearest_vertex_index_returns_nearest_within_epsilon() -> None:


### PR DESCRIPTION
`nearest_edge_index` builds its edge candidates with `np.roll(points, 1)`, which always adds a wrap-around segment from the last point back to the first (at index 0). That segment is the closing edge of a polygon, but a linestrip is an open polyline and the renderer never draws it (`_shape_render.py` special-cases linestrip as open). As a result, hovering or clicking near that invisible diagonal was treated as a hit: edge hover highlighted it, add-point-to-edge inserted a point on it, and body selection grabbed the shape.

The fix masks that one phantom segment to `inf` for linestrip shapes only. Polygons keep their real closing edge, and `line` shapes are unaffected (their two roll-segments are the same physical edge). The guard keys off `shape_type` rather than `Shape.closed` on purpose: shapes loaded from an annotation file are set `closed=True` unconditionally, including linestrips, so `closed` is not a reliable "renders a closing edge" signal.

## Test plan
- [x] Added `test_nearest_edge_index_ignores_phantom_closing_edge_for_linestrip` (fails before the fix: returns edge `0`) and `test_nearest_edge_index_matches_drawn_edge_for_linestrip`
- [x] `uv run pytest tests/unit` (610 passed)
- [x] `uv run ruff check` / `uv run ty check labelme/_shape.py`
- [x] Drove `find_hover_target` end-to-end on a loaded (`closed=True`) linestrip: the phantom point yields no hit while real edge and vertex still register
