### PR TITLE
fix: AI suppression PIL coordinate-type crash on older Pillow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed AI Assist / AI Box crashing with `ValueError: incorrect coordinate type` when suppressing detections that overlap an existing polygon or oriented-rectangle shape on Pillow older than 11.2.1; the overlap check rasterized the existing shape by passing a list-of-lists (`ndarray.tolist()`) to `PIL.ImageDraw.polygon`, which older Pillow rejects, so it now passes the documented list-of-tuples form as elsewhere in the codebase ([#2331](https://github.com/wkentaro/labelme/pull/2331))
+
 ## [7.0.3] - 2026-07-11
 
 ### Fixed

--- a/labelme/_automation/_suppression.py
+++ b/labelme/_automation/_suppression.py
@@ -209,7 +209,7 @@ def _rasterize_shape(
     if shape.shape_type in ("polygon", "oriented_rectangle"):
         image = PIL.Image.new("L", (width, height), 0)
         draw = PIL.ImageDraw.Draw(image)
-        points_local = (shape.points - [xmin, ymin]).tolist()
+        points_local = [tuple(point) for point in (shape.points - [xmin, ymin])]
         draw.polygon(points_local, fill=1)
         return np.asarray(image, dtype=np.bool_)
     raise ValueError(f"Unsupported shape_type: {shape.shape_type!r}")


### PR DESCRIPTION
AI Assist / AI Box crashed with `ValueError: incorrect coordinate type` when a
detection overlapped an existing polygon or oriented-rectangle shape, on Pillow
older than 11.2.1. The overlap-suppression check rasterized the existing shape by
passing `ndarray.tolist()` (a list of lists) to `PIL.ImageDraw.polygon`, which
older Pillow rejects. Pass the documented list-of-tuples form instead, the same
idiom already used in `labelme/_utils/shape.py`, so it works on every supported
Pillow version.

Reported by a user running the packaged Windows build, which ships Pillow 11.0.0.
Dev and CI resolve Pillow 12.2 (which accepts the old form), so the existing
suppression tests passed there and the crash surfaced only in the build.

## Test plan
- [x] existing suppression tests pass, and now also pass under a pinned Pillow 11.0.0 (2 previously failed with the reported error)
- [x] `make lint` (ruff, ty)
