### PR TITLE
test(_yaml): cover safe_load parsing, streams, and unsafe-tag rejection

### DIFF
--- a/tests/unit/_yaml_test.py
+++ b/tests/unit/_yaml_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from ruamel.yaml import YAMLError
+
+from labelme import _yaml
+
+
+def test_safe_load_parses_string_into_nested_structure() -> None:
+    assert _yaml.safe_load("a: 1\nb:\n  - 2\n  - 3\n") == {"a": 1, "b": [2, 3]}
+
+
+def test_safe_load_accepts_file_like_stream() -> None:
+    assert _yaml.safe_load(io.StringIO("x: hello\n")) == {"x": "hello"}
+
+
+def test_safe_load_returns_none_for_empty_string() -> None:
+    assert _yaml.safe_load("") is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '!!python/object/apply:os.system ["echo hi"]',
+        '!!python/object/new:os.system ["echo hi"]',
+        "!!python/name:os.system",
+        "!!python/module:os",
+    ],
+)
+def test_safe_load_rejects_unsafe_python_tag(payload: str) -> None:
+    with pytest.raises(YAMLError):
+        _yaml.safe_load(payload)


### PR DESCRIPTION
`labelme/_yaml.py`'s `safe_load` had no unit test of its own — it was only exercised incidentally through config-loading paths, so its contract was unpinned. It's the sole YAML entry point behind `load_config` and the `--config` CLI value, and it uses `typ="safe"` specifically to reject dangerous `!!python/...` tags in user-editable config files.

This adds a test file pinning that contract: nested-structure parsing, `IO[str]` stream input, empty-string returning `None`, and rejection of unsafe python tags across four attack vectors. The rejection assertion binds to ruamel's public `YAMLError` base class rather than an internal exception subtype.

## Test plan
- [x] `uv run pytest tests/unit/_yaml_test.py` (7 cases pass)
- [x] `uv run ruff check` / `uv run ty check` clean
