### PR TITLE
refactor: drop package re-exports orphaned by public-API removal

### DIFF
--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -5,7 +5,6 @@ from ._shape_builders import MASK_REQUIRED_SHAPE_TYPES
 from ._shape_builders import Detection
 from ._shape_builders import shapes_from_detections
 from ._suppression import suppress_detections_greedy
-from ._suppression import suppress_detections_overlapping_existing_shapes
 from ._text_detection import get_bboxes_from_texts
 from ._text_detection import nms_bboxes
 from ._types import AiOutputFormat

--- a/labelme/_widgets/__init__.py
+++ b/labelme/_widgets/__init__.py
@@ -6,7 +6,6 @@ from .brightness_contrast_dialog import BrightnessContrastDialog
 from .canvas import Canvas
 from .download import download_ai_model
 from .label_dialog import LabelDialog
-from .label_dialog import LabelQLineEdit
 from .label_list_widget import LabelListWidget
 from .label_list_widget import LabelListWidgetItem
 from .label_list_widget import format_shape_label


### PR DESCRIPTION
Since the public Python API was removed (#2249), the only consumers of
`suppress_detections_overlapping_existing_shapes` and `LabelQLineEdit` import
them from their defining submodules (`_automation._suppression`,
`_widgets.label_dialog`), never from the package namespace. These two
package-level re-exports are now dead. Sibling of #2321.

## Test plan
- [x] `uv run pytest tests/` (762 passed)
- [x] `make lint` clean (ruff format, ruff check, ty) on `labelme` and `tests`
- [x] `import labelme._automation, labelme._widgets` still resolve
