### PR TITLE
fix(canvas): allow undoing first shape

### DIFF
--- a/changelog.d/2523.fixed.2.md
+++ b/changelog.d/2523.fixed.2.md
@@ -1,0 +1,1 @@
+Fixed Undo appearing enabled immediately after opening an image whose Shapes were carried forward via Keep Previous Annotation / Ctrl+Shift, which could silently discard the carried-forward Shapes if clicked before any edit on the new image

--- a/changelog.d/2523.fixed.md
+++ b/changelog.d/2523.fixed.md
@@ -1,0 +1,1 @@
+Fixed Undo remaining disabled after committing the first Shape on a raw Image. Undo now removes that Shape from the canvas, Annotation List, and both manually saved and auto-saved Annotation Files

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1324,6 +1324,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle(self._get_window_title(dirty=True))
 
     def mark_clean(self) -> None:
+        canvas = self._canvas_widgets.canvas
+        self._actions.undo.setEnabled(
+            not canvas.is_drawing and canvas.can_restore_shape
+        )
         self._is_changed = False
         self._actions.save.setEnabled(False)
         self.setWindowTitle(self._get_window_title(dirty=False))
@@ -1458,7 +1462,6 @@ class MainWindow(QtWidgets.QMainWindow):
             ),
         )
 
-        self._canvas_widgets.canvas.backup_shapes()
         self._load_shapes(shapes, replace=False)
         self.mark_dirty()
 
@@ -1487,7 +1490,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # In the middle of drawing, toggling between modes should be disabled.
         self._actions.edit_mode.setEnabled(not drawing)
         self._actions.undo_last_point.setEnabled(drawing)
-        self._actions.undo.setEnabled(not drawing)
+        self._actions.undo.setEnabled(
+            not drawing and self._canvas_widgets.canvas.can_restore_shape
+        )
         self._actions.delete.setEnabled(not drawing)
 
     def _switch_canvas_mode(
@@ -2239,12 +2244,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
         logger.debug("Loaded pixmap in {:.0f}ms", (time.time() - t0) * 1000)
         flags = {k: False for k in self._config["flags"] or []}
-        if label_file_path is not None:
-            self._load_shapes(shapes=shapes)
-            flags.update(annotation.flags)
+        # Record one baseline state. Loading carried-forward shapes separately
+        # would create a false Undo step that discards them before any edit.
+        carry_prev_shapes = bool(prev_shapes) and not shapes
+        self._load_shapes(shapes=prev_shapes if carry_prev_shapes else shapes)
+        flags.update(annotation.flags)
         self._load_flags(flags=flags, widget=self._docks.flag_list)
-        if prev_shapes and self.has_no_shapes():
-            self._load_shapes(shapes=prev_shapes, replace=False)
+        if carry_prev_shapes:
             self.mark_dirty()
         else:
             self.mark_clean()

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -225,6 +225,11 @@ def test_text_prompt_creates_shapes(
     win._save_label_file()
     assert_labelfile_sanity(out_file)
 
+    win._actions.undo.trigger()
+    assert not canvas.shapes
+    assert not canvas.can_restore_shape
+    assert not win._actions.undo.isEnabled()
+
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 
 

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -186,6 +186,39 @@ def test_auto_save_on_undo(
 
 
 @pytest.mark.gui
+def test_auto_save_on_undo_of_first_shape(
+    qtbot: QtBot,
+    _raw_auto_save_win: MainWindow,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    label_file = tmp_path / f"{Path(_RAW_FILE_NAME).stem}.json"
+    canvas = _raw_auto_save_win._canvas_widgets.canvas
+
+    draw_and_commit_polygon(
+        qtbot=qtbot,
+        win=_raw_auto_save_win,
+        label="first",
+        vertices=_VERTICES,
+    )
+
+    assert _raw_auto_save_win._actions.undo.isEnabled()
+    with label_file.open() as f:
+        assert len(json.load(f)["shapes"]) == 1
+
+    _raw_auto_save_win._actions.undo.trigger()
+
+    assert not canvas.shapes
+    assert len(_raw_auto_save_win._docks.label_list) == 0
+    assert not canvas.can_restore_shape
+    assert not _raw_auto_save_win._actions.undo.isEnabled()
+    with label_file.open() as f:
+        assert json.load(f)["shapes"] == []
+
+    close_or_pause(qtbot=qtbot, widget=_raw_auto_save_win, pause=pause)
+
+
+@pytest.mark.gui
 def test_failed_auto_save_keeps_annotation_dirty_and_allows_manual_retry(
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -421,11 +421,13 @@ def test_draw_actions_disable_only_active_mode(
 @pytest.mark.gui
 def test_cancel_drawing_with_escape(
     qtbot: QtBot,
-    annotated_win: MainWindow,
+    raw_win: MainWindow,
     pause: bool,
 ) -> None:
-    canvas = annotated_win._canvas_widgets.canvas
-    annotated_win._switch_canvas_mode(edit=False, create_mode="polygon")
+    canvas = raw_win._canvas_widgets.canvas
+    assert not raw_win._actions.undo.isEnabled()
+
+    raw_win._switch_canvas_mode(edit=False, create_mode="polygon")
     qtbot.wait(50)
 
     for xy in [(0.3, 0.3), (0.6, 0.3)]:
@@ -437,7 +439,10 @@ def test_cancel_drawing_with_escape(
     qtbot.wait(50)
 
     assert canvas._current is None
-    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+    assert not raw_win._actions.undo.isEnabled()
+    assert not raw_win._is_changed
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
 
 
 @pytest.mark.gui

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+import json
 from functools import partial
+from pathlib import Path
 from typing import Final
 
 import pytest
 from PySide6.QtCore import QPointF
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 from pytestqt.qtbot import QtBot
 
 from labelme._app import MainWindow
 from labelme._widgets.label_dialog import LabelDialog
 
 from ..conftest import close_or_pause
+from .conftest import MainWinFactory
 from .conftest import draw_and_commit_polygon
 from .conftest import draw_triangle
 from .conftest import schedule_on_dialog
 from .conftest import select_shape
+from .conftest import show_window_and_wait_for_imagedata
 
 _SHAPE_TIMEOUT_MS: Final = 5_000
 _VERTICES: Final = ((0.2, 0.2), (0.6, 0.2), (0.6, 0.6))
@@ -32,6 +37,15 @@ def _schedule_capture_then_cancel(
         label_dialog.reject()
 
     schedule_on_dialog(label_dialog=label_dialog, action=_action)
+
+
+@pytest.fixture()
+def discard_unsaved_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        lambda *args, **kwargs: QMessageBox.StandardButton.Discard,
+    )
 
 
 @pytest.mark.gui
@@ -91,3 +105,157 @@ def test_restore_last_shape_via_undo(
     ] == original_points
 
     close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_first_and_subsequent_shapes_can_be_undone_and_saved(
+    qtbot: QtBot,
+    main_win: MainWinFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    data_path: Path,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    raw_win = main_win(
+        file_or_dir=data_path / "raw/2011_000003.jpg",
+        config_overrides={"auto_save": False},
+        output_dir=tmp_path,
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=raw_win)
+
+    canvas = raw_win._canvas_widgets.canvas
+    label_list = raw_win._docks.label_list
+
+    assert not canvas.shapes
+    assert not canvas.can_restore_shape
+    assert not raw_win._actions.undo.isEnabled()
+
+    _draw_and_commit_polygon(qtbot=qtbot, win=raw_win, label="first")
+
+    assert canvas.can_restore_shape
+    assert raw_win._actions.undo.isEnabled()
+    assert len(canvas.shapes) == 1
+    assert len(label_list) == 1
+
+    _draw_and_commit_polygon(qtbot=qtbot, win=raw_win, label="second")
+
+    raw_win._actions.undo.trigger()
+    assert [shape.label for shape in canvas.shapes] == ["first"]
+    assert len(label_list) == 1
+
+    raw_win._actions.undo.trigger()
+    assert not canvas.shapes
+    assert len(label_list) == 0
+    assert not canvas.can_restore_shape
+    assert not raw_win._actions.undo.isEnabled()
+
+    label_path = tmp_path / "manual-save.json"
+    monkeypatch.setattr(raw_win, "prompt_save_file_path", lambda: str(label_path))
+    raw_win._save_label_file()
+
+    with label_path.open() as f:
+        assert json.load(f)["shapes"] == []
+
+    close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_undo_not_enabled_after_opening_image_with_shapes_carried_forward(
+    qtbot: QtBot,
+    main_win: MainWinFactory,
+    discard_unsaved_changes: None,
+    data_path: Path,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=data_path / "raw",
+        config_overrides={"keep_prev": True, "auto_save": False},
+        output_dir=tmp_path,
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    _draw_and_commit_polygon(qtbot=qtbot, win=win, label="carried")
+    assert len(canvas.shapes) == 1
+
+    win._actions.open_next_img.trigger()
+    qtbot.waitUntil(lambda: len(canvas.shapes) == 1, timeout=_SHAPE_TIMEOUT_MS)
+
+    # Keep Previous Annotation carried the shape onto the next image, but
+    # nothing has been edited on this image yet: Undo must stay disabled so
+    # a stray trigger cannot silently discard the carried-forward shape.
+    assert [shape.label for shape in canvas.shapes] == ["carried"]
+    assert not canvas.can_restore_shape
+    assert not win._actions.undo.isEnabled()
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("image_dir", ["raw", "annotated"])
+def test_navigation_disables_undo_for_clean_image_history(
+    qtbot: QtBot,
+    main_win: MainWinFactory,
+    discard_unsaved_changes: None,
+    data_path: Path,
+    image_dir: str,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=data_path / image_dir,
+        config_overrides={"auto_save": False},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    _draw_and_commit_polygon(qtbot=qtbot, win=win, label="new")
+    assert win._actions.undo.isEnabled()
+
+    image_path = win._image_path
+
+    win._actions.open_next_img.trigger()
+    qtbot.waitUntil(lambda: win._image_path != image_path, timeout=_SHAPE_TIMEOUT_MS)
+
+    assert not canvas.can_restore_shape
+    assert not win._actions.undo.isEnabled()
+    assert not win._is_changed
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_save_keeps_shape_undo_disabled_while_drawing(
+    qtbot: QtBot,
+    main_win: MainWinFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    data_path: Path,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=data_path / "raw/2011_000003.jpg",
+        config_overrides={"auto_save": False},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    _draw_and_commit_polygon(qtbot=qtbot, win=win, label="committed")
+    _draw_triangle(qtbot=qtbot, win=win)
+
+    assert canvas.is_drawing
+    assert not win._actions.undo.isEnabled()
+    assert win._actions.undo_last_point.isEnabled()
+
+    monkeypatch.setattr(
+        win,
+        "prompt_save_file_path",
+        lambda: str(tmp_path / "save-while-drawing.json"),
+    )
+    win._save_label_file()
+
+    assert canvas.is_drawing
+    assert not win._actions.undo.isEnabled()
+    assert win._actions.undo_last_point.isEnabled()
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)


### PR DESCRIPTION
Stacked on #2553; merge that PR first.

Raw images previously had no baseline Shape history, so committing their first annotation left Undo disabled. This seeds one baseline state per image while keeping clean loads, carried-forward Shapes, and active drawing non-undoable.

## Test plan

- [x] `make lint`; `make test` — 1,297 passed, 6 skipped; `towncrier build --draft`

- [x] Isolated real GUI: toolbar Undo removed the first rectangle, Command+Z removed the first polygon, both cleared the canvas and Annotation List and auto-saved `shapes: []`, and a clean relaunch kept Undo disabled

Closes #2518
