### PR TITLE
fix(export): round fractional Mask bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed exported Mask Shapes with fractional bounds being shifted by integer truncation instead of matching their canvas position ([#2504](https://github.com/wkentaro/labelme/pull/2504))
 - Fixed Keep Previous Zoom preserving the scale while resetting the viewport position on each newly opened image. It now carries the previous horizontal and vertical scroll positions forward, while still restoring an image's own saved viewport when revisiting it ([#2484](https://github.com/wkentaro/labelme/pull/2484))
 - Fixed dropped image files entering the File List with forward slashes on Windows; `QUrl` reports a dropped path with forward slashes while every other path in the File List carries the separator of the platform, so the same image could be listed twice once its directory was also opened ([#2497](https://github.com/wkentaro/labelme/pull/2497))
 - Fixed images opened through the file dialog on Windows neither selecting their File List row nor receiving the saved checkmark; Qt file dialogs report a chosen path with forward slashes while the File List carries the separator of the platform, and both lookups compare exact strings ([#2499](https://github.com/wkentaro/labelme/pull/2499))

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -157,10 +157,13 @@ def shapes_to_label(
             if not isinstance(shape["mask"], np.ndarray):
                 raise ValueError("shape['mask'] must be numpy.ndarray")
             mask = np.zeros(img_shape[:2], dtype=bool)
-            (x1, y1), (x2, y2) = np.asarray(points).astype(int)
+            # The stored mask keeps its extent when fractional bounds round apart.
+            (origin, _) = points
+            x1, y1 = np.asarray(origin).round().astype(int)
+            patch_height, patch_width = shape["mask"].shape
             height, width = img_shape[:2]
-            y_start, y_stop = max(y1, 0), min(y2 + 1, height)
-            x_start, x_stop = max(x1, 0), min(x2 + 1, width)
+            y_start, y_stop = max(y1, 0), min(y1 + patch_height, height)
+            x_start, x_stop = max(x1, 0), min(x1 + patch_width, width)
             if y_start < y_stop and x_start < x_stop:
                 mask[y_start:y_stop, x_start:x_stop] = shape["mask"][
                     y_start - y1 : y_stop - y1, x_start - x1 : x_stop - x1

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -157,10 +157,14 @@ def shapes_to_label(
             if not isinstance(shape["mask"], np.ndarray):
                 raise ValueError("shape['mask'] must be numpy.ndarray")
             mask = np.zeros(img_shape[:2], dtype=bool)
-            # The stored mask keeps its extent when fractional bounds round apart.
-            (origin, _) = points
-            x1, y1 = np.asarray(origin).round().astype(int)
-            patch_height, patch_width = shape["mask"].shape
+            point_array = np.asarray(points)
+            (x1, y1), (x2, y2) = point_array.round().astype(int)
+            # Integer bounds retain legacy cropping, while fractional bounds use
+            # the stored extent so independently rounded corners cannot resize it.
+            if np.array_equal(point_array, np.trunc(point_array)):
+                patch_height, patch_width = y2 - y1 + 1, x2 - x1 + 1
+            else:
+                patch_height, patch_width = shape["mask"].shape
             height, width = img_shape[:2]
             y_start, y_stop = max(y1, 0), min(y1 + patch_height, height)
             x_start, x_stop = max(x1, 0), min(x1 + patch_width, width)

--- a/labelme/_utils/shape.py
+++ b/labelme/_utils/shape.py
@@ -104,10 +104,13 @@ def shapes_to_label(
             if not isinstance(shape["mask"], np.ndarray):
                 raise ValueError("shape['mask'] must be numpy.ndarray")
             mask = np.zeros(img_shape[:2], dtype=bool)
-            (x1, y1), (x2, y2) = np.asarray(points).astype(int)
+            # The stored mask keeps its extent when fractional bounds round apart.
+            (origin, _) = points
+            x1, y1 = np.asarray(origin).round().astype(int)
+            patch_height, patch_width = shape["mask"].shape
             height, width = img_shape[:2]
-            y_start, y_stop = max(y1, 0), min(y2 + 1, height)
-            x_start, x_stop = max(x1, 0), min(x2 + 1, width)
+            y_start, y_stop = max(y1, 0), min(y1 + patch_height, height)
+            x_start, x_stop = max(x1, 0), min(x1 + patch_width, width)
             if y_start < y_stop and x_start < x_stop:
                 mask[y_start:y_stop, x_start:x_stop] = shape["mask"][
                     y_start - y1 : y_stop - y1, x_start - x1 : x_stop - x1

--- a/labelme/_utils/shape.py
+++ b/labelme/_utils/shape.py
@@ -104,10 +104,14 @@ def shapes_to_label(
             if not isinstance(shape["mask"], np.ndarray):
                 raise ValueError("shape['mask'] must be numpy.ndarray")
             mask = np.zeros(img_shape[:2], dtype=bool)
-            # The stored mask keeps its extent when fractional bounds round apart.
-            (origin, _) = points
-            x1, y1 = np.asarray(origin).round().astype(int)
-            patch_height, patch_width = shape["mask"].shape
+            point_array = np.asarray(points)
+            (x1, y1), (x2, y2) = point_array.round().astype(int)
+            # Integer bounds retain legacy cropping, while fractional bounds use
+            # the stored extent so independently rounded corners cannot resize it.
+            if np.array_equal(point_array, np.trunc(point_array)):
+                patch_height, patch_width = y2 - y1 + 1, x2 - x1 + 1
+            else:
+                patch_height, patch_width = shape["mask"].shape
             height, width = img_shape[:2]
             y_start, y_stop = max(y1, 0), min(y1 + patch_height, height)
             x_start, x_stop = max(x1, 0), min(x1 + patch_width, width)

--- a/tests/unit/examples/utils_test.py
+++ b/tests/unit/examples/utils_test.py
@@ -65,12 +65,32 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     assert np.array_equal(cls > 0, painted)
 
 
-def test_shapes_to_label_mask_rounds_origin_without_cropping_mask() -> None:
+@pytest.mark.parametrize(
+    ("points", "expected_origin"),
+    [
+        ([[2.7, 1.7], [6.3, 3.3]], (3, 2)),
+        ([[2.5, 1.5], [6.5, 3.5]], (2, 2)),
+    ],
+    ids=["different-fractions", "ties-to-even"],
+)
+def test_shapes_to_label_mask_rounds_origin_without_cropping_mask(
+    points: list[list[float]], expected_origin: tuple[int, int]
+) -> None:
     patch = np.ones((3, 5), dtype=bool)
-    shape = _mask_shape(points=[[2.7, 1.7], [6.3, 3.3]], mask=patch)
+    shape = _mask_shape(points=points, mask=patch)
     cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
     painted = np.zeros((20, 20), dtype=bool)
-    painted[2:5, 3:8] = True
+    x, y = expected_origin
+    painted[y : y + patch.shape[0], x : x + patch.shape[1]] = True
+    assert np.array_equal(cls > 0, painted)
+
+
+def test_shapes_to_label_mask_keeps_integer_bbox_extent() -> None:
+    patch = np.ones((3, 5), dtype=bool)
+    shape = _mask_shape(points=[[2.0, 1.0], [4.0, 3.0]], mask=patch)
+    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    painted = np.zeros((20, 20), dtype=bool)
+    painted[1:4, 2:5] = True
     assert np.array_equal(cls > 0, painted)
 
 

--- a/tests/unit/examples/utils_test.py
+++ b/tests/unit/examples/utils_test.py
@@ -65,6 +65,15 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     assert np.array_equal(cls > 0, painted)
 
 
+def test_shapes_to_label_mask_rounds_origin_without_cropping_mask() -> None:
+    patch = np.ones((3, 5), dtype=bool)
+    shape = _mask_shape(points=[[2.7, 1.7], [6.3, 3.3]], mask=patch)
+    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    painted = np.zeros((20, 20), dtype=bool)
+    painted[2:5, 3:8] = True
+    assert np.array_equal(cls > 0, painted)
+
+
 def _encode_png(img_pil: PIL.Image.Image) -> bytes:
     buf = io.BytesIO()
     img_pil.save(buf, format="PNG")

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -163,6 +163,39 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     assert np.array_equal(cls > 0, painted)
 
 
+@pytest.mark.parametrize(
+    ("points", "expected_origin"),
+    [
+        ([[2.3, 1.3], [6.3, 3.3]], (2, 1)),
+        ([[2.7, 1.7], [6.7, 3.7]], (3, 2)),
+        ([[2.7, 1.7], [6.3, 3.3]], (3, 2)),
+    ],
+    ids=["down", "up", "different-fractions"],
+)
+def test_shapes_to_label_mask_rounds_fractional_bounds(
+    points: list[list[float]], expected_origin: tuple[int, int]
+) -> None:
+    patch = np.ones((3, 5), dtype=bool)
+    shape = _mask_shape(points=points, mask=patch)
+    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    painted = np.zeros((20, 20), dtype=bool)
+    x, y = expected_origin
+    painted[y : y + patch.shape[0], x : x + patch.shape[1]] = True
+    assert np.array_equal(cls > 0, painted)
+
+
+def test_shapes_to_label_mask_rounds_negative_bounds_to_nearest_pixel() -> None:
+    patch = np.zeros((5, 5), dtype=bool)
+    patch[2, 3] = True  # -> canvas (0, 0)
+    patch[4, 4] = True  # -> canvas (2, 1)
+    shape = _mask_shape(points=[[-2.6, -1.6], [1.4, 2.4]], mask=patch)
+    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    painted = np.zeros((20, 20), dtype=bool)
+    painted[0, 0] = True
+    painted[2, 1] = True
+    assert np.array_equal(cls > 0, painted)
+
+
 def test_shape_to_mask() -> None:
     img, data = get_img_and_data()
     for shape in data["shapes"]:

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -163,14 +163,24 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     assert np.array_equal(cls > 0, painted)
 
 
+def test_shapes_to_label_mask_keeps_integer_bbox_extent() -> None:
+    patch = np.ones((3, 5), dtype=bool)
+    shape = _mask_shape(points=[[2.0, 1.0], [4.0, 3.0]], mask=patch)
+    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    painted = np.zeros((20, 20), dtype=bool)
+    painted[1:4, 2:5] = True
+    assert np.array_equal(cls > 0, painted)
+
+
 @pytest.mark.parametrize(
     ("points", "expected_origin"),
     [
         ([[2.3, 1.3], [6.3, 3.3]], (2, 1)),
         ([[2.7, 1.7], [6.7, 3.7]], (3, 2)),
+        ([[2.5, 1.5], [6.5, 3.5]], (2, 2)),
         ([[2.7, 1.7], [6.3, 3.3]], (3, 2)),
     ],
-    ids=["down", "up", "different-fractions"],
+    ids=["down", "up", "ties-to-even", "different-fractions"],
 )
 def test_shapes_to_label_mask_rounds_fractional_bounds(
     points: list[list[float]], expected_origin: tuple[int, int]


### PR DESCRIPTION
Closes #2479.

Mask export truncated fractional bounds while Mask construction and hit-testing round them, shifting exported labels by up to one pixel. Fractional origins now use the existing ties-to-even rounding convention and the stored Mask extent, so independently rounded corners cannot crop or expand the patch.

Integer-aligned Masks retain the legacy bbox extent and therefore remain byte-identical, including accepted files whose bbox and stored Mask extents differ. `examples/utils.py` carries the independent rasterizer used by the shipped converters, so it mirrors the same behavior without importing labelme internals.

## Test plan

- [x] `uv run pytest -q tests/unit/utils/shape_test.py tests/unit/examples/utils_test.py` (42 passed)
- [x] `make lint`
- [x] `make test` (1268 passed, 6 skipped)