### PR TITLE
fix: keep viewport position with previous zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Keep Previous Zoom preserving the scale while resetting the viewport position on each newly opened image. It now carries the previous horizontal and vertical scroll positions forward, while still restoring an image's own saved viewport when revisiting it ([#2484](https://github.com/wkentaro/labelme/pull/2484))
 - Fixed failed auto-saves leaving an edited Annotation marked clean. The dirty title, Save action, and unsaved-changes prompt now remain active, while repeated failures for the same target show only one error until a save succeeds or the target changes ([#2472](https://github.com/wkentaro/labelme/pull/2472))
 - Fixed a cancelled close still overwriting the Window State (window size, position, and dock layout); `closeEvent` ignored the close event but kept going, so cancelling the unsaved-changes prompt saved the current geometry anyway and the next session started from a layout the user never closed on. The Window State is now written only when the close goes through ([#2478](https://github.com/wkentaro/labelme/pull/2478))
 - Fixed Mask Shape construction for Model Session detections with fractional bounding boxes by using the same rounding for Shape points and Mask extents, preventing placement drift and Existing Shape Suppression errors ([#2464](https://github.com/wkentaro/labelme/pull/2464))

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1943,6 +1943,13 @@ class MainWindow(QtWidgets.QMainWindow):
         if self._image_path is not None:
             self._scroll_values[orientation][self._image_path] = value
 
+    def _remember_current_viewport(self) -> None:
+        if self._image_path is None:
+            return
+        for orientation, bar in self._canvas_widgets.scroll_bars.items():
+            self._scroll_values[orientation][self._image_path] = bar.value()
+        self._prev_image_path = self._image_path
+
     def _set_zoom(self, value: float, pos: QtCore.QPointF | None = None) -> None:
         if self._image_path is None:
             logger.warning("image_path is None, cannot set zoom")
@@ -2117,7 +2124,7 @@ class MainWindow(QtWidgets.QMainWindow):
             == (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier)
             else []
         )
-        self._prev_image_path = self._image_path
+        self._remember_current_viewport()
         self.reset_state()
         self._canvas_widgets.canvas.setEnabled(False)
         if not QtCore.QFile.exists(image_or_label_path):
@@ -2186,6 +2193,20 @@ class MainWindow(QtWidgets.QMainWindow):
             self.mark_clean()
             self._reset_label_file_actions()
         self._canvas_widgets.canvas.setEnabled(True)
+        # Zoom changes the live scroll positions, so resolve the intended
+        # viewport first.
+        target_scroll_values: dict[Qt.Orientation, float] = {}
+        for orientation, values_by_image in self._scroll_values.items():
+            if self._image_path in values_by_image:
+                target_scroll_values[orientation] = values_by_image[self._image_path]
+            elif (
+                self._config["keep_prev_scale"]
+                and self._prev_image_path is not None
+                and self._prev_image_path in values_by_image
+            ):
+                target_scroll_values[orientation] = values_by_image[
+                    self._prev_image_path
+                ]
         # set zoom values
         is_initial_load = not self._zoom_values
         if self._image_path in self._zoom_values:
@@ -2195,11 +2216,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self._zoom_mode = _ZoomMode.FIT_WINDOW
             self._adjust_scale()
         # set scroll values
-        for orientation in self._scroll_values:
-            if self._image_path in self._scroll_values[orientation]:
-                self.set_scroll_value(
-                    orientation, self._scroll_values[orientation][self._image_path]
-                )
+        for orientation, value in target_scroll_values.items():
+            self.set_scroll_value(orientation=orientation, value=value)
         self.open_brightness_contrast_dialog(value=False, is_initial_load=True)
         self._paint_canvas()
         self.update_action_states(True)
@@ -2410,6 +2428,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def close_file(self, _value: bool = False) -> None:
         if not self._can_continue():
             return
+        self._remember_current_viewport()
         self.reset_state()
         self.mark_clean()
         self._reset_label_file_actions()
@@ -2839,6 +2858,7 @@ class MainWindow(QtWidgets.QMainWindow):
         return lst
 
     def import_dropped_image_files(self, image_files: list[str]) -> None:
+        self._remember_current_viewport()
         extensions = _list_supported_image_extensions()
         already_loaded = set(self.image_list)
         new_files = [
@@ -2868,6 +2888,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self._can_continue() or not root_dir:
             return
 
+        self._remember_current_viewport()
         self._docks.file_dock.setEnabled(True)
         self._docks.file_dock.setToolTip("")
 

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -18,6 +18,7 @@ from .conftest import MainWinFactory
 from .conftest import show_window_and_wait_for_imagedata
 
 _TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
+_VIEWPORT_ZOOM: Final[int] = 300
 
 
 @pytest.fixture()
@@ -94,6 +95,195 @@ def test_zoom_step_keeps_fractional_precision(
     assert _win._canvas_widgets.zoom_widget.value() == pytest.approx(115.5)
 
     close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
+
+
+def _set_scroll_bars_to_fraction(
+    qtbot: QtBot,
+    win: MainWindow,
+    numerator: int,
+    denominator: int,
+) -> dict[Qt.Orientation, int]:
+    scroll_bars = win._canvas_widgets.scroll_bars
+    qtbot.waitUntil(lambda: all(bar.maximum() > 0 for bar in scroll_bars.values()))
+
+    values: dict[Qt.Orientation, int] = {}
+    for orientation, bar in scroll_bars.items():
+        value = bar.maximum() * numerator // denominator
+        assert value > 0
+        bar.setValue(value)
+        values[orientation] = value
+    return values
+
+
+def _wait_for_viewport(
+    qtbot: QtBot,
+    win: MainWindow,
+    scroll_values: dict[Qt.Orientation, int],
+) -> None:
+    scroll_bars = win._canvas_widgets.scroll_bars
+    qtbot.waitUntil(
+        lambda: win._canvas_widgets.zoom_widget.value() == _VIEWPORT_ZOOM
+        and all(
+            scroll_bars[orientation].value() == expected
+            for orientation, expected in scroll_values.items()
+        )
+    )
+    assert win._canvas_widgets.zoom_widget.value() == _VIEWPORT_ZOOM
+    for orientation, expected in scroll_values.items():
+        assert scroll_bars[orientation].value() == expected
+
+
+@pytest.fixture(name="scrolled_win")
+def _make_scrolled_win(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+) -> tuple[MainWindow, dict[Qt.Orientation, int]]:
+    win = main_win(
+        file_or_dir=str(data_path / "raw/2011_000003.jpg"),
+        config_overrides={"keep_prev_scale": True},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    win._set_zoom(value=_VIEWPORT_ZOOM)
+    scroll_values = _set_scroll_bars_to_fraction(
+        qtbot=qtbot,
+        win=win,
+        numerator=1,
+        denominator=3,
+    )
+    return win, scroll_values
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("keep_prev_scale", [True, False])
+def test_navigation_restores_each_image_viewport(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    keep_prev_scale: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / "raw"),
+        config_overrides={"keep_prev_scale": keep_prev_scale},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    win._set_zoom(value=_VIEWPORT_ZOOM)
+    scroll_bars = win._canvas_widgets.scroll_bars
+    first_scroll_values = _set_scroll_bars_to_fraction(
+        qtbot=qtbot,
+        win=win,
+        numerator=1,
+        denominator=3,
+    )
+
+    first_image_path = win._image_path
+    assert first_image_path is not None
+    win._open_next_image()
+    qtbot.waitUntil(lambda: win._image_path != first_image_path)
+
+    if keep_prev_scale:
+        _wait_for_viewport(
+            qtbot=qtbot,
+            win=win,
+            scroll_values=first_scroll_values,
+        )
+    else:
+        qtbot.waitUntil(
+            lambda: win._zoom_mode == _ZoomMode.FIT_WINDOW
+            and all(bar.value() == bar.minimum() for bar in scroll_bars.values())
+        )
+        assert win._zoom_mode == _ZoomMode.FIT_WINDOW
+        assert win._canvas_widgets.zoom_widget.value() != 300
+        for bar in scroll_bars.values():
+            assert bar.value() == bar.minimum()
+
+    win._set_zoom(value=250)
+    second_scroll_values = _set_scroll_bars_to_fraction(
+        qtbot=qtbot,
+        win=win,
+        numerator=2,
+        denominator=3,
+    )
+    assert second_scroll_values != first_scroll_values
+
+    win._open_prev_image()
+    qtbot.waitUntil(lambda: win._image_path == first_image_path)
+    _wait_for_viewport(
+        qtbot=qtbot,
+        win=win,
+        scroll_values=first_scroll_values,
+    )
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_open_file_keeps_previous_viewport(
+    scrolled_win: tuple[MainWindow, dict[Qt.Orientation, int]],
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win, expected_scroll_values = scrolled_win
+    next_image_path = str(data_path / "raw/2011_000006.jpg")
+
+    win._load_from_file_or_dir(file_or_dir=next_image_path)
+    qtbot.waitUntil(lambda: win._image_path == next_image_path)
+    _wait_for_viewport(
+        qtbot=qtbot,
+        win=win,
+        scroll_values=expected_scroll_values,
+    )
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_file_search_keeps_previous_viewport(
+    scrolled_win: tuple[MainWindow, dict[Qt.Orientation, int]],
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win, expected_scroll_values = scrolled_win
+    next_image_path = str(data_path / "raw/2011_000006.jpg")
+
+    win._docks.file_search.setText("2011_000006")
+    win._open_next_image()
+    qtbot.waitUntil(lambda: win._image_path == next_image_path)
+    _wait_for_viewport(
+        qtbot=qtbot,
+        win=win,
+        scroll_values=expected_scroll_values,
+    )
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("next_image_name", ["2011_000003.jpg", "2011_000006.jpg"])
+def test_close_and_open_restores_viewport(
+    scrolled_win: tuple[MainWindow, dict[Qt.Orientation, int]],
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    next_image_name: str,
+) -> None:
+    win, expected_scroll_values = scrolled_win
+    next_image_path = str(data_path / "raw" / next_image_name)
+
+    win.close_file()
+    win._load_from_file_or_dir(file_or_dir=next_image_path)
+    qtbot.waitUntil(lambda: win._image_path == next_image_path)
+    _wait_for_viewport(
+        qtbot=qtbot,
+        win=win,
+        scroll_values=expected_scroll_values,
+    )
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 
 
 def _make_wheel_event(


### PR DESCRIPTION
## Summary

- carry the previous horizontal and vertical scroll positions to newly opened images when **Keep Previous Zoom** is enabled
- continue restoring an image's own saved viewport when revisiting it
- add a GUI regression test covering zoom and viewport preservation across image navigation

## Root cause

Labelme retained the zoom widget value across images, but scroll positions were keyed only by image path. A newly opened image therefore had no stored scroll values and reset its viewport even though the zoom level was preserved.

## User impact

Annotators working through aligned image sequences can keep the same magnified region centered while moving between frames, avoiding repetitive panning on every image.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest tests/e2e/zoom_test.py -q` (8 passed)
- `uv run ruff format --check labelme/_app.py tests/e2e/zoom_test.py`
- `uv run ruff check labelme/_app.py tests/e2e/zoom_test.py`
- `uv run ty check labelme/_app.py tests/e2e/zoom_test.py`
- `git diff --check`
