### PR TITLE
ci: gate releases on the test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,10 @@ on:
   push:
     tags: [v*]
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
   release:
+    needs: test
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Bottom of a stack; #2471 builds on this. Replaces #2490, which GitHub auto-marked as merged during the stack reorder.

A tag push never triggered the Test workflow, so a release could publish from a commit whose tests never ran. This makes the Test workflow callable and has the release job depend on it, so publishing a tag requires the full OS and Python matrix and the network test to pass on the tagged commit first.

## Test plan

- [x] yamlfix and actionlint pass on both workflows
- [ ] The `workflow_call` path only truly executes on a tag push; the first release candidate tag is its live trial
