### PR TITLE
refactor(app): drop dead walrus guard in text-prompt download check

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1339,7 +1339,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         model_name: str = self._ai_text.get_model_name()
         model_type = osam.apis.get_model_type_by_name(model_name)
-        if not (_is_already_downloaded := model_type.get_size() is not None):
+        if model_type.get_size() is None:
             if not download_ai_model(model_name=model_name, parent=self):
                 return
         if (


### PR DESCRIPTION
`_submit_ai_prompt` guarded the model-download prompt with
`if not (_is_already_downloaded := model_type.get_size() is not None):`. The
walrus-bound `_is_already_downloaded` is never read anywhere, and
`not (size is not None)` is just `size is None`, so the binding and double
negation are pure ceremony. Collapse it to a direct `is None` check.

Behavior-identical; no user-facing change, so no CHANGELOG entry.

## Test plan
- [x] `uv run pytest tests/` (754 passed)
- [x] `make lint` (ruff format/check + ty clean)
