### PR TITLE
docs(agents): document GitHub wayfinding operations convention

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -20,3 +20,22 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+GitHub's native sub-issue / dependency APIs are not reliably reachable via `gh`, so wayfinder maps use a body convention here:
+
+- **Map**: an issue labelled `wayfinder:map` plus a per-effort topic label `wayfinder:<effort>` (e.g. `wayfinder:config`). Body follows the wayfinder map template.
+
+- **Ticket**: a child issue labelled `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`) **and** the same `wayfinder:<effort>` topic label. Body ends with a metadata block:
+
+  ```
+  Map: #<map-number>
+  Blocked by: none            # or: #<n>, #<m>
+  ```
+
+- **Claim**: assign the ticket to the effort's dev (here, `wkentaro`) before any work. An open, **unassigned** ticket is unclaimed. The map issue is assigned to the owner from creation; that is ownership, not a claim.
+
+- **Frontier query**: `gh issue list --label wayfinder:<effort> --state open --json number,title,assignees,body` then keep tickets that are unassigned **and** whose every `Blocked by:` issue is closed.
+
+- **Resolve**: post the answer as a comment, `gh issue close`, then append a one-line gist + link to the map's Decisions-so-far.


### PR DESCRIPTION
Wayfinder maps need map/ticket/blocking/frontier operations on the issue tracker, but GitHub's native sub-issue and dependency APIs are not reliably reachable via `gh`. This records the body-convention fallback the config-robustness map (#2376) already runs on — a per-effort topic label for membership and the frontier query, `Blocked by:` lines for dependencies, assignee as the claim — so every wayfinder session on this repo works the map identically.

## Test plan
- [x] Markdown renders on GitHub (docs-only change)