### PR TITLE
refactor(_utils): drop dead masks_to_bboxes helper

### DIFF
--- a/labelme/_utils/__init__.py
+++ b/labelme/_utils/__init__.py
@@ -15,6 +15,5 @@ from .qt import new_action
 from .qt import new_icon
 from .qt import project_point_on_line
 from .qt import project_point_on_perpendicular_line
-from .shape import masks_to_bboxes
 from .shape import shape_to_mask
 from .shape import shapes_to_label

--- a/labelme/_utils/shape.py
+++ b/labelme/_utils/shape.py
@@ -113,16 +113,3 @@ def shapes_to_label(
         ins[mask] = ins_id
 
     return cls, ins
-
-
-def masks_to_bboxes(masks: NDArray[np.bool_]) -> NDArray[np.float32]:
-    if masks.ndim != 3:
-        raise ValueError(f"masks.ndim must be 3, but it is {masks.ndim}")
-    if masks.dtype != bool:
-        raise ValueError(f"masks.dtype must be bool type, but it is {masks.dtype}")
-    bboxes = []
-    for mask in masks:
-        where = np.argwhere(mask)
-        (y1, x1), (y2, x2) = where.min(0), where.max(0) + 1
-        bboxes.append((y1, x1, y2, x2))
-    return np.asarray(bboxes, dtype=np.float32)

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -225,36 +225,3 @@ def test_shape_to_mask_point_marks_pixels_around_center() -> None:
     assert mask[60, 43]  # 3px from center, inside point_size=5
     assert mask[62, 40]  # off the center row: a filled disk, not a horizontal line
     assert not mask[60, 46]  # 1px past the point_size=5 edge
-
-
-def test_masks_to_bboxes_returns_yxyx_bboxes() -> None:
-    masks = np.zeros((2, 10, 10), dtype=bool)
-    masks[0, 2:5, 3:7] = True
-    masks[1, 0:3, 0:4] = True
-    bboxes = shape_module.masks_to_bboxes(masks)
-    assert bboxes.shape == (2, 4)
-    assert bboxes.dtype == np.float32
-    # bboxes are returned in (y1, x1, y2, x2) order, not the more common xyxy.
-    assert np.array_equal(bboxes[0], [2, 3, 5, 7])
-    assert np.array_equal(bboxes[1], [0, 0, 3, 4])
-
-
-def test_masks_to_bboxes_raises_for_wrong_ndim() -> None:
-    masks = np.zeros((10, 10), dtype=bool)
-    with pytest.raises(ValueError, match=r"masks\.ndim must be 3"):
-        shape_module.masks_to_bboxes(masks)
-
-
-def test_masks_to_bboxes_raises_for_non_bool_dtype() -> None:
-    masks = np.zeros((1, 10, 10), dtype=np.uint8)
-    with pytest.raises(ValueError, match=r"masks\.dtype must be bool"):
-        shape_module.masks_to_bboxes(masks)
-
-
-def test_masks_to_bboxes_raises_for_all_false_mask() -> None:
-    # An all-False mask has no foreground pixels, so no bbox is defined: the
-    # implementation currently raises rather than returning a sentinel. Pin that
-    # behavior without depending on numpy's internal message.
-    masks = np.zeros((1, 10, 10), dtype=bool)
-    with pytest.raises(ValueError):
-        shape_module.masks_to_bboxes(masks)


### PR DESCRIPTION
`masks_to_bboxes` in `labelme/_utils/shape.py` has had zero callers anywhere in the repo since the code that used it was refactored away. It lives in the already-privatized `_utils` package (underscore prefix, no external contract), so its four unit tests were only exercising dead code. This removes the function, its re-export in `labelme/_utils/__init__.py`, and those four tests.

No CHANGELOG entry: the symbol was never user-facing, matching precedent for prior internal dead-code removals in this repo.

## Test plan
- [x] `grep -rn masks_to_bboxes labelme tests` returns zero hits after removal
- [x] `uv run ruff check` / `uv run ruff format --check` clean on touched files
- [x] `uv run ty check` clean
- [x] `uv run pytest tests/unit` green (604 passed)
