### PR TITLE
refactor(_utils): drop unused img_data_to_arr re-export

### DIFF
--- a/labelme/_utils/__init__.py
+++ b/labelme/_utils/__init__.py
@@ -2,7 +2,6 @@ from .image import apply_exif_orientation
 from .image import img_arr_to_b64
 from .image import img_arr_to_data
 from .image import img_b64_to_arr
-from .image import img_data_to_arr
 from .image import img_data_to_pil
 from .image import img_qt_to_arr
 from .qt import add_actions


### PR DESCRIPTION
`img_data_to_arr` has no consumer via `labelme._utils` — it is only called internally by `img_b64_to_arr` in `image.py`. This drops the orphaned package-level re-export left behind after the public API surface removal, keeping the function itself (still used internally).

Same cleanup as the earlier drop of the sibling `img_pil_to_data` re-export (cd4fd993); this one was missed because the function still has an internal caller. Verified via repo-wide grep that no code under `labelme/` or `tests/` imports it via the package namespace; the `examples/` scripts use their own self-contained copy in `examples/utils.py`.

## Test plan
- [x] `uv run pytest tests/unit` (727 passed)
- [x] `uv run ruff check` / `uv run ty check`
- [x] `img_data_to_arr` still imports directly from `labelme._utils.image`; re-export gone from `labelme._utils`