### PR TITLE
test: make widget exposure waits effective

### DIFF
--- a/tests/unit/widgets/label_dialog/screen_fit_test.py
+++ b/tests/unit/widgets/label_dialog/screen_fit_test.py
@@ -24,8 +24,8 @@ def test_flag_spacing_is_identical_with_and_without_scrollbar(qtbot: QtBot) -> N
     few = _make_dialog(qtbot, flag_count=3)
     many = _make_dialog(qtbot, flag_count=12)
     for dialog in (few, many):
-        dialog.show()
-        qtbot.waitExposed(dialog)
+        with qtbot.waitExposed(dialog):
+            dialog.show()
 
     assert few._flags_scroll.verticalScrollBar().maximum() == 0
     assert many._flags_scroll.verticalScrollBar().maximum() > 0
@@ -38,8 +38,8 @@ def test_flag_spacing_is_identical_with_and_without_scrollbar(qtbot: QtBot) -> N
 
 def test_many_flags_are_capped_and_scrollable(qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=60)
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     assert dialog._flags_scroll.height() <= 150
     assert dialog._flags_scroll.verticalScrollBar().maximum() > 0
@@ -47,8 +47,8 @@ def test_many_flags_are_capped_and_scrollable(qtbot: QtBot) -> None:
 
 def test_few_flags_shrink_below_cap(qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=2)
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     assert dialog._flags_scroll.height() < 150
     assert dialog._flags_scroll.verticalScrollBar().maximum() == 0
@@ -57,8 +57,8 @@ def test_few_flags_shrink_below_cap(qtbot: QtBot) -> None:
 @pytest.mark.parametrize("corner", ["topLeft", "topRight", "bottomLeft", "bottomRight"])
 def test_move_keeps_dialog_within_screen(qtbot: QtBot, corner: str) -> None:
     dialog = _make_dialog(qtbot, flag_count=3)
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     available = QtGui.QGuiApplication.primaryScreen().availableGeometry()
     dialog._move_within_screen(getattr(available, corner)())
@@ -68,8 +68,8 @@ def test_move_keeps_dialog_within_screen(qtbot: QtBot, corner: str) -> None:
 
 def test_move_anchors_content_corner_at_target(qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=3)
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     target = QtGui.QGuiApplication.primaryScreen().availableGeometry().center()
     dialog._move_within_screen(target)
@@ -79,8 +79,8 @@ def test_move_anchors_content_corner_at_target(qtbot: QtBot) -> None:
 
 def test_clamp_does_not_move_dialog_already_on_screen(qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=3)
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     available = QtGui.QGuiApplication.primaryScreen().availableGeometry()
     target = available.center()

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -252,8 +252,8 @@ def test_navigation_elides_long_localized_names_without_squeezing_content(
         assert navigation.textElideMode() == QtCore.Qt.TextElideMode.ElideRight
         assert navigation.width() == 240
 
-        dialog.show()
-        qtbot.waitExposed(dialog)
+        with qtbot.waitExposed(dialog):
+            dialog.show()
         if dialog.width() >= dialog.sizeHint().width():
             assert dialog._page._scroll_area.horizontalScrollBar().maximum() == 0
     finally:
@@ -263,8 +263,8 @@ def test_navigation_elides_long_localized_names_without_squeezing_content(
 def test_default_size_scrolls_vertically_only(
     qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     scroll_area = dialog._page._scroll_area
     assert (dialog.width(), dialog.height()) == (760, 590)
@@ -283,8 +283,8 @@ def test_dialog_is_resizable(dialog: SettingsDialog) -> None:
 def test_dialog_prevents_narrow_content_overflow(
     qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
     minimum_width = dialog.width()
 
     dialog.resize(minimum_width - 200, dialog.height())
@@ -297,8 +297,8 @@ def test_dialog_prevents_narrow_content_overflow(
 def test_navigation_jumps_to_group(
     qtbot: QtBot, dialog: SettingsDialog, target: int
 ) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     scroll_bar = dialog._page._scroll_area.verticalScrollBar()
     # Start scrolled: from the top, a broken jump that moves the scroll bar but not
@@ -325,8 +325,8 @@ def test_navigation_jumps_to_group(
 
 
 def test_scrolling_updates_navigation(qtbot: QtBot, dialog: SettingsDialog) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     scroll_bar = dialog._page._scroll_area.verticalScrollBar()
     scroll_bar.setValue(scroll_bar.maximum() - 1)
@@ -339,8 +339,8 @@ def test_scrolling_updates_navigation(qtbot: QtBot, dialog: SettingsDialog) -> N
 def test_scrolling_updates_navigation_after_a_jump(
     qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     navigation = dialog._page._navigation
     item = navigation.item(1)
@@ -359,8 +359,8 @@ def test_scrolling_updates_navigation_after_a_jump(
 def test_navigation_returns_to_first_group_when_resize_removes_scrollbar(
     qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     scroll_bar = dialog._page._scroll_area.verticalScrollBar()
     scroll_bar.setValue(scroll_bar.maximum())
@@ -376,8 +376,8 @@ def test_navigation_returns_to_first_group_when_resize_removes_scrollbar(
 def test_reopening_preserves_scroll_position(
     qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
     scroll_bar = dialog._page._scroll_area.verticalScrollBar()
     scroll_bar.setValue(scroll_bar.maximum() // 2)
     expected = scroll_bar.value()
@@ -390,8 +390,8 @@ def test_reopening_preserves_scroll_position(
 
 def test_short_dialog_scrolls_page(qtbot: QtBot, dialog: SettingsDialog) -> None:
     dialog.resize(dialog.width(), 160)
-    dialog.show()
-    qtbot.waitExposed(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
 
     assert dialog._page._scroll_area.verticalScrollBar().maximum() > 0
 
@@ -405,8 +405,8 @@ def test_large_font_uses_default_size_with_scrolling(
     QtWidgets.QApplication.setFont(large_font)
     try:
         dialog = _make_dialog(qtbot=qtbot, applied=applied, overrides={})
-        dialog.show()
-        qtbot.waitExposed(dialog)
+        with qtbot.waitExposed(dialog):
+            dialog.show()
 
         available_size = dialog.screen().availableGeometry().size()
         scroll_bar_width = dialog.style().pixelMetric(


### PR DESCRIPTION
Closes #2431.

Bare `qtbot.waitExposed(...)` calls only build the context manager and never wait, so 16 exposure waits were no-ops. They now use the context-managed form around `show()`, and a new AST-based repository test rejects any future bare call.

## Test plan
- [x] New repository test scans tests/ for bare `waitExposed` calls
- [x] `make lint` and `make test` (1165 passed)