### PR TITLE
test(_shape): cover Shape rejecting an unknown shape_type

### DIFF
--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -204,6 +204,11 @@ def test_can_add_point(shape_type: ShapeType, expected: bool) -> None:
     assert Shape(shape_type=shape_type).can_add_point() is expected
 
 
+def test_constructor_rejects_unknown_shape_type() -> None:
+    with pytest.raises(ValueError, match="Unexpected shape_type: bogus"):
+        Shape(shape_type="bogus")  # ty: ignore[invalid-argument-type]
+
+
 def test_insert_point_keeps_points_and_labels_in_sync() -> None:
     shape = _make_square_polygon()
 


### PR DESCRIPTION
`Shape.__post_init__` guards every construction against an invalid `shape_type`
(`raise ValueError(f"Unexpected shape_type: ...")`), but that branch was the sole
uncovered line in `_shape.py`. This adds a test pinning that contract so a
regression in the guard is caught.

## Test plan
- [x] `uv run pytest tests/unit/_shape_test.py -q` (57 passed)
- [x] `uv run ruff check` and `uv run ty check` on the file
