### PR TITLE
test(config): cover add_point_to_edge shortcut migration

### DIFF
--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -135,6 +135,21 @@ def test_migrate_polygon_shortcut_skips_when_new_key_exists() -> None:
     assert "edit_polygon" in config["shortcuts"]
 
 
+def test_migrate_removes_add_point_to_edge_shortcut() -> None:
+    config = {"shortcuts": {"add_point_to_edge": "Ctrl+X"}}
+    _config._migrate_config_from_file(config)
+    assert "add_point_to_edge" not in config["shortcuts"]
+
+
+def test_load_config_tolerates_removed_add_point_to_edge_shortcut(
+    tmp_path: Path,
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("shortcuts:\n  add_point_to_edge: Ctrl+X\n")
+    config = _config.load_config(config_file=config_file, config_overrides={})
+    assert "add_point_to_edge" not in config["shortcuts"]
+
+
 @pytest.mark.parametrize(
     ("old_config", "expected"),
     [


### PR DESCRIPTION
`add_point_to_edge` was removed from `default_config.yaml`'s `shortcuts` section, and `_migrate_config_from_file` pops it so an old `.labelmerc` still loads instead of crashing on the unknown-key check. Every sibling migration in that function had a regression test except this one; this backfills it, matching the file's existing unit + integration pairing.

## Test plan
- [x] `uv run pytest tests/unit/_config_test.py` (40 passed)
- [x] confirmed both new tests fail without the migration (`ValueError: Unexpected key in config: add_point_to_edge`)
