### PR TITLE
refactor(cli): drop _LoggerIO overrides that restate io.StringIO defaults

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -35,20 +35,10 @@ class _LoggerIO(io.StringIO):
             logger.debug(stripped_s)
         return len(s)
 
-    def flush(self) -> None:
-        pass
-
-    def writable(self) -> bool:
-        return True
-
     def readable(self) -> bool:
         return False
 
     def seekable(self) -> bool:
-        return False
-
-    @property
-    def closed(self) -> bool:
         return False
 
 

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -11,6 +11,7 @@ import pytest
 from loguru import logger
 from PySide6 import QtCore
 
+from labelme.__main__ import _LoggerIO
 from labelme.__main__ import _parse_list_arg
 from labelme.__main__ import _route_qt_logging_to_loguru
 from labelme.__main__ import main
@@ -96,6 +97,31 @@ def test_parse_list_arg_reads_and_strips_file_lines(tmp_path: Path) -> None:
     labels_file.write_text("  cat  \n\ndog\n  \nperson\n", encoding="utf-8")
 
     assert _parse_list_arg(str(labels_file)) == ["cat", "dog", "person"]
+
+
+def test_logger_io_forwards_stripped_writes_to_debug() -> None:
+    forwarded: list[tuple[str, str]] = []
+    sink_id = logger.add(
+        lambda m: forwarded.append((m.record["level"].name, m.record["message"])),
+        level="DEBUG",
+    )
+    try:
+        stream = _LoggerIO()
+        assert stream.write("  qt noise  \n") == len("  qt noise  \n")
+        assert stream.write("   \n") == len("   \n")
+    finally:
+        logger.remove(sink_id)
+
+    assert forwarded == [("DEBUG", "qt noise")]
+
+
+def test_logger_io_is_a_write_only_non_seekable_sink() -> None:
+    stream = _LoggerIO()
+    assert stream.writable() is True
+    assert stream.readable() is False
+    assert stream.seekable() is False
+    assert stream.closed is False
+    assert stream.flush() is None
 
 
 def test_route_qt_logging_drops_noise_and_forwards_the_rest() -> None:


### PR DESCRIPTION
`_LoggerIO` subclasses `io.StringIO` (only to satisfy the `redirect_stderr(new_target=...)` type) and overrode six methods. Three of them — `flush()`, `writable()`, and `closed` — returned exactly what `io.StringIO` already provides by default, so they added nothing. This drops those three and keeps `readable()`/`seekable()`, which genuinely deviate (both default to `True`; the sink is write-only and non-seekable).

The one case where the removed overrides would differ from the base — after `.close()` is called on the instance — is unreachable: `contextlib.redirect_stderr` never closes its target and nothing else references the sink.

Internal-only refactor with no user-facing behavior change, so no CHANGELOG entry. A characterization test locks the resulting stream contract (write forwards stripped content to loguru; `readable`/`seekable` are `False`).

## Test plan
- [x] `pytest tests/unit/__main___test.py` (19 passed, incl. 2 new `_LoggerIO` tests)
- [x] full suite `pytest tests/` (764 passed)
- [x] `ruff format --check`, `ruff check`, `ty check` clean
- [x] smoke-drove the production path: `redirect_stderr(new_target=_LoggerIO())` still forwards stderr writes to loguru with the stream contract intact
