### PR TITLE
test(shape-builders): cover dropping a detection with neither bbox nor mask

### DIFF
--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import math
+import typing
 
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
 from labelme._automation import MASK_REQUIRED_SHAPE_TYPES
+from labelme._automation import AiOutputFormat
 from labelme._automation import Detection
 from labelme._automation import shapes_from_detections
 
@@ -215,6 +217,20 @@ def test_shapes_from_detections_mask_drops_empty_mask() -> None:
         ],
         shape_type="mask",
     )
+    assert shapes == []
+
+
+@pytest.mark.parametrize("shape_type", typing.get_args(AiOutputFormat))
+def test_shapes_from_detections_without_bbox_or_mask_is_dropped(
+    shape_type: AiOutputFormat,
+) -> None:
+    # Every shape type needs a bbox, a mask, or both; with neither there is
+    # nothing to derive geometry from, so the detection is dropped.
+    shapes = shapes_from_detections(
+        detections=[Detection()],
+        shape_type=shape_type,
+    )
+
     assert shapes == []
 
 


### PR DESCRIPTION
`shapes_from_detections` builds a shape per detection, dropping any whose
geometry cannot be derived. Every output format needs a bbox, a mask, or both:
`rectangle` reads the bbox, `polygon` traces the mask, `mask` requires both, and
`circle`/`oriented_rectangle` derive from the mask with a bbox fallback. A
detection carrying neither is therefore dropped rather than emitted as a
degenerate shape.

Only the `rectangle` slice of that contract was covered
(`test_shapes_from_detections_rectangle_without_bbox_is_dropped`, which still
supplies a mask); the other formats were tested only for the "bbox present, mask
absent" fallback. This test parametrizes over `typing.get_args(AiOutputFormat)`
so the previously-untested "neither present" branch is covered for every format
and a newly added format is automatically held to the same contract, mirroring
how `MASK_REQUIRED_SHAPE_TYPES` is derived in the module itself.

## Test plan
- [x] `pytest tests/unit/_automation/_shape_builders_test.py` (21 passed)
- [x] `ruff check` / `ruff format --check` / `ty check` clean