### PR TITLE
refactor(ai-assist): resolve the default model via the combo's findText

### DIFF
--- a/labelme/_widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/_widgets/_ai_assisted_annotation_widget.py
@@ -92,12 +92,8 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
         layout.addWidget(body)
 
-        model_ui_names = [
-            option.display_name for option in _ai_models.AI_ASSIST_MODEL_OPTIONS
-        ]
-        if default_model in model_ui_names:
-            model_index = model_ui_names.index(default_model)
-        else:
+        model_index = self._model_combo.findText(default_model)
+        if model_index < 0:
             logger.warning("Default AI model is not found: {!r}", default_model)
             model_index = 0
 


### PR DESCRIPTION
Split out of #2370 to keep that bugfix minimal. `_init_ui` resolved the configured default model by building a `model_ui_names` list from `AI_ASSIST_MODEL_OPTIONS` and scanning it twice (`in` + `.index`), while `set_current_model` in the same class already does the identical display-name lookup with the combo's own `findText`; the combo is populated from the same options a few lines above, so it is the canonical table. No behavior change: known names resolve to the same index, unknown names still warn and fall back to index 0.

## Test plan
- [x] Full `pytest` suite and `make lint` green; #2370 adds direct tests for first-listed, non-first, and unknown `ai.default` resolution that cover this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
