### PR TITLE
test(_utils/image): cover img_qt_to_arr pixel layout and scanline padding

### DIFF
--- a/tests/unit/utils/image_test.py
+++ b/tests/unit/utils/image_test.py
@@ -6,6 +6,7 @@ from typing import Final
 import numpy as np
 import PIL.Image
 import pytest
+from PySide6 import QtGui
 
 from labelme._utils import image as image_module
 
@@ -25,6 +26,54 @@ def test_img_arr_to_b64() -> None:
     img_b64 = image_module.img_arr_to_b64(img_arr)
     img_arr2 = image_module.img_b64_to_arr(img_b64)
     np.testing.assert_allclose(img_arr, img_arr2)
+
+
+def test_img_qt_to_arr_returns_bgra_pixels() -> None:
+    img_qt = QtGui.QImage(4, 3, QtGui.QImage.Format.Format_RGB32)
+    img_qt.fill(QtGui.QColor(0, 0, 0))
+    img_qt.setPixelColor(0, 0, QtGui.QColor(10, 20, 30))
+    img_qt.setPixelColor(3, 2, QtGui.QColor(40, 50, 60))
+
+    arr = image_module.img_qt_to_arr(img_qt)
+
+    assert arr.dtype == np.uint8
+    assert arr.shape == (3, 4, 4)
+    # Format_RGB32 is stored as BGRA on little-endian, with a filled alpha byte.
+    np.testing.assert_array_equal(arr[0, 0], [30, 20, 10, 255])
+    np.testing.assert_array_equal(arr[2, 3], [60, 50, 40, 255])
+
+
+def test_img_qt_to_arr_strips_scanline_padding() -> None:
+    # width 3 * 3 channels = 9 bytes/row, but Qt pads each scanline to a 4-byte
+    # boundary, so bytesPerLine() is 12; the padding must not leak into the array.
+    img_qt = QtGui.QImage(3, 2, QtGui.QImage.Format.Format_RGB888)
+    assert img_qt.bytesPerLine() > 3 * 3
+    columns = [
+        QtGui.QColor(255, 0, 0),
+        QtGui.QColor(0, 255, 0),
+        QtGui.QColor(0, 0, 255),
+    ]
+    for y in range(2):
+        for x, color in enumerate(columns):
+            img_qt.setPixelColor(x, y, color)
+
+    arr = image_module.img_qt_to_arr(img_qt)
+
+    assert arr.shape == (2, 3, 3)
+    expected = np.array([[[255, 0, 0], [0, 255, 0], [0, 0, 255]]] * 2, dtype=np.uint8)
+    np.testing.assert_array_equal(arr, expected)
+
+
+def test_img_qt_to_arr_copies_source_buffer() -> None:
+    # The array must own its data, not alias the QImage's buffer, so it stays
+    # valid after the source is overwritten or freed.
+    img_qt = QtGui.QImage(2, 2, QtGui.QImage.Format.Format_RGB32)
+    img_qt.fill(QtGui.QColor(10, 20, 30))
+
+    arr = image_module.img_qt_to_arr(img_qt)
+    img_qt.fill(QtGui.QColor(200, 210, 220))
+
+    np.testing.assert_array_equal(arr[0, 0], [30, 20, 10, 255])
 
 
 def _make_jpeg_with_red_marker(orientation: int) -> PIL.Image.Image:


### PR DESCRIPTION
`img_qt_to_arr` (`labelme/_utils/image.py`) converts a `QImage` to a numpy array on the hot path (`_app.py`, `canvas.py`) but had zero test coverage. Its two subtle behaviors are easy to regress: the byte layout of `Format_RGB32` (BGRA on little-endian) and Qt's 4-byte scanline padding, which must be stripped so a padded row never leaks garbage columns into the array.

Three characterization tests pin these down:
- `test_img_qt_to_arr_returns_bgra_pixels` — asserts the BGRA-with-filled-alpha layout at two corners.
- `test_img_qt_to_arr_strips_scanline_padding` — uses a width where `bytesPerLine()` (12) exceeds `width * channels` (9) to exercise the padding-strip branch.
- `test_img_qt_to_arr_copies_source_buffer` — mutates the source `QImage` after conversion and asserts the array is unchanged, locking in that the result owns its data (guards a future zero-copy refactor from reintroducing dangling-buffer UB).

## Test plan
- [x] `QT_QPA_PLATFORM=offscreen uv run pytest tests/unit/utils/image_test.py -q` (15 passed)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` on the file
