### PR TITLE
test(_utils/qt): cover zero-length-line guard in point projections

### DIFF
--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -50,6 +50,16 @@ def test_project_point_on_perpendicular_line(
     assert (projected.x(), projected.y()) == pytest.approx(expected)
 
 
+def test_project_point_on_perpendicular_line_zero_length_returns_point() -> None:
+    # A zero-length line has no direction, so the perpendicular is undefined and
+    # the point is returned unchanged instead of dividing by the zero length.
+    point = QPointF(4.0, 7.0)
+    projected = project_point_on_perpendicular_line(
+        point=point, line_start=QPointF(2.0, 2.0), line_end=QPointF(2.0, 2.0)
+    )
+    assert (projected.x(), projected.y()) == pytest.approx((4.0, 7.0))
+
+
 @pytest.mark.parametrize(
     "point, expected",
     [
@@ -62,6 +72,16 @@ def test_project_point_on_line(point: QPointF, expected: tuple[float, float]) ->
         point=point, line_start=QPointF(0.0, 0.0), line_end=QPointF(10.0, 0.0)
     )
     assert (projected.x(), projected.y()) == pytest.approx(expected)
+
+
+def test_project_point_on_line_zero_length_returns_point() -> None:
+    # A zero-length line has no direction to project onto, so the point is
+    # returned unchanged instead of dividing by the zero length.
+    point = QPointF(4.0, 7.0)
+    projected = project_point_on_line(
+        point=point, line_start=QPointF(2.0, 2.0), line_end=QPointF(2.0, 2.0)
+    )
+    assert (projected.x(), projected.y()) == pytest.approx((4.0, 7.0))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`project_point_on_line` and `project_point_on_perpendicular_line` guard the degenerate zero-length line (`length_sq == 0.0`) by returning the point unchanged instead of dividing by the zero segment length, but that branch was unexercised. Removing either guard raises `ZeroDivisionError`, so this locks the guarded behavior down with one test per helper.

## Test plan
- [x] `uv run pytest tests/unit/utils/qt_test.py -q` (47 passed)
- [x] Mutation check: deleting either guard makes the new tests fail with `ZeroDivisionError`; restoring it passes
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check`
