### PR TITLE
fix(settings): group polygon detail with AI assist

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -258,7 +258,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._ai_annotation = AiAssistedAnnotationWidget(
             default_model=self._config["ai"]["default"],
-            polygon_detail=self._config["shape"]["polygon_detail"],
+            polygon_detail=self._config["mask_polygonization"]["detail"],
             on_model_changed=self._on_ai_model_changed,
             on_output_format_changed=self._canvas_widgets.canvas.set_ai_output_format,
             on_polygon_detail_changed=self._on_ai_polygon_detail_changed,
@@ -271,7 +271,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._ai_annotation.output_format
         )
         self._canvas_widgets.canvas.set_ai_polygon_detail(
-            self._config["shape"]["polygon_detail"]
+            self._config["mask_polygonization"]["detail"]
         )
         self._ai_annotation.setEnabled(False)
         self._ai_buttons_highlighted = False
@@ -1468,7 +1468,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 if self._config["canvas"]["allow_out_of_bounds_points"]
                 else (self._image.width(), self._image.height())
             ),
-            polygon_detail=self._config["shape"]["polygon_detail"],
+            polygon_detail=self._config["mask_polygonization"]["detail"],
         )
         _automation.assign_available_group_ids(
             shapes=shapes,
@@ -2626,7 +2626,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_ai_polygon_detail_changed(self, detail: int) -> None:
         self._apply_setting_change(
-            key_path=("shape", "polygon_detail"),
+            key_path=("mask_polygonization", "detail"),
             value=detail,
         )
 
@@ -2722,8 +2722,8 @@ class MainWindow(QtWidgets.QMainWindow):
             canvas = self._canvas_widgets.canvas
             canvas.set_show_labels(self._config["shape"]["show_labels"])
             canvas.update()
-        elif key_path == ("shape", "polygon_detail"):
-            detail = self._config["shape"]["polygon_detail"]
+        elif key_path == ("mask_polygonization", "detail"):
+            detail = self._config["mask_polygonization"]["detail"]
             self._ai_annotation.set_polygon_detail(detail)
             self._canvas_widgets.canvas.set_ai_polygon_detail(detail)
         elif key_path == ("canvas", "allow_out_of_bounds_points"):

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -19,11 +19,13 @@ here = Path(__file__).resolve().parent
 def _update_dict(
     target_dict: dict[str, object],
     new_dict: dict[str, object],
-    validate_item: Callable[[str, object], None] | None = None,
+    validate_item: Callable[[tuple[str, ...], object], None] | None = None,
+    key_path: tuple[str, ...] = (),
 ) -> None:
     for key, value in new_dict.items():
+        item_path = (*key_path, key)
         if validate_item:
-            validate_item(key, value)
+            validate_item(item_path, value)
         if key not in target_dict:
             raise ValueError(f"Unexpected key in config: {key}")
         if not isinstance(target_dict[key], dict):
@@ -47,15 +49,18 @@ def _update_dict(
             cast(dict[str, object], target_dict[key]),
             cast(dict[str, object], value),
             validate_item=validate_item,
+            key_path=item_path,
         )
 
 
-def _validate_config_item(key: str, value: object) -> None:
-    if key == "polygon_detail" and (
+def _validate_config_item(key_path: tuple[str, ...], value: object) -> None:
+    key = key_path[-1]
+    if key_path == ("mask_polygonization", "detail") and (
         isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 100
     ):
         raise ValueError(
-            f"polygon_detail must be an integer between 0 and 100, but got {value!r}"
+            "mask_polygonization.detail must be an integer between 0 and 100, "
+            f"but got {value!r}"
         )
     if key == "validate_label" and value not in [None, "exact"]:
         raise ValueError(f"Unexpected value for config key 'validate_label': {value}")

--- a/labelme/_config/_schema.py
+++ b/labelme/_config/_schema.py
@@ -206,21 +206,6 @@ SETTINGS: Final[tuple[Setting, ...]] = (
         beta=True,
     ),
     Setting(
-        key_path=("shape", "polygon_detail"),
-        group="Drawing and canvas",
-        label=cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Polygon detail")),
-        kind="int",
-        note=cast(
-            str,
-            QT_TRANSLATE_NOOP(
-                "SettingsDialog",
-                "Higher values preserve more Mask boundary detail and smaller lands.",
-            ),
-        ),
-        minimum=0,
-        maximum=100,
-    ),
-    Setting(
         key_path=("labels",),
         group="Label sources",
         label=cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Predefined labels")),
@@ -296,6 +281,21 @@ SETTINGS: Final[tuple[Setting, ...]] = (
             cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Sam2 (accuracy)")),
             cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Sam3")),
         ),
+    ),
+    Setting(
+        key_path=("mask_polygonization", "detail"),
+        group="AI assist",
+        label=cast(str, QT_TRANSLATE_NOOP("SettingsDialog", "Polygon detail")),
+        kind="int",
+        note=cast(
+            str,
+            QT_TRANSLATE_NOOP(
+                "SettingsDialog",
+                "Higher values preserve more Mask boundary detail and smaller lands.",
+            ),
+        ),
+        minimum=0,
+        maximum=100,
     ),
     Setting(
         key_path=("ai", "suppress_existing_shape_matches"),

--- a/labelme/_config/default_config.yaml
+++ b/labelme/_config/default_config.yaml
@@ -35,7 +35,8 @@ shape:
   hvertex_fill_color: [255, 255, 255, 255]
   point_size: 8
   show_labels: false
-  polygon_detail: 80
+mask_polygonization:
+  detail: 80
 ai:
   default: Sam2 (balanced)
   suppress_existing_shape_matches: false

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -739,17 +739,17 @@ def test_polygon_detail_popover_and_settings_stay_in_sync(
 ) -> None:
     win = main_win(config_file=editable_config_file)
     dialog = _open_settings_dialog(win=win)
-    settings_slider = dialog._editors[("shape", "polygon_detail")]
+    settings_slider = dialog._editors[("mask_polygonization", "detail")]
     assert isinstance(settings_slider, IntegerSlider)
 
     toolbar_slider = win._ai_annotation._polygon_detail_slider
     toolbar_slider.set_value(60)
 
-    assert win._config["shape"]["polygon_detail"] == 60
+    assert win._config["mask_polygonization"]["detail"] == 60
     assert settings_slider.value == 60
     assert win._canvas_widgets.canvas._ai_assist_session.polygon_detail == 60
     persisted = safe_load(editable_config_file.read_text())
-    assert persisted["shape"]["polygon_detail"] == 60
+    assert persisted["mask_polygonization"]["detail"] == 60
 
     settings_slider.set_value(70)
 

--- a/tests/unit/_config/api_test.py
+++ b/tests/unit/_config/api_test.py
@@ -96,9 +96,11 @@ def test_load_config_rejects_invalid_polygon_detail(
     tmp_path: Path, value: object
 ) -> None:
     config_file = tmp_path / "config.yaml"
-    config_file.write_text(f"shape:\n  polygon_detail: {json.dumps(value)}\n")
+    config_file.write_text(f"mask_polygonization:\n  detail: {json.dumps(value)}\n")
 
-    with pytest.raises(ValueError, match="polygon_detail must be an integer"):
+    with pytest.raises(
+        ValueError, match=r"mask_polygonization\.detail must be an integer"
+    ):
         _config.load_config(config_file=config_file, config_overrides={})
 
 

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -84,13 +84,13 @@ def test_existing_shape_suppression_is_disabled_by_default(
 def test_polygon_detail_slider_applies_integer_value(
     dialog: SettingsDialog, applied: Applied
 ) -> None:
-    slider = dialog._editors[("shape", "polygon_detail")]
+    slider = dialog._editors[("mask_polygonization", "detail")]
     assert isinstance(slider, IntegerSlider)
     assert slider.value == 80
 
     slider.set_value(60)
 
-    assert (("shape", "polygon_detail"), 60) in applied
+    assert (("mask_polygonization", "detail"), 60) in applied
 
 
 def test_unbounded_integer_edit_accepts_python_ints(


### PR DESCRIPTION
Polygon Detail governs Mask Polygonization, not Polygon Shape display; this gives the Setting the neutral `mask_polygonization.detail` Config File path while keeping its contextual live-preview control in the AI toolbar and its comprehensive control under AI assist.

The former `shape.polygon_detail` path is unreleased, so this carries no compatibility alias or migration.

## Test plan

- [x] `.venv/bin/python -m pytest -q tests/unit/_config/api_test.py tests/unit/_config/writer_test.py tests/unit/_config/schema_test.py tests/unit/widgets/settings_dialog_test.py tests/e2e/settings_test.py` (225 passed)

- [x] `.venv/bin/ruff format --check labelme tests`, `.venv/bin/ruff check labelme tests`, and `.venv/bin/ty check --no-progress`