### PR TITLE
fix(shape): copy the caller's arrays so a Shape owns its points

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -48,8 +48,8 @@ class Shape:
     def __post_init__(self) -> None:
         if self.shape_type not in typing.get_args(ShapeType):
             raise ValueError(f"Unexpected shape_type: {self.shape_type}")
-        self.points = np.asarray(self.points, dtype=np.float64).reshape(-1, 2)
-        self.point_labels = np.asarray(self.point_labels, dtype=np.int_).reshape(-1)
+        self.points = np.array(self.points, dtype=np.float64).reshape(-1, 2)
+        self.point_labels = np.array(self.point_labels, dtype=np.int_).reshape(-1)
         if len(self.point_labels) == 0 and len(self.points) > 0:
             self.point_labels = np.ones(len(self.points), dtype=np.int_)
 

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -348,6 +348,28 @@ def test_move_vertex_replaces_only_target_point() -> None:
     assert shape.points[3] == pytest.approx((0.0, 10.0))
 
 
+def test_move_vertex_does_not_mutate_the_array_given_to_the_constructor() -> None:
+    points = np.array([(0.0, 0.0), (10.0, 0.0)], dtype=np.float64)
+    shape = Shape(shape_type="line", points=points)
+
+    shape.move_vertex(i=0, pos=(999.0, 999.0))
+
+    assert points[0] == pytest.approx((0.0, 0.0))
+
+
+def test_constructor_copies_the_given_point_labels() -> None:
+    point_labels = np.array([1, 1], dtype=np.int_)
+    shape = Shape(
+        shape_type="line",
+        points=np.array([(0.0, 0.0), (10.0, 0.0)], dtype=np.float64),
+        point_labels=point_labels,
+    )
+
+    point_labels[1] = 0
+
+    assert int(shape.point_labels[1]) == 1
+
+
 def test_translate_shifts_all_points_by_offset() -> None:
     shape = _make_square_polygon()
 


### PR DESCRIPTION
`Shape.__post_init__` normalized `points` / `point_labels` with `np.asarray`, which returns the caller's buffer untouched when it already has the target dtype and layout. `move_vertex` writes into `self.points` in place, so editing a `Shape` silently mutated the array its constructor was handed:

```python
points = np.array([[0.0, 0.0], [10.0, 10.0]], dtype=np.float64)
shape = Shape(shape_type="line", points=points)
shape.move_vertex(i=0, pos=(999.0, 999.0))
points[0]  # -> [999., 999.], never touched by the caller
```

`np.array` copies unconditionally, so a `Shape` now owns its arrays.

No `CHANGELOG.md` entry: the bug is latent, not user-reachable. All three construction sites already hand over a fresh array — `np.array(...)` in `_app.py:2822` and `canvas.py:86`, and a dtype-mismatched `float32`/list in `_shape_builders.py:40`, which forces `asarray` to copy — so no shipped flow could observe it. The extra copy costs microseconds on shapes of 2-4 points (a few hundred at most for a polygon), and `Shape` construction is not a hot loop.

## Test plan
- [x] two regression tests in `tests/unit/_shape_test.py`, both failing before the fix: a shape edit no longer leaks into the caller's `points`, and a caller's edit no longer leaks into `shape.point_labels`
- [x] `make test` (893 passed), including the offscreen e2e suite that drives the real window through shape editing, annotation, and oriented-rectangle drag
- [x] `make lint`
