### PR TITLE
docs: document GitHub label contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ Record user-facing changes to the packaged application as towncrier fragments, f
 
 Issues are tracked as GitHub issues on `wkentaro/labelme` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
-### Triage labels
+### Issue and pull-request labels
 
-Five canonical triage roles map 1:1 to label strings of the same name (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+For issue triage and type labels or pull-request verdict labels, follow `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -8,21 +8,21 @@ Every triaged issue carries exactly one `type:` label and one triage label. An i
 
 The `type:` axis classifies the work:
 
-| Label | Meaning |
-| --- | --- |
-| `type: bug` | Reporting a defect to fix |
+| Label           | Meaning                                    |
+| --------------- | ------------------------------------------ |
+| `type: bug`     | Reporting a defect to fix                  |
 | `type: feature` | Requesting a new capability or improvement |
-| `type: task` | Other work: maintenance, refactor, or docs |
+| `type: task`    | Other work: maintenance, refactor, or docs |
 
 The triage axis records whose turn it is:
 
-| Role and label | Meaning |
-| --- | --- |
-| `needs-triage` | Maintainer needs to evaluate this issue |
-| `needs-info` | Waiting on the reporter for more information |
-| `ready-for-agent` | Fully specified and ready for an AFK agent |
-| `ready-for-human` | Requires human implementation |
-| `wontfix` | Will not be actioned |
+| Role and label    | Meaning                                      |
+| ----------------- | -------------------------------------------- |
+| `needs-triage`    | Maintainer needs to evaluate this issue      |
+| `needs-info`      | Waiting on the reporter for more information |
+| `ready-for-agent` | Fully specified and ready for an AFK agent   |
+| `ready-for-human` | Requires human implementation                |
+| `wontfix`         | Will not be actioned                         |
 
 ## Pull request states
 
@@ -30,10 +30,10 @@ A non-draft pull request with no verdict is ready for an agent to finalize. A dr
 
 After finalizing a pull request, an agent applies exactly one mutually exclusive verdict:
 
-| Verdict | Meaning |
-| --- | --- |
-| `recommend-merge` | Agent endorses it for maintainer review and merge |
-| `recommend-close` | Agent recommends that the maintainer review and close it |
+| Verdict            | Meaning                                                                   |
+| ------------------ | ------------------------------------------------------------------------- |
+| `recommend-merge`  | Agent endorses it for maintainer review and merge                         |
+| `recommend-close`  | Agent recommends that the maintainer review and close it                  |
 | `recommend-triage` | Code is sound, but the maintainer must make the product or scope decision |
 
 `maintainer-approved` records an explicit maintainer decision to merge after required checks pass. Apply it only at the maintainer's direction; it may coexist with an agent verdict because the labels record different authorities.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,17 +1,41 @@
-# Triage Labels
+# Issue and Pull Request Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+Use labels to record whose turn it is and what they must do. Tool-managed and repository-specific labels are outside this contract.
 
-| Canonical role    | Label in our tracker | Meaning                                  |
-| ----------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
-| `wontfix`         | `wontfix`            | Will not be actioned                     |
+## Issue labels
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+Every triaged issue carries exactly one `type:` label and one triage label. An issue with no triage label is fresh work for an agent to route; `needs-triage` is reserved for a maintainer decision.
 
-These labels do not yet exist on `wkentaro/labelme` — the triage skill will create them on first use via `gh label create`. Existing category labels (`issue:bug`, `feature`, `docs`, `refactor`, `test`, `ui`, `perf`, `i18n`, `dependencies`, `python:uv`, `others`) live in a separate namespace and are unaffected.
+The `type:` axis classifies the work:
 
-Edit the right-hand column to remap any role to an existing label.
+| Label | Meaning |
+| --- | --- |
+| `type: bug` | Reporting a defect to fix |
+| `type: feature` | Requesting a new capability or improvement |
+| `type: task` | Other work: maintenance, refactor, or docs |
+
+The triage axis records whose turn it is:
+
+| Role and label | Meaning |
+| --- | --- |
+| `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | Waiting on the reporter for more information |
+| `ready-for-agent` | Fully specified and ready for an AFK agent |
+| `ready-for-human` | Requires human implementation |
+| `wontfix` | Will not be actioned |
+
+## Pull request states
+
+A non-draft pull request with no verdict is ready for an agent to finalize. A draft is still being built or iterated. `needs-info` is shared with issues and means the pull request is waiting on an outside human.
+
+After finalizing a pull request, an agent applies exactly one mutually exclusive verdict:
+
+| Verdict | Meaning |
+| --- | --- |
+| `recommend-merge` | Agent endorses it for maintainer review and merge |
+| `recommend-close` | Agent recommends that the maintainer review and close it |
+| `recommend-triage` | Code is sound, but the maintainer must make the product or scope decision |
+
+`maintainer-approved` records an explicit maintainer decision to merge after required checks pass. Apply it only at the maintainer's direction; it may coexist with an agent verdict because the labels record different authorities.
+
+Verdicts record decisions, not merge or close actions. A new commit makes every applicable verdict stale: remove it and have the corresponding authority review the new head before renewing it.


### PR DESCRIPTION
Prevents agents from following the stale instruction that canonical triage labels do not exist.

All 12 canonical labels are already present on GitHub and were reapplied before this change. This records their issue and pull-request routing contract and makes the root pointer cover both issue labels and PR verdicts.
