### PR TITLE
fix(cli): reject --output json path case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `--output` guard rejecting only lowercase `.json` paths; an upper- or mixed-case file path such as `--output notes.JSON` slipped past the "expects a directory" check and was treated as an output directory. The guard now reuses the canonical case-insensitive `is_label_file_path` helper ([#2317](https://github.com/wkentaro/labelme/pull/2317))
+
 ## [7.0.4] - 2026-07-12
 
 ### Fixed

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -23,6 +23,7 @@ from . import _config
 from . import _locale
 from . import _yaml
 from ._app import MainWindow
+from ._label_file import is_label_file_path
 from ._utils import apply_color_theme
 from ._utils import new_icon
 
@@ -321,7 +322,7 @@ def main() -> None:
 
     output_dir = None
     if output is not None:
-        if output.endswith(".json"):
+        if is_label_file_path(filename=output):
             parser.error(
                 f"--output expects a directory path, but '{output}' looks like a file."
                 " Remove the .json extension or provide a directory path."

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -26,6 +26,16 @@ def test_removed_flag_errors_as_unknown(
     assert exc.value.code == 2
 
 
+@pytest.mark.parametrize("output", ["notes.json", "notes.JSON"])
+def test_output_rejects_json_file_path_case_insensitively(
+    output: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["labelme", "--output", output])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 2
+
+
 @pytest.mark.parametrize(
     ("argv", "canonical"),
     [


### PR DESCRIPTION
The `--output` guard used `output.endswith(".json")`, which is case-sensitive, so an upper- or mixed-case path such as `--output notes.JSON` slipped past the "expects a directory path" check and was silently treated as an output directory.

The fix routes the check through the canonical `is_label_file_path()` helper (`Path(...).suffix.lower() == ".json"`), matching how `_app.py` already classifies label-file paths at two other call sites — removing the ad-hoc, drifted duplicate.

## Behavior notes

Delegating to `is_label_file_path` aligns `__main__` with the repo-wide classification. Two degenerate inputs change accordingly, because `pathlib` gives them no `.json` suffix:

- a bare `--output .json` (a leading-dot dotfile name), and
- a trailing-slash `--output foo.json/`

are now treated as directories rather than rejected as file-like. This is intentional: it is what the canonical predicate returns everywhere else, and no realistic invocation names an output directory `*.json`.

## Test plan
- [x] Added `test_output_rejects_json_file_path_case_insensitively`, parametrized over `notes.json` / `notes.JSON`, asserting `SystemExit(2)` from the guard
- [x] Full unit suite green: `602 passed`
- [x] `ruff check` + `ruff format --check` + `ty check` clean
- [x] End-to-end smoke of the real `labelme` binary: `--output notes.json` / `notes.JSON` / `notes.Json` all rejected (exit 2); a normal directory path is accepted and the app launches
