### PR TITLE
fix: offset duplicated and pasted shapes

### DIFF
--- a/changelog.d/2536.fixed.md
+++ b/changelog.d/2536.fixed.md
@@ -1,0 +1,1 @@
+Fixed Duplicate and Paste placing a Shape on its source coordinates, where the copy was hidden underneath and easy to stack unnoticed. Both now offset the copy by a visible distance that stays inside the Image, while pasting into another Image keeps the copied coordinates

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1823,6 +1823,11 @@ class MainWindow(QtWidgets.QMainWindow):
     def _insert_shapes(self, shapes: list[Shape]) -> None:
         if not shapes:
             return
+        # A copy landing on the shape it came from is invisible, and the user
+        # cannot tell that anything was created. This has to run before the
+        # shapes join the canvas, or they would read as occupying the very
+        # placement they are being offered.
+        self._canvas_widgets.canvas.offset_shapes_for_insertion(shapes=shapes)
         self._load_shapes(shapes=shapes, replace=False)
         self._canvas_widgets.canvas.select_shapes(shapes)
         self.mark_dirty()

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import typing
 from collections.abc import Callable
+from collections.abc import Iterator
 from collections.abc import Sequence
 from typing import Any
 from typing import Final
@@ -12,6 +13,7 @@ from typing import Literal
 from typing import cast
 
 import numpy as np
+import numpy.typing as npt
 from loguru import logger
 from PySide6 import QtCore
 from PySide6 import QtGui
@@ -1304,6 +1306,93 @@ class Canvas(QtWidgets.QWidget):
         self.selection_changed.emit(shapes)
         self.update()
 
+    def offset_shapes_for_insertion(self, shapes: list[Shape]) -> None:
+        if not shapes:
+            return
+        OFFSET_SCREEN_PX: Final[float] = 12.0
+
+        # Points live in image coordinates, so dividing by the zoom keeps the
+        # copy the same distance from its source on screen at any zoom level.
+        step = OFFSET_SCREEN_PX / self.scale
+        bounds = _compute_shapes_bounds(shapes=shapes)
+        # Nothing to offer means nothing to move, so the copy stays put.
+        offset = QPointF()
+        for candidate in self._iter_insertion_offsets(bounds=bounds, step=step):
+            offset = candidate
+            if not self._is_placement_occupied(shapes=shapes, offset=candidate):
+                break
+        for shape in shapes:
+            shape.translate(offset=(offset.x(), offset.y()))
+
+    def _iter_insertion_offsets(
+        self, *, bounds: QRectF, step: float
+    ) -> Iterator[QPointF]:
+        MAX_PLACEMENTS: Final[int] = 100
+        MIN_VISIBLE_SCREEN_PX: Final[float] = 3.0
+
+        if self._allow_out_of_bounds_points or self.pixmap.isNull():
+            yield QPointF()
+            for count in range(1, MAX_PLACEMENTS + 1):
+                yield QPointF(step * count, step * count)
+            return
+
+        image_size = self.pixmap.size()
+        # Shapes copied from a larger image start outside this one, where they
+        # are invisible and out of reach, so the search starts from wherever
+        # they first fit. Coordinates that already fit are left alone: pasting
+        # between frames of one scene relies on them.
+        entry = _compute_containment_offset(bounds=bounds, image_size=image_size)
+        bounds = bounds.translated(entry)
+        # It is also the only placement a shape spanning the whole image can
+        # take, the one case where a copy stays hidden under its source.
+        yield entry
+
+        previous = entry
+        # Widen the gap first, since a copy far from its source is the easiest
+        # to spot. The caller settles for the last placement even when it is
+        # occupied: a stacked copy inside the image beats one pushed outside.
+        for count in range(1, MAX_PLACEMENTS + 1):
+            candidate = entry + _compute_insertion_offset(
+                bounds=bounds, image_size=image_size, step=step * count
+            )
+            if candidate == previous:
+                break  # the image edge clamps every wider gap to this one
+            if not self._is_gap_visible(
+                gap=candidate - entry, minimum_screen_px=MIN_VISIBLE_SCREEN_PX
+            ):
+                return
+            previous = candidate
+            yield candidate
+        # Done widening, whether the edge clamped every wider gap or the budget
+        # ran out, so look for a spot between the source and the widest gap.
+        for count in range(2, MAX_PLACEMENTS + 1):
+            candidate = entry + _compute_insertion_offset(
+                bounds=bounds, image_size=image_size, step=step / count
+            )
+            if candidate == previous:
+                continue
+            if not self._is_gap_visible(
+                gap=candidate - entry, minimum_screen_px=MIN_VISIBLE_SCREEN_PX
+            ):
+                return
+            previous = candidate
+            yield candidate
+
+    def _is_gap_visible(self, *, gap: QPointF, minimum_screen_px: float) -> bool:
+        # A gap the eye cannot resolve is no better than the stack it avoids,
+        # and how far it reads on screen is what the zoom decides.
+        gap_on_screen = max(abs(gap.x()), abs(gap.y())) * self.scale
+        return gap_on_screen >= minimum_screen_px
+
+    def _is_placement_occupied(self, *, shapes: list[Shape], offset: QPointF) -> bool:
+        delta = np.array([offset.x(), offset.y()])
+        placements = [(inserted, inserted.points + delta) for inserted in shapes]
+        return any(
+            _is_same_placement(existing=existing, inserted=inserted, points=points)
+            for inserted, points in placements
+            for existing in self.shapes
+        )
+
     def _select_shape_point(
         self, point: QPointF, multiple_selection_mode: bool
     ) -> None:
@@ -2114,12 +2203,116 @@ def _opposite_corner_in_parallelogram(
     return neighbor1 + neighbor2 - opposite_to
 
 
+def _is_same_placement(
+    *, existing: Shape, inserted: Shape, points: npt.NDArray[np.float64]
+) -> bool:
+    TOLERANCE_PX: Final[float] = 1e-3
+
+    if existing.shape_type != inserted.shape_type:
+        return False
+    if existing.points.shape != points.shape or points.size == 0:
+        return False
+    # An image can carry thousands of shapes and every candidate placement is
+    # measured against all of them, so reject on one coordinate before paying
+    # for the whole-array comparison.
+    if abs(existing.points[0, 0] - points[0, 0]) > TOLERANCE_PX:
+        return False
+    if not np.allclose(existing.points, points, rtol=0.0, atol=TOLERANCE_PX):
+        return False
+    # A mask shape carries only its bounding box in the points, so two masks
+    # can share a box and still cover different pixels.
+    if existing.mask is None:
+        return inserted.mask is None
+    if inserted.mask is None:
+        return False
+    return np.array_equal(existing.mask, inserted.mask)
+
+
+def _compute_containment_offset(*, bounds: QRectF, image_size: QtCore.QSize) -> QPointF:
+    return QPointF(
+        _compute_axis_containment(
+            low_edge=bounds.left(),
+            high_edge=bounds.right(),
+            image_extent=float(image_size.width()),
+        ),
+        _compute_axis_containment(
+            low_edge=bounds.top(),
+            high_edge=bounds.bottom(),
+            image_extent=float(image_size.height()),
+        ),
+    )
+
+
+def _compute_axis_containment(
+    *, low_edge: float, high_edge: float, image_extent: float
+) -> float:
+    if high_edge - low_edge > image_extent:
+        # Too wide to fit inside, so the best it can do is cover the image,
+        # and only a shape that has drifted clear of it has to move at all.
+        if high_edge <= 0.0:
+            return -low_edge
+        if low_edge >= image_extent:
+            return image_extent - high_edge
+        return 0.0
+    if high_edge > image_extent:
+        return image_extent - high_edge
+    if low_edge < 0.0:
+        return -low_edge
+    return 0.0
+
+
+def _compute_insertion_offset(
+    *, bounds: QRectF, image_size: QtCore.QSize, step: float
+) -> QPointF:
+    return QPointF(
+        _compute_axis_offset(
+            low_edge=bounds.left(),
+            high_edge=bounds.right(),
+            image_extent=float(image_size.width()),
+            step=step,
+        ),
+        _compute_axis_offset(
+            low_edge=bounds.top(),
+            high_edge=bounds.bottom(),
+            image_extent=float(image_size.height()),
+            step=step,
+        ),
+    )
+
+
+def _compute_axis_offset(
+    *, low_edge: float, high_edge: float, image_extent: float, step: float
+) -> float:
+    if high_edge - low_edge > image_extent:
+        # A shape wider than the image can never sit inside it, so its room is
+        # what it can give up while still covering the image.
+        room_forward = -low_edge
+        room_backward = high_edge - image_extent
+    else:
+        room_forward = image_extent - high_edge
+        room_backward = low_edge
+    if room_forward >= step:
+        return step
+    if room_backward >= step:
+        return -step
+    # Against an edge the full step does not fit either way, so take whatever
+    # room is left: a cramped copy still beats one stacked exactly on top.
+    if room_forward >= room_backward:
+        return max(room_forward, 0.0)
+    return -max(room_backward, 0.0)
+
+
 def _compute_shapes_bounds(*, shapes: list[Shape]) -> QRectF:
     assert shapes
-    bounds = _shape_bounds(shape=shapes[0])
-    for shape in shapes[1:]:
-        bounds = bounds.united(_shape_bounds(shape=shape))
-    return bounds
+    # A point draws as a rectangle of no width or height, which united()
+    # discards as null, so the union runs over the edges instead.
+    rects = [_shape_bounds(shape=shape) for shape in shapes if len(shape.points)]
+    if not rects:
+        return QRectF()
+    return QRectF(
+        QPointF(min(r.left() for r in rects), min(r.top() for r in rects)),
+        QPointF(max(r.right() for r in rects), max(r.bottom() for r in rects)),
+    )
 
 
 def _project_oriented_rectangle_corners(

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +10,7 @@ from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
 from labelme._app import MainWindow
+from labelme._shape import Shape
 from labelme._widgets._shape_render import bounds as _shape_bounds
 from labelme._widgets.canvas import Canvas
 
@@ -41,6 +43,32 @@ def _open_and_select_shape(
 
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=shape_index)
     return win, canvas
+
+
+def _assert_offset_within_image(
+    *, canvas: Canvas, inserted: Shape, source_points: np.ndarray
+) -> None:
+    assert not np.array_equal(inserted.points, source_points)
+    # What has to stay inside the image is the drawn extent, which a circle
+    # carries beyond its points.
+    drawn = _shape_bounds(shape=inserted)
+    assert drawn.left() >= 0
+    assert drawn.top() >= 0
+    assert drawn.right() <= canvas.pixmap.width()
+    assert drawn.bottom() <= canvas.pixmap.height()
+
+
+def _assert_round_trip_keeps_last_shape(
+    *, win: MainWindow, canvas: Canvas, label_path: Path
+) -> None:
+    inserted_points = canvas.shapes[-1].points.copy()
+    win._save_label_file()
+    assert_labelfile_sanity(str(label_path))
+    saved = json.loads(label_path.read_text())["shapes"][-1]["points"]
+    assert np.array(saved, dtype=np.float64) == pytest.approx(inserted_points)
+
+    win._load_file(image_or_label_path=str(label_path))
+    assert canvas.shapes[-1].points == pytest.approx(inserted_points)
 
 
 def _delete_selected_shape(
@@ -86,6 +114,7 @@ def test_copy_paste_shape(
     )
 
     original_label = canvas.selected_shapes[0].label
+    original_points = canvas.selected_shapes[0].points.copy()
     num_shapes_before = len(canvas.shapes)
 
     win._actions.copy.trigger()
@@ -93,10 +122,16 @@ def test_copy_paste_shape(
     qtbot.wait(50)
 
     assert len(canvas.shapes) == num_shapes_before + 1
-    assert canvas.shapes[-1].label == original_label
+    pasted = canvas.shapes[-1]
+    assert pasted.label == original_label
+    _assert_offset_within_image(
+        canvas=canvas, inserted=pasted, source_points=original_points
+    )
+    assert canvas.selected_shapes == [pasted]
 
-    win._save_label_file()
-    assert_labelfile_sanity(str(tmp_path / "2011_000003.json"))
+    _assert_round_trip_keeps_last_shape(
+        win=win, canvas=canvas, label_path=tmp_path / "2011_000003.json"
+    )
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 
@@ -117,15 +152,79 @@ def test_duplicate_shape(
         output_dir=str(tmp_path),
     )
 
+    original_points = canvas.selected_shapes[0].points.copy()
     num_shapes_before = len(canvas.shapes)
 
     win._actions.duplicate.trigger()
     qtbot.wait(50)
 
     assert len(canvas.shapes) == num_shapes_before + 1
+    duplicated = canvas.shapes[-1]
+    _assert_offset_within_image(
+        canvas=canvas, inserted=duplicated, source_points=original_points
+    )
+    assert canvas.selected_shapes == [duplicated]
 
-    win._save_label_file()
-    assert_labelfile_sanity(str(tmp_path / "2011_000003.json"))
+    _assert_round_trip_keeps_last_shape(
+        win=win, canvas=canvas, label_path=tmp_path / "2011_000003.json"
+    )
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_paste_into_another_image_keeps_the_copied_coordinates(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win, canvas = _open_and_select_shape(
+        main_win=main_win, qtbot=qtbot, data_path=data_path
+    )
+    copied_points = canvas.selected_shapes[0].points.copy()
+    win._actions.copy.trigger()
+
+    win._load_file(image_or_label_path=str(data_path / "annotated/2011_000006.json"))
+    qtbot.wait(50)
+    win._actions.paste.trigger()
+    qtbot.wait(50)
+
+    # Transferring annotations between frames of the same scene relies on the
+    # pasted geometry landing where it was copied from.
+    assert canvas.shapes[-1].points == pytest.approx(copied_points)
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("action_name", ["duplicate", "paste"])
+def test_repeated_insert_keeps_copies_apart_and_inside_image(
+    action_name: str,
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win, canvas = _open_and_select_shape(
+        main_win=main_win, qtbot=qtbot, data_path=data_path
+    )
+    if action_name == "paste":
+        win._actions.copy.trigger()
+
+    placements = [canvas.selected_shapes[0].points.copy()]
+    for _ in range(5):
+        getattr(win._actions, action_name).trigger()
+        qtbot.wait(50)
+        _assert_offset_within_image(
+            canvas=canvas, inserted=canvas.shapes[-1], source_points=placements[-1]
+        )
+        placements.append(canvas.shapes[-1].points.copy())
+
+    # Every copy must sit on its own spot, not just clear of its predecessor:
+    # an offset that reverses at the image edge would otherwise alternate
+    # between two placements forever.
+    assert len({points.tobytes() for points in placements}) == len(placements)
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -18,9 +18,13 @@ from pytestqt.qtbot import QtBot
 from labelme._automation._ai_assist import AiAssistProposal
 from labelme._shape import Shape
 from labelme._shape import ShapeType
+from labelme._widgets._shape_render import bounds as _shape_bounds
 from labelme._widgets.canvas import Canvas
+from labelme._widgets.canvas import _compute_axis_offset
+from labelme._widgets.canvas import _compute_insertion_offset
 from labelme._widgets.canvas import _compute_intersection_edges_image
 from labelme._widgets.canvas import _compute_overscroll_slack
+from labelme._widgets.canvas import _compute_shapes_bounds
 from labelme._widgets.canvas import _draft_to_shape
 from labelme._widgets.canvas import _DraftShape
 from labelme._widgets.canvas import _is_degenerate_draft
@@ -1882,6 +1886,17 @@ def test_snap_cursor_pos_for_square(
     assert (result.x(), result.y()) == pytest.approx(expected)
 
 
+def _make_inner_rectangle() -> Shape:
+    return Shape(shape_type="rectangle", points=np.array([(10, 10), (40, 30)]))
+
+
+def _make_corner_rectangle() -> Shape:
+    return Shape(
+        shape_type="rectangle",
+        points=np.array([(_WIDTH - 20, _HEIGHT - 20), (_WIDTH, _HEIGHT)]),
+    )
+
+
 def _make_polygon() -> Shape:
     return Shape(
         shape_type="polygon",
@@ -1955,3 +1970,399 @@ def test_end_move_in_place_copies_points(canvas: Canvas) -> None:
 
     assert np.array_equal(shape.points, clone.points)
     assert not np.shares_memory(shape.points, clone.points)
+
+
+@pytest.mark.parametrize(
+    ("low_edge", "high_edge", "expected"),
+    [
+        pytest.param(10.0, 40.0, 12.0, id="room_ahead_takes_full_step"),
+        pytest.param(10.0, 88.0, 12.0, id="step_exactly_fits_ahead"),
+        pytest.param(
+            50.0, 88.0, 12.0, id="a_fitting_step_ahead_beats_more_room_behind"
+        ),
+        pytest.param(60.0, 95.0, -12.0, id="no_room_ahead_steps_back"),
+        pytest.param(3.0, 95.0, 5.0, id="cramped_both_ways_takes_larger_room_ahead"),
+        pytest.param(8.0, 98.0, -8.0, id="cramped_both_ways_takes_larger_room_behind"),
+        pytest.param(0.0, 100.0, 0.0, id="shape_exactly_fills_image_stays_put"),
+        pytest.param(-20.0, 120.0, 12.0, id="shape_wider_than_image_takes_full_step"),
+        pytest.param(
+            0.0, 140.0, -12.0, id="shape_wider_than_image_gives_up_room_it_covers"
+        ),
+        pytest.param(
+            -8.0, 104.0, 8.0, id="shape_wider_than_image_stops_uncovering_the_image"
+        ),
+    ],
+)
+def test_compute_axis_offset(
+    low_edge: float, high_edge: float, expected: float
+) -> None:
+    assert _compute_axis_offset(
+        low_edge=low_edge, high_edge=high_edge, image_extent=100.0, step=12.0
+    ) == pytest.approx(expected)
+
+
+def test_compute_insertion_offset_clamps_each_axis_independently() -> None:
+    offset = _compute_insertion_offset(
+        bounds=QtCore.QRectF(10.0, 40.0, 20.0, 8.0),
+        image_size=QSize(_WIDTH, _HEIGHT),
+        step=12.0,
+    )
+
+    # Horizontally there is room to advance; vertically the shape sits against
+    # the bottom edge, so the copy has to go back up.
+    assert offset.x() == pytest.approx(12.0)
+    assert offset.y() == pytest.approx(-12.0)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_shifts_copy_off_its_source(
+    canvas: Canvas,
+) -> None:
+    source = _make_inner_rectangle()
+    canvas.load_shapes(shapes=[source])
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points - source.points, np.full((2, 2), 12.0))
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_leaves_a_free_position_alone(
+    canvas: Canvas,
+) -> None:
+    # Pasting onto another image finds the source position empty, and the
+    # coordinates the shapes were copied from are worth keeping.
+    source = _make_inner_rectangle()
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points, source.points)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_keeps_screen_distance_when_zoomed(
+    canvas: Canvas,
+) -> None:
+    source = _make_polygon()
+    canvas.load_shapes(shapes=[source])
+    inserted = source.copy()
+    canvas.scale = 4.0
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points - source.points, np.full((4, 2), 3.0))
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_moves_a_group_as_one(canvas: Canvas) -> None:
+    first = _make_polygon()
+    second = _make_polygon()
+    second.translate(offset=(5.0, 0.0))
+    canvas.load_shapes(shapes=[first, second])
+    inserted = [first.copy(), second.copy()]
+
+    canvas.offset_shapes_for_insertion(shapes=inserted)
+
+    assert not np.array_equal(inserted[0].points, first.points)
+    assert np.array_equal(
+        inserted[1].points - inserted[0].points, np.tile((5.0, 0.0), (4, 1))
+    )
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_keeps_copy_inside_image(canvas: Canvas) -> None:
+    source = _make_corner_rectangle()
+    canvas.load_shapes(shapes=[source])
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert inserted.points.min() >= 0.0
+    assert inserted.points[:, 0].max() <= _WIDTH
+    assert inserted.points[:, 1].max() <= _HEIGHT
+    assert inserted.points[0][0] == pytest.approx(_WIDTH - 32)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_steps_past_an_occupied_placement(
+    canvas: Canvas,
+) -> None:
+    source = _make_inner_rectangle()
+    occupant = Shape(shape_type="rectangle", points=source.points + 12.0)
+    canvas.load_shapes(shapes=[source, occupant])
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    # Two steps along x, but only the room left along y: widening the gap still
+    # respects the image edge.
+    assert np.array_equal(inserted.points, source.points + (24.0, 20.0))
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_never_reuses_an_edge_placement(
+    canvas: Canvas,
+) -> None:
+    # Against an edge the offset reverses direction, which on its own would
+    # walk a chain of copies back onto placements it already used.
+    shape = _make_inner_rectangle()
+    canvas.load_shapes(shapes=[shape])
+    placements = [shape.points.copy()]
+
+    for _ in range(8):
+        inserted = canvas.shapes[-1].copy()
+        canvas.offset_shapes_for_insertion(shapes=[inserted])
+        canvas.load_shapes(shapes=[inserted], replace=False)
+        placements.append(inserted.points.copy())
+
+    assert len({points.tobytes() for points in placements}) == len(placements)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_leaves_a_full_image_shape_in_place(
+    canvas: Canvas,
+) -> None:
+    # The issue asks for copies to stay inside the image, and a shape spanning
+    # it has no other placement, so this one copy stays under its source.
+    shape = Shape(shape_type="rectangle", points=np.array([(0, 0), (_WIDTH, _HEIGHT)]))
+    canvas.load_shapes(shapes=[shape])
+    inserted = shape.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points, shape.points)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_ignores_bounds_when_allowed(
+    canvas: Canvas,
+) -> None:
+    canvas.set_allow_out_of_bounds_points(True)
+    source = _make_corner_rectangle()
+    canvas.load_shapes(shapes=[source])
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert inserted.points[1][0] == pytest.approx(_WIDTH + 12)
+    assert inserted.points[1][1] == pytest.approx(_HEIGHT + 12)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_narrows_the_gap_when_the_image_is_full(
+    canvas: Canvas,
+) -> None:
+    # A shape nearly as wide as the image saturates the widening search after
+    # one step, and every later copy would restack without the narrowing pass.
+    source = Shape(shape_type="rectangle", points=np.array([(0, 0), (_WIDTH - 12, 20)]))
+    canvas.load_shapes(shapes=[source])
+    placements = [source.points.copy()]
+
+    for _ in range(4):
+        inserted = source.copy()
+        canvas.offset_shapes_for_insertion(shapes=[inserted])
+        canvas.load_shapes(shapes=[inserted], replace=False)
+        placements.append(inserted.points.copy())
+
+    assert len({points.tobytes() for points in placements}) == len(placements)
+    assert all(points[:, 0].max() <= _WIDTH for points in placements)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_keeps_moving_a_shape_wider_than_the_image(
+    canvas: Canvas,
+) -> None:
+    # Such a shape cannot be placed inside the image at all, so clamping it
+    # would freeze every copy onto one spot.
+    source = Shape(
+        shape_type="rectangle", points=np.array([(-20, -20), (_WIDTH + 20, _HEIGHT)])
+    )
+    canvas.load_shapes(shapes=[source])
+    placements = [source.points.copy()]
+
+    for _ in range(6):
+        inserted = canvas.shapes[-1].copy()
+        canvas.offset_shapes_for_insertion(shapes=[inserted])
+        canvas.load_shapes(shapes=[inserted], replace=False)
+        placements.append(inserted.points.copy())
+
+    assert len({points.tobytes() for points in placements}) == len(placements)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_never_settles_for_an_invisible_gap(
+    canvas: Canvas,
+) -> None:
+    MIN_VISIBLE_PX: Final[float] = 3.0
+
+    # A shape nearly as wide as the image runs out of room quickly, and the
+    # narrowing search must stop while the gap can still be seen.
+    source = Shape(shape_type="rectangle", points=np.array([(0, 0), (_WIDTH - 12, 20)]))
+    canvas.load_shapes(shapes=[source])
+
+    for _ in range(12):
+        inserted = canvas.shapes[-1].copy()
+        previous_points = inserted.points.copy()
+        canvas.offset_shapes_for_insertion(shapes=[inserted])
+        canvas.load_shapes(shapes=[inserted], replace=False)
+        gap = np.abs(inserted.points - previous_points).max()
+        assert gap == 0.0 or gap >= MIN_VISIBLE_PX
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_stays_put_when_no_visible_gap_fits(
+    canvas: Canvas,
+) -> None:
+    source = Shape(
+        shape_type="rectangle", points=np.array([(1, 1), (_WIDTH - 1, _HEIGHT - 1)])
+    )
+    canvas.load_shapes(shapes=[source])
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points, source.points)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_takes_a_gap_zooming_in_makes_visible(
+    canvas: Canvas,
+) -> None:
+    # The same one pixel of room the fit-to-window view cannot show is a wide
+    # gap once the image is magnified.
+    source = Shape(
+        shape_type="rectangle", points=np.array([(1, 1), (_WIDTH - 1, _HEIGHT - 1)])
+    )
+    canvas.load_shapes(shapes=[source])
+    canvas.scale = 8.0
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points - source.points, np.full((2, 2), 1.0))
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_pulls_a_copy_from_a_larger_image_inside(
+    canvas: Canvas,
+) -> None:
+    # Coordinates copied from a larger image land off this one, where the copy
+    # is neither visible nor clickable.
+    inserted = Shape(
+        shape_type="rectangle",
+        points=np.array([(_WIDTH + 300, _HEIGHT + 200), (_WIDTH + 340, _HEIGHT + 230)]),
+    )
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert inserted.points.min() >= 0.0
+    assert inserted.points[:, 0].max() <= _WIDTH
+    assert inserted.points[:, 1].max() <= _HEIGHT
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_brings_an_oversized_copy_back_onto_the_image(
+    canvas: Canvas,
+) -> None:
+    # Too wide to ever fit inside, and pasted from far off the image, so the
+    # best placement is the one that covers the image.
+    inserted = Shape(
+        shape_type="rectangle",
+        points=np.array([(5000, 10), (5000 + _WIDTH + 50, 30)]),
+    )
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert inserted.points[0][0] <= 0.0
+    assert inserted.points[1][0] >= _WIDTH
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_keeps_an_oversized_copy_over_the_image(
+    canvas: Canvas,
+) -> None:
+    # Every copy has to stay over the image instead of marching off it.
+    source = Shape(
+        shape_type="rectangle", points=np.array([(-20, -20), (_WIDTH + 20, 30)])
+    )
+    canvas.load_shapes(shapes=[source])
+
+    for _ in range(10):
+        inserted = canvas.shapes[-1].copy()
+        canvas.offset_shapes_for_insertion(shapes=[inserted])
+        canvas.load_shapes(shapes=[inserted], replace=False)
+        assert inserted.points[0][0] <= 0.0
+        assert inserted.points[1][0] >= _WIDTH
+
+
+def test_compute_shapes_bounds_covers_a_point_shape() -> None:
+    # A point contributes no width or height, and dropping it from the union
+    # would let the group move it off the image.
+    bounds = _compute_shapes_bounds(
+        shapes=[
+            _make_inner_rectangle(),
+            Shape(shape_type="point", points=np.array([(_WIDTH, _HEIGHT)])),
+        ]
+    )
+
+    assert bounds.right() == pytest.approx(_WIDTH)
+    assert bounds.bottom() == pytest.approx(_HEIGHT)
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_keeps_a_group_with_a_point_inside(
+    canvas: Canvas,
+) -> None:
+    rectangle = _make_inner_rectangle()
+    point = Shape(shape_type="point", points=np.array([(_WIDTH - 1, _HEIGHT - 1)]))
+    canvas.load_shapes(shapes=[rectangle, point])
+    inserted = [rectangle.copy(), point.copy()]
+
+    canvas.offset_shapes_for_insertion(shapes=inserted)
+
+    assert inserted[1].points[0][0] <= _WIDTH
+    assert inserted[1].points[0][1] <= _HEIGHT
+    assert inserted[0].points.min() >= 0.0
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_keeps_a_circle_inside_the_image(
+    canvas: Canvas,
+) -> None:
+    # A circle reaches a radius past its center point, so its drawn extent is
+    # what has to stay inside the image, not its two points.
+    source = Shape(
+        shape_type="circle", points=np.array([(_WIDTH - 15, 15), (_WIDTH - 5, 15)])
+    )
+    canvas.load_shapes(shapes=[source])
+    inserted = source.copy()
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    drawn = _shape_bounds(shape=inserted)
+    assert drawn.left() >= 0.0
+    assert drawn.top() >= 0.0
+    assert drawn.right() <= _WIDTH
+    assert drawn.bottom() <= _HEIGHT
+
+
+@pytest.mark.gui
+def test_offset_shapes_for_insertion_tells_masks_with_one_box_apart(
+    canvas: Canvas,
+) -> None:
+    # Mask shapes carry only their bounding box as points, so an existing mask
+    # sharing the box does not mean the placement is taken.
+    points = np.array([(10, 10), (30, 20)])
+    existing = Shape(
+        shape_type="mask", points=points, mask=np.ones((10, 20), dtype=bool)
+    )
+    canvas.load_shapes(shapes=[existing])
+    inserted = Shape(
+        shape_type="mask", points=points.copy(), mask=np.zeros((10, 20), dtype=bool)
+    )
+
+    canvas.offset_shapes_for_insertion(shapes=[inserted])
+
+    assert np.array_equal(inserted.points, points)


### PR DESCRIPTION
Closes #2527.

Duplicate and Paste placed the copy on the source coordinates, so the new shape sat hidden underneath and users could stack annotations without noticing. Both paths now search for a placement the copy can have to itself.

Four non-obvious bits:

1. The search starts at a zero offset, so pasting into a different image keeps the copied coordinates — transferring annotations between frames of one scene depends on that. In the same image the source occupies that spot, so Duplicate and Paste always move the copy; a copy carrying coordinates from a larger image is brought onto this one first.

2. The step is a fixed on-screen distance converted through the zoom, so the gap looks the same at any magnification and the saved geometry depends on the zoom level. Gaps under 3 screen pixels are refused rather than accepted as success.

3. The search widens the gap first, then narrows it once the image edge stops making room. It is finite by design: roughly 41 distinct placements on a 500x375 image and 103 on 1920x1080 before positions repeat under repeated Paste of one clipboard. When every placement is taken, or a shape spans the whole image, the copy stays inside the image rather than being pushed out of it — the issue asks for in-bounds copies, and this is the one case where a copy stays under its source.

4. `_compute_shapes_bounds` now unions the edges instead of calling `QRectF.united()`, which discards a zero-extent rect. A point shape draws with no width or height, so a mixed selection was dropping it from the group bounds and could carry it off the image. This also fixes the same latent bug on the group-drag path.

Verified against the packaged entry point on the annotated example, offscreen: clicking a shape then Duplicate and Copy/Paste each produced a copy 12 screen pixels clear of its source and left it selected, the saved JSON matched the canvas with every point inside the image, and Undo removed the copy.

![three offset copies of one polygon](https://github.com/user-attachments/assets/534cab7b-246b-4601-8479-725d54f80aa0)

## Test plan

- [x] `make test` — 1330 passed, 1 skipped
- [x] `make lint` — ruff, ty, taplo, mdformat, yamlfix, typos
- [x] Regression coverage for both paths: repeated Duplicate and repeated Paste, cross-image paste, in-bounds after save and reload, group with a point shape, circle drawn extent, mask bounding boxes, shapes wider than the image, and the zoom-scaled gap
