### PR TITLE
fix(settings): size the dialog to what its content cannot give up

### DIFF
--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -114,6 +114,20 @@ class _SettingsPage(QtWidgets.QWidget):
         )
         navigation.setCurrentRow(0)
 
+    @property
+    def _required_width(self) -> int:
+        # The width below which the settings scroll sideways. The page size hint
+        # does not report it: QScrollArea caps its own hint at 36 character
+        # widths and ignores how far its widget refuses to shrink, so a font
+        # wider than the one the layout was tuned for would size the page too
+        # narrow. Swap the scroll area's hint for what the content cannot give
+        # up, and keep the rest of the page hint as measured.
+        return (
+            self.sizeHint().width()
+            - self._scroll_area.sizeHint().width()
+            + self._content.minimumSizeHint().width()
+        )
+
     def _scroll_to_group(self, index: int) -> None:
         if not 0 <= index < len(self._groups):
             return
@@ -211,10 +225,12 @@ class SettingsDialog(QtWidgets.QDialog):
         scroll_bar_width = self.style().pixelMetric(
             QtWidgets.QStyle.PixelMetric.PM_ScrollBarExtent
         )
+        page_width = max(page.sizeHint().width(), page._required_width)
+        dialog_chrome_width = self.sizeHint().width() - page.sizeHint().width()
         preferred_dialog_size = QtCore.QSize(
             max(
                 DEFAULT_DIALOG_SIZE.width(),
-                self.sizeHint().width() + scroll_bar_width,
+                page_width + dialog_chrome_width + scroll_bar_width,
             ),
             DEFAULT_DIALOG_SIZE.height(),
         )

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -22,6 +22,18 @@ def applied() -> Applied:
     return []
 
 
+def _preferred_width(dialog: SettingsDialog) -> int:
+    # The width the dialog opens at on an unconstrained screen: its page held
+    # out of sideways scrolling plus its own chrome, never below the default.
+    page = dialog._page
+    scroll_bar_width = dialog.style().pixelMetric(
+        QtWidgets.QStyle.PixelMetric.PM_ScrollBarExtent
+    )
+    page_width = max(page.sizeHint().width(), page._required_width)
+    dialog_chrome_width = dialog.sizeHint().width() - page.sizeHint().width()
+    return max(760, page_width + dialog_chrome_width + scroll_bar_width)
+
+
 def _make_dialog(
     qtbot: QtBot, applied: Applied, overrides: dict, succeed: bool = True
 ) -> SettingsDialog:
@@ -254,8 +266,11 @@ def test_navigation_elides_long_localized_names_without_squeezing_content(
 
         with qtbot.waitExposed(dialog):
             dialog.show()
-        if dialog.width() >= dialog.sizeHint().width():
-            assert dialog._page._scroll_area.horizontalScrollBar().maximum() == 0
+        # A screen narrower than the dialog wants leaves it no room to keep the
+        # content out of a horizontal scroll bar.
+        if dialog.width() < _preferred_width(dialog):
+            pytest.skip("this screen is narrower than the settings content")
+        assert dialog._page._scroll_area.horizontalScrollBar().maximum() == 0
     finally:
         qapp.removeTranslator(translator)
 
@@ -265,6 +280,9 @@ def test_default_size_scrolls_vertically_only(
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
+
+    if _preferred_width(dialog) > 760:
+        pytest.skip("this font needs the dialog wider than its default size")
 
     scroll_area = dialog._page._scroll_area
     assert (dialog.width(), dialog.height()) == (760, 590)
@@ -285,6 +303,8 @@ def test_dialog_prevents_narrow_content_overflow(
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
+    if dialog.width() < _preferred_width(dialog):
+        pytest.skip("this screen is narrower than the settings content")
     minimum_width = dialog.width()
 
     dialog.resize(minimum_width - 200, dialog.height())
@@ -409,13 +429,8 @@ def test_large_font_uses_default_size_with_scrolling(
             dialog.show()
 
         available_size = dialog.screen().availableGeometry().size()
-        scroll_bar_width = dialog.style().pixelMetric(
-            QtWidgets.QStyle.PixelMetric.PM_ScrollBarExtent
-        )
-        assert dialog.width() == min(
-            max(760, dialog.sizeHint().width() + scroll_bar_width),
-            available_size.width(),
-        )
+        assert _preferred_width(dialog) >= 760
+        assert dialog.width() == min(_preferred_width(dialog), available_size.width())
         assert dialog.height() == min(590, available_size.height())
         assert dialog._page._scroll_area.verticalScrollBar().maximum() > 0
     finally:


### PR DESCRIPTION
On Windows the Settings dialog opens with 140–236 px of content behind a horizontal scroll bar. `QScrollArea` caps its own size hint at 36 character widths and ignores how far its content refuses to shrink, so the dialog under-sizes wherever the platform font is wider than the one the layout was tuned for — Segoe UI is. The dialog now swaps the scroll area's capped hint for what the content cannot give up.

No changelog entry: the scroll-area dialog is unreleased ([Unreleased] rewrite; v7.0.4 ships the previous tab-based dialog), so this is net-zero since the last release.

Split out of #2467, whose Windows matrix cells surfaced the bug (three cells failed asserting the horizontal scroll range was 0); that PR is stacked on this one and its cells exercise the fix on every OS.

## Test plan

- [x] The settings-dialog width tests in #2467 assert no horizontal scrolling; they failed on all three Windows cells before this fix and pass after
- [x] `make lint` and `make test`
