### PR TITLE
test(_app): cover _shapes_from_dicts label_flags merge on load

### DIFF
--- a/tests/unit/_app_test.py
+++ b/tests/unit/_app_test.py
@@ -4,6 +4,7 @@ import struct
 import zlib
 from collections.abc import Callable
 
+import numpy as np
 import pytest
 from PySide6 import QtCore
 from PySide6 import QtGui
@@ -12,6 +13,7 @@ from PySide6 import QtWidgets
 from labelme import __appname__
 from labelme import _app
 from labelme import _automation
+from labelme._label_file import ShapeDict
 
 
 @pytest.mark.parametrize(
@@ -219,3 +221,111 @@ def test_make_image_too_large_message_is_none_within_allocation_limit(
         )
         is None
     )
+
+
+def _make_shape_dict(*, label: str, flags: dict[str, bool]) -> ShapeDict:
+    return ShapeDict(
+        label=label,
+        points=[[0.0, 0.0], [10.0, 20.0]],
+        shape_type="rectangle",
+        flags=flags,
+        description="",
+        group_id=None,
+        mask=None,
+        other_data={},
+    )
+
+
+@pytest.mark.parametrize(
+    "label, saved_flags, label_flags, expected",
+    [
+        (
+            "cat",
+            {},
+            {"^cat$": ["occluded", "truncated"]},
+            {"occluded": False, "truncated": False},
+        ),
+        (
+            "cat",
+            {"occluded": True},
+            {"^cat$": ["occluded", "truncated"]},
+            {"occluded": True, "truncated": False},
+        ),
+        (
+            "cat",
+            {"reviewed": True},
+            {"^cat$": ["occluded"]},
+            {"occluded": False, "reviewed": True},
+        ),
+        ("dog", {}, {"^cat$": ["occluded"]}, {}),
+        ("bigcat", {}, {"cat$": ["occluded"]}, {}),
+        (
+            "cat",
+            {},
+            {"^cat$": ["occluded"], "^ca": ["blurry"], "^dog$": ["truncated"]},
+            {"occluded": False, "blurry": False},
+        ),
+        ("cat", {"occluded": True}, None, {"occluded": True}),
+        ("cat", {"occluded": True}, {}, {"occluded": True}),
+    ],
+    ids=[
+        "matched-keys-default-to-false",
+        "saved-flag-overrides-default",
+        "saved-flag-outside-config-kept",
+        "unmatched-pattern-seeds-nothing",
+        "pattern-anchored-at-the-label-start",
+        "matching-patterns-union",
+        "label-flags-none",
+        "label-flags-empty",
+    ],
+)
+def test_shapes_from_dicts_merges_label_flags(
+    label: str,
+    saved_flags: dict[str, bool],
+    label_flags: dict[str, list[str]] | None,
+    expected: dict[str, bool],
+) -> None:
+    (shape,) = _app._shapes_from_dicts(
+        shape_dicts=[_make_shape_dict(label=label, flags=saved_flags)],
+        label_flags=label_flags,
+    )
+    assert shape.flags == expected
+
+
+def test_shapes_from_dicts_gives_each_shape_its_own_flags() -> None:
+    shapes = _app._shapes_from_dicts(
+        shape_dicts=[
+            _make_shape_dict(label="cat", flags={"occluded": True}),
+            _make_shape_dict(label="cat", flags={}),
+        ],
+        label_flags={"^cat$": ["occluded"]},
+    )
+    assert [shape.flags for shape in shapes] == [
+        {"occluded": True},
+        {"occluded": False},
+    ]
+
+
+def test_shapes_from_dicts_carries_over_the_shape_fields() -> None:
+    mask = np.ones((2, 3), dtype=bool)
+    shape_dict = ShapeDict(
+        label="car",
+        points=[[1.0, 2.0], [3.0, 4.0]],
+        shape_type="mask",
+        flags={},
+        description="a parked car",
+        group_id=7,
+        mask=mask,
+        other_data={"score": 0.9},
+    )
+
+    (shape,) = _app._shapes_from_dicts(shape_dicts=[shape_dict], label_flags=None)
+
+    assert shape.label == "car"
+    assert shape.shape_type == "mask"
+    assert shape.description == "a parked car"
+    assert shape.group_id == 7
+    assert shape.other_data == {"score": 0.9}
+    np.testing.assert_array_equal(shape.mask, mask)
+    assert shape.points.dtype == np.float64
+    assert shape.points.tolist() == [[1.0, 2.0], [3.0, 4.0]]


### PR DESCRIPTION
`_shapes_from_dicts` is the annotation-load path that rebuilds Shapes from saved
ShapeDicts and seeds each Shape's Flags from the `label_flags` config. It had no test,
so a regression in that merge would silently reset every Shape Flag on reopened
Annotation Files — data loss that surfaces long after the change that caused it.

These tests pin the merge contract: keys of a matching pattern default to `False`, saved
Flags win over those defaults, saved Flags outside the config are kept, patterns are
anchored at the label start (`re.match`, matching `LabelDialog`'s behavior), and each
Shape gets its own Flags dict rather than sharing one. A separate test covers the plain
field carry-over (label, shape_type, group_id, description, mask, other_data, and the
float64 points conversion).

No production code changes.

## Test plan
- [x] tests added: `tests/unit/_app_test.py` (10 cases)
- [x] mutation-checked — each of these makes the new tests fail: reversing the merge
      order so defaults overwrite saved Flags, `re.match` -> `re.search`, and seeding
      defaults as `True`
- [x] `make test` (901 passed), `make lint`
