### PR TITLE
fix(app): synchronize canvas mode status

### DIFF
--- a/changelog.d/2521.fixed.md
+++ b/changelog.d/2521.fixed.md
@@ -1,0 +1,1 @@
+Synchronized the status bar with shape creation and editing modes immediately.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -191,6 +191,7 @@ class MainWindow(QtWidgets.QMainWindow):
     _prev_opened_dir: str | None
     _canvas_widgets: _CanvasWidgets
     _status_bar: _StatusBarWidgets
+    _status_mouse_pos: QtCore.QPointF | None
     _docks: _DockWidgets
     _actions: _Actions
     _persistent_actions: dict[tuple[str, ...], QtGui.QAction]
@@ -237,6 +238,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._prev_opened_dir = None
         self._label_list_menu_origin: QtCore.QPoint | None = None
+        self._status_mouse_pos = None
         self._docks = self._setup_dock_widgets()
 
         self.setAcceptDrops(True)
@@ -1509,9 +1511,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._actions.delete.setEnabled(not drawing)
 
     def _switch_canvas_mode(self, *, edit: bool, create_mode: str | None) -> None:
-        self._canvas_widgets.canvas.set_editing(value=edit)
-        if create_mode is not None:
-            self._canvas_widgets.canvas.create_mode = create_mode
+        self._canvas_widgets.canvas.set_editing(value=edit, create_mode=create_mode)
+        self._refresh_status_stats()
         if edit:
             for _, draw_action in self._actions.draw:
                 draw_action.setEnabled(True)
@@ -3061,9 +3062,17 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle(self._get_window_title(dirty=self._is_changed))
 
     def _update_status_stats(self, mouse_pos: QtCore.QPointF, /) -> None:
+        self._status_mouse_pos = QtCore.QPointF(mouse_pos)
+        self._refresh_status_stats()
+
+    def _refresh_status_stats(self) -> None:
         stats: list[str] = []
         stats.append(f"mode={self._canvas_widgets.canvas.mode.name}")
-        stats.append(f"x={mouse_pos.x():6.1f}, y={mouse_pos.y():6.1f}")
+        if self._status_mouse_pos is not None:
+            stats.append(
+                f"x={self._status_mouse_pos.x():6.1f}, "
+                f"y={self._status_mouse_pos.y():6.1f}"
+            )
         self._status_bar.stats.setText(" | ".join(stats))
 
 

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -401,11 +401,16 @@ class Canvas(QtWidgets.QWidget):
 
     @create_mode.setter
     def create_mode(self, value: str, /) -> None:
+        if not self._set_create_mode(value=value):
+            return
+        self._update_status(extra_messages=None)
+
+    def _set_create_mode(self, *, value: str) -> bool:
         if value not in typing.get_args(_CreateMode):
             raise ValueError(f"Unsupported create_mode: {value}")
         new_mode = cast(_CreateMode, value)
         if new_mode == self._create_mode:
-            return
+            return False
         old_mode = self._create_mode
         # Update the mode before reconciling so any signals fired from a cancel
         # observe the new mode rather than the one being left behind.
@@ -414,6 +419,7 @@ class Canvas(QtWidgets.QWidget):
         self._reconcile_partial_shape_on_mode_switch(
             old_mode=old_mode, new_mode=new_mode
         )
+        return True
 
     def _reconcile_partial_shape_on_mode_switch(
         self, *, old_mode: _CreateMode, new_mode: _CreateMode
@@ -550,7 +556,11 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self._update_status(extra_messages=None)
 
-    def set_editing(self, *, value: bool = True) -> None:
+    def set_editing(
+        self, *, value: bool = True, create_mode: str | None = None
+    ) -> None:
+        if create_mode is not None:
+            self._set_create_mode(value=create_mode)
         new_mode = _CanvasMode.EDIT if value else _CanvasMode.CREATE
         if new_mode is not self.mode:
             self._clear_ai_existing_shape_highlights()
@@ -569,6 +579,7 @@ class Canvas(QtWidgets.QWidget):
             need_update |= self.deselect_shape()
             if need_update:
                 self.update()
+        self._update_status(extra_messages=None)
 
     def _set_highlight(
         self,

--- a/tests/e2e/status_bar_messages_test.py
+++ b/tests/e2e/status_bar_messages_test.py
@@ -4,15 +4,72 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+from PySide6.QtCore import QPointF
 from PySide6.QtCore import QTimer
 from pytestqt.qtbot import QtBot
 
 from labelme._app import MainWindow
+from labelme._widgets.canvas import _CanvasMode
 
 from ..conftest import close_or_pause
 from .conftest import MainWinFactory
 from .conftest import dismiss_active_modal
 from .conftest import show_window_and_wait_for_imagedata
+
+
+@pytest.mark.gui
+def test_shape_mode_actions_update_status_without_pointer_movement(
+    *,
+    raw_win: MainWindow,
+    qtbot: QtBot,
+    pause: bool,
+) -> None:
+    canvas = raw_win._canvas_widgets.canvas
+    status_messages: list[str] = []
+    canvas.status_updated.connect(status_messages.append)
+
+    for create_mode, action in raw_win._actions.draw:
+        status_messages.clear()
+        action.trigger()
+
+        assert canvas.mode == _CanvasMode.CREATE
+        assert canvas.create_mode == create_mode
+        assert len(status_messages) == 1
+        assert raw_win._status_bar.message.text().startswith(
+            f"Creating {create_mode!r}"
+        )
+        assert raw_win._status_bar.stats.text() == "mode=CREATE"
+
+        status_messages.clear()
+        raw_win._actions.edit_mode.trigger()
+
+        assert canvas.mode == _CanvasMode.EDIT
+        assert status_messages == ["Editing shapes"]
+        assert raw_win._status_bar.message.text() == "Editing shapes"
+        assert raw_win._status_bar.stats.text() == "mode=EDIT"
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_mode_status_preserves_pointer_coordinates_across_transition(
+    *,
+    raw_win: MainWindow,
+    qtbot: QtBot,
+    pause: bool,
+) -> None:
+    canvas = raw_win._canvas_widgets.canvas
+    raw_win._actions.create_rectangle_mode.trigger()
+
+    canvas.mouse_moved.emit(QPointF(12, 34))
+
+    assert raw_win._status_bar.stats.text() == ("mode=CREATE | x=  12.0, y=  34.0")
+
+    raw_win._actions.edit_mode.trigger()
+
+    assert raw_win._status_bar.stats.text() == "mode=EDIT | x=  12.0, y=  34.0"
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
 
 
 def _wait_for_status_message_containing(


### PR DESCRIPTION
Mode changes now update both the descriptive status and the `mode=…` indicator atomically, so toolbar, menu, and shortcut actions no longer wait for canvas pointer movement.

## Test plan

- [x] `make lint`

- [x] `make test` — 1,369 passed, 6 skipped

- [x] `uv run pytest -q tests/e2e/status_bar_messages_test.py` — 5 passed

- [x] Isolated GUI smoke: toolbar Rectangle and Edit menu showed `Creating 'rectangle' … mode=CREATE` then `Editing shapes mode=EDIT`; ⌘N and ⌘J repeated the creation/edit transitions without pointer movement

Closes #2517
