### PR TITLE
fix(shape): guard insert_point against non-polyline shapes

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -57,6 +57,13 @@ class Shape:
         return self.shape_type in POLYLINE_SHAPE_TYPES
 
     def insert_point(self, i: int, point: npt.ArrayLike, label: int = 1) -> None:
+        if not self.can_add_point():
+            logger.warning(
+                "Cannot add point to: shape_type={!r}, len(points)={:d}",
+                self.shape_type,
+                len(self.points),
+            )
+            return
         point = np.asarray(point, dtype=np.float64).reshape(2)
         self.points = np.insert(self.points, i, point, axis=0)
         self.point_labels = np.insert(self.point_labels, i, label)

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -223,6 +223,36 @@ def test_insert_point_records_label() -> None:
     assert int(shape.point_labels[0]) == 0
 
 
+def test_insert_point_is_noop_for_non_polyline() -> None:
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array([(0.0, 0.0), (10.0, 10.0)], dtype=np.float64),
+    )
+
+    shape.insert_point(i=1, point=(5.0, 5.0))
+
+    assert len(shape.points) == 2
+    assert len(shape.point_labels) == 2
+
+
+def test_insert_point_noop_logs_shape_state() -> None:
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array([(0.0, 0.0), (10.0, 10.0)], dtype=np.float64),
+    )
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda m: messages.append(m.record["message"]), level="WARNING"
+    )
+
+    try:
+        shape.insert_point(i=1, point=(5.0, 5.0))
+    finally:
+        logger.remove(sink_id)
+
+    assert messages == ["Cannot add point to: shape_type='rectangle', len(points)=2"]
+
+
 def test_can_remove_point_polygon_requires_more_than_three() -> None:
     shape = _make_square_polygon()
     assert shape.can_remove_point() is True


### PR DESCRIPTION
`Shape.remove_point` guards on `can_remove_point()` and no-ops with a warning
when the shape type does not support point removal, but its sibling
`Shape.insert_point` had no analogous check: it would happily insert a vertex
into a fixed-cardinality shape (rectangle, circle, line, point,
oriented_rectangle, mask), corrupting its point count. This adds the symmetric
`can_add_point()` guard so the model layer is self-consistent.

Defense-in-depth only: the sole production caller (`add_point_to_edge`) is
already gated upstream by `find_hover_target`'s edge pass, which filters on
`can_add_point()`, so this is not reachable through the current UI. No
CHANGELOG entry for that reason, consistent with how internal refactor/test
PRs in this repo skip the changelog.

## Test plan
- [x] Added `test_insert_point_is_noop_for_non_polyline` and `test_insert_point_noop_logs_shape_state`, mirroring the existing `remove_point` no-op tests
- [x] `uv run pytest tests/unit/_shape_test.py` (54 passed)
- [x] `uv run ruff check` / `ruff format --check` / `ty check` on the changed files
- [x] `uv run pytest tests/e2e/canvas_interaction_test.py tests/e2e/oriented_rectangle_test.py tests/e2e/shape_editing_test.py` (add-point-to-edge flow still green)
