### PR TITLE
refactor(config): group shape color settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Grouped Shape coloring under one `shape_color` setting with explicit `auto`, `uniform`, and `by_label` modes, replacing the loosely coupled `default_shape_color`, `shift_auto_shape_color`, and `label_colors` keys. Existing Config Files and inline `--config` values are migrated in memory, preserving their behavior and override precedence ([#2426](https://github.com/wkentaro/labelme/pull/2426))
+
 ### Removed
 
 - Removed the `logger_level` config key, which had no effect: log verbosity has always been controlled solely by the `--logger-level` CLI flag. A `logger_level` entry remaining in an existing `~/.labelmerc` is dropped on load, so old config files keep working unchanged ([#2402](https://github.com/wkentaro/labelme/pull/2402))

--- a/examples/instance_segmentation/README.md
+++ b/examples/instance_segmentation/README.md
@@ -3,7 +3,7 @@
 ## Annotation
 
 ```bash
-labelme data_annotated --labels labels.txt --validate-label exact --config '{shift_auto_shape_color: -2}'
+labelme data_annotated --labels labels.txt --validate-label exact --config '{shape_color: {mode: auto, auto: {shift: -2}}}'
 labelme data_annotated --labels labels.txt --label-flags '{.*: [occluded, truncated], person: [male]}'
 ```
 

--- a/examples/semantic_segmentation/README.md
+++ b/examples/semantic_segmentation/README.md
@@ -3,7 +3,7 @@
 ## Annotation
 
 ```bash
-labelme data_annotated --labels labels.txt --validate-label exact --config '{shift_auto_shape_color: -2}'
+labelme data_annotated --labels labels.txt --validate-label exact --config '{shape_color: {mode: auto, auto: {shift: -2}}}'
 ```
 
 ![](.readme/annotation.jpg)

--- a/examples/video_annotation/README.md
+++ b/examples/video_annotation/README.md
@@ -3,7 +3,7 @@
 ## Annotation
 
 ```bash
-labelme data_annotated --labels labels.txt --keep-prev --config '{shift_auto_shape_color: -2}'
+labelme data_annotated --labels labels.txt --keep-prev --config '{shape_color: {mode: auto, auto: {shift: -2}}}'
 ```
 
 <img src=".readme/00000100.jpg" width="49%" /> <img src=".readme/00000101.jpg" width="49%" />

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -17,12 +17,10 @@ from typing import NamedTuple
 from typing import TypeAlias
 from typing import cast
 
-import imgviz
 import natsort
 import numpy as np
 import osam
 from loguru import logger
-from numpy.typing import NDArray
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
@@ -46,6 +44,7 @@ from ._label_file import write_label_file
 from ._shape import Shape
 from ._shape import ShapeType
 from ._shape_clipboard import ShapeClipboard
+from ._shape_color import resolve_shape_color
 from ._widgets import AiAssistedAnnotationWidget
 from ._widgets import AiTextToAnnotationWidget
 from ._widgets import BrightnessContrastDialog
@@ -61,8 +60,6 @@ from ._widgets import UniqueLabelQListWidget
 from ._widgets import ZoomWidget
 from ._widgets import download_ai_model
 from ._widgets import format_shape_label
-
-LABEL_COLORMAP: NDArray[np.uint8] = imgviz.label_colormap()
 
 
 class _ZoomMode(enum.Enum):
@@ -1717,28 +1714,17 @@ class MainWindow(QtWidgets.QMainWindow):
         label: str,
         unique_label_list: UniqueLabelQListWidget,
     ) -> tuple[int, int, int]:
-        if self._config["shape_color"] == "auto":
-            item = unique_label_list.find_label_item(label)
-            item_index: int = (
-                unique_label_list.indexFromItem(item).row()
-                if item
-                else unique_label_list.count()
-            )
-            label_id: int = (
-                1  # skip black color by default
-                + item_index
-                + self._config["shift_auto_shape_color"]
-            )
-            return _rgb_from_colormap_id(label_id=label_id)
-        if self._config["shape_color"] == "manual":
-            rgb = _rgb_from_label_colors(
-                label=label, label_colors=self._config["label_colors"]
-            )
-            if rgb is not None:
-                return rgb
-        if self._config["default_shape_color"]:
-            return self._config["default_shape_color"]
-        return (0, 255, 0)
+        item = unique_label_list.find_label_item(label)
+        label_index: int = (
+            unique_label_list.indexFromItem(item).row()
+            if item
+            else unique_label_list.count()
+        )
+        return resolve_shape_color(
+            config=self._config["shape_color"],
+            label=label,
+            label_index=label_index,
+        )
 
     def remove_labels(self, shapes: list[Shape]) -> None:
         self._docks.label_list.item_dropped.disconnect(self._on_label_order_changed)
@@ -2854,23 +2840,6 @@ def _resolve_text_annotation_shape_type(
     if create_mode in typing.get_args(_TextToAnnotationCreateMode):
         return cast(_TextToAnnotationCreateMode, create_mode)
     return None
-
-
-def _rgb_from_colormap_id(*, label_id: int) -> tuple[int, int, int]:
-    r, g, b = LABEL_COLORMAP[label_id % len(LABEL_COLORMAP)].tolist()
-    return r, g, b
-
-
-def _rgb_from_label_colors(
-    *, label: str, label_colors: dict[str, list[int]] | None
-) -> tuple[int, int, int] | None:
-    if not label_colors or label not in label_colors:
-        return None
-    rgb = label_colors[label]
-    if len(rgb) != 3 or not all(0 <= c <= 255 for c in rgb):
-        raise ValueError(f"Color for label must be 0-255 RGB tuple, but got: {rgb}")
-    r, g, b = rgb
-    return r, g, b
 
 
 def _is_valid_label(

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import re
 from collections.abc import Callable
 from collections.abc import Sized
@@ -9,6 +10,8 @@ from typing import cast
 from loguru import logger
 
 from .. import _yaml
+from ._shape_color import migrate_shape_color
+from ._shape_color import validate_shape_color
 from ._writer import set_overrides
 
 here = Path(__file__).resolve().parent
@@ -51,8 +54,6 @@ def _update_dict(
 def _validate_config_item(key: str, value: object) -> None:
     if key == "validate_label" and value not in [None, "exact"]:
         raise ValueError(f"Unexpected value for config key 'validate_label': {value}")
-    if key == "shape_color" and value not in [None, "auto", "manual"]:
-        raise ValueError(f"Unexpected value for config key 'shape_color': {value}")
     if (
         key == "labels"
         and isinstance(value, Sized)
@@ -62,6 +63,7 @@ def _validate_config_item(key: str, value: object) -> None:
 
 
 def _migrate_config_from_file(config_from_yaml: dict) -> None:
+    migrate_shape_color(config=config_from_yaml)
     keep_prev_brightness: bool = config_from_yaml.pop("keep_prev_brightness", False)
     keep_prev_contrast: bool = config_from_yaml.pop("keep_prev_contrast", False)
     if keep_prev_brightness or keep_prev_contrast:
@@ -174,11 +176,18 @@ def load_config(config_file: Path | None, config_overrides: dict) -> dict:
             config_from_yaml = _yaml.safe_load(f)
         if isinstance(config_from_yaml, dict):
             _migrate_config_from_file(config_from_yaml=config_from_yaml)
+            if "shape_color" in config_from_yaml:
+                validate_shape_color(config=config_from_yaml["shape_color"])
             _update_dict(config, config_from_yaml, validate_item=_validate_config_item)
 
+    config_overrides = copy.deepcopy(config_overrides)
+    migrate_shape_color(config=config_overrides)
+    if "shape_color" in config_overrides:
+        validate_shape_color(config=config_overrides["shape_color"])
     _update_dict(config, config_overrides, validate_item=_validate_config_item)
 
     if not config["labels"] and config["validate_label"]:
         raise ValueError("labels must be specified when validate_label is enabled")
+    validate_shape_color(config=config["shape_color"])
 
     return config

--- a/labelme/_config/_shape_color.py
+++ b/labelme/_config/_shape_color.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import cast
+
+from loguru import logger
+
+
+def _is_rgb(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) == 3
+        and all(
+            isinstance(channel, int)
+            and not isinstance(channel, bool)
+            and 0 <= channel <= 255
+            for channel in value
+        )
+    )
+
+
+def _validate_rgb(*, path: str, value: object) -> None:
+    if not _is_rgb(value):
+        raise ValueError(f"{path} must be a list of three integers from 0 to 255")
+
+
+def validate_shape_color(*, config: object) -> None:
+    if not isinstance(config, dict):
+        raise ValueError("shape_color must be a mapping")
+    config = cast(dict[str, object], config)
+    if "mode" in config and config["mode"] not in ["auto", "uniform", "by_label"]:
+        raise ValueError(
+            "shape_color.mode must be one of 'auto', 'uniform', or 'by_label'"
+        )
+    if "auto" in config:
+        auto = config["auto"]
+        if auto is None:
+            auto = {}
+        if not isinstance(auto, dict):
+            raise ValueError("shape_color.auto must be a mapping")
+        auto = cast(dict[str, object], auto)
+        if "shift" in auto:
+            shift = auto["shift"]
+            if not isinstance(shift, int) or isinstance(shift, bool):
+                raise ValueError("shape_color.auto.shift must be an integer")
+    if "uniform" in config:
+        uniform = config["uniform"]
+        if uniform is None:
+            uniform = {}
+        if not isinstance(uniform, dict):
+            raise ValueError("shape_color.uniform must be a mapping")
+        uniform = cast(dict[str, object], uniform)
+        if "color" in uniform:
+            _validate_rgb(path="shape_color.uniform.color", value=uniform["color"])
+    if "by_label" in config:
+        by_label = config["by_label"]
+        if by_label is None:
+            by_label = {}
+        if not isinstance(by_label, dict):
+            raise ValueError("shape_color.by_label must be a mapping")
+        by_label = cast(dict[str, object], by_label)
+        if "fallback" in by_label:
+            _validate_rgb(
+                path="shape_color.by_label.fallback", value=by_label["fallback"]
+            )
+        if "colors" in by_label and by_label["colors"] is not None:
+            colors = by_label["colors"]
+            if not isinstance(colors, dict):
+                raise ValueError("shape_color.by_label.colors must be a mapping")
+            for label, color in colors.items():
+                if not isinstance(label, str) or not label:
+                    raise ValueError(
+                        "shape_color.by_label.colors keys must be non-empty strings"
+                    )
+                _validate_rgb(path=f"shape_color.by_label.colors.{label}", value=color)
+
+
+def migrate_shape_color(*, config: dict) -> None:
+    """Migrate legacy shape color keys in place."""
+    legacy_siblings = {
+        "default_shape_color",
+        "shift_auto_shape_color",
+        "label_colors",
+    }
+    raw_shape_color = config.get("shape_color")
+    has_legacy_shape_color = "shape_color" in config and not isinstance(
+        raw_shape_color, dict
+    )
+    has_legacy_sibling = any(key in config for key in legacy_siblings)
+    if isinstance(raw_shape_color, dict):
+        if has_legacy_sibling:
+            raise ValueError(
+                "New shape_color config cannot be combined with legacy color keys"
+            )
+        return
+    if not has_legacy_shape_color and not has_legacy_sibling:
+        return
+    if raw_shape_color not in [None, "auto", "manual"]:
+        raise ValueError(
+            f"Unexpected value for config key 'shape_color': {raw_shape_color}"
+        )
+
+    logger.info("Migrating legacy shape color config to nested shape_color settings")
+    shape_color: dict = {}
+    if has_legacy_shape_color:
+        shape_color["mode"] = {
+            "auto": "auto",
+            "manual": "by_label",
+            None: "uniform",
+        }[raw_shape_color]
+    if "shift_auto_shape_color" in config:
+        shape_color["auto"] = {"shift": config.pop("shift_auto_shape_color")}
+    if "default_shape_color" in config:
+        default_color = config.pop("default_shape_color")
+        if default_color is None:
+            default_color = [0, 255, 0]
+        shape_color["uniform"] = {"color": default_color}
+        shape_color.setdefault("by_label", {})["fallback"] = default_color
+    if "label_colors" in config:
+        shape_color.setdefault("by_label", {})["colors"] = config.pop("label_colors")
+    config.pop("shape_color", None)
+    config["shape_color"] = shape_color

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -12,6 +12,8 @@ from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.comments import CommentedSeq
 
 from .. import _yaml
+from ._shape_color import migrate_shape_color
+from ._shape_color import validate_shape_color
 
 here = Path(__file__).resolve().parent
 
@@ -87,6 +89,11 @@ def set_overrides(
     )
     if not isinstance(doc, CommentedMap):
         doc = CommentedMap()
+    writes_shape_color = any(
+        key_path and key_path[0] == "shape_color" for key_path, _value in overrides
+    )
+    if writes_shape_color:
+        migrate_shape_color(config=doc)
 
     # All overrides mutate the in-memory doc before the single write below, so a
     # bad key anywhere in the batch leaves the file untouched (all-or-nothing).
@@ -97,6 +104,9 @@ def set_overrides(
             _prune(doc=doc, key_path=key_path)
         else:
             _assign(doc=doc, key_path=key_path, value=value)
+
+    if writes_shape_color and "shape_color" in doc:
+        validate_shape_color(config=doc["shape_color"])
 
     content = ""
     if doc:

--- a/labelme/_config/default_config.yaml
+++ b/labelme/_config/default_config.yaml
@@ -15,10 +15,15 @@ labels:
 file_search:
 sort_labels: true
 validate_label:
-default_shape_color: [0, 255, 0]
-shape_color: auto  # null, 'auto', 'manual'
-shift_auto_shape_color: 0
-label_colors:
+shape_color:
+  mode: auto  # auto, uniform, by_label
+  auto:
+    shift: 0
+  uniform:
+    color: [0, 255, 0]
+  by_label:
+    colors:
+    fallback: [0, 255, 0]
 shape:
   # drawing
   line_color: [0, 255, 0, 128]

--- a/labelme/_shape_color.py
+++ b/labelme/_shape_color.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import imgviz
+import numpy as np
+from numpy.typing import NDArray
+
+_LABEL_COLORMAP: NDArray[np.uint8] = imgviz.label_colormap()
+
+
+def resolve_shape_color(
+    *, config: dict, label: str, label_index: int
+) -> tuple[int, int, int]:
+    mode = config["mode"]
+    if mode == "auto":
+        label_id = 1 + label_index + config["auto"]["shift"]
+        r, g, b = _LABEL_COLORMAP[label_id % len(_LABEL_COLORMAP)].tolist()
+        return r, g, b
+    if mode == "uniform":
+        r, g, b = config["uniform"]["color"]
+        return r, g, b
+
+    colors = config["by_label"]["colors"]
+    rgb = colors.get(label) if colors else None
+    if rgb is None:
+        rgb = config["by_label"]["fallback"]
+    r, g, b = rgb
+    return r, g, b

--- a/tests/unit/_app_test.py
+++ b/tests/unit/_app_test.py
@@ -38,48 +38,6 @@ def test_resolve_text_annotation_shape_type(
 
 
 @pytest.mark.parametrize(
-    "label, label_colors, expected",
-    [
-        ("cat", None, None),
-        ("cat", {}, None),
-        ("cat", {"dog": [1, 2, 3]}, None),
-        ("cat", {"cat": [255, 0, 128]}, (255, 0, 128)),
-        ("cat", {"cat": [0, 0, 0]}, (0, 0, 0)),
-    ],
-    ids=[
-        "colors-none",
-        "colors-empty",
-        "label-not-in-colors",
-        "valid-rgb",
-        "valid-rgb-zero-bound",
-    ],
-)
-def test_rgb_from_label_colors_returns_rgb_or_none(
-    label: str,
-    label_colors: dict[str, list[int]] | None,
-    expected: tuple[int, int, int] | None,
-) -> None:
-    assert (
-        _app._rgb_from_label_colors(label=label, label_colors=label_colors) == expected
-    )
-
-
-@pytest.mark.parametrize(
-    "rgb",
-    [[256, 0, 0], [-1, 0, 0], [0, 0], [0, 0, 0, 0]],
-    ids=[
-        "channel-too-high",
-        "channel-too-low",
-        "too-few-channels",
-        "too-many-channels",
-    ],
-)
-def test_rgb_from_label_colors_rejects_invalid_rgb(rgb: list[int]) -> None:
-    with pytest.raises(ValueError, match="0-255 RGB tuple"):
-        _app._rgb_from_label_colors(label="cat", label_colors={"cat": rgb})
-
-
-@pytest.mark.parametrize(
     "label, existing_labels, policy, expected",
     [
         ("cat", [], None, True),

--- a/tests/unit/_config/_writer_test.py
+++ b/tests/unit/_config/_writer_test.py
@@ -104,10 +104,85 @@ def test_writes_list_in_flow_style(tmp_path: Path) -> None:
 
     _config.set_overrides(
         config_file=config_file,
-        overrides=[(["default_shape_color"], [255, 0, 0])],
+        overrides=[(["shape_color", "uniform", "color"], [255, 0, 0])],
     )
 
-    assert "default_shape_color: [255, 0, 0]" in config_file.read_text(encoding="utf-8")
+    assert "color: [255, 0, 0]" in config_file.read_text(encoding="utf-8")
+
+
+def test_nested_shape_color_write_migrates_legacy_scalar_config(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text(
+        "shape_color: manual\nlabel_colors:\n  cat: [1, 2, 3]\n",
+        encoding="utf-8",
+    )
+
+    _config.set_overrides(
+        config_file=config_file,
+        overrides=[(["shape_color", "by_label", "fallback"], [4, 5, 6])],
+    )
+
+    assert _parse(config_file) == {
+        "shape_color": {
+            "mode": "by_label",
+            "by_label": {
+                "colors": {"cat": [1, 2, 3]},
+                "fallback": [4, 5, 6],
+            },
+        }
+    }
+    config = _config.load_config(config_file=config_file, config_overrides={})
+    assert config["shape_color"]["by_label"]["fallback"] == [4, 5, 6]
+
+
+def test_nested_shape_color_write_removes_legacy_sibling_keys(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text(
+        "default_shape_color: [1, 2, 3]\n",
+        encoding="utf-8",
+    )
+
+    _config.set_overrides(
+        config_file=config_file,
+        overrides=[(["shape_color", "auto", "shift"], 2)],
+    )
+
+    assert _parse(config_file) == {
+        "shape_color": {
+            "auto": {"shift": 2},
+            "uniform": {"color": [1, 2, 3]},
+            "by_label": {"fallback": [1, 2, 3]},
+        }
+    }
+    _config.load_config(config_file=config_file, config_overrides={})
+
+
+def test_shape_color_write_rejects_invalid_legacy_values(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    original = "shape_color: manual\nshift_auto_shape_color: invalid\n"
+    config_file.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="shape_color.auto.shift"):
+        _config.set_overrides(
+            config_file=config_file,
+            overrides=[(["shape_color", "by_label", "fallback"], [4, 5, 6])],
+        )
+
+    assert config_file.read_text(encoding="utf-8") == original
+
+
+def test_shape_color_write_rejects_invalid_new_value(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    original = "shape_color: manual\n"
+    config_file.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="shape_color.by_label.fallback"):
+        _config.set_overrides(
+            config_file=config_file,
+            overrides=[(["shape_color", "by_label", "fallback"], [999, 0, 0])],
+        )
+
+    assert config_file.read_text(encoding="utf-8") == original
 
 
 def test_set_overrides_applies_batch_in_one_write(tmp_path: Path) -> None:

--- a/tests/unit/_config_test.py
+++ b/tests/unit/_config_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -291,4 +292,204 @@ def test_load_config_requires_labels_when_validate_label_enabled() -> None:
     ):
         _config.load_config(
             config_file=None, config_overrides={"validate_label": "exact"}
+        )
+
+
+@pytest.mark.parametrize(
+    ("legacy", "expected"),
+    [
+        (
+            {"shape_color": "auto", "shift_auto_shape_color": -2},
+            {
+                "mode": "auto",
+                "auto": {"shift": -2},
+                "uniform": {"color": [0, 255, 0]},
+                "by_label": {"colors": None, "fallback": [0, 255, 0]},
+            },
+        ),
+        (
+            {
+                "shape_color": None,
+                "default_shape_color": [215, 60, 233],
+            },
+            {
+                "mode": "uniform",
+                "auto": {"shift": 0},
+                "uniform": {"color": [215, 60, 233]},
+                "by_label": {"colors": None, "fallback": [215, 60, 233]},
+            },
+        ),
+        (
+            {
+                "shape_color": "manual",
+                "default_shape_color": [215, 60, 233],
+                "label_colors": {"cat": [255, 0, 0]},
+            },
+            {
+                "mode": "by_label",
+                "auto": {"shift": 0},
+                "uniform": {"color": [215, 60, 233]},
+                "by_label": {
+                    "colors": {"cat": [255, 0, 0]},
+                    "fallback": [215, 60, 233],
+                },
+            },
+        ),
+    ],
+    ids=["auto", "uniform", "by-label"],
+)
+def test_load_config_migrates_legacy_shape_color_from_file(
+    tmp_path: Path, legacy: dict, expected: dict
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(json.dumps(legacy))
+
+    config = _config.load_config(config_file=config_file, config_overrides={})
+
+    assert config["shape_color"] == expected
+    assert "default_shape_color" not in config
+    assert "shift_auto_shape_color" not in config
+    assert "label_colors" not in config
+
+
+def test_load_config_migrates_legacy_shape_color_from_overrides() -> None:
+    config = _config.load_config(
+        config_file=None,
+        config_overrides={
+            "shape_color": "manual",
+            "default_shape_color": [215, 60, 233],
+            "label_colors": {"cat": [255, 0, 0]},
+        },
+    )
+
+    assert config["shape_color"]["mode"] == "by_label"
+    assert config["shape_color"]["by_label"] == {
+        "colors": {"cat": [255, 0, 0]},
+        "fallback": [215, 60, 233],
+    }
+
+
+def test_load_config_migrates_legacy_shape_color_sibling_without_mode() -> None:
+    config = _config.load_config(
+        config_file=None,
+        config_overrides={"default_shape_color": [215, 60, 233]},
+    )
+
+    assert config["shape_color"]["mode"] == "auto"
+    assert config["shape_color"]["uniform"]["color"] == [215, 60, 233]
+
+
+def test_load_config_rejects_invalid_migrated_legacy_shape_color(
+    tmp_path: Path,
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        json.dumps(
+            {
+                "shape_color": "manual",
+                "shift_auto_shape_color": "invalid",
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="shape_color.auto.shift"):
+        _config.load_config(config_file=config_file, config_overrides={})
+
+
+def test_load_config_rejects_falsey_invalid_legacy_default_shape_color(
+    tmp_path: Path,
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("shape_color: null\ndefault_shape_color: []\n")
+
+    with pytest.raises(ValueError, match="shape_color.uniform.color"):
+        _config.load_config(config_file=config_file, config_overrides={})
+
+
+def test_load_config_native_empty_shape_color_section_keeps_defaults() -> None:
+    config = _config.load_config(
+        config_file=None,
+        config_overrides={"shape_color": {"auto": None}},
+    )
+
+    assert config["shape_color"]["auto"] == {"shift": 0}
+
+
+def test_load_config_validates_native_shape_color_over_legacy_file(
+    tmp_path: Path,
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("shape_color: manual\n")
+
+    with pytest.raises(ValueError, match="shape_color.auto.shift"):
+        _config.load_config(
+            config_file=config_file,
+            config_overrides={"shape_color": {"auto": {"shift": "invalid"}}},
+        )
+
+
+def test_legacy_shape_color_override_preserves_config_file_values(
+    tmp_path: Path,
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+shape_color:
+  mode: uniform
+  uniform:
+    color: [1, 2, 3]
+  by_label:
+    colors:
+      cat: [4, 5, 6]
+    fallback: [7, 8, 9]
+"""
+    )
+
+    config = _config.load_config(
+        config_file=config_file,
+        config_overrides={"shift_auto_shape_color": -2},
+    )
+
+    assert config["shape_color"] == {
+        "mode": "uniform",
+        "auto": {"shift": -2},
+        "uniform": {"color": [1, 2, 3]},
+        "by_label": {
+            "colors": {"cat": [4, 5, 6]},
+            "fallback": [7, 8, 9],
+        },
+    }
+
+
+def test_load_config_rejects_mixed_new_and_legacy_shape_color() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _config.load_config(
+            config_file=None,
+            config_overrides={
+                "shape_color": {"mode": "uniform"},
+                "default_shape_color": [215, 60, 233],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("shape_color", "message"),
+    [
+        ({"mode": "random"}, "shape_color.mode"),
+        ({"auto": {"shift": True}}, "shape_color.auto.shift"),
+        ({"uniform": {"color": [256, 0, 0]}}, "shape_color.uniform.color"),
+        (
+            {"by_label": {"colors": {"cat": [0, 0]}}},
+            "shape_color.by_label.colors.cat",
+        ),
+    ],
+    ids=["mode", "shift", "uniform-rgb", "label-rgb"],
+)
+def test_load_config_rejects_invalid_shape_color(
+    shape_color: dict, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _config.load_config(
+            config_file=None,
+            config_overrides={"shape_color": shape_color},
         )

--- a/tests/unit/_shape_color_test.py
+++ b/tests/unit/_shape_color_test.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from labelme._shape_color import resolve_shape_color
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "mode": "auto",
+                "auto": {"shift": -1},
+                "uniform": {"color": [0, 255, 0]},
+                "by_label": {"colors": None, "fallback": [0, 255, 0]},
+            },
+            (0, 0, 0),
+        ),
+        (
+            {
+                "mode": "uniform",
+                "auto": {"shift": 0},
+                "uniform": {"color": [215, 60, 233]},
+                "by_label": {"colors": None, "fallback": [0, 255, 0]},
+            },
+            (215, 60, 233),
+        ),
+        (
+            {
+                "mode": "by_label",
+                "auto": {"shift": 0},
+                "uniform": {"color": [0, 255, 0]},
+                "by_label": {
+                    "colors": {"cat": [255, 0, 0]},
+                    "fallback": [215, 60, 233],
+                },
+            },
+            (255, 0, 0),
+        ),
+        (
+            {
+                "mode": "by_label",
+                "auto": {"shift": 0},
+                "uniform": {"color": [0, 255, 0]},
+                "by_label": {
+                    "colors": {"dog": [0, 0, 255]},
+                    "fallback": [215, 60, 233],
+                },
+            },
+            (215, 60, 233),
+        ),
+    ],
+    ids=["auto", "uniform", "by-label-match", "by-label-fallback"],
+)
+def test_resolve_shape_color(config: dict, expected: tuple[int, int, int]) -> None:
+    assert resolve_shape_color(config=config, label="cat", label_index=0) == expected


### PR DESCRIPTION
## Summary
- replace the four loosely coupled Shape-color keys with one mode-based nested Setting
- migrate legacy Config Files and inline `--config` overrides while preserving layered override precedence and inactive values
- validate the complete color schema during config loading and resolve colors through a Qt-free module

Legacy values remain accepted and are normalized in memory; canonical configuration uses `auto`, `uniform`, or `by_label` modes.

## Test plan
- [x] migration and resolution regression tests
- [x] `uv run pytest -q tests` (897 passed)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check --no-progress`