### PR TITLE
fix(cli): keep help usage stable on Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,12 +80,6 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.12', '3.13', '3.14']
-        exclude:
-          # The installed console script prints no usage here and exits 0.
-          # Pre-existing on main, unrelated to packaging, tracked separately.
-          # https://github.com/wkentaro/labelme/issues/2495
-          - os: windows-latest
-            python-version: '3.14'
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7

--- a/changelog.d/2559.fixed.md
+++ b/changelog.d/2559.fixed.md
@@ -1,0 +1,1 @@
+Fixed `labelme --help` showing a Python executable and temporary launcher path instead of the stable `labelme` command on Windows with Python 3.14.

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -210,7 +210,7 @@ def _resolve_config_source(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog="labelme")
     parser.add_argument("--version", "-V", action="store_true", help="show version")
     parser.add_argument(
         "--reset-config",

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -22,6 +22,18 @@ from labelme.__main__ import _setup_loguru
 from labelme.__main__ import main
 
 
+def test_help_uses_console_script_name(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["launcher-path", "--help"])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    assert capsys.readouterr().out.startswith("usage: labelme ")
+
+
 @pytest.mark.parametrize("flag", ["--nodata", "--autosave"])
 def test_removed_flag_errors_as_unknown(
     flag: str, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Python 3.14 changed argparse's default program-name derivation, so Windows console-script launches rendered `usage: python.exe …\Scripts\labelme`; the artifact smoke caught that mismatch.

Setting the public CLI name explicitly keeps help output stable across launchers and lets the advertised Windows/Python 3.14 artifact cell remain enabled. Fixes #2495.
