### PR TITLE
test(shapes-to-label): cover mask-shape compositing and instance grouping

### DIFF
--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -37,6 +37,73 @@ def test_shapes_to_label_raises_clear_error_for_unknown_label() -> None:
         shape_module.shapes_to_label((20, 20), [shape], {"road": 1})
 
 
+def test_shapes_to_label_places_mask_shape_at_its_bbox() -> None:
+    # A "mask" shape carries a local boolean patch plus a bbox (2 points, xy).
+    # The patch is composited into the full-image label maps at that bbox, with
+    # the bbox upper bound inclusive. mask is indexed [row=y, col=x].
+    patch = np.ones((3, 7), dtype=bool)
+    patch[0, 0] = False  # cleared cell proves the patch content drives the fill
+    shape = ShapeDict(
+        label="car",
+        points=[[2.0, 3.0], [8.0, 5.0]],  # x in [2, 8], y in [3, 5]
+        shape_type="mask",
+        flags={},
+        description="",
+        group_id=None,
+        mask=patch,
+        other_data={},
+    )
+    cls, ins = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    assert cls[3, 2] == 0  # patch[0, 0] is False, so the bbox corner stays empty
+    assert cls[3, 3] == 1
+    assert cls[5, 8] == 1  # bottom-right corner; a row/col swap would miss it
+    assert ins[5, 8] == 1
+    assert cls[6, 8] == 0  # one row past the inclusive y2 bound
+    assert cls[3, 9] == 0  # one col past the inclusive x2 bound
+
+
+def test_shapes_to_label_raises_when_mask_shape_has_no_ndarray() -> None:
+    shape = ShapeDict(
+        label="car",
+        points=[[0.0, 0.0], [3.0, 3.0]],
+        shape_type="mask",
+        flags={},
+        description="",
+        group_id=None,
+        mask=None,
+        other_data={},
+    )
+    with pytest.raises(ValueError, match=r"shape\['mask'\] must be numpy.ndarray"):
+        shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+
+
+def test_shapes_to_label_groups_instances_by_label_and_group_id() -> None:
+    def _rectangle(points: list[list[float]], group_id: int) -> ShapeDict:
+        return ShapeDict(
+            label="car",
+            points=points,
+            shape_type="rectangle",
+            flags={},
+            description="",
+            group_id=group_id,
+            mask=None,
+            other_data={},
+        )
+
+    shapes = [
+        _rectangle([[0.0, 0.0], [4.0, 4.0]], group_id=1),
+        _rectangle([[10.0, 10.0], [14.0, 14.0]], group_id=2),
+        _rectangle([[16.0, 16.0], [19.0, 19.0]], group_id=1),
+    ]
+    cls, ins = shape_module.shapes_to_label((20, 20), shapes, {"car": 1})
+    assert cls[2, 2] == 1
+    assert cls[12, 12] == 1
+    assert cls[17, 17] == 1
+    assert ins[2, 2] == 1  # first (label, group_id) pair
+    assert ins[12, 12] == 2  # different group_id -> distinct instance
+    assert ins[17, 17] == 1  # same (label, group_id) as the first -> same instance
+
+
 def test_shape_to_mask() -> None:
     img, data = get_img_and_data()
     for shape in data["shapes"]:


### PR DESCRIPTION
Adds focused coverage for `labelme._utils.shape.shapes_to_label`, whose
`shape_type == "mask"` branch and instance-grouping logic were previously
unexercised. This function is a load-bearing conversion path shipped in the
example/export scripts (`examples/instance_segmentation/labelme2voc.py`,
`examples/tutorial/*`), so a silent regression there corrupts exported label
maps.

The three new tests cover:
- mask-shape bbox compositing: the local boolean patch is placed into the
  full-image `cls`/`ins` maps at the given bbox, with inclusive upper bounds
  (the assertions probe patch-content fidelity, a row/col swap, and one-past
  each bound).
- the `ValueError` guard when a mask shape carries no ndarray.
- instance-id grouping by `(label, group_id)` — distinct group_ids get
  distinct instance ids; a repeated `(label, group_id)` reuses its id.

Test-only change; no production code touched.

## Test plan
- [x] `uv run pytest tests/unit/utils/shape_test.py` (17 passed)
- [x] `uv run pytest tests/` (757 passed)
- [x] `uv run ruff format --check` / `ruff check` / `ty check` clean
