### PR TITLE
test(shape-render): cover is_hit_by_point and bounds branches

### DIFF
--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -9,6 +9,7 @@ from labelme._shape import ShapeType
 from labelme._widgets._shape_render import Palette
 from labelme._widgets._shape_render import ShapeRenderContext
 from labelme._widgets._shape_render import bounds
+from labelme._widgets._shape_render import is_hit_by_point
 from labelme._widgets._shape_render import render_shape
 
 _SIZE = 200
@@ -19,6 +20,14 @@ def _polygon(label: str | None) -> Shape:
         label=label,
         shape_type="polygon",
         points=np.array([[50, 50], [150, 50], [150, 150], [50, 150]], dtype=np.float64),
+        closed=True,
+    )
+
+
+def _unit_square_polygon() -> Shape:
+    return Shape(
+        shape_type="polygon",
+        points=np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.float64),
         closed=True,
     )
 
@@ -168,3 +177,80 @@ def test_label_anchor_tracks_scale(qapp: QtGui.QGuiApplication) -> None:
         )
         > 0
     )
+
+
+def _hit(shape: Shape, point: tuple[float, float]) -> bool:
+    return is_hit_by_point(
+        shape=shape,
+        point=np.array(point, dtype=np.float64),
+        scale=1.0,
+        point_size=8,
+        epsilon=5.0,
+    )
+
+
+def test_line_is_hit_near_its_segment() -> None:
+    shape = Shape(
+        shape_type="line",
+        points=np.array([[0, 0], [100, 0]], dtype=np.float64),
+    )
+    assert _hit(shape, (50, 2)) is True
+    assert _hit(shape, (50, 20)) is False
+
+
+def test_linestrip_hit_ignores_phantom_closing_edge() -> None:
+    shape = Shape(
+        shape_type="linestrip",
+        points=np.array([[0, 0], [100, 0], [100, 100]], dtype=np.float64),
+    )
+    # Near a real segment (the bottom edge) is a hit.
+    assert _hit(shape, (50, 2)) is True
+    # The diagonal from the last point back to the first is never drawn, so a
+    # click on it must not register as a hit.
+    assert _hit(shape, (50, 50)) is False
+
+
+def test_points_shape_is_never_body_hit() -> None:
+    shape = Shape(
+        shape_type="points",
+        points=np.array([[10, 10], [20, 20]], dtype=np.float64),
+    )
+    assert _hit(shape, (10, 10)) is False
+
+
+def test_point_shape_hit_within_radius() -> None:
+    shape = Shape(
+        shape_type="point",
+        points=np.array([[10, 10]], dtype=np.float64),
+    )
+    # point_size / 2 == 4, so a point 2px away hits and one 10px away misses.
+    assert _hit(shape, (10, 12)) is True
+    assert _hit(shape, (10, 20)) is False
+
+
+def test_empty_point_shape_is_not_hit() -> None:
+    shape = Shape(shape_type="point")
+    assert _hit(shape, (0, 0)) is False
+
+
+def test_mask_shape_hit_reads_the_translated_pixel() -> None:
+    mask = np.zeros((5, 5), dtype=np.bool_)
+    mask[2, 3] = True
+    shape = Shape(
+        shape_type="mask",
+        points=np.array([[10, 10], [15, 15]], dtype=np.float64),
+        mask=mask,
+    )
+    # The mask origin is the bbox top-left (10, 10), so mask[2, 3] is at (13, 12).
+    assert _hit(shape, (13, 12)) is True
+    # Inside the bbox but where the mask is False.
+    assert _hit(shape, (11, 11)) is False
+    # Outside the mask array bounds is guarded to a miss.
+    assert _hit(shape, (5, 5)) is False
+    assert _hit(shape, (100, 100)) is False
+
+
+def test_polygon_hit_uses_path_containment() -> None:
+    shape = _unit_square_polygon()
+    assert _hit(shape, (5, 5)) is True
+    assert _hit(shape, (50, 50)) is False


### PR DESCRIPTION
`is_hit_by_point` is the shape hit-test that canvas selection and hover depend on, yet it had no direct unit coverage despite five distinct branches (line/linestrip edge distance, `points` never-hit, `point` radius, `mask` pixel lookup with an out-of-bounds guard, and the polygon/rectangle path-containment fallback) — it was exercised only transitively through GUI e2e canvas tests. This adds focused unit tests for each branch plus `bounds()`.

The two tests that reach the `QPainterPath` fallback are left unmarked (no `@pytest.mark.gui` / `qapp`): `QPainterPath` is a Qt value type whose `contains()` / `boundingRect()` run with no `QApplication`, confirmed by running them in isolation.

## Test plan
- [x] `uv run pytest tests/unit/widgets/_shape_render_test.py -q` — 12 passed
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean
