### PR TITLE
fix: keep zoom focal point under cursor

### DIFF
--- a/changelog.d/2553.fixed.md
+++ b/changelog.d/2553.fixed.md
@@ -1,0 +1,1 @@
+Kept the image point beneath the cursor stationary during Ctrl/Cmd-wheel zoom without canvas flicker.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -94,6 +94,13 @@ class _CanvasWidgets(NamedTuple):
     scroll_bars: dict[Qt.Orientation, QtWidgets.QScrollBar]
 
 
+class _ViewportState(NamedTuple):
+    zoom_mode: _ZoomMode
+    zoom_value: float
+    scroll_values: dict[Qt.Orientation, int]
+    view_offset: QtCore.QPointF
+
+
 class _DockWidgets(NamedTuple):
     flag_dock: QtWidgets.QDockWidget
     flag_list: QtWidgets.QListWidget
@@ -199,9 +206,8 @@ class MainWindow(QtWidgets.QMainWindow):
     _file_list_image_path: str | None
     _loaded_image_paths: list[str]
     _prev_image_path: str | None
-    _zoom_values: dict[str, tuple[_ZoomMode, float]]
+    _viewport_states: dict[str, _ViewportState]
     _brightness_contrast_values: dict[str, tuple[int | None, int | None]]
-    _scroll_values: dict[Qt.Orientation, dict[str, float]]
     _default_state: QtCore.QByteArray
 
     def __init__(
@@ -1002,12 +1008,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._file_list_image_path = None
         self._loaded_image_paths = []
         self._prev_image_path = None
-        self._zoom_values = {}
+        self._viewport_states = {}
         self._brightness_contrast_values = {}
-        self._scroll_values = {
-            Qt.Orientation.Horizontal: {},
-            Qt.Orientation.Vertical: {},
-        }
 
         if self._config["file_search"]:
             self._docks.file_search.setText(self._config["file_search"])
@@ -1951,21 +1953,42 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_pan_request(self, step: QtCore.QPoint) -> None:
         # Pan moves the viewport opposite to the cursor delta so the image
         # tracks the grabbed point one-for-one in widget pixels.
+        self._move_canvas_view(step=QtCore.QPointF(step))
+
+    def _move_canvas_view(
+        self, step: QtCore.QPointF, *, constrain_to_center: bool = True
+    ) -> None:
         h_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Horizontal]
         v_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
+        h_old = h_bar.value()
+        v_old = v_bar.value()
         self.set_scroll_value(Qt.Orientation.Horizontal, h_bar.value() - step.x())
         self.set_scroll_value(Qt.Orientation.Vertical, v_bar.value() - step.y())
+        # Scrollbars take the movement they can; the render offset carries any
+        # clamped remainder without changing canvas geometry.
+        self._canvas_widgets.canvas.pan_view(
+            step=QtCore.QPointF(
+                step.x() + h_bar.value() - h_old,
+                step.y() + v_bar.value() - v_old,
+            ),
+            constrain_to_center=constrain_to_center,
+        )
 
     def set_scroll_value(self, orientation: Qt.Orientation, value: float) -> None:
         self._canvas_widgets.scroll_bars[orientation].setValue(int(value))
-        if self._image_path is not None:
-            self._scroll_values[orientation][self._image_path] = value
 
     def _remember_current_viewport(self) -> None:
         if self._image_path is None:
             return
-        for orientation, bar in self._canvas_widgets.scroll_bars.items():
-            self._scroll_values[orientation][self._image_path] = bar.value()
+        self._viewport_states[self._image_path] = _ViewportState(
+            zoom_mode=self._zoom_mode,
+            zoom_value=self._canvas_widgets.zoom_widget.value(),
+            scroll_values={
+                orientation: bar.value()
+                for orientation, bar in self._canvas_widgets.scroll_bars.items()
+            },
+            view_offset=self._canvas_widgets.canvas.get_view_offset(),
+        )
         self._prev_image_path = self._image_path
 
     def _set_zoom(self, value: float, pos: QtCore.QPointF | None = None) -> None:
@@ -1973,31 +1996,30 @@ class MainWindow(QtWidgets.QMainWindow):
             logger.warning("image_path is None, cannot set zoom")
             return
 
+        canvas = self._canvas_widgets.canvas
+        if self._zoom_mode != _ZoomMode.MANUAL_ZOOM:
+            canvas.reset_view_offset()
+            self._sync_zoom_mode_actions()
+            self._canvas_widgets.zoom_widget.setValue(value)
+            return
+
         if pos is None:
-            pos = QtCore.QPointF(
-                self._canvas_widgets.canvas.visibleRegion().boundingRect().center()
-            )
-        canvas_width_old: int = self._canvas_widgets.canvas.width()
+            pos = QtCore.QPointF(canvas.visibleRegion().boundingRect().center())
+        scroll_area = self.centralWidget()
+        assert isinstance(scroll_area, QtWidgets.QScrollArea)
+        viewport = scroll_area.viewport()
+        image_pos = canvas.transform_widget_point_to_image(pos)
+        viewport_pos = canvas.mapTo(viewport, pos)
 
         self._sync_zoom_mode_actions()
         self._canvas_widgets.zoom_widget.setValue(value)  # triggers self._paint_canvas
-        self._zoom_values[self._image_path] = (self._zoom_mode, value)
 
-        canvas_width_new: int = self._canvas_widgets.canvas.width()
-        if canvas_width_old == canvas_width_new:
-            return
-        canvas_scale_factor = canvas_width_new / canvas_width_old
-        x_shift: float = pos.x() * canvas_scale_factor - pos.x()
-        y_shift: float = pos.y() * canvas_scale_factor - pos.y()
-        self.set_scroll_value(
-            Qt.Orientation.Horizontal,
-            self._canvas_widgets.scroll_bars[Qt.Orientation.Horizontal].value()
-            + x_shift,
+        target = canvas.transform_image_point_to_widget(
+            image_pos, area=canvas.sizeHint()
         )
-        self.set_scroll_value(
-            Qt.Orientation.Vertical,
-            self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical].value() + y_shift,
-        )
+        current = canvas.mapFrom(viewport, viewport_pos)
+        shift = target - current
+        self._move_canvas_view(step=-shift, constrain_to_center=False)
 
     def _set_zoom_to_original(self) -> None:
         self._zoom_mode = _ZoomMode.MANUAL_ZOOM
@@ -2230,31 +2252,32 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.setEnabled(True)
         # Zoom changes the live scroll positions, so resolve the intended
         # viewport first.
-        target_scroll_values: dict[Qt.Orientation, float] = {}
-        for orientation, values_by_image in self._scroll_values.items():
-            if self._image_path in values_by_image:
-                target_scroll_values[orientation] = values_by_image[self._image_path]
-            elif (
-                self._config["keep_prev_scale"]
-                and self._prev_image_path is not None
-                and self._prev_image_path in values_by_image
-            ):
-                target_scroll_values[orientation] = values_by_image[
-                    self._prev_image_path
-                ]
+        target_viewport = self._viewport_states.get(self._image_path)
+        if (
+            target_viewport is None
+            and self._config["keep_prev_scale"]
+            and self._prev_image_path is not None
+        ):
+            target_viewport = self._viewport_states.get(self._prev_image_path)
         # set zoom values
-        is_initial_load = not self._zoom_values
-        if self._image_path in self._zoom_values:
-            self._zoom_mode = self._zoom_values[self._image_path][0]
-            self._set_zoom(self._zoom_values[self._image_path][1])
+        is_initial_load = not self._viewport_states
+        if target_viewport is not None:
+            self._zoom_mode = target_viewport.zoom_mode
+            self._set_zoom(target_viewport.zoom_value)
         elif is_initial_load or not self._config["keep_prev_scale"]:
             self._zoom_mode = _ZoomMode.FIT_WINDOW
             self._adjust_scale()
-        # set scroll values
-        for orientation, value in target_scroll_values.items():
-            self.set_scroll_value(orientation=orientation, value=value)
-        self.open_brightness_contrast_dialog(value=False, is_initial_load=True)
+        # The zoom value can be unchanged across images, so update geometry
+        # explicitly before restoring positions against the new scroll range.
         self._paint_canvas()
+        if target_viewport is not None:
+            for orientation, value in target_viewport.scroll_values.items():
+                self.set_scroll_value(orientation=orientation, value=value)
+            self._canvas_widgets.canvas.reset_view_offset()
+            self._canvas_widgets.canvas.pan_view(
+                step=target_viewport.view_offset, constrain_to_center=False
+            )
+        self.open_brightness_contrast_dialog(value=False, is_initial_load=True)
         self.update_action_states(True)
         # A load never pulls the keyboard out of the File List, whatever drove
         # it; otherwise an arrow-key walk of the list ends after one keypress.
@@ -2307,9 +2330,21 @@ class MainWindow(QtWidgets.QMainWindow):
         return min(scale_by_width, scale_by_height)
 
     def _fit_width_scale(self) -> float:
-        FIT_WIDTH_SCROLLBAR_MARGIN: Final[float] = 15.0
-        available_w = self.centralWidget().width() - FIT_WIDTH_SCROLLBAR_MARGIN
-        return available_w / self._canvas_widgets.canvas.pixmap.width()
+        scroll_area = self.centralWidget()
+        assert isinstance(scroll_area, QtWidgets.QScrollArea)
+        viewport_size = scroll_area.maximumViewportSize()
+        pixmap = self._canvas_widgets.canvas.pixmap
+        precision = 10 ** self._canvas_widgets.zoom_widget.decimals()
+        available_w = viewport_size.width()
+        scale_percent = available_w / pixmap.width() * 100
+        # The zoom control rounds on assignment; fitting must never round up
+        # far enough to create horizontal overflow.
+        scale_percent = math.floor(scale_percent * precision) / precision
+        if int(pixmap.height() * scale_percent / 100) > viewport_size.height():
+            available_w -= scroll_area.verticalScrollBar().sizeHint().width()
+            scale_percent = available_w / pixmap.width() * 100
+            scale_percent = math.floor(scale_percent * precision) / precision
+        return scale_percent / 100
 
     def _reset_layout(self) -> None:
         self._window_state.remove(WINDOW_LAYOUT_KEY)

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -285,6 +285,36 @@ class Canvas(QtWidgets.QWidget):
     def set_allow_out_of_bounds_points(self, value: bool) -> None:
         self._allow_out_of_bounds_points = value
 
+    def pan_view(self, step: QPointF, *, constrain_to_center: bool = True) -> None:
+        viewport = self._scroll_viewport()
+        if viewport is None:
+            return
+        target = self._view_offset + step
+        if constrain_to_center:
+            # A focal zoom can leave the image away from the center. Manual
+            # panning may bring it back but must not move it farther away.
+            x_limit = max(
+                min(self.pixmap.width() * self.scale, viewport.width()) / 2,
+                abs(self._view_offset.x()),
+            )
+            y_limit = max(
+                min(self.pixmap.height() * self.scale, viewport.height()) / 2,
+                abs(self._view_offset.y()),
+            )
+            target = QPointF(
+                max(-x_limit, min(x_limit, target.x())),
+                max(-y_limit, min(y_limit, target.y())),
+            )
+        self._view_offset = target
+        self.update()
+
+    def reset_view_offset(self) -> None:
+        self._view_offset = QPointF()
+        self.update()
+
+    def get_view_offset(self) -> QPointF:
+        return QPointF(self._view_offset)
+
     def set_color_resolver(
         self, resolver: Callable[[str], tuple[int, int, int]]
     ) -> None:
@@ -614,7 +644,7 @@ class Canvas(QtWidgets.QWidget):
 
     def mouseMoveEvent(self, a0: QtGui.QMouseEvent) -> None:
         try:
-            pos = self._transform_point_widget_to_image(a0.position())
+            pos = self.transform_widget_point_to_image(a0.position())
         except AttributeError:
             return
         self.mouse_moved.emit(pos)
@@ -963,7 +993,7 @@ class Canvas(QtWidgets.QWidget):
         return True
 
     def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
-        pos: QPointF = self._transform_point_widget_to_image(a0.position())
+        pos: QPointF = self.transform_widget_point_to_image(a0.position())
         self._dispatch_pointer_press(pos=pos, event=a0)
         self._update_status()
 
@@ -976,9 +1006,8 @@ class Canvas(QtWidgets.QWidget):
         if button == Qt.MouseButton.RightButton and self.mode == _CanvasMode.EDIT:
             self._press_right(pos=pos, event=event)
             return
-        if (
-            button == Qt.MouseButton.MiddleButton
-            and self._is_image_overflowing_viewport()
+        if button == Qt.MouseButton.MiddleButton and (
+            self._is_image_overflowing_viewport() or not self._view_offset.isNull()
         ):
             self._begin_pan(event=event)
 
@@ -1226,14 +1255,16 @@ class Canvas(QtWidgets.QWidget):
         return scaled_w > viewport.width() or scaled_h > viewport.height()
 
     def _scroll_viewport(self) -> QtWidgets.QWidget | None:
-        # Walk up the parent chain to the enclosing scroll area and return
-        # its viewport. Returning None when no scroll area is found lets
-        # callers degrade gracefully if the canvas is reparented (e.g. into
-        # a splitter or a test harness).
+        scroll_area = self._find_scroll_area()
+        return scroll_area.viewport() if scroll_area is not None else None
+
+    def _find_scroll_area(self) -> QtWidgets.QAbstractScrollArea | None:
+        # Parentage can include viewport chrome, so do not assume the direct
+        # parent owns scrolling.
         node: QtWidgets.QWidget | None = self.parentWidget()
         while node is not None:
             if isinstance(node, QtWidgets.QAbstractScrollArea):
-                return node.viewport()
+                return node
             node = node.parentWidget()
         return None
 
@@ -1665,19 +1696,25 @@ class Canvas(QtWidgets.QWidget):
             return proposal.new_shapes[0]
         return None
 
-    def _transform_point_widget_to_image(self, point: QPointF) -> QPointF:
+    def transform_widget_point_to_image(self, point: QPointF) -> QPointF:
         origin = self._compute_image_origin_offset()
         image_x = point.x() / self.scale - origin.x()
         image_y = point.y() / self.scale - origin.y()
         return QPointF(image_x, image_y)
 
-    def _compute_image_origin_offset(self) -> QPointF:
-        area = super().size()
+    def transform_image_point_to_widget(
+        self, point: QPointF, *, area: QtCore.QSize | None = None
+    ) -> QPointF:
+        return (point + self._compute_image_origin_offset(area=area)) * self.scale
+
+    def _compute_image_origin_offset(self, area: QtCore.QSize | None = None) -> QPointF:
+        if area is None:
+            area = super().size()
         scaled_w = self.pixmap.width() * self.scale
         scaled_h = self.pixmap.height() * self.scale
         slack_w = max(area.width() - scaled_w, 0.0)
         slack_h = max(area.height() - scaled_h, 0.0)
-        return QPointF(slack_w, slack_h) / (2.0 * self.scale)
+        return (QPointF(slack_w, slack_h) / 2.0 + self._view_offset) / self.scale
 
     def is_out_of_pixmap(self, p: QPointF) -> bool:
         return _is_out_of_image(p, self.pixmap.size())
@@ -1768,12 +1805,23 @@ class Canvas(QtWidgets.QWidget):
             return super().minimumSizeHint()
         scaled_w = int(self.pixmap.width() * self.scale)
         scaled_h = int(self.pixmap.height() * self.scale)
-        viewport = self._scroll_viewport()
-        if viewport is None:
+        scroll_area = self._find_scroll_area()
+        if scroll_area is None:
             return QtCore.QSize(scaled_w, scaled_h)
-        slack_w = _compute_overscroll_slack(scaled=scaled_w, viewport=viewport.width())
-        slack_h = _compute_overscroll_slack(scaled=scaled_h, viewport=viewport.height())
-        return QtCore.QSize(scaled_w + slack_w, scaled_h + slack_h)
+
+        viewport_size = scroll_area.maximumViewportSize()
+        h_bar_height = scroll_area.horizontalScrollBar().sizeHint().height()
+        v_bar_width = scroll_area.verticalScrollBar().sizeHint().width()
+        needs_h_bar = scaled_w > viewport_size.width()
+        needs_v_bar = scaled_h > viewport_size.height()
+        if needs_v_bar:
+            needs_h_bar = scaled_w > viewport_size.width() - v_bar_width
+        if needs_h_bar:
+            needs_v_bar = scaled_h > viewport_size.height() - h_bar_height
+
+        available_w = viewport_size.width() - (v_bar_width if needs_v_bar else 0)
+        available_h = viewport_size.height() - (h_bar_height if needs_h_bar else 0)
+        return QtCore.QSize(max(scaled_w, available_w), max(scaled_h, available_h))
 
     def sizeHint(self) -> QtCore.QSize:
         return self._compute_canvas_size()
@@ -1785,10 +1833,14 @@ class Canvas(QtWidgets.QWidget):
         self._clear_ai_existing_shape_highlights()
         mods: Qt.KeyboardModifier = a0.modifiers()
         delta: QPoint = a0.angleDelta()
+        if delta.isNull():
+            a0.accept()
+            return
         if mods == Qt.KeyboardModifier.ControlModifier:
             # with Ctrl/Command key
             # zoom
-            self.zoom_request.emit(delta.y(), a0.position())
+            if delta.y() != 0:
+                self.zoom_request.emit(delta.y(), a0.position())
         elif mods == Qt.KeyboardModifier.ShiftModifier and delta.x() == 0:
             # Shift+wheel scrolls horizontally. macOS swaps the axis for us,
             # but Linux/Windows deliver the delta on y and expect the app to
@@ -1982,6 +2034,7 @@ class Canvas(QtWidgets.QWidget):
         self.selected_shapes = []
         self._selected_shapes_copy = []
         self._current = None
+        self._view_offset = QPointF()
         self._highlight = None
         self._rotation_highlight = None
         self._set_ai_existing_shape_highlights(shapes=[])
@@ -2034,18 +2087,6 @@ def _snap_cursor_pos_for_square(pos: QPointF, opposite_vertex: QPointF) -> QPoin
         np.sign(pos_from_opposite.x()) * square_size,
         np.sign(pos_from_opposite.y()) * square_size,
     )
-
-
-def _compute_overscroll_slack(*, scaled: int, viewport: int) -> int:
-    # Floor (viewport // 8) keeps middle-drag pan responsive at slight
-    # overflow; without it, scroll range equals the overflow and a
-    # 2-px-overflowing image feels locked under the cursor. The floor
-    # reintroduces a viewport/16 image shift at the threshold, 4x smaller
-    # than the original viewport/4 jump. Cap (viewport // 2) lets each
-    # image edge be panned to the viewport center but no further.
-    if scaled <= viewport:
-        return 0
-    return max(viewport // 8, min(viewport // 2, scaled - viewport))
 
 
 def _compute_intersection_edges_image(

--- a/tests/e2e/brightness_contrast_test.py
+++ b/tests/e2e/brightness_contrast_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from PySide6.QtCore import QPointF
 from pytestqt.qtbot import QtBot
 
 import labelme._utils
@@ -18,6 +19,8 @@ def test_brightness_contrast_dialog(
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
     original_pixmap = canvas.pixmap.copy()
+    canvas.pan_view(step=QPointF(17, 23), constrain_to_center=False)
+    expected_view_offset = canvas.get_view_offset()
 
     assert annotated_win._annotation is not None
     dialog = BrightnessContrastDialog(
@@ -33,5 +36,6 @@ def test_brightness_contrast_dialog(
 
     updated_pixmap = canvas.pixmap
     assert original_pixmap.toImage() != updated_pixmap.toImage()
+    assert canvas.get_view_offset() == expected_view_offset
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -43,7 +43,7 @@ def session_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 def image_to_widget_pos(canvas: Canvas, image_pos: QPointF) -> QPoint:
-    widget_pos = (image_pos + canvas._compute_image_origin_offset()) * canvas.scale
+    widget_pos = canvas.transform_image_point_to_widget(image_pos)
     return QPoint(int(widget_pos.x()), int(widget_pos.y()))
 
 

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -4,6 +4,7 @@ from typing import Final
 
 import pytest
 from PySide6.QtCore import QPoint
+from PySide6.QtCore import QPointF
 from PySide6.QtCore import Qt
 from pytestqt.qtbot import QtBot
 
@@ -12,6 +13,7 @@ from labelme._widgets.canvas import Canvas
 
 from ..conftest import close_or_pause
 from .conftest import drag_canvas
+from .conftest import image_to_widget_pos
 
 _DRAG_OFFSET_PX: Final[int] = 40
 
@@ -96,5 +98,47 @@ def test_middle_drag_no_pan_when_image_fits_viewport(
             start=start,
             end=end,
         )
+
+    close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_middle_drag_recenters_fitting_image_after_focal_zoom(
+    qtbot: QtBot,
+    annotated_win: MainWindow,
+    pause: bool,
+) -> None:
+    canvas = annotated_win._canvas_widgets.canvas
+    viewport = canvas._scroll_viewport()
+    assert viewport is not None
+    image_pos = QPointF(canvas.pixmap.width() * 0.8, canvas.pixmap.height() / 2)
+    cursor = canvas.mapTo(
+        viewport, image_to_widget_pos(canvas=canvas, image_pos=image_pos)
+    )
+
+    for _ in range(12):
+        old_scale = canvas.scale
+        annotated_win._add_zoom(
+            increment=0.9,
+            pos=QPointF(canvas.mapFrom(viewport, cursor)),
+        )
+        qtbot.waitUntil(
+            lambda: canvas.scale != old_scale and canvas.size() == canvas.sizeHint()
+        )
+
+    assert not canvas._is_image_overflowing_viewport()
+    before = abs(canvas.get_view_offset().x())
+    assert before > 0
+
+    start = canvas.mapFrom(viewport, viewport.rect().center())
+    drag_canvas(
+        qtbot=qtbot,
+        canvas=canvas,
+        button=Qt.MouseButton.MiddleButton,
+        start=start,
+        end=start - QPoint(_DRAG_OFFSET_PX, 0),
+    )
+
+    assert abs(canvas.get_view_offset().x()) < before
 
     close_or_pause(qtbot=qtbot, widget=annotated_win, pause=pause)

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Final
 
 import pytest
 from PySide6 import QtGui
+from PySide6 import QtWidgets
 from PySide6.QtCore import QPoint
 from PySide6.QtCore import QPointF
 from PySide6.QtCore import Qt
@@ -15,6 +17,7 @@ from labelme._app import _ZoomMode
 
 from ..conftest import close_or_pause
 from .conftest import MainWinFactory
+from .conftest import image_to_widget_pos
 from .conftest import show_window_and_wait_for_imagedata
 
 _TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
@@ -62,6 +65,86 @@ def test_zoom_fit_width(
     fit_width_zoom = _win._canvas_widgets.zoom_widget.value()
     assert fit_width_zoom > 0
     assert _win._zoom_mode == _ZoomMode.FIT_WIDTH
+
+    close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_zoom_fit_width_does_not_scroll_horizontally(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    image_path = tmp_path / "portrait.png"
+    image = QtGui.QImage(2076, 3000, QtGui.QImage.Format.Format_RGB32)
+    image.fill(0)
+    assert image.save(str(image_path))
+    win = main_win(file_or_dir=str(image_path))
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    win.set_fit_width_mode(True)
+    scroll_bars = win._canvas_widgets.scroll_bars
+    qtbot.waitUntil(
+        lambda: scroll_bars[Qt.Orientation.Vertical].maximum() > 0
+        and scroll_bars[Qt.Orientation.Horizontal].maximum() == 0
+    )
+    assert scroll_bars[Qt.Orientation.Horizontal].maximum() == 0
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_fit_width_uses_full_width_when_quantized_image_fits_height(
+    qtbot: QtBot,
+    _win: MainWindow,
+    pause: bool,
+) -> None:
+    scroll_area = _win.centralWidget()
+    assert isinstance(scroll_area, QtWidgets.QScrollArea)
+    viewport_size = scroll_area.maximumViewportSize()
+    zoom_widget = _win._canvas_widgets.zoom_widget
+    precision = 10 ** zoom_widget.decimals()
+    image_width = viewport_size.width() + 1
+    expected_percent = (
+        math.floor(viewport_size.width() / image_width * 100 * precision) / precision
+    )
+    expected_scale = expected_percent / 100
+    image_height = math.floor(viewport_size.height() / expected_scale) + 1
+    image = QtGui.QImage(
+        image_width,
+        image_height,
+        QtGui.QImage.Format.Format_RGB32,
+    )
+    image.fill(0)
+    _win._image = image
+    _win._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
+
+    _win.set_fit_width_mode(True)
+
+    assert image_height * expected_scale > viewport_size.height()
+    assert int(image_height * expected_scale) == viewport_size.height()
+    assert zoom_widget.value() == expected_percent
+    assert all(bar.maximum() == 0 for bar in _win._canvas_widgets.scroll_bars.values())
+
+    close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
+
+
+@pytest.mark.gui
+def test_manual_zoom_only_scrolls_the_overflowing_axis(
+    qtbot: QtBot,
+    _win: MainWindow,
+    pause: bool,
+) -> None:
+    _win._set_zoom_to_original()
+    _win._set_zoom(value=110)
+
+    scroll_bars = _win._canvas_widgets.scroll_bars
+    qtbot.waitUntil(
+        lambda: scroll_bars[Qt.Orientation.Horizontal].maximum() > 0
+        and scroll_bars[Qt.Orientation.Vertical].maximum() == 0
+    )
+    assert scroll_bars[Qt.Orientation.Vertical].maximum() == 0
 
     close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
 
@@ -169,6 +252,7 @@ def test_navigation_restores_each_image_viewport(
     )
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
 
+    canvas = win._canvas_widgets.canvas
     win._set_zoom(value=_VIEWPORT_ZOOM)
     scroll_bars = win._canvas_widgets.scroll_bars
     first_scroll_values = _set_scroll_bars_to_fraction(
@@ -177,6 +261,8 @@ def test_navigation_restores_each_image_viewport(
         numerator=1,
         denominator=3,
     )
+    canvas.pan_view(step=QPointF(17, 23))
+    first_view_offset = canvas.get_view_offset()
 
     first_image_path = win._image_path
     assert first_image_path is not None
@@ -189,6 +275,7 @@ def test_navigation_restores_each_image_viewport(
             win=win,
             scroll_values=first_scroll_values,
         )
+        assert canvas.get_view_offset() == first_view_offset
     else:
         qtbot.waitUntil(
             lambda: win._zoom_mode == _ZoomMode.FIT_WINDOW
@@ -198,6 +285,7 @@ def test_navigation_restores_each_image_viewport(
         assert win._canvas_widgets.zoom_widget.value() != 300
         for bar in scroll_bars.values():
             assert bar.value() == bar.minimum()
+        assert canvas.get_view_offset().isNull()
 
     win._set_zoom(value=250)
     second_scroll_values = _set_scroll_bars_to_fraction(
@@ -206,7 +294,9 @@ def test_navigation_restores_each_image_viewport(
         numerator=2,
         denominator=3,
     )
+    canvas.pan_view(step=QPointF(-31, -19))
     assert second_scroll_values != first_scroll_values
+    assert canvas.get_view_offset() != first_view_offset
 
     win._open_prev_image()
     qtbot.waitUntil(lambda: win._image_path == first_image_path)
@@ -215,6 +305,91 @@ def test_navigation_restores_each_image_viewport(
         win=win,
         scroll_values=first_scroll_values,
     )
+    assert canvas.get_view_offset() == first_view_offset
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_navigation_restores_view_offset_with_retained_brightness(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+) -> None:
+    win = main_win(
+        file_or_dir=str(data_path / "raw"),
+        config_overrides={
+            "keep_prev_scale": True,
+            "keep_prev_brightness_contrast": True,
+        },
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    canvas = win._canvas_widgets.canvas
+    canvas.pan_view(step=QPointF(17, 23))
+    expected_view_offset = canvas.get_view_offset()
+    first_image_path = win._image_path
+    assert first_image_path is not None
+    win._brightness_contrast_values[first_image_path] = (75, 50)
+
+    win._open_next_image()
+    qtbot.waitUntil(lambda: win._image_path != first_image_path)
+
+    assert canvas.get_view_offset() == expected_view_offset
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+def test_navigation_restores_viewport_after_layout_settles(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    tmp_path: Path,
+    pause: bool,
+) -> None:
+    for name, size in [("a.png", (1000, 1500)), ("b.png", (1200, 800))]:
+        image = QtGui.QImage(*size, QtGui.QImage.Format.Format_RGB32)
+        image.fill(0)
+        assert image.save(str(tmp_path / name))
+    win = main_win(
+        file_or_dir=str(tmp_path),
+        config_overrides={"keep_prev_scale": True},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+
+    win.set_fit_width_mode(True)
+    v_bar = win._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
+    qtbot.waitUntil(lambda: v_bar.maximum() > 0)
+    v_bar.setValue(v_bar.maximum() * 2 // 3)
+    with qtbot.waitSignal(v_bar.rangeChanged):
+        win._add_zoom(increment=0.9)
+
+    first_image_path = win._image_path
+    assert first_image_path is not None
+    expected_scroll_values = {
+        orientation: bar.value()
+        for orientation, bar in win._canvas_widgets.scroll_bars.items()
+    }
+    expected_view_offset = win._canvas_widgets.canvas.get_view_offset()
+
+    win._open_next_image()
+    qtbot.waitUntil(lambda: win._image_path != first_image_path)
+    win._open_prev_image()
+    qtbot.waitUntil(lambda: win._image_path == first_image_path)
+    qtbot.waitUntil(
+        lambda: win._canvas_widgets.canvas.size()
+        == win._canvas_widgets.canvas.sizeHint()
+        and all(
+            win._canvas_widgets.scroll_bars[orientation].value() == expected
+            for orientation, expected in expected_scroll_values.items()
+        )
+        and win._canvas_widgets.canvas.get_view_offset() == expected_view_offset
+    )
+
+    for orientation, expected in expected_scroll_values.items():
+        assert win._canvas_widgets.scroll_bars[orientation].value() == expected
+    assert win._canvas_widgets.canvas.get_view_offset() == expected_view_offset
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 
@@ -290,6 +465,7 @@ def _make_wheel_event(
     pos: QPointF,
     angle_delta: QPoint,
     modifiers: Qt.KeyboardModifier,
+    phase: Qt.ScrollPhase = Qt.ScrollPhase.NoScrollPhase,
 ) -> QtGui.QWheelEvent:
     # PySide6's QWheelEvent constructor takes positional args;
     # the 8-arg form matches the modern Qt6 signature.
@@ -300,7 +476,7 @@ def _make_wheel_event(
         angle_delta,
         Qt.MouseButton.NoButton,
         modifiers,
-        Qt.ScrollPhase.NoScrollPhase,
+        phase,
         False,
     )
 
@@ -368,3 +544,89 @@ def test_canvas_wheel_event_dispatches_signal(
         assert non_zero[0] == (angle_delta.y(), expected_orientation)
 
     close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("angle_delta", "phase"),
+    [
+        pytest.param(QPoint(), Qt.ScrollPhase.ScrollBegin, id="scroll_begin"),
+        pytest.param(
+            QPoint(120, 0),
+            Qt.ScrollPhase.NoScrollPhase,
+            id="horizontal_only",
+        ),
+    ],
+)
+def test_canvas_wheel_event_ignores_non_vertical_zoom(
+    qtbot: QtBot,
+    _win: MainWindow,
+    pause: bool,
+    angle_delta: QPoint,
+    phase: Qt.ScrollPhase,
+) -> None:
+    canvas = _win._canvas_widgets.canvas
+
+    with qtbot.assertNotEmitted(canvas.zoom_request):
+        canvas.wheelEvent(
+            _make_wheel_event(
+                pos=QPointF(canvas.width() / 2, canvas.height() / 2),
+                angle_delta=angle_delta,
+                modifiers=Qt.KeyboardModifier.ControlModifier,
+                phase=phase,
+            )
+        )
+
+    close_or_pause(qtbot=qtbot, widget=_win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("angle_delta", "repetitions"),
+    [
+        pytest.param(120, 1, id="zoom_in"),
+        pytest.param(-120, 12, id="repeated_zoom_out"),
+    ],
+)
+def test_ctrl_wheel_keeps_image_point_under_cursor(
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    angle_delta: int,
+    repetitions: int,
+) -> None:
+    win = main_win(file_or_dir=str(data_path / "raw/2011_000003.jpg"))
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    canvas = win._canvas_widgets.canvas
+    viewport = canvas._scroll_viewport()
+    assert viewport is not None
+
+    image_pos = QPointF(canvas.pixmap.width() * 0.8, canvas.pixmap.height() / 2)
+    cursor = QPointF(
+        canvas.mapTo(viewport, image_to_widget_pos(canvas=canvas, image_pos=image_pos))
+    ) + QPointF(0.25, 0.75)
+
+    def _get_image_point_under_cursor() -> QPointF:
+        return canvas.transform_widget_point_to_image(canvas.mapFrom(viewport, cursor))
+
+    before = _get_image_point_under_cursor()
+    for _ in range(repetitions):
+        old_scale = canvas.scale
+        QtWidgets.QApplication.sendEvent(
+            canvas,
+            _make_wheel_event(
+                pos=canvas.mapFrom(viewport, cursor),
+                angle_delta=QPoint(0, angle_delta),
+                modifiers=Qt.KeyboardModifier.ControlModifier,
+            ),
+        )
+        qtbot.waitUntil(
+            lambda: canvas.scale != old_scale and canvas.size() == canvas.sizeHint()
+        )
+
+        after = _get_image_point_under_cursor()
+        assert after.x() == pytest.approx(before.x(), abs=0.01)
+        assert after.y() == pytest.approx(before.y(), abs=0.01)
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -20,7 +20,6 @@ from labelme._shape import Shape
 from labelme._shape import ShapeType
 from labelme._widgets.canvas import Canvas
 from labelme._widgets.canvas import _compute_intersection_edges_image
-from labelme._widgets.canvas import _compute_overscroll_slack
 from labelme._widgets.canvas import _draft_to_shape
 from labelme._widgets.canvas import _DraftShape
 from labelme._widgets.canvas import _is_degenerate_draft
@@ -1777,22 +1776,6 @@ def test_reproject_oriented_rectangle_clips_degenerate_projection() -> None:
         assert 0 <= corner.y() <= _HEIGHT
 
 
-@pytest.mark.parametrize(
-    ("scaled", "viewport", "expected"),
-    [
-        pytest.param(399, 400, 0, id="image_fits_below_threshold"),
-        pytest.param(400, 400, 0, id="image_exactly_fills_viewport"),
-        pytest.param(401, 400, 50, id="slight_overflow_floored_to_viewport_eighth"),
-        pytest.param(450, 400, 50, id="overflow_at_floor_boundary"),
-        pytest.param(500, 400, 100, id="ramp_grows_with_overflow_past_floor"),
-        pytest.param(600, 400, 200, id="overflow_at_cap_boundary"),
-        pytest.param(1000, 400, 200, id="large_overflow_capped_at_viewport_half"),
-    ],
-)
-def test_compute_overscroll_slack(scaled: int, viewport: int, expected: int) -> None:
-    assert _compute_overscroll_slack(scaled=scaled, viewport=viewport) == expected
-
-
 def test_should_reselect_on_right_press_with_empty_selection() -> None:
     # Empty selection reselects even when hovering nothing; without the guard this
     # input would fall through to `hovered_shape is None` and wrongly return False.
@@ -1925,6 +1908,29 @@ def test_remove_selected_point_repaints(
 
     assert len(shape.points) == n_before - 1
     update.assert_called_once()  # repaint now, not only on the next mouse move (#890)
+
+
+@pytest.mark.gui
+def test_reset_view_offset_repaints(
+    canvas: Canvas, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    canvas._view_offset = QPointF(17, 23)
+    update = Mock()
+    monkeypatch.setattr(canvas, "update", update)
+
+    canvas.reset_view_offset()
+
+    assert canvas.get_view_offset().isNull()
+    update.assert_called_once()
+
+
+@pytest.mark.gui
+def test_reset_state_clears_view_offset(canvas: Canvas) -> None:
+    canvas._view_offset = QPointF(17, 23)
+
+    canvas.reset_state()
+
+    assert canvas.get_view_offset().isNull()
 
 
 @pytest.mark.gui


### PR DESCRIPTION
## Summary

- Keep the image coordinate beneath the cursor stationary across settled scrollbar transitions and repeated Ctrl/Cmd-wheel zoom-out.
- Preserve the exact per-image viewport through brightness changes and image navigation.
- Use native scrollbar geometry and zoom precision for Fit Width, while keeping manual middle-drag bounded and focal correction unrestricted.

## Test plan

- [x] Qt GUI regressions for modifier-wheel zoom, repeated zoom-out, Fit Width thresholds, middle-drag recovery, brightness, and navigation
- [x] Real desktop QA for annotated launch, rectangle creation, polygon Undo, clean restart, Fit Window, brightness, and per-image navigation
- [x] `make lint`
- [x] `make test` — 1,295 passed, 6 skipped
