### PR TITLE
refactor(_utils): drop unused img_pil_to_data re-export

### DIFF
--- a/labelme/_utils/__init__.py
+++ b/labelme/_utils/__init__.py
@@ -4,7 +4,6 @@ from .image import img_arr_to_data
 from .image import img_b64_to_arr
 from .image import img_data_to_arr
 from .image import img_data_to_pil
-from .image import img_pil_to_data
 from .image import img_qt_to_arr
 from .qt import add_actions
 from .qt import apply_color_theme


### PR DESCRIPTION
`img_pil_to_data` has no consumer via `labelme._utils`: it is only called
internally by `img_arr_to_data` in `labelme/_utils/image.py`. This drops the
orphaned package re-export left behind after the public-API-surface removal,
keeping the function itself since it is still used internally.

Same cleanup class as the earlier drop of the `new_button` / `distance` /
`distance_to_line` / `img_data_to_png_data` re-exports (20604696); this sibling
was missed because the function still has an internal caller, so a naive
"no caller" search over the function name did not flag it.

## Test plan
- [x] `pytest tests/` (754 passed)
- [x] `ruff check labelme/_utils/__init__.py`, `ty check` (clean)
