### PR TITLE
refactor(canvas): copy the dragged points into the moved shape

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1272,7 +1272,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _apply_in_place_move(self) -> None:
         for original, clone in zip(self.selected_shapes, self._selected_shapes_copy):
-            original.points = clone.points
+            original.points = clone.points.copy()
 
     def _can_close_shape(self) -> bool:
         if self.mode != _CanvasMode.CREATE:

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -1940,3 +1940,18 @@ def test_remove_selected_point_deselects_vertex(canvas: Canvas) -> None:
     assert len(shape.points) == 3  # the point was removed
     # Vertex is no longer selected, so the next move won't drag the neighbor (#968).
     assert not canvas._is_vertex_selected()
+
+
+@pytest.mark.gui
+def test_end_move_in_place_copies_points(canvas: Canvas) -> None:
+    shape = _make_polygon()
+    canvas.load_shapes(shapes=[shape])
+    canvas.selected_shapes = [shape]
+    clone = shape.copy()
+    clone.translate(offset=(5, -5))
+    canvas._selected_shapes_copy = [clone]
+
+    canvas.end_move(copy=False)
+
+    assert np.array_equal(shape.points, clone.points)
+    assert not np.shares_memory(shape.points, clone.points)


### PR DESCRIPTION
Preserves `Shape` point-array ownership when committing an in-place move. The copy-drag path already promotes the clone and is unchanged.

Closes #2413

## Test plan

- `make test` (1290 passed, 6 skipped)
- `make lint`