### PR TITLE
docs: link unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 <!-- towncrier release notes start -->
 
 ## [7.1.0] - 2026-08-21
@@ -774,3 +776,4 @@ See the [GitHub Releases](https://github.com/wkentaro/labelme/releases) page for
 [7.0.3]: https://github.com/wkentaro/labelme/compare/v7.0.2...v7.0.3
 [7.0.4]: https://github.com/wkentaro/labelme/compare/v7.0.3...v7.0.4
 [7.1.0]: https://github.com/wkentaro/labelme/compare/v7.0.4...v7.1.0
+[unreleased]: https://github.com/wkentaro/labelme/compare/v7.1.0...main

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -20,7 +20,8 @@ To release version `X.Y.Z` on `YYYY-MM-DD`:
 
 1. Run `uv run towncrier build --yes --version X.Y.Z --date YYYY-MM-DD`.
 2. Add `[X.Y.Z]: https://github.com/wkentaro/labelme/compare/v<previous>...vX.Y.Z`
-   to the link list at the bottom of `CHANGELOG.md`.
+   to the link list at the bottom of `CHANGELOG.md`, then update `[Unreleased]`
+   to compare `vX.Y.Z...main`.
 3. Commit the updated changelog and deleted fragments, then tag that commit.
 
 Prerelease tags render pending fragments without changing files.


### PR DESCRIPTION
Make pending release scope visible from the changelog without maintaining a mutable `next` milestone. The `Unreleased` link compares the latest release tag to `main`, and the release checklist advances its base tag after each release.

## Test plan

- [x] `uv run pytest tests/unit/tools/release_notes_test.py` and `uv run towncrier build --draft --version 7.2.0`
