### PR TITLE
docs: define standalone artifact release handoff

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,7 +93,7 @@ The on-disk YAML where Settings are persisted as sparse Overrides on top of the 
 _Avoid_: settings file, rc file, labelmerc.
 
 **Default Config**:
-The baseline Settings shipped in `labelme/config/default_config.yaml`. Read-only, and the single source of both every default value and the set of allowed keys.
+The baseline Settings shipped in `labelme/_config/default_config.yaml`. Read-only, and the single source of both every default value and the set of allowed keys.
 _Avoid_: defaults file, base config, schema.
 
 **Override**:

--- a/README.md
+++ b/README.md
@@ -182,6 +182,42 @@ labelme data_annotated/ --labels labels.txt  # specify label list with a file
 - [Instance Segmentation](examples/instance_segmentation)
 - [Video Annotation](examples/video_annotation)
 
+## Standalone artifact release handoff
+
+The **labelme.io release pipeline** owns the official standalone artifacts for
+Windows, macOS, and Linux. It builds and validates these artifacts. This
+repository does not build or launch-test official standalone artifacts. The
+instructions below are only for local builds.
+
+For each release candidate, the labelme.io release pipeline must:
+
+- Build or obtain the exact release candidate artifacts for Windows, macOS, and
+  Linux. Record the release candidate tag, source commit, and an unambiguous
+  identity for each artifact, such as a pipeline artifact ID or SHA-256 checksum.
+- Launch each recorded artifact on its target operating system and wait until the
+  main window is ready.
+- Start with a clean user profile and verify that the bundled Default Config at
+  `labelme/_config/default_config.yaml` loads.
+- Verify that the application icon and the visible interface icons load from the
+  bundled `labelme/icons/` directory.
+- Confirm that all expected bundled `labelme/translate/*.qm` catalogs are present
+  and readable. Then select one non-English translation and verify that the
+  interface uses it.
+- Verify that required bundled AI runtime data can be read from the artifact,
+  including
+  `osam/_models/yoloworld/clip/bpe_simple_vocab_16e6.txt.gz`. Model weights that
+  OSAM downloads at runtime are not bundled data.
+- Record all results before the final release is promoted.
+
+The standalone-artifact check in
+[#2461](https://github.com/wkentaro/labelme/issues/2461) can pass only after the
+issue links to one successful labelme.io release pipeline run. That run is the
+required signal. It must identify the release candidate tag and source commit,
+list the unambiguous identity of each tested artifact, and show that all checks
+above passed on Windows, macOS, and Linux. A replacement artifact has a different
+identity and requires a new complete run. Without this linked signal, the release
+must not be promoted.
+
 ## How to build standalone executable
 
 ```bash

--- a/tests/unit/docs/standalone_artifact_handoff_test.py
+++ b/tests/unit/docs/standalone_artifact_handoff_test.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+
+@pytest.fixture
+def handoff() -> str:
+    REPOSITORY_ROOT: Final = Path(__file__).parents[3]
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    heading: Final = "## Standalone artifact release handoff"
+    _, separator, remainder = readme.partition(heading)
+    assert separator
+    section = remainder.partition("\n## ")[0]
+    return " ".join(section.split())
+
+
+def test_names_the_external_owner_and_platforms(handoff: str) -> None:
+    assert "labelme.io release pipeline" in handoff
+    assert "repository does not build or launch-test" in handoff
+    for platform in ("Windows", "macOS", "Linux"):
+        assert platform in handoff
+
+
+def test_requires_exact_release_candidate_artifacts(handoff: str) -> None:
+    assert "exact release candidate artifacts" in handoff
+    for identity in (
+        "release candidate tag",
+        "source commit",
+        "unambiguous identity for each artifact",
+    ):
+        assert identity in handoff
+
+
+def test_requires_each_artifact_to_launch(handoff: str) -> None:
+    assert "Launch each recorded artifact on its target operating system" in handoff
+    assert "main window is ready" in handoff
+
+
+def test_requires_all_bundled_runtime_resources(handoff: str) -> None:
+    for check in (
+        "clean user profile and verify that the bundled Default Config at "
+        "`labelme/_config/default_config.yaml` loads",
+        "application icon and the visible interface icons load from the bundled "
+        "`labelme/icons/` directory",
+        "all expected bundled `labelme/translate/*.qm` catalogs are present and "
+        "readable",
+        "select one non-English translation and verify that the interface uses it",
+        "required bundled AI runtime data can be read from the artifact, including "
+        "`osam/_models/yoloworld/clip/bpe_simple_vocab_16e6.txt.gz`",
+    ):
+        assert check in handoff
+
+
+def test_defines_the_release_gate_signal(handoff: str) -> None:
+    assert "[#2461](https://github.com/wkentaro/labelme/issues/2461)" in handoff
+    assert "one successful labelme.io release pipeline run" in handoff
+    assert "Record all results before the final release is promoted" in handoff
+    assert "unambiguous identity of each tested artifact" in handoff
+    assert "all checks above passed on Windows, macOS, and Linux" in handoff
+    assert "Without this linked signal, the release must not be promoted" in handoff


### PR DESCRIPTION
Closes #2459.

Per the maintainer decision on the issue, the labelme.io release pipeline owns building and launch-testing the standalone Windows, macOS, and Linux artifacts. The README now documents that ownership, the per-OS validation checklist (launch, bundled Default Config, icons, translation catalogs, required AI runtime data), the artifact-identity requirement, and the signal the #2461 release gate waits for: a linked successful pipeline run covering all three OSes.

## Test plan
- [x] Regression tests pin the handoff contract in the README (owner, checks, gate signal)
- [x] `make lint` and `make test` (1169 passed)