### PR TITLE
test(_automation): cover mask happy-path and polygon bbox offset

### DIFF
--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -176,6 +176,36 @@ def test_shapes_from_detections_polygon_drops_degenerate_thin_mask() -> None:
     assert shapes == []
 
 
+def test_shapes_from_detections_polygon_with_bbox_offsets_contour() -> None:
+    # The mask traces a contour in mask-local coordinates; a bbox origin shifts
+    # every contour point by (bbox[0], bbox[1]) into image coordinates.
+    mask = np.ones((20, 20), dtype=bool)
+    [local, offset] = shapes_from_detections(
+        detections=[
+            Detection(mask=mask),
+            Detection(bbox=(10, 20, 30, 40), mask=mask),
+        ],
+        shape_type="polygon",
+    )
+
+    assert offset.shape_type == "polygon"
+    np.testing.assert_allclose(offset.points, local.points + [10, 20])
+
+
+def test_shapes_from_detections_mask_uses_truncated_bbox_corners() -> None:
+    mask = np.ones((31, 21), dtype=bool)
+    [shape] = shapes_from_detections(
+        detections=[Detection(bbox=(10.4, 20.6, 30.9, 50.1), mask=mask)],
+        shape_type="mask",
+    )
+
+    assert shape.shape_type == "mask"
+    assert (shape.points[0][0], shape.points[0][1]) == pytest.approx((10, 20))
+    assert (shape.points[1][0], shape.points[1][1]) == pytest.approx((30, 50))
+    assert shape.mask is not None
+    assert np.array_equal(shape.mask, mask)
+
+
 def test_shapes_from_detections_mask_drops_empty_mask() -> None:
     # OSAM occasionally returns a bbox whose segmentation mask is all-False;
     # without this guard the shape would render as bbox-only (no visible mask).


### PR DESCRIPTION
`shapes_from_detections` builds AI-detection results into `Shape`s, but two of its `_shape_from_detection` branches were only partially covered: the `shape_type="mask"` path was exercised solely through the drop-empty rejection case, and the `shape_type="polygon"` path only without a bbox. So the `int()` truncation of the mask bbox corners and the bbox-origin offset applied to a traced polygon contour went untested, even though the sibling `circle` and `oriented_rectangle` branches both already have with-bbox offset tests. This closes that asymmetry.

## Test plan
- [x] `uv run pytest tests/unit/_automation/_shape_builders_test.py` (16 passed)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` clean
