### PR TITLE
refactor(config): replace set_override with batched writes

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2476,17 +2476,23 @@ class MainWindow(QtWidgets.QMainWindow):
             flags=self._config["label_flags"],
         )
 
+    def _try_set_overrides(
+        self, overrides: list[tuple[tuple[str, ...], object]]
+    ) -> bool:
+        assert self._config_file is not None
+        try:
+            _config.set_overrides(config_file=self._config_file, overrides=overrides)
+        except (OSError, ValueError) as e:
+            QtWidgets.QMessageBox.warning(self, self.tr("Configuration Error"), str(e))
+            return False
+        return True
+
     def _on_setting_changed(self, key_path: tuple[str, ...], value: object) -> bool:
         # The dialog only opens with an editable config file (see _open_settings),
         # so there is always a file to persist to.
         if self._config_file is None:
             return False
-        try:
-            _config.set_override(
-                config_file=self._config_file, key_path=key_path, value=value
-            )
-        except (OSError, ValueError) as e:
-            QtWidgets.QMessageBox.warning(self, self.tr("Configuration Error"), str(e))
+        if not self._try_set_overrides(overrides=[(key_path, value)]):
             return False
 
         node: dict = self._config

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -9,7 +9,7 @@ from typing import cast
 from loguru import logger
 
 from .. import _yaml
-from ._writer import set_override
+from ._writer import set_overrides
 
 here = Path(__file__).resolve().parent
 

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -74,10 +74,9 @@ def _atomic_write(config_file: Path, content: str) -> None:
         raise
 
 
-def set_override(config_file: Path, key_path: Sequence[str], value: object) -> None:
-    if not key_path:
-        raise ValueError("key_path must not be empty")
-
+def set_overrides(
+    config_file: Path, overrides: Sequence[tuple[Sequence[str], object]]
+) -> None:
     yaml = YAML()
     yaml.preserve_quotes = True
     yaml.indent(mapping=2, sequence=4, offset=2)
@@ -89,10 +88,15 @@ def set_override(config_file: Path, key_path: Sequence[str], value: object) -> N
     if not isinstance(doc, CommentedMap):
         doc = CommentedMap()
 
-    if value == _default_value(key_path=key_path):
-        _prune(doc=doc, key_path=key_path)
-    else:
-        _assign(doc=doc, key_path=key_path, value=value)
+    # All overrides mutate the in-memory doc before the single write below, so a
+    # bad key anywhere in the batch leaves the file untouched (all-or-nothing).
+    for key_path, value in overrides:
+        if not key_path:
+            raise ValueError("key_path must not be empty")
+        if value == _default_value(key_path=key_path):
+            _prune(doc=doc, key_path=key_path)
+        else:
+            _assign(doc=doc, key_path=key_path, value=value)
 
     content = ""
     if doc:

--- a/tests/unit/_config/_writer_test.py
+++ b/tests/unit/_config/_writer_test.py
@@ -19,7 +19,7 @@ def _parse(config_file: Path) -> dict | None:
 def test_creates_file_when_missing(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
+    _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], False)])
 
     assert _parse(config_file) == {"auto_save": False}
 
@@ -28,8 +28,8 @@ def test_preserves_comment_on_untouched_key(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("# my custom note\nauto_save: false\n", encoding="utf-8")
 
-    _config.set_override(
-        config_file=config_file, key_path=["with_image_data"], value=True
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["with_image_data"], True)]
     )
 
     content = config_file.read_text(encoding="utf-8")
@@ -44,7 +44,7 @@ def test_prunes_key_when_value_equals_default(tmp_path: Path) -> None:
     )
 
     # auto_save default is true, so setting it back to true removes the override
-    _config.set_override(config_file=config_file, key_path=["auto_save"], value=True)
+    _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], True)])
 
     assert _parse(config_file) == {"with_image_data": True}
 
@@ -52,8 +52,8 @@ def test_prunes_key_when_value_equals_default(tmp_path: Path) -> None:
 def test_writes_nested_key(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(
-        config_file=config_file, key_path=["shape", "point_size"], value=12
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["shape", "point_size"], 12)]
     )
 
     content = config_file.read_text(encoding="utf-8")
@@ -66,8 +66,8 @@ def test_prunes_nested_key_and_empty_parent(tmp_path: Path) -> None:
     config_file.write_text("shape:\n  point_size: 12\n", encoding="utf-8")
 
     # point_size default is 8; reverting empties shape, which should be pruned too
-    _config.set_override(
-        config_file=config_file, key_path=["shape", "point_size"], value=8
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["shape", "point_size"], 8)]
     )
 
     assert _parse(config_file) is None
@@ -79,8 +79,8 @@ def test_keeps_sibling_when_pruning_nested_key(tmp_path: Path) -> None:
         "shape:\n  point_size: 12\n  line_color: [1, 2, 3, 4]\n", encoding="utf-8"
     )
 
-    _config.set_override(
-        config_file=config_file, key_path=["shape", "point_size"], value=8
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["shape", "point_size"], 8)]
     )
 
     assert _parse(config_file) == {"shape": {"line_color": [1, 2, 3, 4]}}
@@ -89,11 +89,11 @@ def test_keeps_sibling_when_pruning_nested_key(tmp_path: Path) -> None:
 def test_toggle_then_revert_is_idempotent(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(
-        config_file=config_file, key_path=["shape", "point_size"], value=12
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["shape", "point_size"], 12)]
     )
-    _config.set_override(
-        config_file=config_file, key_path=["shape", "point_size"], value=8
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["shape", "point_size"], 8)]
     )
 
     assert _parse(config_file) is None
@@ -102,20 +102,47 @@ def test_toggle_then_revert_is_idempotent(tmp_path: Path) -> None:
 def test_writes_list_in_flow_style(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(
+    _config.set_overrides(
         config_file=config_file,
-        key_path=["default_shape_color"],
-        value=[255, 0, 0],
+        overrides=[(["default_shape_color"], [255, 0, 0])],
     )
 
     assert "default_shape_color: [255, 0, 0]" in config_file.read_text(encoding="utf-8")
 
 
+def test_set_overrides_applies_batch_in_one_write(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("auto_save: false\n", encoding="utf-8")
+
+    # auto_save reverts to its default (pruned) while point_size becomes an
+    # override, in a single write
+    _config.set_overrides(
+        config_file=config_file,
+        overrides=[(["auto_save"], True), (["shape", "point_size"], 12)],
+    )
+
+    assert _parse(config_file) == {"shape": {"point_size": 12}}
+
+
+def test_set_overrides_bad_key_leaves_file_untouched(tmp_path: Path) -> None:
+    config_file = tmp_path / ".labelmerc"
+    config_file.write_text("auto_save: false\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unknown config key"):
+        _config.set_overrides(
+            config_file=config_file,
+            overrides=[(["with_image_data"], True), (["nope"], 1)],
+        )
+
+    # the batch is all-or-nothing: the valid first item must not be persisted
+    assert _parse(config_file) == {"auto_save": False}
+
+
 def test_label_named_like_a_boolean_survives_round_trip(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(
-        config_file=config_file, key_path=["labels"], value=["yes", "no"]
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["labels"], ["yes", "no"])]
     )
 
     config = _config.load_config(config_file=config_file, config_overrides={})
@@ -126,14 +153,14 @@ def test_empty_key_path_raises(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     with pytest.raises(ValueError, match="key_path must not be empty"):
-        _config.set_override(config_file=config_file, key_path=[], value=1)
+        _config.set_overrides(config_file=config_file, overrides=[([], 1)])
 
 
 def test_unknown_key_raises(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     with pytest.raises(ValueError, match="Unknown config key"):
-        _config.set_override(config_file=config_file, key_path=["nope"], value=1)
+        _config.set_overrides(config_file=config_file, overrides=[(["nope"], 1)])
 
 
 def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
@@ -141,8 +168,8 @@ def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
     config_file.write_text("shape: 42\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="non-mapping"):
-        _config.set_override(
-            config_file=config_file, key_path=["shape", "point_size"], value=12
+        _config.set_overrides(
+            config_file=config_file, overrides=[(["shape", "point_size"], 12)]
         )
 
 
@@ -150,7 +177,7 @@ def test_overwrites_when_top_level_is_not_a_mapping(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("- one\n- two\n", encoding="utf-8")
 
-    _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
+    _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], False)])
 
     assert _parse(config_file) == {"auto_save": False}
 
@@ -160,7 +187,7 @@ def test_empties_file_when_last_override_pruned(tmp_path: Path) -> None:
     config_file.write_text("auto_save: false\n", encoding="utf-8")
 
     # reverting the only override to its default leaves nothing to persist
-    _config.set_override(config_file=config_file, key_path=["auto_save"], value=True)
+    _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], True)])
 
     assert config_file.read_text(encoding="utf-8") == ""
 
@@ -168,9 +195,9 @@ def test_empties_file_when_last_override_pruned(tmp_path: Path) -> None:
 def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(config_file=config_file, key_path=["auto_save"], value=False)
-    _config.set_override(
-        config_file=config_file, key_path=["shape", "point_size"], value=12
+    _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], False)])
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["shape", "point_size"], 12)]
     )
 
     config = _config.load_config(config_file=config_file, config_overrides={})
@@ -184,8 +211,8 @@ def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
 def test_non_ascii_label_round_trips(tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
-    _config.set_override(
-        config_file=config_file, key_path=["labels"], value=["ラベル", "café"]
+    _config.set_overrides(
+        config_file=config_file, overrides=[(["labels"], ["ラベル", "café"])]
     )
 
     config = _config.load_config(config_file=config_file, config_overrides={})
@@ -206,8 +233,8 @@ def test_non_ascii_label_round_trips_under_non_utf8_locale(tmp_path: Path) -> No
         from labelme import _config
 
         config_file = Path({str(config_file)!r})
-        _config.set_override(
-            config_file=config_file, key_path=["labels"], value=["ラベル"]
+        _config.set_overrides(
+            config_file=config_file, overrides=[(["labels"], ["ラベル"])]
         )
         config = _config.load_config(config_file=config_file, config_overrides={{}})
         assert config["labels"] == ["ラベル"], config["labels"]
@@ -247,8 +274,8 @@ def test_write_failure_leaves_no_temp_file(
     monkeypatch.setattr("labelme._config._writer.os.replace", _fail)
 
     with pytest.raises(OSError, match="disk full"):
-        _config.set_override(
-            config_file=config_file, key_path=["auto_save"], value=False
+        _config.set_overrides(
+            config_file=config_file, overrides=[(["auto_save"], False)]
         )
 
     assert not config_file.exists()


### PR DESCRIPTION
Extracted from #2403 so batched config writes can be reviewed and merged independently. The singular `set_override` API is removed rather than retained as a compatibility shim because all repository callers migrate in the same change.

## Test plan

- [x] `uv run pytest -q tests/unit/_config/_writer_test.py tests/unit/widgets/settings_dialog_test.py`
- [x] `uv run ruff check .`
- [x] `uv run ty check --no-progress`
