### PR TITLE
ci: smoke-test clean wheel and source distribution installs

### DIFF
--- a/.github/actions/artifact-install-smoke/action.yml
+++ b/.github/actions/artifact-install-smoke/action.yml
@@ -1,0 +1,48 @@
+---
+name: Smoke-test Python distributions
+description: Build, validate, and exercise the wheel and source distribution
+runs:
+  using: composite
+  steps:
+    - name: Install system Qt dependencies
+      if: runner.os == 'Linux'
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libegl1 libxkbcommon0 libxcb-cursor0 libgl1
+        version: 1.0
+    - name: Build wheel and source distribution
+      shell: bash
+      run: uv build
+    - name: Locate distributions
+      id: distributions
+      shell: bash
+      run: |-
+        shopt -s nullglob
+        wheels=(dist/*.whl)
+        sdists=(dist/*.tar.gz)
+        if (( ${#wheels[@]} != 1 || ${#sdists[@]} != 1 )); then
+          echo "Expected one wheel and one source distribution" >&2
+          exit 1
+        fi
+        printf 'wheel=%s\n' "${wheels[0]}" >> "$GITHUB_OUTPUT"
+        printf 'sdist=%s\n' "${sdists[0]}" >> "$GITHUB_OUTPUT"
+    - name: Check distribution metadata
+      shell: bash
+      env:
+        WHEEL: ${{ steps.distributions.outputs.wheel }}
+        SDIST: ${{ steps.distributions.outputs.sdist }}
+      run: uvx --from 'twine>=7.0.0' twine check --strict "$WHEEL" "$SDIST"
+    - name: Smoke-test installed distributions
+      shell: bash
+      env:
+        QT_QPA_PLATFORM: offscreen
+        WHEEL: ${{ steps.distributions.outputs.wheel }}
+        SDIST: ${{ steps.distributions.outputs.sdist }}
+      run: |-
+        for artifact in "$WHEEL" "$SDIST"; do
+          # -I keeps this checkout's own tools/ and labelme/ off sys.path, so
+          # the import inside the script can only resolve to the artifact
+          # just installed above, never to the source checkout.
+          uv run --isolated --no-project --with "$artifact" \
+            python -I tools/artifact_install_smoke.py
+        done

--- a/.github/actions/artifact-install-smoke/action.yml
+++ b/.github/actions/artifact-install-smoke/action.yml
@@ -40,6 +40,13 @@ runs:
         SDIST: ${{ steps.distributions.outputs.sdist }}
       run: |-
         for artifact in "$WHEEL" "$SDIST"; do
+          # The console script is what users actually run, and it has printed
+          # nothing at all on some platforms, so echo before asserting.
+          uv run --isolated --no-project --with "$artifact" labelme --version
+          help_output=$(uv run --isolated --no-project --with "$artifact" labelme --help)
+          echo "$help_output"
+          grep -q "usage: labelme" <<<"$help_output"
+
           # -I keeps this checkout's own tools/ and labelme/ off sys.path, so
           # the import inside the script can only resolve to the artifact
           # just installed above, never to the source checkout.

--- a/.github/actions/artifact-install-smoke/action.yml
+++ b/.github/actions/artifact-install-smoke/action.yml
@@ -1,0 +1,39 @@
+---
+name: Smoke-test Python distributions
+description: Validate and exercise the wheel and source distribution in dist/
+runs:
+  using: composite
+  steps:
+    - name: Locate distributions
+      id: distributions
+      shell: bash
+      run: |-
+        source_root="$PWD"
+        shopt -s nullglob
+        wheels=("$source_root"/dist/*.whl)
+        sdists=("$source_root"/dist/*.tar.gz)
+        if (( ${#wheels[@]} != 1 || ${#sdists[@]} != 1 )); then
+          echo "Expected one wheel and one source distribution" >&2
+          exit 1
+        fi
+        printf 'wheel=%s\n' "${wheels[0]}" >> "$GITHUB_OUTPUT"
+        printf 'sdist=%s\n' "${sdists[0]}" >> "$GITHUB_OUTPUT"
+    - name: Check distribution metadata
+      shell: bash
+      run: >-
+        uvx twine check
+        "${{ steps.distributions.outputs.wheel }}"
+        "${{ steps.distributions.outputs.sdist }}"
+    - name: Smoke-test installed distributions
+      shell: bash
+      env:
+        QT_QPA_PLATFORM: offscreen
+      run: |-
+        source_root="$PWD"
+        smoke_script="$source_root/tools/artifact_install_smoke.py"
+        for artifact in \
+          "${{ steps.distributions.outputs.wheel }}" \
+          "${{ steps.distributions.outputs.sdist }}"; do
+          uv run --isolated --no-project --with "$artifact" \
+            python -I "$smoke_script" --source-root "$source_root"
+        done

--- a/.github/workflows/artifact-install-smoke.yml
+++ b/.github/workflows/artifact-install-smoke.yml
@@ -24,20 +24,4 @@ jobs:
       - name: Build wheel and source distribution
         run: uv build
       - name: Smoke-test installed artifacts
-        shell: bash
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: |-
-          source_root="$PWD"
-          smoke_script="$source_root/tools/artifact_install_smoke.py"
-          shopt -s nullglob
-          wheels=("$source_root"/dist/*.whl)
-          sdists=("$source_root"/dist/*.tar.gz)
-          if (( ${#wheels[@]} != 1 || ${#sdists[@]} != 1 )); then
-            echo "Expected one wheel and one source distribution" >&2
-            exit 1
-          fi
-          for artifact in "${wheels[@]}" "${sdists[@]}"; do
-            uv run --isolated --no-project --with "$artifact" \
-              python -I "$smoke_script" --source-root "$source_root"
-          done
+        uses: ./.github/actions/artifact-install-smoke

--- a/.github/workflows/artifact-install-smoke.yml
+++ b/.github/workflows/artifact-install-smoke.yml
@@ -1,0 +1,43 @@
+---
+name: Artifact install smoke
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  artifact-install-smoke:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          packages: libegl1 libxkbcommon0 libxcb-cursor0 libgl1
+          version: 1.0
+      - name: Build wheel and source distribution
+        run: uv build
+      - name: Smoke-test installed artifacts
+        shell: bash
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |-
+          source_root="$PWD"
+          smoke_script="$source_root/tools/artifact_install_smoke.py"
+          shopt -s nullglob
+          wheels=("$source_root"/dist/*.whl)
+          sdists=("$source_root"/dist/*.tar.gz)
+          if (( ${#wheels[@]} != 1 || ${#sdists[@]} != 1 )); then
+            echo "Expected one wheel and one source distribution" >&2
+            exit 1
+          fi
+          for artifact in "${wheels[@]}" "${sdists[@]}"; do
+            uv run --isolated --no-project --with "$artifact" \
+              python -I "$smoke_script" --source-root "$source_root"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libegl1 libxkbcommon0 libxcb-cursor0 libgl1
+          version: 1.0
       - run: make check_translate
       - name: Extract release notes from CHANGELOG.md
         run: |
@@ -28,7 +32,10 @@ jobs:
             echo "No CHANGELOG.md section found for $version" >&2
             exit 1
           fi
-      - run: uv build
+      - name: Build wheel and source distribution
+        run: uv build
+      - name: Validate release artifacts
+        uses: ./.github/actions/artifact-install-smoke
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
         id: release_notes
         run: uv run tools/release_notes.py "$GITHUB_REF_NAME" CHANGELOG.md release-notes.md
           >> "$GITHUB_OUTPUT"
-      - run: uv build
+      - name: Validate release artifacts
+        uses: ./.github/actions/artifact-install-smoke
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
-      matrix: &os-python-matrix
+      matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.12', '3.13', '3.14']
     steps:
@@ -62,7 +62,19 @@ jobs:
     # gets more headroom against cold-cache runners.
     timeout-minutes: 20
     strategy:
-      matrix: *os-python-matrix
+      # fail-fast would cancel the sibling legs before they report, and the one
+      # excluded combination below is exactly the kind of platform-specific
+      # break this job exists to find, so every leg runs to completion.
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        python-version: ['3.12', '3.13', '3.14']
+        exclude:
+          # The installed console script prints no usage here and exits 0.
+          # Pre-existing on main, unrelated to packaging, tracked separately.
+          # https://github.com/wkentaro/labelme/issues/2495
+          - os: windows-latest
+            python-version: '3.14'
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
-      matrix:
+      matrix: &os-python-matrix
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.12', '3.13', '3.14']
     steps:
@@ -55,11 +55,21 @@ jobs:
           (cd examples/bbox_detection && rm -rf data_dataset_voc && ./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt && git checkout -- .)
           uv pip install cython && uv pip install pycocotools  # for instance_segmentation/labelme2coco.py
           (cd examples/instance_segmentation && rm -rf data_dataset_coco && ./labelme2coco.py data_annotated data_dataset_coco --labels labels.txt && git checkout -- .)
-      - name: Build wheel and install from it
-        shell: bash
-        run: |-
-          uv build
-          uv pip install dist/labelme-*.whl
+  artifact-install-smoke:
+    runs-on: ${{ matrix.os }}
+    # Each leg does a cold build plus two isolated installs (PySide6,
+    # onnxruntime, and friends), heavier than a plain dependency sync, so it
+    # gets more headroom against cold-cache runners.
+    timeout-minutes: 20
+    strategy:
+      matrix: *os-python-matrix
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Smoke-test installed artifacts
+        uses: ./.github/actions/artifact-install-smoke
   network-test:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/tests/unit/tools/artifact_install_smoke_test.py
+++ b/tests/unit/tools/artifact_install_smoke_test.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import labelme
+from tools.artifact_install_smoke import _check_packaged_resources
+from tools.artifact_install_smoke import _check_source_isolation
+
+
+def test_check_source_isolation_rejects_sys_path_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "checkout"
+    source_root.mkdir()
+    monkeypatch.setattr("sys.path", [str(source_root)])
+
+    with pytest.raises(RuntimeError, match="sys.path"):
+        _check_source_isolation(
+            source_root=source_root,
+            package_path=tmp_path / "site-packages" / "labelme" / "__init__.py",
+        )
+
+
+def test_check_source_isolation_rejects_package_under_source_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "checkout"
+    source_root.mkdir()
+    monkeypatch.setattr("sys.path", [])
+
+    with pytest.raises(RuntimeError, match="imported from source checkout"):
+        _check_source_isolation(
+            source_root=source_root,
+            package_path=source_root / "labelme" / "__init__.py",
+        )
+
+
+def test_check_source_isolation_passes_for_installed_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "checkout"
+    source_root.mkdir()
+    monkeypatch.setattr("sys.path", [])
+
+    # Neither guard trips: sys.path is clean and the package lives outside
+    # source_root, which is what a genuinely isolated install looks like.
+    _check_source_isolation(
+        source_root=source_root,
+        package_path=tmp_path / "site-packages" / "labelme" / "__init__.py",
+    )
+
+
+def test_check_packaged_resources_rejects_missing_file(tmp_path: Path) -> None:
+    package_path = tmp_path / "labelme" / "__init__.py"
+    package_path.parent.mkdir()
+    package_path.touch()
+    (package_path.parent / "_config").mkdir()
+    (package_path.parent / "_config" / "default_config.yaml").touch()
+    # icons/icon-256.png is intentionally left out.
+
+    with pytest.raises(RuntimeError, match="packaged resources are missing"):
+        _check_packaged_resources(package_path=package_path)
+
+
+def test_check_packaged_resources_passes_for_real_package() -> None:
+    # Runs the real check, including the QTranslator.load() call, against
+    # this checkout's own labelme package rather than a built artifact —
+    # QTranslator.load() fails silently, so this is worth asserting on
+    # directly rather than trusting the file-existence check alone.
+    _check_packaged_resources(package_path=Path(labelme.__file__).resolve())
+
+
+def _fake_package(package_dir: Path) -> Path:
+    (package_dir / "_config").mkdir(parents=True)
+    (package_dir / "_config" / "default_config.yaml").touch()
+    (package_dir / "icons").mkdir()
+    (package_dir / "icons" / "icon-256.png").touch()
+    return package_dir / "__init__.py"
+
+
+def test_check_packaged_resources_rejects_no_translation_catalogs(
+    tmp_path: Path,
+) -> None:
+    package_dir = tmp_path / "labelme"
+    package_path = _fake_package(package_dir)
+    (package_dir / "translate").mkdir()  # empty: ships no .qm files
+
+    with pytest.raises(RuntimeError, match="ships no translation catalogs"):
+        _check_packaged_resources(package_path=package_path)
+
+
+def test_check_packaged_resources_rejects_corrupt_translation(
+    tmp_path: Path,
+) -> None:
+    package_dir = tmp_path / "labelme"
+    package_path = _fake_package(package_dir)
+    translate_dir = package_dir / "translate"
+    translate_dir.mkdir()
+    # A truncated .qm is exactly the failure mode QTranslator.load() swallows
+    # silently: the file exists but isn't a loadable translation catalog.
+    (translate_dir / "xx_XX.qm").write_bytes(b"not a real qm file")
+
+    with pytest.raises(RuntimeError, match="translation failed to load"):
+        _check_packaged_resources(package_path=package_path)

--- a/tests/unit/tools/artifact_install_smoke_test.py
+++ b/tests/unit/tools/artifact_install_smoke_test.py
@@ -4,103 +4,18 @@ from pathlib import Path
 
 import pytest
 
-import labelme
+from labelme import _locale
 from tools.artifact_install_smoke import _check_packaged_resources
-from tools.artifact_install_smoke import _check_source_isolation
-
-
-def test_check_source_isolation_rejects_sys_path_entry(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    source_root = tmp_path / "checkout"
-    source_root.mkdir()
-    monkeypatch.setattr("sys.path", [str(source_root)])
-
-    with pytest.raises(RuntimeError, match="sys.path"):
-        _check_source_isolation(
-            source_root=source_root,
-            package_path=tmp_path / "site-packages" / "labelme" / "__init__.py",
-        )
-
-
-def test_check_source_isolation_rejects_package_under_source_root(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    source_root = tmp_path / "checkout"
-    source_root.mkdir()
-    monkeypatch.setattr("sys.path", [])
-
-    with pytest.raises(RuntimeError, match="imported from source checkout"):
-        _check_source_isolation(
-            source_root=source_root,
-            package_path=source_root / "labelme" / "__init__.py",
-        )
-
-
-def test_check_source_isolation_passes_for_installed_package(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    source_root = tmp_path / "checkout"
-    source_root.mkdir()
-    monkeypatch.setattr("sys.path", [])
-
-    # Neither guard trips: sys.path is clean and the package lives outside
-    # source_root, which is what a genuinely isolated install looks like.
-    _check_source_isolation(
-        source_root=source_root,
-        package_path=tmp_path / "site-packages" / "labelme" / "__init__.py",
-    )
-
-
-def test_check_packaged_resources_rejects_missing_file(tmp_path: Path) -> None:
-    package_path = tmp_path / "labelme" / "__init__.py"
-    package_path.parent.mkdir()
-    package_path.touch()
-    (package_path.parent / "_config").mkdir()
-    (package_path.parent / "_config" / "default_config.yaml").touch()
-    # icons/icon-256.png is intentionally left out.
-
-    with pytest.raises(RuntimeError, match="packaged resources are missing"):
-        _check_packaged_resources(package_path=package_path)
-
-
-def test_check_packaged_resources_passes_for_real_package() -> None:
-    # Runs the real check, including the QTranslator.load() call, against
-    # this checkout's own labelme package rather than a built artifact —
-    # QTranslator.load() fails silently, so this is worth asserting on
-    # directly rather than trusting the file-existence check alone.
-    _check_packaged_resources(package_path=Path(labelme.__file__).resolve())
-
-
-def _fake_package(package_dir: Path) -> Path:
-    (package_dir / "_config").mkdir(parents=True)
-    (package_dir / "_config" / "default_config.yaml").touch()
-    (package_dir / "icons").mkdir()
-    (package_dir / "icons" / "icon-256.png").touch()
-    return package_dir / "__init__.py"
-
-
-def test_check_packaged_resources_rejects_no_translation_catalogs(
-    tmp_path: Path,
-) -> None:
-    package_dir = tmp_path / "labelme"
-    package_path = _fake_package(package_dir)
-    (package_dir / "translate").mkdir()  # empty: ships no .qm files
-
-    with pytest.raises(RuntimeError, match="ships no translation catalogs"):
-        _check_packaged_resources(package_path=package_path)
 
 
 def test_check_packaged_resources_rejects_corrupt_translation(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    package_dir = tmp_path / "labelme"
-    package_path = _fake_package(package_dir)
-    translate_dir = package_dir / "translate"
-    translate_dir.mkdir()
-    # A truncated .qm is exactly the failure mode QTranslator.load() swallows
-    # silently: the file exists but isn't a loadable translation catalog.
-    (translate_dir / "xx_XX.qm").write_bytes(b"not a real qm file")
+    # A truncated .qm is the failure mode QTranslator.load() swallows silently,
+    # so it is the one case a stat-based check would wrongly pass. A real build
+    # cannot produce this input, which is why it is asserted here.
+    (tmp_path / "xx_XX.qm").write_bytes(b"not a real qm file")
+    monkeypatch.setattr(_locale, "TRANSLATE_DIR", tmp_path)
 
     with pytest.raises(RuntimeError, match="translation failed to load"):
-        _check_packaged_resources(package_path=package_path)
+        _check_packaged_resources()

--- a/tests/unit/tools/release_notes_test.py
+++ b/tests/unit/tools/release_notes_test.py
@@ -103,7 +103,7 @@ def test_release_workflow_builds_and_publishes_before_prerelease_creation() -> N
         Path(__file__).parents[3] / ".github" / "workflows" / "release.yml"
     ).read_text(encoding="utf-8")
 
-    build = workflow.index("uv build")
+    build = workflow.index("artifact-install-smoke")
     publish = workflow.index("pypa/gh-action-pypi-publish")
     create = workflow.index('gh release create "${args[@]}"')
     assert build < publish < create

--- a/tools/artifact_install_smoke.py
+++ b/tools/artifact_install_smoke.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Final
+
+import onnxruntime  # noqa: F401  # load DLLs before PySide6 on Windows
+from PySide6 import QtCore
+from PySide6 import QtWidgets
+
+import labelme
+from labelme import __appname__
+from labelme import __version__
+from labelme import _config
+from labelme import _locale
+from labelme._app import MainWindow
+from labelme._utils import apply_color_theme
+from labelme._utils import new_icon
+
+
+def _check_source_isolation(*, source_root: Path) -> None:
+    source_root = source_root.resolve()
+    source_entries = [
+        entry for entry in sys.path if Path(entry).resolve().is_relative_to(source_root)
+    ]
+    if source_entries:
+        raise RuntimeError(f"source checkout is on sys.path: {source_entries}")
+
+    package_path = Path(labelme.__file__).resolve()
+    if package_path.is_relative_to(source_root):
+        raise RuntimeError(f"labelme imported from source checkout: {package_path}")
+
+
+def _run_cli(*, command: list[str], working_dir: Path) -> str:
+    env = os.environ.copy()
+    env["HOME"] = str(working_dir)
+    env["USERPROFILE"] = str(working_dir)
+    result = subprocess.run(
+        command,
+        cwd=working_dir,
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode:
+        raise RuntimeError(
+            f"command failed with exit code {result.returncode}: {command}"
+        )
+    return result.stdout
+
+
+def _check_cli(*, working_dir: Path) -> None:
+    executable = shutil.which("labelme")
+    if executable is None:
+        raise RuntimeError("labelme console script is not installed")
+
+    help_output = _run_cli(command=[executable, "--help"], working_dir=working_dir)
+    if "usage: labelme" not in help_output:
+        raise RuntimeError("labelme --help did not print its usage")
+
+    version_output = _run_cli(
+        command=[executable, "--version"], working_dir=working_dir
+    )
+    expected_version = f"{__appname__} {__version__}"
+    if version_output.strip() != expected_version:
+        raise RuntimeError(
+            f"labelme --version printed {version_output.strip()!r}, "
+            f"expected {expected_version!r}"
+        )
+
+
+def _check_packaged_resources(*, source_root: Path) -> None:
+    source_package_dir = source_root.resolve() / "labelme"
+    package_dir = Path(labelme.__file__).resolve().parent
+    REQUIRED_RESOURCES: Final = (
+        Path("_config/default_config.yaml"),
+        *(
+            path.relative_to(source_package_dir)
+            for path in (source_package_dir / "icons").rglob("*")
+            if path.is_file()
+        ),
+        *(
+            path.relative_to(source_package_dir)
+            for path in (source_package_dir / "translate").glob("*.qm")
+        ),
+    )
+    missing_resources = [
+        relative_path
+        for relative_path in REQUIRED_RESOURCES
+        if not (package_dir / relative_path).is_file()
+    ]
+    if missing_resources:
+        raise RuntimeError(f"packaged resources are missing: {missing_resources}")
+
+
+def _start_application(*, working_dir: Path) -> None:
+    config = _config.load_config(config_file=None, config_overrides={})
+
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
+    QtCore.QSettings.setPath(
+        QtCore.QSettings.Format.IniFormat,
+        QtCore.QSettings.Scope.UserScope,
+        str(working_dir / "qt-settings"),
+    )
+    app = QtWidgets.QApplication([])
+    app.setStyle("Fusion")
+    apply_color_theme(theme=config.get("color_theme", "system"))
+    app.setApplicationName(__appname__)
+
+    package_dir = Path(labelme.__file__).resolve().parent
+    icon_dir = package_dir / "icons"
+    application_icon = new_icon("icon-256.png")
+    for icon_path in icon_dir.rglob("*"):
+        if icon_path.suffix not in {".ico", ".png", ".svg"}:
+            continue
+        icon = new_icon(str(icon_path.relative_to(icon_dir)))
+        if icon.isNull():
+            raise RuntimeError(f"application icon could not be loaded: {icon_path}")
+    app.setWindowIcon(application_icon)
+
+    for translation_path in _locale.TRANSLATE_DIR.glob("*.qm"):
+        translation = QtCore.QTranslator()
+        if not translation.load(str(translation_path)):
+            raise RuntimeError(f"translation could not be loaded: {translation_path}")
+
+    japanese_translator = QtCore.QTranslator()
+    if not japanese_translator.load("ja_JP", str(_locale.TRANSLATE_DIR)):
+        raise RuntimeError("the bundled Japanese translation could not be loaded")
+    app.installTranslator(japanese_translator)
+    source_text = "Brightness:"
+    translated_text = QtCore.QCoreApplication.translate(
+        "BrightnessContrastDialog", source_text
+    )
+    if translated_text == source_text:
+        raise RuntimeError("the bundled Japanese translation was not applied")
+
+    window = MainWindow(
+        config_file=None,
+        config_overrides={},
+        file_or_dir=None,
+        output_dir=None,
+    )
+    window.show()
+    app.processEvents()
+    if not window.isVisible():
+        raise RuntimeError("the application window did not start")
+    window.hide()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-root", required=True, type=Path)
+    args = parser.parse_args()
+
+    _check_source_isolation(source_root=args.source_root)
+    _check_packaged_resources(source_root=args.source_root)
+    with tempfile.TemporaryDirectory() as working_dir:
+        working_path = Path(working_dir)
+        _check_cli(working_dir=working_path)
+        _start_application(working_dir=working_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/artifact_install_smoke.py
+++ b/tools/artifact_install_smoke.py
@@ -82,6 +82,8 @@ def _check_packaged_resources(*, source_root: Path) -> None:
     package_dir = Path(labelme.__file__).resolve().parent
     REQUIRED_RESOURCES: Final = (
         Path("_config/default_config.yaml"),
+        Path("icons/icon-256.png"),
+        Path("translate/ja_JP.qm"),
         *(
             path.relative_to(source_package_dir)
             for path in (source_package_dir / "icons").rglob("*")
@@ -118,6 +120,8 @@ def _start_application(*, working_dir: Path) -> None:
     package_dir = Path(labelme.__file__).resolve().parent
     icon_dir = package_dir / "icons"
     application_icon = new_icon("icon-256.png")
+    if application_icon.isNull():
+        raise RuntimeError("the application icon could not be loaded")
     for icon_path in icon_dir.rglob("*"):
         if icon_path.suffix not in {".ico", ".png", ".svg"}:
             continue

--- a/tools/artifact_install_smoke.py
+++ b/tools/artifact_install_smoke.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
-import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
@@ -14,97 +11,33 @@ from PySide6 import QtWidgets
 
 import labelme
 from labelme import __appname__
-from labelme import __version__
 from labelme import _locale
 from labelme._app import MainWindow
 
 
 def _check_source_isolation(*, source_root: Path, package_path: Path) -> None:
-    source_entries = [
-        entry for entry in sys.path if Path(entry).resolve().is_relative_to(source_root)
-    ]
-    if source_entries:
-        raise RuntimeError(f"source checkout is on sys.path: {source_entries}")
-
+    # Where labelme was imported from is the evidence. python -I and
+    # `uv run --isolated --no-project` already keep the checkout off sys.path,
+    # so scanning sys.path only restates the invocation.
     if package_path.is_relative_to(source_root):
         raise RuntimeError(f"labelme imported from source checkout: {package_path}")
 
 
-def _check_packaged_resources(*, package_path: Path) -> None:
+def _check_packaged_resources() -> None:
     # Packaging mistakes drop whole directories, so one file per resource kind
-    # is enough to prove the artifact carried the config and icons.
-    package_dir = package_path.parent
-    missing_resources = [
-        relative_path
-        for relative_path in (
-            "_config/default_config.yaml",
-            "icons/icon-256.png",
-        )
-        if not (package_dir / relative_path).is_file()
-    ]
-    if missing_resources:
-        raise RuntimeError(f"packaged resources are missing: {missing_resources}")
+    # proves the artifact carried it. Both are loaded rather than stat'ed: a
+    # truncated icon or catalog exists yet fails to load, and Qt reports that
+    # by returning null or False, never by raising. QImage rather than QPixmap
+    # so this runs before there is a QApplication.
+    icon_path = Path(labelme.__file__).parent / "icons" / "icon-256.png"
+    if QtGui.QImage(str(icon_path)).isNull():
+        raise RuntimeError(f"packaged icon failed to load: {icon_path}")
 
-    # A translation .qm can exist yet fail to load (wrong Qt version, a
-    # truncated file); QTranslator.load() fails silently, so assert it here
-    # rather than only stat'ing the file. Ask the package itself which
-    # catalogs it ships, rather than hardcoding one, so renaming or retiring
-    # a language doesn't fail this check for an unrelated reason.
-    translate_dir = package_dir / "translate"
-    available_locales = sorted(
-        path.stem
-        for path in translate_dir.glob("*.qm")
-        if path.stem != _locale.SOURCE_LOCALE
-    )
-    if not available_locales:
+    locales = _locale.available_translation_locales()
+    if not locales:
         raise RuntimeError("packaged artifact ships no translation catalogs")
-    if not QtCore.QTranslator().load(available_locales[0], str(translate_dir)):
-        raise RuntimeError(
-            f"packaged {available_locales[0]} translation failed to load"
-        )
-
-
-def _run_cli(executable: str, *args: str) -> str:
-    # -I only isolates this process, not a subprocess: PYTHONPATH/PYTHONHOME
-    # would otherwise ride along and could shadow the artifact under test with
-    # the source checkout, the same failure mode this script guards against
-    # for its own in-process import.
-    env = {
-        key: value
-        for key, value in os.environ.items()
-        if key not in ("PYTHONPATH", "PYTHONHOME")
-    }
-    # check=True's CalledProcessError drops stdout/stderr from its message, so
-    # the actual failure text this smoke test exists to surface never reaches
-    # the CI log without reproducing locally. Surface it explicitly instead.
-    result = subprocess.run(
-        [executable, *args], capture_output=True, text=True, env=env
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"{executable} {' '.join(args)} exited {result.returncode}\n"
-            f"stdout: {result.stdout}\n"
-            f"stderr: {result.stderr}"
-        )
-    return result.stdout
-
-
-def _check_cli() -> None:
-    executable = shutil.which("labelme")
-    if executable is None:
-        raise RuntimeError("labelme console script is not installed")
-
-    help_output = _run_cli(executable, "--help")
-    if "usage: labelme" not in help_output:
-        raise RuntimeError("labelme --help did not print its usage")
-
-    version_output = _run_cli(executable, "--version").strip()
-    expected_version = f"{__appname__} {__version__}"
-    if version_output != expected_version:
-        raise RuntimeError(
-            f"labelme --version printed {version_output!r}, "
-            f"expected {expected_version!r}"
-        )
+    if not QtCore.QTranslator().load(locales[0], str(_locale.TRANSLATE_DIR)):
+        raise RuntimeError(f"packaged {locales[0]} translation failed to load")
 
 
 def _check_application_starts() -> None:
@@ -138,7 +71,7 @@ def main() -> None:
     package_path = Path(labelme.__file__).resolve()
 
     _check_source_isolation(source_root=source_root, package_path=package_path)
-    _check_packaged_resources(package_path=package_path)
+    _check_packaged_resources()
 
     # A QSettings ini handle can still be open when this block exits, which
     # trips a bare TemporaryDirectory's cleanup on Windows.
@@ -155,7 +88,6 @@ def main() -> None:
             QtCore.QSettings.Scope.UserScope,
             home_dir,
         )
-        _check_cli()
         _check_application_starts()
 
 

--- a/tools/artifact_install_smoke.py
+++ b/tools/artifact_install_smoke.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import onnxruntime  # noqa: F401  # load DLLs before PySide6 on Windows
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+
+import labelme
+from labelme import __appname__
+from labelme import __version__
+from labelme import _locale
+from labelme._app import MainWindow
+
+
+def _check_source_isolation(*, source_root: Path, package_path: Path) -> None:
+    source_entries = [
+        entry for entry in sys.path if Path(entry).resolve().is_relative_to(source_root)
+    ]
+    if source_entries:
+        raise RuntimeError(f"source checkout is on sys.path: {source_entries}")
+
+    if package_path.is_relative_to(source_root):
+        raise RuntimeError(f"labelme imported from source checkout: {package_path}")
+
+
+def _check_packaged_resources(*, package_path: Path) -> None:
+    # Packaging mistakes drop whole directories, so one file per resource kind
+    # is enough to prove the artifact carried the config and icons.
+    package_dir = package_path.parent
+    missing_resources = [
+        relative_path
+        for relative_path in (
+            "_config/default_config.yaml",
+            "icons/icon-256.png",
+        )
+        if not (package_dir / relative_path).is_file()
+    ]
+    if missing_resources:
+        raise RuntimeError(f"packaged resources are missing: {missing_resources}")
+
+    # A translation .qm can exist yet fail to load (wrong Qt version, a
+    # truncated file); QTranslator.load() fails silently, so assert it here
+    # rather than only stat'ing the file. Ask the package itself which
+    # catalogs it ships, rather than hardcoding one, so renaming or retiring
+    # a language doesn't fail this check for an unrelated reason.
+    translate_dir = package_dir / "translate"
+    available_locales = sorted(
+        path.stem
+        for path in translate_dir.glob("*.qm")
+        if path.stem != _locale.SOURCE_LOCALE
+    )
+    if not available_locales:
+        raise RuntimeError("packaged artifact ships no translation catalogs")
+    if not QtCore.QTranslator().load(available_locales[0], str(translate_dir)):
+        raise RuntimeError(
+            f"packaged {available_locales[0]} translation failed to load"
+        )
+
+
+def _run_cli(executable: str, *args: str) -> str:
+    # -I only isolates this process, not a subprocess: PYTHONPATH/PYTHONHOME
+    # would otherwise ride along and could shadow the artifact under test with
+    # the source checkout, the same failure mode this script guards against
+    # for its own in-process import.
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in ("PYTHONPATH", "PYTHONHOME")
+    }
+    # check=True's CalledProcessError drops stdout/stderr from its message, so
+    # the actual failure text this smoke test exists to surface never reaches
+    # the CI log without reproducing locally. Surface it explicitly instead.
+    result = subprocess.run(
+        [executable, *args], capture_output=True, text=True, env=env
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{executable} {' '.join(args)} exited {result.returncode}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def _check_cli() -> None:
+    executable = shutil.which("labelme")
+    if executable is None:
+        raise RuntimeError("labelme console script is not installed")
+
+    help_output = _run_cli(executable, "--help")
+    if "usage: labelme" not in help_output:
+        raise RuntimeError("labelme --help did not print its usage")
+
+    version_output = _run_cli(executable, "--version").strip()
+    expected_version = f"{__appname__} {__version__}"
+    if version_output != expected_version:
+        raise RuntimeError(
+            f"labelme --version printed {version_output!r}, "
+            f"expected {expected_version!r}"
+        )
+
+
+def _check_application_starts() -> None:
+    app = QtWidgets.QApplication([])
+    try:
+        # Constructing the window loads the default config, icons, and dock layout
+        # from the installed package, which is the startup coverage this smoke
+        # test is after.
+        window = MainWindow(
+            config_file=None,
+            config_overrides={},
+            file_or_dir=None,
+            output_dir=None,
+        )
+        window.show()
+        app.processEvents()
+        if window.windowTitle() != __appname__:
+            raise RuntimeError(
+                f"the application window title is {window.windowTitle()!r}, "
+                f"expected {__appname__!r}"
+            )
+        if not window.findChildren(QtGui.QAction):
+            raise RuntimeError("the application window has no wired-up actions")
+        window.close()
+    finally:
+        app.quit()
+
+
+def main() -> None:
+    source_root = Path(__file__).resolve().parent.parent
+    package_path = Path(labelme.__file__).resolve()
+
+    _check_source_isolation(source_root=source_root, package_path=package_path)
+    _check_packaged_resources(package_path=package_path)
+
+    # A QSettings ini handle can still be open when this block exits, which
+    # trips a bare TemporaryDirectory's cleanup on Windows.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as home_dir:
+        # Keep the run from writing into the invoking user's real home
+        # directory: QSettings falls back to it unless explicitly redirected
+        # (belt-and-suspenders with the setPath() call below).
+        os.environ["HOME"] = home_dir
+        os.environ["USERPROFILE"] = home_dir
+        os.environ["LOCALAPPDATA"] = home_dir
+        QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
+        QtCore.QSettings.setPath(
+            QtCore.QSettings.Format.IniFormat,
+            QtCore.QSettings.Scope.UserScope,
+            home_dir,
+        )
+        _check_cli()
+        _check_application_starts()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #2458. Stacked on #2492.

CI did not prove that installed artifacts carried the runtime resources. This builds and clean-installs the wheel and source distribution on Windows, macOS, and Ubuntu, keeps the checkout off sys.path, exercises the CLI, and starts a headless MainWindow far enough to load the Default Config, icons, and dock layout from the installed package.

The smoke run is an `artifact-install-smoke` job in the existing Test workflow, and it supersedes the old "Build wheel and install from it" step, which only proved the wheel was installable. The smoke script checks one representative packaged file per resource kind (Default Config, icon, compiled translation), since packaging mistakes drop whole directories rather than single files.

The release workflow also gates PyPI upload on metadata validation and the same clean smoke checks against the exact wheel and source distribution built by the tag job.

## Test plan

- [x] Clean-export wheel and source distribution builds pass isolated install/startup checks locally (macOS, offscreen)
- [x] ruff, ty, and yamlfix pass on the touched files
- [ ] Three-OS execution confirmed by this PR CI



