### PR TITLE
test: isolate network-dependent AI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,27 @@ jobs:
         run: |-
           uv build
           uv pip install dist/labelme-*.whl
+  network-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+          activate-environment: true
+      - shell: bash
+        run: |
+          make setup
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: xvfb libegl1 libxkbcommon0 libxcb-cursor0 libgl1
+          version: 1.0
+      - name: Test real model download
+        shell: bash
+        env:
+          MPLBACKEND: agg
+        run: |-
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          export DISPLAY=:99
+          make test PYTEST_ARGS="-m network --numprocesses=1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,12 @@ dev = [
 labelme = "labelme.__main__:main"
 
 [tool.pytest.ini_options]
+addopts = "-m 'not network'"
 qt_api = "pyside6"
-markers = ["gui: mark a test as a GUI test."]
+markers = [
+  "gui: mark a test as a GUI test.",
+  "network: mark a test that accesses an external network service.",
+]
 
 [tool.ruff.lint]
 select = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import json
 import os
 import shutil
+from collections.abc import Generator
 from pathlib import Path
 
 import imgviz
 import pytest
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QProgressDialog
 from PySide6.QtWidgets import QWidget
 from pytestqt.qtbot import QtBot
 
@@ -41,6 +45,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 def pytest_configure(config: pytest.Config) -> None:
     if not config.getoption("--headed"):
         os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+
+@pytest.fixture()
+def close_failed_download_dialog(
+    qapp: QApplication,
+) -> Generator[None, None, None]:
+    timer = QTimer()
+
+    def close_error_dialog() -> None:
+        for widget in qapp.topLevelWidgets():
+            if not isinstance(widget, QProgressDialog):
+                continue
+            if not widget.isVisible():
+                continue
+            if widget.labelText().startswith("Failed to download"):
+                widget.close()
+
+    timer.timeout.connect(close_error_dialog)
+    timer.start(10)
+    yield
+    timer.stop()
 
 
 @pytest.fixture()

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -95,6 +95,7 @@ _AI_MODEL = "efficientsam:10m"
             None,
             "polygon",
             id="ai_points-polygon",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_points_to_shape",
@@ -104,6 +105,7 @@ _AI_MODEL = "efficientsam:10m"
             2,
             "mask",
             id="ai_points-mask",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_points_to_shape",
@@ -113,6 +115,7 @@ _AI_MODEL = "efficientsam:10m"
             2,
             "rectangle",
             id="ai_points-rectangle",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_points_to_shape",
@@ -122,6 +125,7 @@ _AI_MODEL = "efficientsam:10m"
             2,
             "circle",
             id="ai_points-circle",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_points_to_shape",
@@ -131,6 +135,7 @@ _AI_MODEL = "efficientsam:10m"
             4,
             "oriented_rectangle",
             id="ai_points-oriented_rectangle",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_box_to_shape",
@@ -140,6 +145,7 @@ _AI_MODEL = "efficientsam:10m"
             None,
             "polygon",
             id="ai_box-polygon",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_box_to_shape",
@@ -149,6 +155,7 @@ _AI_MODEL = "efficientsam:10m"
             2,
             "mask",
             id="ai_box-mask",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_box_to_shape",
@@ -158,6 +165,7 @@ _AI_MODEL = "efficientsam:10m"
             2,
             "rectangle",
             id="ai_box-rectangle",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_box_to_shape",
@@ -167,6 +175,7 @@ _AI_MODEL = "efficientsam:10m"
             2,
             "circle",
             id="ai_box-circle",
+            marks=pytest.mark.network,
         ),
         pytest.param(
             "ai_box_to_shape",
@@ -176,12 +185,14 @@ _AI_MODEL = "efficientsam:10m"
             4,
             "oriented_rectangle",
             id="ai_box-oriented_rectangle",
+            marks=pytest.mark.network,
         ),
     ],
 )
 def test_annotate_shape_types(
     main_win: MainWinFactory,
     qtbot: QtBot,
+    close_failed_download_dialog: None,
     data_path: Path,
     tmp_path: Path,
     pause: bool,

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import osam.types._blob
 import pytest
 from PySide6.QtCore import QPoint
 from PySide6.QtCore import Qt
@@ -259,52 +258,5 @@ def test_annotate_shape_types(
 
     win._save_label_file()
     assert_labelfile_sanity(out_file)
-
-    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
-
-
-@pytest.mark.gui
-def test_ai_model_download(
-    main_win: MainWinFactory,
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    data_path: Path,
-    tmp_path: Path,
-    pause: bool,
-) -> None:
-    win = main_win(
-        file_or_dir=str(data_path / "raw/2011_000003.jpg"),
-    )
-    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
-
-    canvas = win._canvas_widgets.canvas
-    canvas.set_ai_model_name(_AI_MODEL)
-    canvas.set_ai_output_format("polygon")
-
-    win._switch_canvas_mode(edit=False, create_mode="ai_box_to_shape")
-    qtbot.wait(50)
-
-    # Redirect osam blob storage to a temp directory so it thinks the model is not
-    # downloaded. This exercises the download_ai_model dialog without touching the
-    # real model cache in ~/.cache/osam.
-    blob_base = str(tmp_path / "osam_blobs")
-
-    def patched_path(self: osam.types._blob.Blob) -> str:
-        if self.attachments:
-            safe_hash = self.hash.replace("sha256:", "sha256-")
-            return str(Path(blob_base) / safe_hash / self.filename)
-        return str(Path(blob_base) / self.hash)
-
-    monkeypatch.setattr(osam.types._blob.Blob, "path", property(patched_path))
-
-    # Reset cached osam session so the fresh model is loaded from temp dir
-    canvas._ai_assist_session._session = None
-
-    canvas_size = canvas.size()
-    pos = QPoint(int(canvas_size.width() * 0.5), int(canvas_size.height() * 0.5))
-    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=pos)
-
-    # Verify the model was downloaded to the temp dir
-    assert any(Path(blob_base).rglob("*"))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/unit/widgets/download_test.py
+++ b/tests/unit/widgets/download_test.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Final
+
+import osam.apis
+import osam.types
+import osam.types._blob
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QProgressDialog
+from PySide6.QtWidgets import QWidget
+from pytestqt.qtbot import QtBot
+
+from labelme._widgets.download import download_ai_model
+
+_MODEL_NAME: Final = "efficientsam:10m"
+
+
+@pytest.fixture()
+def isolated_model_type(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> type[osam.types.Model]:
+    # Redirect osam blob storage to a temp directory so the model reads as not
+    # downloaded, without touching the real model cache in ~/.cache/osam.
+    blob_base = tmp_path / "osam_blobs"
+
+    def patched_path(self: osam.types._blob.Blob) -> str:
+        if self.attachments:
+            safe_hash = self.hash.replace("sha256:", "sha256-")
+            return str(blob_base / safe_hash / self.filename)
+        return str(blob_base / self.hash)
+
+    monkeypatch.setattr(osam.types._blob.Blob, "path", property(patched_path))
+    return osam.apis.get_model_type_by_name(_MODEL_NAME)
+
+
+@pytest.mark.gui
+def test_download_ai_model_returns_true_when_pull_succeeds(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_model_type: type[osam.types.Model],
+    close_failed_download_dialog: None,
+) -> None:
+    expected_paths = [Path(blob.path) for blob in isolated_model_type._blobs.values()]
+    TEST_MODEL_DATA: Final = b"test model"
+
+    def fake_pull(
+        cls: type[osam.types.Model],
+        progress: Callable[[str, int, int | None], None] | None = None,
+    ) -> None:
+        for blob in cls._blobs.values():
+            path = Path(blob.path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if progress is not None:
+                progress(blob.filename, 0, len(TEST_MODEL_DATA))
+            path.write_bytes(TEST_MODEL_DATA)
+            if progress is not None:
+                progress(
+                    blob.filename,
+                    len(TEST_MODEL_DATA),
+                    len(TEST_MODEL_DATA),
+                )
+
+    monkeypatch.setattr(isolated_model_type, "pull", classmethod(fake_pull))
+
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    assert download_ai_model(model_name=_MODEL_NAME, parent=parent) is True
+    assert all(path.read_bytes() == TEST_MODEL_DATA for path in expected_paths)
+    assert not any(
+        isinstance(widget, QProgressDialog) and widget.isVisible()
+        for widget in QApplication.topLevelWidgets()
+    )
+
+
+@pytest.mark.gui
+def test_download_ai_model_returns_false_when_pull_fails(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    close_failed_download_dialog: None,
+) -> None:
+    model_type = osam.apis.get_model_type_by_name(_MODEL_NAME)
+
+    def fail_pull(
+        cls: type[osam.types.Model],
+        progress: Callable[[str, int, int | None], None] | None = None,
+    ) -> None:
+        raise RuntimeError("download failed")
+
+    monkeypatch.setattr(model_type, "get_size", classmethod(lambda cls: None))
+    monkeypatch.setattr(model_type, "pull", classmethod(fail_pull))
+
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    assert download_ai_model(model_name=_MODEL_NAME, parent=parent) is False

--- a/tests/unit/widgets/download_test.py
+++ b/tests/unit/widgets/download_test.py
@@ -98,3 +98,19 @@ def test_download_ai_model_returns_false_when_pull_fails(
     qtbot.addWidget(parent)
 
     assert download_ai_model(model_name=_MODEL_NAME, parent=parent) is False
+
+
+@pytest.mark.gui
+@pytest.mark.network
+def test_download_ai_model_from_network(
+    qtbot: QtBot,
+    isolated_model_type: type[osam.types.Model],
+    close_failed_download_dialog: None,
+) -> None:
+    expected_paths = [Path(blob.path) for blob in isolated_model_type._blobs.values()]
+
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    assert download_ai_model(model_name=_MODEL_NAME, parent=parent) is True
+    assert all(path.is_file() for path in expected_paths)


### PR DESCRIPTION
> *This was generated by AI.*

Model-download failures could leave the test suite waiting indefinitely on a modal error dialog. This keeps the default suite hermetic while running real model download and inference coverage once on Ubuntu with Python 3.12.

## Test plan

- [x] `make lint`
- [x] `make test` (910 passed)
- [x] `make test PYTEST_ARGS="-m network --numprocesses=1"` (11 passed)
