### PR TITLE
refactor(config): remove dead logger_level config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the `logger_level` config key, which had no effect: log verbosity has always been controlled solely by the `--logger-level` CLI flag. A `logger_level` entry remaining in an existing `~/.labelmerc` is dropped on load, so old config files keep working unchanged ([#2402](https://github.com/wkentaro/labelme/pull/2402))
+
 ### Fixed
 
 - Fixed clicking or hovering near a linestrip's unrendered "closing" line (the straight path from its last point back to its first) being treated as a hit on the shape; edge hover, add-point-to-edge, and body selection now ignore that phantom segment, since a linestrip is an open polyline and never draws it ([#2307](https://github.com/wkentaro/labelme/pull/2307))

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -77,6 +77,10 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         logger.info("Migrating old config: store_data -> with_image_data")
         config_from_yaml["with_image_data"] = config_from_yaml.pop("store_data")
 
+    if "logger_level" in config_from_yaml:
+        logger.info("Migrating old config: removing logger_level")
+        del config_from_yaml["logger_level"]
+
     # A malformed section (e.g. `shortcuts: oops`) is left untouched here so the
     # merge in _update_dict reports it as a config error instead of crashing.
     shortcuts = config_from_yaml.get("shortcuts")

--- a/labelme/_config/default_config.yaml
+++ b/labelme/_config/default_config.yaml
@@ -5,7 +5,6 @@ with_image_data: false
 keep_prev: false
 keep_prev_scale: false
 keep_prev_brightness_contrast: false
-logger_level: info
 # UI language as a locale code (e.g. ja_JP); null follows the system locale.
 language:
 # Color theme: 'system' follows the OS appearance, or force 'light' / 'dark'.

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -43,6 +43,13 @@ def test_migrate_store_data_to_with_image_data(tmp_path: Path, old_value: bool) 
     assert "store_data" not in config
 
 
+def test_migrate_removes_logger_level(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("logger_level: info\n")
+    config = _config.load_config(config_file=config_file, config_overrides={})
+    assert "logger_level" not in config
+
+
 @pytest.mark.parametrize(
     "input_name, expected_name",
     [


### PR DESCRIPTION
The `logger_level` key in `default_config.yaml` is never read from the loaded config: `__main__.py` pops it out of the CLI overrides, and only the `--logger-level` flag configures loguru. This removes the dead key and adds a migration that drops it from existing `~/.labelmerc` files so they keep loading without an unknown-key error.

## Test plan
- [x] `test_migrate_removes_logger_level` covers a config file that still contains the key
- [x] `uv run pytest tests -x -q` (883 passed), ruff + ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
