### PR TITLE
fix(ai-assist): reject unsupported point prompts early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed AI-Points mode allowing SAM3 to start unsupported point-prompt inference, which wasted time extracting image features before failing and displayed the prompt draft as a prediction ([#2437](https://github.com/wkentaro/labelme/pull/2437))
 - Fixed opening an image too large for Qt to decode reporting the misleading "Allowed formats" unsupported-format message; the dialog now states that the image is too large, shows its pixel dimensions and the ceiling that was actually hit (the decode allocation limit, or the raster engine's ~32767 pixel per-side limit, which no amount of raising the allocation limit can lift), and suggests tiling with `gdal_retile.py` or opening a smaller copy ([#2417](https://github.com/wkentaro/labelme/pull/2417))
 - Fixed clicking or hovering near a linestrip's unrendered "closing" line (the straight path from its last point back to its first) being treated as a hit on the shape; edge hover, add-point-to-edge, and body selection now ignore that phantom segment, since a linestrip is an open polyline and never draws it ([#2307](https://github.com/wkentaro/labelme/pull/2307))
 - Fixed the `--output` guard rejecting only lowercase `.json` paths; an upper- or mixed-case file path such as `--output notes.JSON` slipped past the "expects a directory" check and was treated as an output directory. The guard now reuses the canonical case-insensitive `is_label_file_path` helper ([#2317](https://github.com/wkentaro/labelme/pull/2317))

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,10 @@ _Avoid_: AI annotation (too vague), text-to-annotation (verbose), auto-detect.
 A loaded ML model that backs AI Assist or AI Text Prompt. One Model Session serves many proposals across the lifetime of the app. The legacy code directory `_automation/` hosts this layer.
 _Avoid_: automation (legacy code-only term), backend, engine.
 
+**Prompt Compatibility**:
+The prompt kinds a Model Session can answer. A model can support point, box, or text prompts independently; selecting a model does not imply compatibility with every AI Assist mode.
+_Avoid_: treating an unsupported prompt kind as an inference failure.
+
 **Mask Shape**:
 A Shape whose `shape_type` is `mask` — hybrid representation combining a rectangular bounding box (2 points) with a Mask (the raster pixels) that fills the bbox. The only `shape_type` that carries dense pixel data.
 _Avoid_: raster shape, pixel polygon; do not say "mask" when you mean the whole Shape.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -74,7 +74,6 @@ _AI_CREATE_MODES: tuple[str, ...] = (
     "ai_points_to_shape",
     "ai_box_to_shape",
 )
-_AI_MODELS_WITHOUT_POINT_SUPPORT: tuple[str, ...] = ("sam3:latest",)
 
 
 class _StatusBarWidgets(NamedTuple):
@@ -1468,7 +1467,7 @@ class MainWindow(QtWidgets.QMainWindow):
     ) -> None:
         if create_mode == "ai_points_to_shape":
             model_name = self._canvas_widgets.canvas.get_ai_model_name()
-            if model_name in _AI_MODELS_WITHOUT_POINT_SUPPORT:
+            if not _automation.supports_point_prompts(model_name=model_name):
                 QtWidgets.QMessageBox.warning(
                     self,
                     self.tr("AI-Points Unavailable"),
@@ -1499,10 +1498,9 @@ class MainWindow(QtWidgets.QMainWindow):
             in (*typing.get_args(_TextToAnnotationCreateMode), *_AI_CREATE_MODES)
         )
         self._ai_annotation.setEnabled(not edit and create_mode in _AI_CREATE_MODES)
-        if create_mode == "ai_points_to_shape":
-            self._ai_annotation.set_disabled_models(_AI_MODELS_WITHOUT_POINT_SUPPORT)
-        else:
-            self._ai_annotation.set_disabled_models(())
+        self._ai_annotation.set_point_prompt_mode(
+            enabled=create_mode == "ai_points_to_shape"
+        )
 
     def _highlight_ai_buttons(self, highlight: bool) -> None:
         self._ai_buttons_highlighted = highlight

--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -1,4 +1,6 @@
+from ._ai_assist import AI_ASSIST_MODEL_OPTIONS
 from ._ai_assist import AiAssistSession
+from ._ai_assist import supports_point_prompts
 from ._geometry import shape_to_xyxy_bbox
 from ._osam_session import OsamSession
 from ._shape_builders import MASK_REQUIRED_SHAPE_TYPES
@@ -8,3 +10,4 @@ from ._suppression import suppress_detections_greedy
 from ._text_detection import get_bboxes_from_texts
 from ._text_detection import nms_bboxes
 from ._types import AiOutputFormat
+from ._types import AiPromptKind

--- a/labelme/_automation/_ai_assist.py
+++ b/labelme/_automation/_ai_assist.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import dataclasses
+from typing import Final
+
 import numpy as np
 import osam
 from loguru import logger
@@ -12,6 +15,70 @@ from ._shape_builders import shapes_from_detections
 from ._suppression import suppress_detections_greedy
 from ._suppression import suppress_detections_overlapping_existing_shapes
 from ._types import AiOutputFormat
+from ._types import AiPromptKind
+
+
+@dataclasses.dataclass(frozen=True)
+class AiAssistModelOption:
+    model_name: str
+    display_name: str
+    supports_point_prompts: bool
+
+
+AI_ASSIST_MODEL_OPTIONS: Final[tuple[AiAssistModelOption, ...]] = (
+    AiAssistModelOption(
+        model_name="efficientsam:10m",
+        display_name="EfficientSam (speed)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="efficientsam:latest",
+        display_name="EfficientSam (accuracy)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam:100m",
+        display_name="Sam (speed)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam:300m",
+        display_name="Sam (balanced)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam:latest",
+        display_name="Sam (accuracy)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam2:small",
+        display_name="Sam2 (speed)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam2:latest",
+        display_name="Sam2 (balanced)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam2:large",
+        display_name="Sam2 (accuracy)",
+        supports_point_prompts=True,
+    ),
+    AiAssistModelOption(
+        model_name="sam3:latest",
+        display_name="Sam3",
+        supports_point_prompts=False,
+    ),
+)
+
+
+def supports_point_prompts(*, model_name: str) -> bool:
+    for option in AI_ASSIST_MODEL_OPTIONS:
+        if option.model_name == model_name:
+            return option.supports_point_prompts
+    return True
 
 
 class AiAssistSession:
@@ -38,10 +105,15 @@ class AiAssistSession:
         *,
         image: NDArray[np.uint8],
         image_id: str,
+        prompt_kind: AiPromptKind,
         points: NDArray[np.floating],
         point_labels: NDArray[np.intp],
         existing_shapes: list[Shape],
     ) -> list[Shape]:
+        if prompt_kind == "points" and not supports_point_prompts(
+            model_name=self.model_name
+        ):
+            raise ValueError(f"{self.model_name} does not support point prompts")
         response: osam.types.GenerateResponse = self._get_session().run(
             image=image,
             image_id=image_id,

--- a/labelme/_automation/_types.py
+++ b/labelme/_automation/_types.py
@@ -1,6 +1,8 @@
 from typing import Literal
 from typing import TypeAlias
 
+AiPromptKind: TypeAlias = Literal["points", "box"]
+
 AiOutputFormat: TypeAlias = Literal[
     "rectangle", "polygon", "mask", "circle", "oriented_rectangle"
 ]

--- a/labelme/_widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/_widgets/_ai_assisted_annotation_widget.py
@@ -1,32 +1,19 @@
 from __future__ import annotations
 
-import typing
 from collections.abc import Callable
+from typing import cast
 
 from loguru import logger
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
 
-from .._automation import AiOutputFormat
+from .. import _automation
 from ._info_button import InfoButton
 
 
 class AiAssistedAnnotationWidget(QtWidgets.QWidget):
     hover_highlight_requested = QtCore.Signal(bool)
-
-    _available_models: list[tuple[str, str]] = [
-        ("efficientsam:10m", "EfficientSam (speed)"),
-        ("efficientsam:latest", "EfficientSam (accuracy)"),
-        ("sam:100m", "Sam (speed)"),
-        ("sam:300m", "Sam (balanced)"),
-        ("sam:latest", "Sam (accuracy)"),
-        ("sam2:small", "Sam2 (speed)"),
-        ("sam2:latest", "Sam2 (balanced)"),
-        ("sam2:large", "Sam2 (accuracy)"),
-        ("sam3:latest", "Sam3"),
-    ]
 
     _model_combo: QtWidgets.QComboBox
     _output_format_combo: QtWidgets.QComboBox
@@ -36,7 +23,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         self,
         default_model: str,
         on_model_changed: Callable[[str], None],
-        on_output_format_changed: Callable[[AiOutputFormat], None],
+        on_output_format_changed: Callable[[_automation.AiOutputFormat], None],
         parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
@@ -47,14 +34,14 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         )
 
     @property
-    def output_format(self) -> AiOutputFormat:
+    def output_format(self) -> _automation.AiOutputFormat:
         return self._output_format_combo.currentData()
 
     def _init_ui(
         self,
         default_model: str,
         on_model_changed: Callable[[str], None],
-        on_output_format_changed: Callable[[AiOutputFormat], None],
+        on_output_format_changed: Callable[[_automation.AiOutputFormat], None],
     ) -> None:
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(4, 4, 4, 4)
@@ -81,8 +68,8 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
         body.setLayout(body_layout)
 
         self._model_combo = QtWidgets.QComboBox()
-        for model_id, model_display in self._available_models:
-            self._model_combo.addItem(model_display, model_id)
+        for option in _automation.AI_ASSIST_MODEL_OPTIONS:
+            self._model_combo.addItem(option.display_name, option.model_name)
         body_layout.addWidget(self._model_combo)
 
         self._output_format_combo = QtWidgets.QComboBox()
@@ -95,7 +82,9 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
         layout.addWidget(body)
 
-        model_ui_names = [model_display for _, model_display in self._available_models]
+        model_ui_names = [
+            option.display_name for option in _automation.AI_ASSIST_MODEL_OPTIONS
+        ]
         if default_model in model_ui_names:
             model_index = model_ui_names.index(default_model)
         else:
@@ -116,16 +105,12 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
         self.setMaximumWidth(200)
 
-    def set_disabled_models(self, disabled_models: tuple[str, ...]) -> None:
-        model = typing.cast(QtGui.QStandardItemModel, self._model_combo.model())
-        for i in range(self._model_combo.count()):
-            model_id = self._model_combo.itemData(i)
-            item = model.item(i)
+    def set_point_prompt_mode(self, enabled: bool) -> None:
+        model = cast(QtGui.QStandardItemModel, self._model_combo.model())
+        for index, option in enumerate(_automation.AI_ASSIST_MODEL_OPTIONS):
+            item = model.item(index)
             assert item is not None
-            if model_id in disabled_models:
-                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled)
-            else:
-                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEnabled)
+            item.setEnabled(not enabled or option.supports_point_prompts)
 
     def setEnabled(self, a0: bool) -> None:
         self._body.setEnabled(a0)

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -406,13 +406,18 @@ class Canvas(QtWidgets.QWidget):
     def set_ai_output_format(self, output_format: _automation.AiOutputFormat) -> None:
         self._ai_assist_session.output_format = output_format
 
-    def _shapes_from_ai_points(
-        self, points: Sequence[QPointF], point_labels: Sequence[int]
+    def _propose_ai_shapes(
+        self,
+        *,
+        prompt_kind: _automation.AiPromptKind,
+        points: Sequence[QPointF],
+        point_labels: Sequence[int],
     ) -> list[Shape]:
         image: np.ndarray = _utils.img_qt_to_arr(img_qt=self.pixmap.toImage())
         return self._ai_assist_session.propose_shapes(
             image=image[:, :, :3],
             image_id=str(self._pixmap_hash),
+            prompt_kind=prompt_kind,
             points=np.array([[p.x(), p.y()] for p in points]),
             point_labels=np.array(point_labels),
             existing_shapes=self.shapes,
@@ -1549,13 +1554,14 @@ class Canvas(QtWidgets.QWidget):
             preview = preview.add_point(point=self._line.points[1], autoclose=True)
         return _draft_to_shape(preview)
 
-    def _build_ai_points_preview(self, current: _DraftShape) -> Shape:
+    def _build_ai_points_preview(self, current: _DraftShape) -> Shape | None:
         preview = current.add_point(
             point=self._line.points[1],
             label=self._line.point_labels[1],
         )
         try:
-            ai_shapes = self._shapes_from_ai_points(
+            ai_shapes = self._propose_ai_shapes(
+                prompt_kind="points",
                 points=preview.points,
                 point_labels=preview.point_labels,
             )
@@ -1565,11 +1571,11 @@ class Canvas(QtWidgets.QWidget):
             # success re-arms the report.
             if not self._ai_inference_failed:
                 self._report_inference_failure(error=e)
-            return _draft_to_shape(preview)
+            return None
         self._ai_inference_failed = False
         if ai_shapes:
             return ai_shapes[0]
-        return _draft_to_shape(preview)
+        return None
 
     def _transform_point_widget_to_image(self, point: QPointF) -> QPointF:
         origin = self._compute_image_origin_offset()
@@ -1619,13 +1625,15 @@ class Canvas(QtWidgets.QWidget):
     def _build_new_shapes_from_ai_inference(self) -> list[Shape]:
         assert self._current is not None
         if self.create_mode == "ai_points_to_shape":
-            return self._shapes_from_ai_points(
+            return self._propose_ai_shapes(
+                prompt_kind="points",
                 points=self._current.points,
                 point_labels=self._current.point_labels,
             )
         if self.create_mode == "ai_box_to_shape":
             # point_labels: 2=box corner, 3=opposite box corner (SAM convention)
-            return self._shapes_from_ai_points(
+            return self._propose_ai_shapes(
+                prompt_kind="box",
                 points=_normalize_bbox_points(bbox_points=self._current.points),
                 point_labels=[2, 3],
             )

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -6,8 +6,10 @@ import pytest
 from PySide6.QtCore import QPoint
 from PySide6.QtCore import Qt
 from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QComboBox
 from pytestqt.qtbot import QtBot
 
+from labelme._app import MainWindow
 from labelme._automation._types import AiOutputFormat
 
 from ..conftest import assert_labelfile_sanity
@@ -17,6 +19,60 @@ from .conftest import show_window_and_wait_for_imagedata
 
 # Smallest available model (~40MB) to keep download and inference fast
 _AI_MODEL = "efficientsam:10m"
+
+
+@pytest.fixture()
+def ai_model_combo(raw_win: MainWindow) -> QComboBox:
+    return raw_win._ai_annotation._model_combo
+
+
+@pytest.mark.gui
+def test_ai_points_mode_disables_sam3(
+    raw_win: MainWindow,
+    ai_model_combo: QComboBox,
+    qtbot: QtBot,
+    pause: bool,
+) -> None:
+    sam3_index = ai_model_combo.findData("sam3:latest")
+
+    raw_win._actions.create_ai_points_to_shape_mode.trigger()
+
+    assert raw_win._canvas_widgets.canvas.create_mode == "ai_points_to_shape"
+    model = ai_model_combo.model()
+    assert not model.flags(model.index(sam3_index, 0)) & Qt.ItemFlag.ItemIsEnabled
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_ai_points_mode_rejects_selected_sam3(
+    raw_win: MainWindow,
+    ai_model_combo: QComboBox,
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    raw_win._actions.create_ai_box_to_shape_mode.trigger()
+    sam3_index = ai_model_combo.findData("sam3:latest")
+    ai_model_combo.setCurrentIndex(sam3_index)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "labelme._app.QtWidgets.QMessageBox.warning",
+        lambda *args: warnings.append(args[2]),
+    )
+
+    raw_win._actions.create_ai_points_to_shape_mode.trigger()
+
+    assert warnings == [
+        "sam3:latest does not support point prompts.\n"
+        "Please select a different model or use AI-Box mode."
+    ]
+    assert raw_win._canvas_widgets.canvas.create_mode == "ai_box_to_shape"
+    assert ai_model_combo.currentData() == "sam3:latest"
+    model = ai_model_combo.model()
+    assert model.flags(model.index(sam3_index, 0)) & Qt.ItemFlag.ItemIsEnabled
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
 
 
 @pytest.mark.gui

--- a/tests/unit/_automation/_ai_assist_test.py
+++ b/tests/unit/_automation/_ai_assist_test.py
@@ -34,12 +34,23 @@ def install_fake_osam_session(
     return _install
 
 
-def _propose(session: AiAssistSession) -> list[Shape]:
+def _propose(
+    session: AiAssistSession,
+    *,
+    prompt_kind: _ai_assist.AiPromptKind = "points",
+) -> list[Shape]:
+    if prompt_kind == "box":
+        points = np.zeros((2, 2))
+        point_labels = np.array([2, 3])
+    else:
+        points = np.zeros((1, 2))
+        point_labels = np.array([1])
     return session.propose_shapes(
         image=np.zeros((1, 1, 3), dtype=np.uint8),
         image_id="img",
-        points=np.zeros((1, 2)),
-        point_labels=np.array([1]),
+        prompt_kind=prompt_kind,
+        points=points,
+        point_labels=point_labels,
         existing_shapes=[],
     )
 
@@ -88,6 +99,32 @@ def test_default_model_name_and_output_format() -> None:
     session.output_format = "mask"
     assert session.model_name == "efficientsam:latest"
     assert session.output_format == "mask"
+
+
+def test_sam3_point_prompt_is_rejected_before_session_creation(
+    install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
+) -> None:
+    response = osam.types.GenerateResponse(model="stub", annotations=[])
+    created_model_names = install_fake_osam_session(response)
+    session = AiAssistSession(model_name="sam3:latest")
+
+    with pytest.raises(ValueError, match="does not support point prompts"):
+        _propose(session)
+
+    assert created_model_names == []
+
+
+def test_sam3_box_prompt_reaches_session(
+    install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
+) -> None:
+    response = osam.types.GenerateResponse(model="stub", annotations=[])
+    created_model_names = install_fake_osam_session(response)
+    session = AiAssistSession(model_name="sam3:latest")
+
+    shapes = _propose(session, prompt_kind="box")
+
+    assert shapes == []
+    assert created_model_names == ["sam3:latest"]
 
 
 def _annotation(

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -282,7 +282,7 @@ def test_finalize_with_empty_inference_resets_state_and_notifies(
     # an overlapping detection). The empty branch of _finalize must reset the
     # in-progress drawing state so the edit-mode button becomes usable again
     # and notify the user that inference produced nothing.
-    monkeypatch.setattr(canvas, "_shapes_from_ai_points", lambda **_: [])
+    monkeypatch.setattr(canvas, "_propose_ai_shapes", lambda **_: [])
     canvas.create_mode = create_mode
     # ai_box_to_shape normalizes the two bbox corners before delegating to the
     # (monkeypatched) inference call, so the in-progress shape needs 2 points.
@@ -324,7 +324,7 @@ def test_finalize_paints_new_shape_before_notifying(
         points=np.array([(1, 1), (9, 1), (9, 9)], dtype=np.float64),
         closed=True,
     )
-    monkeypatch.setattr(canvas, "_shapes_from_ai_points", lambda **_: [inferred])
+    monkeypatch.setattr(canvas, "_propose_ai_shapes", lambda **_: [inferred])
     with qtbot.waitExposed(canvas):
         canvas.show()
 
@@ -370,7 +370,7 @@ def test_finalize_reports_inference_error_and_cancels(
     def _raise(**_: object) -> list[Shape]:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(canvas, "_shapes_from_ai_points", _raise)
+    monkeypatch.setattr(canvas, "_propose_ai_shapes", _raise)
     canvas.create_mode = create_mode
     canvas._current = _DraftShape(
         shape_type="rectangle",
@@ -391,7 +391,7 @@ def test_finalize_reports_inference_error_and_cancels(
 
 
 @pytest.mark.gui
-def test_points_preview_throttles_inference_errors_until_recovery(
+def test_points_preview_hides_failed_and_empty_predictions(
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -405,7 +405,7 @@ def test_points_preview_throttles_inference_errors_until_recovery(
             raise RuntimeError("boom")
         return []
 
-    monkeypatch.setattr(canvas, "_shapes_from_ai_points", _maybe_raise)
+    monkeypatch.setattr(canvas, "_propose_ai_shapes", _maybe_raise)
     canvas.create_mode = "ai_points_to_shape"
     canvas._line = _DraftShape(
         shape_type="rectangle",
@@ -420,14 +420,14 @@ def test_points_preview_throttles_inference_errors_until_recovery(
     failed: list[str] = []
     canvas.inference_failed.connect(failed.append)
 
-    canvas._build_ai_points_preview(current=current)
-    canvas._build_ai_points_preview(current=current)
+    assert canvas._build_ai_points_preview(current=current) is None
+    assert canvas._build_ai_points_preview(current=current) is None
     assert failed == ["RuntimeError: boom"]
 
     behavior["fail"] = False
-    canvas._build_ai_points_preview(current=current)
+    assert canvas._build_ai_points_preview(current=current) is None
     behavior["fail"] = True
-    canvas._build_ai_points_preview(current=current)
+    assert canvas._build_ai_points_preview(current=current) is None
     assert failed == ["RuntimeError: boom", "RuntimeError: boom"]
 
 


### PR DESCRIPTION
> *This was generated by AI.*

SAM3 does not support point prompts, but Labelme previously let it enter AI-Points mode and begin model setup before OSAM rejected the request.

This change records prompt compatibility with each AI Assist model, disables incompatible choices in AI-Points mode, warns before switching when the selected model is incompatible, and validates again before creating a model session. Failed or empty point-prompt previews are no longer rendered as the prompt draft. AI-Box remains available for SAM3.

## Test plan

- [x] `uv run pytest -q tests/unit/_automation/_ai_assist_test.py tests/unit/widgets/canvas_test.py tests/e2e/annotation_test.py -k 'sam3 or points_preview'` (5 passed)
- [x] `make lint`
- [x] Computer Use QA: verified SAM3 remains available in AI-Box, AI-Points rejects a selected SAM3 with a warning, and SAM3 is disabled while AI-Points is active
