### PR TITLE
refactor(cli): extract shared list-arg parser for --flags/--labels

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -169,6 +169,13 @@ class _DeprecatedAlias(argparse.Action):
         setattr(namespace, self.dest, self.const if self.nargs == 0 else values)
 
 
+def _parse_list_arg(value: str) -> list[str]:
+    if Path(value).is_file():
+        with open(value, encoding="utf-8") as f:
+            return [line.strip() for line in f if line.strip()]
+    return [line for line in value.split(",") if line]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", "-V", action="store_true", help="show version")
@@ -274,18 +281,10 @@ def main() -> None:
     sys.excepthook = _handle_exception
 
     if hasattr(args, "flags"):
-        if Path(args.flags).is_file():
-            with open(args.flags, encoding="utf-8") as f:
-                args.flags = [line.strip() for line in f if line.strip()]
-        else:
-            args.flags = [line for line in args.flags.split(",") if line]
+        args.flags = _parse_list_arg(args.flags)
 
     if hasattr(args, "labels"):
-        if Path(args.labels).is_file():
-            with open(args.labels, encoding="utf-8") as f:
-                args.labels = [line.strip() for line in f if line.strip()]
-        else:
-            args.labels = [line for line in args.labels.split(",") if line]
+        args.labels = _parse_list_arg(args.labels)
 
     if hasattr(args, "label_flags"):
         if Path(args.label_flags).is_file():

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -4,12 +4,14 @@ import sys
 import types
 import warnings
 from collections.abc import Callable
+from pathlib import Path
 from typing import cast
 
 import pytest
 from loguru import logger
 from PySide6 import QtCore
 
+from labelme.__main__ import _parse_list_arg
 from labelme.__main__ import _route_qt_logging_to_loguru
 from labelme.__main__ import main
 
@@ -62,6 +64,28 @@ def test_canonical_flag_does_not_warn(
         with pytest.raises(SystemExit) as exc:
             main()
     assert exc.value.code == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("cat,dog,person", ["cat", "dog", "person"]),
+        ("cat,,dog,", ["cat", "dog"]),
+        ("cat", ["cat"]),
+        ("", []),
+    ],
+)
+def test_parse_list_arg_splits_comma_separated_value(
+    value: str, expected: list[str]
+) -> None:
+    assert _parse_list_arg(value) == expected
+
+
+def test_parse_list_arg_reads_and_strips_file_lines(tmp_path: Path) -> None:
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_text("  cat  \n\ndog\n  \nperson\n", encoding="utf-8")
+
+    assert _parse_list_arg(str(labels_file)) == ["cat", "dog", "person"]
 
 
 def test_route_qt_logging_drops_noise_and_forwards_the_rest() -> None:


### PR DESCRIPTION
The `--flags` and `--labels` options each ran the same file-or-comma parsing block (read+strip lines if the value is a file, else comma-split and drop empties). Collapse both into a `_parse_list_arg` helper so the logic lives in one place. Pure refactor, no behavior change: the `--label-flags` block is left inline since it parses YAML, not a plain list.

The parsing previously only executed inside `main()` (which needs a full Qt app), so it had no direct coverage; the helper is now unit-tested for both the comma-split and file-read-and-strip branches.

## Test plan
- [x] `uv run pytest tests/unit/__main___test.py` (17 passed) and full suite green
- [x] `uv run ruff format --check`, `ruff check`, `ty check` all clean
