### PR TITLE
docs: define Shape Conversion and record its semantics as ADR 0007

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,1 @@
+number = true

--- a/.out-of-scope/conda-support.md
+++ b/.out-of-scope/conda-support.md
@@ -36,7 +36,7 @@ The path is a one-time setup, not a code change in this repo:
 
 1. Open a PR on `conda-forge/labelme-feedstock` adding the maintainer to
    `recipe/meta.yaml` `extra.recipe-maintainers`.
-1. Once merged, enable conda-forge bot automerge so future
+2. Once merged, enable conda-forge bot automerge so future
    `regro-cf-autotick-bot` version PRs merge automatically.
 
 After that it is genuinely zero-effort. Until someone wants to take on that

--- a/CLA.md
+++ b/CLA.md
@@ -12,7 +12,7 @@ you agree to the following terms:
    chooses, including terms different from those of this project's
    open-source license.
 
-1. **Representations**: You represent that (a) you are legally entitled
+2. **Representations**: You represent that (a) you are legally entitled
    to grant the above license, and (b) your contribution is your original
    work or you have the right to submit it under these terms.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,10 @@ _Avoid_: label file, JSON file (when more precision is helpful), annotation json
 A set of Shapes sharing a common `group_id`, marking them as belonging together. The reason for grouping is application-defined — instance segmentation uses it for the visible parts of one occluded object, but the concept is general and not tied to any one use case.
 _Avoid_: instance (it is only one application of grouping), cluster.
 
+**Shape Conversion**:
+Replacing a Shape's geometric kind (its `shape_type`) in place while keeping its identity — Label, Group, Shape Flags, and description. The UI verb is "Convert to…". A Conversion is either lossless (e.g. rectangle → polygon) or lossy (e.g. polygon → rectangle keeps only the bounding box); a lossy Conversion states what it discards at the point of use. Reverting relies on undo history, not on stored originals.
+_Avoid_: turn into, transform, cast, change type.
+
 **AI Assist**:
 Interactive, prompt-driven Shape proposal on the canvas: the user places positive / negative points or draws a box on the Image and a vision model (SAM, SAM2, EfficientSAM, SAM3) returns candidate Shapes. A point prompt contributes one candidate Shape, chosen by how well it satisfies the points and then by model confidence. A SAM3 box prompt is a Sweep. Candidates become new Shapes unless Existing Shape Suppression is enabled.
 _Avoid_: AI annotation (too vague — covers AI Text Prompt too), auto-annotation, automation.

--- a/docs/adr/0007-shape-conversion-semantics.md
+++ b/docs/adr/0007-shape-conversion-semantics.md
@@ -1,0 +1,33 @@
+# Shape Conversion is in-place, undo-revertable, and structure-honest
+
+Shape Conversion replaces a Shape's geometric kind in place while keeping its
+identity (Label, Group, Shape Flags, description). Three semantic commitments
+were made together, each against a real alternative:
+
+1. **Revert is undo history only.** The Annotation File never stores the
+   pre-conversion geometry. Storing originals would make lossy conversions
+   revertable across save/reload, but bloats a file that downstream pipelines
+   parse and creates stale shadow geometry once the converted Shape is edited.
+2. **A multi-part mask converts to one polygon per connected region, sharing a
+   Group when there is more than one.** The keyhole alternative (one
+   self-touching polygon joined by zero-width bridges, as COCO encodes
+   multi-part masks) preserves regions and holes but is hostile to hand-editing
+   — the primary reason users convert. Largest-region-only was rejected as
+   silent data loss. Holes are dropped either way; polygons cannot represent
+   them.
+3. **With multiple Shapes selected, the Convert menu offers the intersection of
+   targets valid for every selected Shape and converts them all in one undoable
+   step.** Union-and-skip-invalid offers more entries but makes the outcome
+   ("converted 3, skipped 2") unpredictable.
+
+## Consequences
+
+- A lossy conversion (e.g. polygon → rectangle) cannot be reverted after the
+  undo history is gone; the menu states each lossy conversion's effect at the
+  point of use instead of warning in a dialog.
+- Conversion can change the Shape count (mask → N Grouped polygons). The
+  reverse is 1:1 per Shape — converting Grouped polygons to masks yields one
+  mask Shape per polygon; merging a Group into one Shape is a separate feature,
+  not a conversion.
+- Every conversion pushes its own undo snapshot; the snapshot guard that
+  compares only point arrays would miss an in-place `shape_type` change.


### PR DESCRIPTION
Writes down the design behind the Shape Conversion effort (#2509, #2510, #2511) before implementation starts, so the tickets can stay thin: a CONTEXT.md glossary entry fixing the term and UI verb ("Convert to…"), and ADR 0007 recording the three semantic commitments — revert via undo history only, per-region Grouped polygons instead of a keyhole polygon for multi-part masks, intersection-of-valid-targets multi-select — each with the alternative it was chosen over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)