### PR TITLE
refactor(app): flatten save_labels duplicate-file check into guard clauses

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1805,9 +1805,9 @@ class MainWindow(QtWidgets.QMainWindow):
             items = self._docks.file_list.findItems(
                 self._image_path, Qt.MatchFlag.MatchExactly
             )
-            if len(items) > 0:
-                if len(items) != 1:
-                    raise RuntimeError("There are duplicate files.")
+            if len(items) > 1:
+                raise RuntimeError("There are duplicate files.")
+            if items:
                 items[0].setCheckState(Qt.CheckState.Checked)
             return True
         except LabelFileError as e:


### PR DESCRIPTION
The nested `len(items) > 0` / `len(items) != 1` check in `save_labels` reads more directly as two guard clauses: raise on more than one match, then check the single match. Behavior is identical for 0, 1, and >1 matches, and it drops a redundant `len()` call.

No CHANGELOG entry: pure internal refactor with no user-facing behavior change.

## Test plan
- [x] `make lint` (ruff format/check, ty) clean
- [x] `uv run pytest tests/` — 807 passed, including the e2e save-path suite that exercises `save_labels`