### PR TITLE
ci: run behavioral tests on every supported OS and Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.12', '3.13', '3.14']
@@ -27,15 +28,18 @@ jobs:
         with:
           packages: xvfb libegl1 libxkbcommon0 libxcb-cursor0 libgl1
           version: 1.0
+      # Pixel snapshots skip themselves off Linux (tests/e2e/conftest.py), so
+      # one plain invocation runs the right set everywhere.
       - name: Test
         shell: bash
-        if: matrix.os == 'ubuntu-latest'
         env:
           MPLBACKEND: agg
         run: |
-          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-          export DISPLAY=:99
-          make test
+          if [ "$RUNNER_OS" = Linux ]; then
+            xvfb-run -a make test
+          else
+            make test
+          fi
       - name: Run examples
         shell: bash
         if: matrix.os != 'windows-latest'
@@ -103,6 +107,4 @@ jobs:
         env:
           MPLBACKEND: agg
         run: |-
-          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-          export DISPLAY=:99
-          make test PYTEST_ARGS="-m network --numprocesses=1"
+          xvfb-run -a make test PYTEST_ARGS="-m network --numprocesses=1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
   workflow_call:
+# Nine GUI cells per push are too expensive to keep running for superseded
+# commits. github.ref is unique per pull request (refs/pull/N/merge) even for
+# fork branches that share a name, and the event condition keeps main pushes
+# and workflow_call runs uncancelled, so only obsolete PR runs are cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.12', '3.13', '3.14']
@@ -26,15 +27,25 @@ jobs:
         with:
           packages: xvfb libegl1 libxkbcommon0 libxcb-cursor0 libgl1
           version: 1.0
-      - name: Test
+      - name: Test behavior
+        shell: bash
+        env:
+          MPLBACKEND: agg
+          PYTEST_ADDOPTS: -m "not network and not snapshot"
+        run: |
+          if [ "${{ runner.os }}" = Linux ]; then
+            xvfb-run -a make test
+          else
+            make test
+          fi
+      - name: Test pixel snapshots
         shell: bash
         if: matrix.os == 'ubuntu-latest'
         env:
           MPLBACKEND: agg
+          PYTEST_ADDOPTS: -m "snapshot and not network"
         run: |
-          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-          export DISPLAY=:99
-          make test
+          xvfb-run -a make test
       - name: Run examples
         shell: bash
         if: matrix.os != 'windows-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ qt_api = "pyside6"
 markers = [
   "gui: mark a test as a GUI test.",
   "network: mark a test that accesses an external network service.",
+  "pixel_snapshot: mark a test that compares rendering against a stored pixel snapshot.",
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ qt_api = "pyside6"
 markers = [
   "gui: mark a test as a GUI test.",
   "network: mark a test that accesses an external network service.",
+  "snapshot: mark a test that compares rendering against a pixel snapshot.",
 ]
 
 [tool.ruff.lint]

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -37,6 +37,34 @@ _TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
 _SHAPE_INDEX: Final[int] = 0
 
 
+def _find_edge_midpoint_clear_of_vertices(canvas: Canvas, shape: Shape) -> QPointF:
+    # Hovering prefers a vertex over an edge within epsilon/scale of it, so the
+    # middle of a short edge stops being hoverable once a smaller screen scales
+    # the image down. Take the edge midpoint standing farthest from any vertex.
+    vertices = np.array(
+        [
+            [float(point[0]), float(point[1])]
+            for other in canvas.shapes
+            for point in other.points
+        ]
+    )
+    points = [(float(point[0]), float(point[1])) for point in shape.points]
+    midpoints = [
+        ((start[0] + end[0]) / 2, (start[1] + end[1]) / 2)
+        for start, end in zip(points, points[1:] + points[:1])
+    ]
+    clearances = [
+        np.linalg.norm(vertices - np.array(midpoint), axis=1).min()
+        for midpoint in midpoints
+    ]
+    best = int(np.argmax(clearances))
+    # Fail with the cause rather than an opaque disabled action if a smaller
+    # screen ever scales every midpoint back into the vertex preference.
+    assert clearances[best] > canvas._epsilon / canvas.scale
+    x, y = midpoints[best]
+    return QPointF(x, y)
+
+
 def _hover_and_drag(
     qtbot: QtBot,
     canvas: Canvas,
@@ -284,10 +312,7 @@ def test_add_point_via_context_menu_action(
 
     assert not annotated_win._actions.add_point_to_edge.isEnabled()
 
-    p0, p1 = shape.points[0], shape.points[1]
-    midpoint = QPointF(
-        (float(p0[0]) + float(p1[0])) / 2, (float(p0[1]) + float(p1[1])) / 2
-    )
+    midpoint = _find_edge_midpoint_clear_of_vertices(canvas=canvas, shape=shape)
     qtbot.mouseMove(canvas, pos=image_to_widget_pos(canvas=canvas, image_pos=midpoint))
     qtbot.wait(100)
 

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -25,10 +25,11 @@ from .conftest import draw_and_commit_polygon
 from .conftest import image_to_widget_pos
 from .conftest import select_shape
 
-# Pinning canvas size + scale + background decouples the snapshot from
-# platform window chrome (toolbar/dock metrics) so the rendered pixels are
-# determined by Qt's raster engine, which is deterministic across platforms
-# for non-text geometry. The Fusion style is set by labelme.__main__.main(),
+pytestmark = pytest.mark.pixel_snapshot
+
+# Pinning canvas size, scale, and background decouples the snapshot from platform
+# window chrome. Reference pixels remain Linux-specific because Qt rendering can
+# differ across platforms. The Fusion style is set by labelme.__main__.main(),
 # which the main_win fixture invokes for every test.
 _RENDER_WIDTH: Final[int] = 600
 _RENDER_HEIGHT: Final[int] = 450

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -25,10 +25,11 @@ from .conftest import draw_and_commit_polygon
 from .conftest import image_to_widget_pos
 from .conftest import select_shape
 
-# Pinning canvas size + scale + background decouples the snapshot from
-# platform window chrome (toolbar/dock metrics) so the rendered pixels are
-# determined by Qt's raster engine, which is deterministic across platforms
-# for non-text geometry. The Fusion style is set by labelme.__main__.main(),
+pytestmark = pytest.mark.snapshot
+
+# Pinning canvas size, scale, and background decouples the snapshot from platform
+# window chrome. Reference pixels remain Linux-specific because Qt rendering can
+# differ across platforms. The Fusion style is set by labelme.__main__.main(),
 # which the main_win fixture invokes for every test.
 _RENDER_WIDTH: Final[int] = 600
 _RENDER_HEIGHT: Final[int] = 450

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -113,6 +113,9 @@ def main_win(
 
         monkeypatch.setattr(sys, "argv", argv)
         monkeypatch.setenv("HOME", str(session_home))
+        # ntpath.expanduser ignores HOME, so without this the app would read and
+        # write the real user profile on Windows.
+        monkeypatch.setenv("USERPROFILE", str(session_home))
 
         app = QApplication.instance()
         assert isinstance(app, QApplication)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -25,6 +25,18 @@ from labelme._widgets.canvas import Canvas
 from labelme._widgets.label_dialog import LabelDialog
 
 
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    # The reference pixels are rendered on Linux, and Qt rendering can differ
+    # across platforms. Gating on the marker here keeps one plain `make test`
+    # correct on every OS, locally and in CI.
+    if sys.platform == "linux":
+        return
+    skip = pytest.mark.skip(reason="reference pixels are rendered on Linux")
+    for item in items:
+        if item.get_closest_marker("pixel_snapshot") is not None:
+            item.add_marker(skip)
+
+
 @pytest.fixture(scope="session")
 def session_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("home")

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -9,6 +8,7 @@ from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme._app import MainWindow
+from labelme._config import _writer
 from labelme._widgets import SettingsDialog
 from labelme._widgets.settings_dialog import _PlainTextEdit
 from labelme._yaml import safe_load
@@ -291,12 +291,7 @@ def test_setting_controls_revert_when_write_fails(
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    if hasattr(os, "geteuid") and os.geteuid() == 0:
-        pytest.skip("a read-only directory is not enforced for root")
-
-    config_dir = tmp_path / "ro"
-    config_dir.mkdir()
-    config_file = config_dir / "labelmerc.yaml"
+    config_file = tmp_path / "labelmerc.yaml"
     config_file.write_text("display_label_popup: true\n")
     win = main_win(config_file=config_file)
 
@@ -319,15 +314,16 @@ def test_setting_controls_revert_when_write_fails(
     ai_dock = win._ai_annotation._model_combo
     assert ai_dock.currentText() == "Sam2 (balanced)"
 
-    # The atomic save writes a temp file in the config directory, so a read-only
-    # directory makes set_override raise.
-    config_dir.chmod(0o500)
-    try:
-        checkbox.setChecked(False)
-        win._actions.save_auto.trigger()
-        ai_dock.setCurrentIndex(ai_dock.findText("EfficientSam (speed)"))
-    finally:
-        config_dir.chmod(0o700)
+    # Refuse the save at the boundary a read-only config directory would;
+    # injecting the failure keeps it reachable on Windows and as root, where
+    # a read-only directory does not block writes.
+    def _refuse_write(config_file: Path, content: str) -> None:
+        raise PermissionError(f"injected write failure: {config_file}")
+
+    monkeypatch.setattr(_writer, "_atomic_write", _refuse_write)
+    checkbox.setChecked(False)
+    win._actions.save_auto.trigger()
+    ai_dock.setCurrentIndex(ai_dock.findText("EfficientSam (speed)"))
 
     assert len(warned) == 3
     assert checkbox.isChecked()  # editor reverted to the last-saved value

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -142,7 +142,9 @@ def test_resolve_config_source_falls_back_to_defaults_on_missing_default_file(
 
     assert resolved == (None, {})
     assert len(warnings_logged) == 1
-    assert str(missing_default) in warnings_logged[0]
+    # The warning quotes the path with !r, which doubles the backslashes of a
+    # Windows path.
+    assert repr(str(missing_default)) in warnings_logged[0]
 
 
 def test_resolve_config_source_reads_an_existing_default_file(tmp_path: Path) -> None:
@@ -283,7 +285,7 @@ def test_setup_loguru_degrades_to_stderr_when_the_log_file_cannot_be_opened(
 
     err = capsys.readouterr().err
     assert "Failed to set up the log file" in err
-    assert str(cache_dir / "labelme.log") in err
+    assert repr(str(cache_dir / "labelme.log")) in err
 
 
 def test_setup_loguru_degrades_to_stderr_without_localappdata(

--- a/tests/unit/_config/api_test.py
+++ b/tests/unit/_config/api_test.py
@@ -8,10 +8,17 @@ import pytest
 from labelme import _config
 
 
+def _steer_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    monkeypatch.setenv("HOME", str(home))
+    # ntpath.expanduser ignores HOME, so without this the test would read and
+    # write the real user profile on Windows.
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+
 def test_get_user_config_file_creates_empty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _steer_home(monkeypatch=monkeypatch, home=tmp_path)
     config_file = _config.get_user_config_file()
     assert Path(config_file).read_text() == ""
 
@@ -19,7 +26,7 @@ def test_get_user_config_file_creates_empty(
 def test_get_user_config_file_does_not_overwrite(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _steer_home(monkeypatch=monkeypatch, home=tmp_path)
     config_path = tmp_path / ".labelmerc"
     config_path.write_text("auto_save: true\n")
     config_file = _config.get_user_config_file()
@@ -30,7 +37,7 @@ def test_get_user_config_file_does_not_overwrite(
 def test_get_user_config_file_skip_creation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _steer_home(monkeypatch=monkeypatch, home=tmp_path)
     config_file = _config.get_user_config_file(create_if_missing=False)
     assert not Path(config_file).exists()
 

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -380,7 +380,9 @@ def test_read_label_file_reports_shape_index_field_and_filename(
     with pytest.raises(LabelFileReadError) as exc_info:
         read_label_file(filename=str(annotated_dst))
 
-    assert str(annotated_dst) in str(exc_info.value)
+    # The message quotes the filename with !r, which doubles the backslashes of
+    # a Windows path.
+    assert repr(str(annotated_dst)) in str(exc_info.value)
     assert "shapes[1]: shape_type" in str(exc_info.value)
 
 
@@ -400,7 +402,7 @@ def test_read_label_file_wraps_coordinate_overflow(
     with pytest.raises(LabelFileReadError) as exc_info:
         read_label_file(filename=str(annotated_dst))
 
-    assert str(annotated_dst) in str(exc_info.value)
+    assert repr(str(annotated_dst)) in str(exc_info.value)
     assert "shapes[0]: points" in str(exc_info.value)
 
 

--- a/tests/unit/widgets/label_dialog/screen_fit_test.py
+++ b/tests/unit/widgets/label_dialog/screen_fit_test.py
@@ -71,7 +71,14 @@ def test_move_anchors_content_corner_at_target(qtbot: QtBot) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
 
-    target = QtGui.QGuiApplication.primaryScreen().availableGeometry().center()
+    # The anchoring is only observable where the dialog needs no clamping, and
+    # the screen center is not that place on a screen barely wider than the
+    # dialog. Target the top-left corner offset by the decoration instead, so
+    # the frame lands exactly inside the screen.
+    available = QtGui.QGuiApplication.primaryScreen().availableGeometry()
+    decoration = dialog.geometry().topLeft() - dialog.frameGeometry().topLeft()
+    target = available.topLeft() + decoration
+
     dialog._move_within_screen(target)
 
     assert dialog.geometry().topLeft() == target

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -1,0 +1,28 @@
+import re
+import tomllib
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+_REPO_ROOT = Path(__file__).parents[1]
+
+
+def test_test_matrix_covers_every_supported_python_version() -> None:
+    # The only silent coverage gap: a new version classifier without a matrix
+    # update keeps CI green while the new version ships untested.
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text("utf-8"))
+    supported_versions = {
+        match.group(1)
+        for classifier in pyproject["project"]["classifiers"]
+        if (
+            match := re.fullmatch(
+                r"Programming Language :: Python :: (3\.\d+)", classifier
+            )
+        )
+    }
+    assert supported_versions
+
+    workflow = YAML(typ="safe").load(_REPO_ROOT / ".github/workflows/test.yml")
+    matrix = workflow["jobs"]["test"]["strategy"]["matrix"]
+    assert set(matrix["python-version"]) == supported_versions
+    assert set(matrix["os"]) == {"windows-latest", "macos-latest", "ubuntu-latest"}

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+def _load_test_workflow() -> dict[str, Any]:
+    workflow_path = Path(__file__).parents[1] / ".github/workflows/test.yml"
+    workflow = YAML(typ="safe").load(workflow_path)
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _get_named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    matching_steps = [step for step in job["steps"] if step.get("name") == name]
+    assert len(matching_steps) == 1
+    return matching_steps[0]
+
+
+def test_behavioral_test_matrix_covers_every_supported_environment() -> None:
+    test_job = _load_test_workflow()["jobs"]["test"]
+    matrix = test_job["strategy"]["matrix"]
+
+    assert matrix == {
+        "os": ["windows-latest", "macos-latest", "ubuntu-latest"],
+        "python-version": ["3.12", "3.13", "3.14"],
+    }
+    assert test_job["strategy"]["fail-fast"] is False
+    assert "if" not in test_job
+
+    behavior_step = _get_named_step(job=test_job, name="Test behavior")
+    assert "if" not in behavior_step
+    assert "make test" in behavior_step["run"]
+    assert "'" not in behavior_step["run"]
+    assert behavior_step["env"]["PYTEST_ADDOPTS"] == '-m "not network and not snapshot"'
+
+
+def test_pixel_snapshots_run_only_on_linux() -> None:
+    test_job = _load_test_workflow()["jobs"]["test"]
+    snapshot_step = _get_named_step(job=test_job, name="Test pixel snapshots")
+
+    assert snapshot_step["if"] == "matrix.os == 'ubuntu-latest'"
+    assert "make test" in snapshot_step["run"]
+    assert snapshot_step["env"]["PYTEST_ADDOPTS"] == '-m "snapshot and not network"'
+
+
+def test_network_tests_remain_in_an_isolated_job() -> None:
+    jobs = _load_test_workflow()["jobs"]
+    test_job = jobs["test"]
+    network_job = jobs["network-test"]
+
+    behavior_step = _get_named_step(job=test_job, name="Test behavior")
+    assert "not network" in behavior_step["env"]["PYTEST_ADDOPTS"]
+
+    snapshot_step = _get_named_step(job=test_job, name="Test pixel snapshots")
+    assert "not network" in snapshot_step["env"]["PYTEST_ADDOPTS"]
+
+    network_step = _get_named_step(job=network_job, name="Test real model download")
+    assert "-m network" in network_step["run"]


### PR DESCRIPTION
Closes #2457.

The test workflow built the project on Windows and macOS but ran the suite only on Ubuntu, so platform regressions shipped untested. All nine OS × Python cells now run the behavioral suite with one plain `make test` invocation, and the matrix immediately earned its keep: it surfaced the dropped-file path-separator bug (split out as #2497, already merged) and the Windows settings-dialog sizing bug (split out as #2500, which this PR is stacked on).

Non-obvious bits:

1. Pixel snapshots are gated by a collection-time skip in `tests/e2e/conftest.py` keyed on the `pixel_snapshot` marker, not by workflow-level `-m` filters. The reference pixels are Linux-rendered, and putting the gate in code makes a plain `make test` correct on every OS — including a contributor's macOS or Windows machine, where the CI-only filter would have let the snapshots run and fail.

2. `tests/workflow_test.py` guards the one gap nothing else catches: the matrix's Python versions are derived from the `pyproject.toml` classifiers, so adding a 3.15 classifier fails the test until the workflow follows. Everything else it once asserted either fails loudly on its own or is visible in a diff, so it was trimmed to this single test.

3. The failed-write settings test now injects a `PermissionError` at the atomic-write boundary instead of chmod-ing the config directory read-only. The chmod trick skipped the test on Windows and covered nothing as root; the injection keeps the revert path tested on every cell.

4. `concurrency` with `cancel-in-progress` stops superseded runs, since each push now costs nine GUI cells. The `github.run_id` fallback keeps main pushes and `workflow_call` invocations (release.yml) in unique groups, so only obsolete PR runs are cancelled; safe.

## Test plan

- [x] `make lint` and `make test` (1246 passed; the 5 skips are the pixel snapshots, off-Linux by design)
- [x] Every commit passes lint and the full suite independently (verified in a detached worktree)
- [ ] The nine-cell run itself is confirmed by this PR's own CI

Stacked on #2500; merge that first (GitHub retargets this PR to main when it lands).
