### PR TITLE
fix(settings): scroll the content pane when a section is selected

### DIFF
--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -103,6 +103,7 @@ class _SettingsPage(QtWidgets.QWidget):
         self._scroll_area = scroll_area
         self._content = content
         self._groups = [group_box for _title, _icon, group_box in groups]
+        self._scrolling_to_group = False
 
         navigation.currentRowChanged.connect(self._scroll_to_group)
         navigation.itemClicked.connect(
@@ -118,13 +119,18 @@ class _SettingsPage(QtWidgets.QWidget):
             return
         group = self._groups[index]
         group_top = group.mapTo(self._content, QtCore.QPoint()).y()
-        scroll_bar = self._scroll_area.verticalScrollBar()
-        with QtCore.QSignalBlocker(scroll_bar):
-            scroll_bar.setValue(group_top)
+        # Blocking the scroll bar would also cut the scroll area's own
+        # valueChanged connection, moving the handle while the content stays put,
+        # so gate the navigation sync instead of silencing the scroll bar.
+        self._scrolling_to_group = True
+        self._scroll_area.verticalScrollBar().setValue(group_top)
+        self._scrolling_to_group = False
         with QtCore.QSignalBlocker(self._navigation):
             self._navigation.setCurrentRow(index)
 
     def _sync_navigation_to_scroll(self, value: int) -> None:
+        if self._scrolling_to_group:
+            return
         viewport = self._scroll_area.viewport()
         # Move the reading point toward the viewport center as the user leaves
         # the top, so short groups near the bottom can become active too.

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -292,6 +292,11 @@ def test_navigation_jumps_to_group(
     dialog.show()
     qtbot.waitExposed(dialog)
 
+    scroll_bar = dialog._page._scroll_area.verticalScrollBar()
+    # Start scrolled: from the top, a broken jump that moves the scroll bar but not
+    # the content can still leave the content where the assertions expect it.
+    scroll_bar.setValue(scroll_bar.maximum() // 2)
+
     navigation = dialog._page._navigation
     item = navigation.item(target)
     assert item is not None
@@ -301,11 +306,13 @@ def test_navigation_jumps_to_group(
         pos=navigation.visualItemRect(item).center(),
     )
 
-    scroll_bar = dialog._page._scroll_area.verticalScrollBar()
     group_top = (
         dialog._page._groups[target].mapTo(dialog._page._content, QtCore.QPoint()).y()
     )
-    assert scroll_bar.value() == min(group_top, scroll_bar.maximum())
+    expected = min(group_top, scroll_bar.maximum())
+    assert scroll_bar.value() == expected
+    viewport = dialog._page._scroll_area.viewport()
+    assert -dialog._page._content.mapTo(viewport, QtCore.QPoint()).y() == expected
     assert navigation.currentRow() == target
 
 
@@ -319,6 +326,26 @@ def test_scrolling_updates_navigation(qtbot: QtBot, dialog: SettingsDialog) -> N
 
     scroll_bar.setValue(scroll_bar.maximum())
     assert dialog._page._navigation.currentRow() == len(dialog._page._groups) - 1
+
+
+def test_scrolling_updates_navigation_after_a_jump(
+    qtbot: QtBot, dialog: SettingsDialog
+) -> None:
+    dialog.show()
+    qtbot.waitExposed(dialog)
+
+    navigation = dialog._page._navigation
+    item = navigation.item(1)
+    assert item is not None
+    qtbot.mouseClick(
+        navigation.viewport(),
+        QtCore.Qt.MouseButton.LeftButton,
+        pos=navigation.visualItemRect(item).center(),
+    )
+
+    scroll_bar = dialog._page._scroll_area.verticalScrollBar()
+    scroll_bar.setValue(scroll_bar.maximum())
+    assert navigation.currentRow() == len(dialog._page._groups) - 1
 
 
 def test_navigation_returns_to_first_group_when_resize_removes_scrollbar(


### PR DESCRIPTION
Selecting a section in the Settings navigation moved the scroll bar handle but left the content pane where it was, so the jump only appeared to work while the user had not scrolled yet. Scrolling still drove the navigation highlight correctly; only the reverse direction was broken.

`_scroll_to_group` set the scroll bar value inside a `QSignalBlocker` to stop `_sync_navigation_to_scroll` from overriding the row it had just selected. `QScrollArea` scrolls its viewport through its own connection to that same `valueChanged` signal, so blocking the scroll bar also cut the wiring that moves the content. The navigation sync is now gated by a flag instead, leaving the scroll bar's signals intact.

`test_navigation_jumps_to_group` asserted only `scroll_bar.value()`, which stays correct while the viewport is frozen, so the bug shipped green.

No CHANGELOG entry: the Settings page is still under `[Unreleased]` (#2403), so this is net-zero for anyone upgrading from v7.0.4.

## Test plan
- [x] `test_navigation_jumps_to_group` starts from a scrolled position and asserts the content's position within the viewport; fails on all 7 sections without the fix
- [x] `test_scrolling_updates_navigation_after_a_jump` covers the flag being released; verified by mutation that it fails when the reset is removed
- [x] `uv run pytest tests/unit/widgets/settings_dialog_test.py tests/e2e/settings_test.py` → 57 passed
- [x] Navigation tests re-run with `--headed` on a real window, since the offscreen platform can re-sync the viewport on its own
- [x] `ruff check`, `ruff format --check`, `ty check`
