### PR TITLE
refactor(label-list): drop no-op HTMLDelegate.__init__ override

### DIFF
--- a/labelme/_widgets/label_list_widget.py
+++ b/labelme/_widgets/label_list_widget.py
@@ -36,9 +36,6 @@ def format_shape_label(shape: Shape, fill_rgb: tuple[int, int, int]) -> str:
 class HTMLDelegate(QtWidgets.QStyledItemDelegate):
     _VERT_FUDGE: Final = 4
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
-        super().__init__(parent)
-
     def paint(
         self,
         painter: QtGui.QPainter,


### PR DESCRIPTION
`HTMLDelegate.__init__` only forwarded `parent` to `super().__init__(parent)`, which `QStyledItemDelegate` already does by inheritance. Removing the override changes nothing: both call sites (`HTMLDelegate()` and `HTMLDelegate(parent=self)`) construct identically against the inherited constructor. Same cleanup as #2339 (dropping `_LoggerIO` overrides that restated `io.StringIO` defaults).

## Test plan
- [x] `uv run pytest tests/` (882 passed)
- [x] `uv run ruff check .` / `uv run ty check` clean on the touched file
