### PR TITLE
test(_automation): cover _detections_from_annotations

### DIFF
--- a/tests/unit/_automation/_ai_assist_test.py
+++ b/tests/unit/_automation/_ai_assist_test.py
@@ -5,9 +5,11 @@ from collections.abc import Callable
 import numpy as np
 import osam
 import pytest
+from numpy.typing import NDArray
 
 from labelme._automation import _ai_assist
 from labelme._automation._ai_assist import AiAssistSession
+from labelme._automation._ai_assist import _detections_from_annotations
 from labelme._shape import Shape
 
 
@@ -86,3 +88,75 @@ def test_default_model_name_and_output_format() -> None:
     session.output_format = "mask"
     assert session.model_name == "efficientsam:latest"
     assert session.output_format == "mask"
+
+
+def _annotation(
+    score: float | None,
+    *,
+    bbox: tuple[int, int, int, int] | None = None,
+    mask: NDArray[np.bool_] | None = None,
+) -> osam.types.Annotation:
+    bounding_box = (
+        osam.types.BoundingBox(xmin=bbox[0], ymin=bbox[1], xmax=bbox[2], ymax=bbox[3])
+        if bbox is not None
+        else None
+    )
+    return osam.types.Annotation(score=score, bounding_box=bounding_box, mask=mask)
+
+
+def test_detections_from_annotations_empty_returns_empty() -> None:
+    assert _detections_from_annotations([]) == []
+
+
+def test_detections_from_annotations_sorts_by_score_descending() -> None:
+    detections = _detections_from_annotations(
+        [
+            _annotation(0.2, bbox=(0, 0, 1, 1)),
+            _annotation(0.9, bbox=(2, 2, 3, 3)),
+            _annotation(0.5, bbox=(4, 4, 5, 5)),
+        ]
+    )
+
+    assert [detection.bbox for detection in detections] == [
+        (2, 2, 3, 3),
+        (4, 4, 5, 5),
+        (0, 0, 1, 1),
+    ]
+
+
+def test_detections_from_annotations_treats_missing_score_as_zero() -> None:
+    detections = _detections_from_annotations(
+        [
+            _annotation(None, bbox=(0, 0, 1, 1)),
+            _annotation(0.5, bbox=(2, 2, 3, 3)),
+        ]
+    )
+
+    assert [detection.bbox for detection in detections] == [
+        (2, 2, 3, 3),
+        (0, 0, 1, 1),
+    ]
+
+
+def test_detections_from_annotations_flattens_bounding_box() -> None:
+    (detection,) = _detections_from_annotations([_annotation(0.5, bbox=(1, 2, 3, 4))])
+
+    assert detection.bbox == (1, 2, 3, 4)
+
+
+def test_detections_from_annotations_keeps_bbox_none_without_bounding_box() -> None:
+    (detection,) = _detections_from_annotations([_annotation(0.5)])
+
+    assert detection.bbox is None
+    assert detection.mask is None
+
+
+def test_detections_from_annotations_passes_mask_through() -> None:
+    mask = np.zeros((2, 2), dtype=bool)
+    mask[0, 0] = True
+
+    (detection,) = _detections_from_annotations(
+        [_annotation(0.5, bbox=(0, 0, 1, 1), mask=mask)]
+    )
+
+    np.testing.assert_array_equal(detection.mask, mask)


### PR DESCRIPTION
`_detections_from_annotations` (the AI-assist helper that turns osam model
outputs into internal `Detection` objects) had no direct coverage — it was only
exercised indirectly through the full `propose_shapes` pipeline, and only on the
two-annotations-with-scores-and-boxes path.

These tests pin its actual contract: empty input returns `[]`, detections come
out sorted by score descending with a missing (`None`) score treated as zero,
the `BoundingBox` is flattened to an `(xmin, ymin, xmax, ymax)` tuple, `bbox`
stays `None` when the annotation has no bounding box, and the mask is carried
through unchanged. The repeated `Annotation`/`BoundingBox` construction is
factored into a small keyword-only `_annotation` builder.

## Test plan
- [x] `uv run pytest tests/unit/_automation/_ai_assist_test.py -q` (8 passed)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check`
