### PR TITLE
fix(label-file): re-encode palette images to a Pillow-writable format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed clicking or hovering near a linestrip's unrendered "closing" line (the straight path from its last point back to its first) being treated as a hit on the shape; edge hover, add-point-to-edge, and body selection now ignore that phantom segment, since a linestrip is an open polyline and never draws it ([#2307](https://github.com/wkentaro/labelme/pull/2307))
 - Fixed the `--output` guard rejecting only lowercase `.json` paths; an upper- or mixed-case file path such as `--output notes.JSON` slipped past the "expects a directory" check and was treated as an output directory. The guard now reuses the canonical case-insensitive `is_label_file_path` helper ([#2317](https://github.com/wkentaro/labelme/pull/2317))
+- Fixed a crash when opening a palette-mode (`P`/`PA`) image, such as a GIF, palette BMP/PNG, or palette TIFF whose bytes need re-encoding (any non-jpg/png extension, or an EXIF-oriented file); the re-encode path picked a format Pillow cannot write the palette mode in (`OSError: cannot write mode P as JPEG` / `cannot write mode PA as PNG`), so every such image crashed. A non-transparent palette image is now converted to `RGB` before the JPEG save, a `P` image carrying index-based transparency is routed to PNG so its transparency is preserved, and a `PA` image (palette + alpha) is converted to `RGBA` before the PNG save ([#2340](https://github.com/wkentaro/labelme/pull/2340))
 
 ## [7.0.4] - 2026-07-12
 

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -179,7 +179,14 @@ def read_image_file(filename: str) -> bytes:
             image_data = f.read()
     else:
         with io.BytesIO() as f:
-            fmt = "PNG" if "A" in oriented.mode else "JPEG"
+            has_transparency = "A" in oriented.mode or (
+                oriented.mode == "P" and "transparency" in oriented.info
+            )
+            fmt = "PNG" if has_transparency else "JPEG"
+            if fmt == "JPEG" and oriented.mode == "P":
+                oriented = oriented.convert("RGB")
+            elif fmt == "PNG" and oriented.mode == "PA":
+                oriented = oriented.convert("RGBA")
             oriented.save(fp=f, format=fmt, quality=95)
             f.seek(0)
             image_data = f.read()

--- a/tests/unit/read_image_file_test.py
+++ b/tests/unit/read_image_file_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import PIL.Image
+import pytest
 import tifffile
 
 from labelme._label_file import read_image_file
@@ -42,6 +43,50 @@ def test_png_returns_raw_bytes(tmp_path: Path) -> None:
     path = _make_image(tmp_path, "test.png")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
+
+
+@pytest.mark.parametrize("ext", ["gif", "bmp"])
+def test_palette_image_without_alpha_encoded_as_jpeg(tmp_path: Path, ext: str) -> None:
+    arr = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+    path = tmp_path / f"test.{ext}"
+    PIL.Image.fromarray(arr, mode="RGB").convert("P").save(str(path))
+    assert PIL.Image.open(str(path)).mode == "P"
+
+    data = read_image_file(filename=str(path))
+    assert data[:2] == b"\xff\xd8"
+
+
+def test_transparent_palette_gif_encoded_as_png(tmp_path: Path) -> None:
+    arr = np.random.randint(0, 255, (100, 100, 4), dtype=np.uint8)
+    arr[:20, :20, 3] = 0
+    path = tmp_path / "test.gif"
+    PIL.Image.fromarray(arr, mode="RGBA").save(str(path), transparency=0)
+    reopened = PIL.Image.open(str(path))
+    assert reopened.mode == "P"
+    assert "transparency" in reopened.info
+
+    data = read_image_file(filename=str(path))
+    assert data[:4] == b"\x89PNG"
+    assert "transparency" in PIL.Image.open(io.BytesIO(data)).info
+
+
+def test_palette_with_alpha_tiff_encoded_as_png(tmp_path: Path) -> None:
+    path = tmp_path / "test.tiff"
+    PIL.Image.new("PA", (100, 100)).save(str(path))
+    assert PIL.Image.open(str(path)).mode == "PA"
+
+    data = read_image_file(filename=str(path))
+    assert data[:4] == b"\x89PNG"
+
+
+def test_bilevel_image_encoded_as_jpeg_without_widening(tmp_path: Path) -> None:
+    path = tmp_path / "test.bmp"
+    PIL.Image.new("1", (100, 100)).save(str(path))
+    assert PIL.Image.open(str(path)).mode == "1"
+
+    data = read_image_file(filename=str(path))
+    assert data[:2] == b"\xff\xd8"
+    assert PIL.Image.open(io.BytesIO(data)).mode == "L"
 
 
 def test_multispectral_tiff_float32(tmp_path: Path) -> None:


### PR DESCRIPTION
`read_image_file` re-encodes any image whose bytes need transforming (a non-jpg/png extension, or an EXIF-oriented file), and it chose the target format from the mode string alone. Palette images then hit a format Pillow cannot write them in and failed to open (the app catches the `OSError` and shows a "failed to open image" dialog):

- a `P` image (GIF, palette BMP/PNG) went to JPEG → `cannot write mode P as JPEG`
- a `PA` image (palette + alpha, e.g. a palette TIFF) went to PNG → `cannot write mode PA as PNG`

The fix converts a non-transparent `P` image to `RGB` before the JPEG save, routes a `P` image carrying index-based transparency to PNG so its transparency is preserved, and converts a `PA` image to `RGBA` before the PNG save.

## Test plan
- [x] New regression tests in `tests/unit/read_image_file_test.py`: palette GIF/BMP → JPEG, transparent palette GIF → PNG (transparency preserved), palette+alpha TIFF → PNG, bilevel `1` → JPEG without RGB widening. All fail on `main`, pass here.
- [x] `uv run pytest tests/unit` (613 passed), `ruff check`, `ruff format --check`, `ty check` all green.
- [x] Smoke: ran `read_image_file` on real palette files (the exact call `_app.py` makes when opening an image). Before: all four palette cases raise `OSError`. After: all load with the correct format/mode and dimensions preserved; a plain RGB control is unchanged.

Not in scope: non-palette `L`/`RGB` images carrying a color-key `transparency` info still route to JPEG (transparency dropped). This is pre-existing and does not crash, so it is left for a separate change.
