### PR TITLE
refactor(app): warn once per shape with a non-str label

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2955,13 +2955,13 @@ def _shapes_from_dicts(
         )
 
         default_flags: dict[str, bool] = {}
-        for pattern, keys in compiled_label_flags.items():
-            if not isinstance(shape.label, str):
-                logger.warning("shape.label is not str: {}", shape.label)
-                continue
-            if pattern.match(shape.label):
-                for key in keys:
-                    default_flags[key] = False
+        if not isinstance(shape.label, str):
+            logger.warning("shape.label is not str: {}", shape.label)
+        else:
+            for pattern, keys in compiled_label_flags.items():
+                if pattern.match(shape.label):
+                    for key in keys:
+                        default_flags[key] = False
         shape.flags = default_flags
         shape.flags.update(shape_dict["flags"])
         shape.other_data = shape_dict["other_data"]

--- a/tests/unit/_app_test.py
+++ b/tests/unit/_app_test.py
@@ -4,9 +4,11 @@ import struct
 import zlib
 from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 import pytest
+from loguru import logger
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
@@ -304,6 +306,29 @@ def test_shapes_from_dicts_merges_label_flags(
         label_flags=label_flags,
     )
     assert shape.flags == expected
+
+
+def test_shapes_from_dicts_warns_once_per_shape_with_a_non_str_label() -> None:
+    # The file format types a shape's label as a string and the reader rejects
+    # a non-string one, so only a caller bypassing the reader reaches the guard.
+    shape_dicts = [
+        _make_shape_dict(label=cast(str, None), flags={"occluded": True}),
+        _make_shape_dict(label=cast(str, None), flags={}),
+    ]
+    warnings_logged: list[str] = []
+    sink_id = logger.add(
+        lambda m: warnings_logged.append(m.record["message"]), level="WARNING"
+    )
+    try:
+        shapes = _app._shapes_from_dicts(
+            shape_dicts=shape_dicts,
+            label_flags={"^cat$": ["occluded"], "^dog$": ["truncated"]},
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert [shape.flags for shape in shapes] == [{"occluded": True}, {}]
+    assert warnings_logged == ["shape.label is not str: None"] * 2
 
 
 def test_shapes_from_dicts_gives_each_shape_its_own_flags() -> None:


### PR DESCRIPTION
Closes #2415.

The label type check did not depend on the pattern loop it sat in, so one shape with a non-str label logged one identical warning per configured pattern.

One deliberate behavior change: the hoisted guard warns even when `label_flags` is empty or every pattern was dropped, where `main` stayed silent. A non-str label is anomalous regardless of the flag config, and `read_label_file` raises `TypeError` on one anyway, so only a caller bypassing the reader reaches the warning at all — which is what the new test does via `cast`.

Worth a follow-up, not done here (#2415 scopes guard removal out): since the guard is unreachable through the app, it could be deleted outright.

## Test plan

- [x] `test_shapes_from_dicts_warns_once_per_shape_with_a_non_str_label` fails against `main` (4 warnings vs the 2 asserted)
- [x] `make test` (1251 passed) and `make lint`
- [x] Loading `examples/tutorial/apc2016_obj3.json` with real `label_flags` yields flags byte-identical to `main` (the str-label path is unchanged code motion)
