### PR TITLE
chore: drop mdformat-gfm

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ On some Linux distributions, labelme is also packaged in the system's native rep
 
 ### Supported Python and platforms
 
-|        | Supported (v7.x)               | Maintenance (v6.3.x) |
+| | Supported (v7.x) | Maintenance (v6.3.x) |
 | ------ | ------------------------------ | -------------------- |
-| Python | 3.12 - 3.14                    | 3.10 - 3.11          |
-| Qt     | Qt6 (PySide6)                  | Qt5                  |
-| OS     | 64-bit macOS / Windows / Linux | older OSes           |
+| Python | 3.12 - 3.14 | 3.10 - 3.11 |
+| Qt | Qt6 (PySide6) | Qt5 |
+| OS | 64-bit macOS / Windows / Linux | older OSes |
 
 labelme follows [SPEC 0](https://scientific-python.org/specs/spec-0000/) (the successor to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)) for dropping Python versions, in step with its core scientific dependencies (numpy, scipy, scikit-image). v6.3.x is the maintenance line for Qt5 and Python 3.10 / 3.11 stragglers.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -8,21 +8,21 @@ Every triaged issue carries exactly one `type:` label and one triage label. An i
 
 The `type:` axis classifies the work:
 
-| Label           | Meaning                                    |
+| Label | Meaning |
 | --------------- | ------------------------------------------ |
-| `type: bug`     | Reporting a defect to fix                  |
+| `type: bug` | Reporting a defect to fix |
 | `type: feature` | Requesting a new capability or improvement |
-| `type: task`    | Other work: maintenance, refactor, or docs |
+| `type: task` | Other work: maintenance, refactor, or docs |
 
 The triage axis records whose turn it is:
 
-| Role and label    | Meaning                                      |
+| Role and label | Meaning |
 | ----------------- | -------------------------------------------- |
-| `needs-triage`    | Maintainer needs to evaluate this issue      |
-| `needs-info`      | Waiting on the reporter for more information |
-| `ready-for-agent` | Fully specified and ready for an AFK agent   |
-| `ready-for-human` | Requires human implementation                |
-| `wontfix`         | Will not be actioned                         |
+| `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | Waiting on the reporter for more information |
+| `ready-for-agent` | Fully specified and ready for an AFK agent |
+| `ready-for-human` | Requires human implementation |
+| `wontfix` | Will not be actioned |
 
 ## Pull request states
 
@@ -30,10 +30,10 @@ A non-draft pull request with no verdict is ready for an agent to finalize. A dr
 
 After finalizing a pull request, an agent applies exactly one mutually exclusive verdict:
 
-| Verdict            | Meaning                                                                   |
+| Verdict | Meaning |
 | ------------------ | ------------------------------------------------------------------------- |
-| `recommend-merge`  | Agent endorses it for maintainer review and merge                         |
-| `recommend-close`  | Agent recommends that the maintainer review and close it                  |
+| `recommend-merge` | Agent endorses it for maintainer review and merge |
+| `recommend-close` | Agent recommends that the maintainer review and close it |
 | `recommend-triage` | Code is sound, but the maintainer must make the product or scope decision |
 
 `maintainer-approved` records an explicit maintainer decision to merge after required checks pass. Apply it only at the maintainer's direction; it may coexist with an agent verdict because the labels record different authorities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dev = [
   "types-pillow>=10.2.0.20240822",
   "typos>=1.45.0",
   "yamlfix>=1.19.1",
-  "mdformat-gfm>=1.0.0",
   "towncrier>=24.8",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,6 @@ dev = [
     { name = "ipython" },
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
-    { name = "mdformat-gfm" },
     { name = "packaging" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -822,7 +821,6 @@ dev = [
     { name = "ipython" },
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },
-    { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -1043,21 +1041,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/94/ccb15e0535f35c21b2b533cafb232f11ac0e7046dd122029b7ec0513c82e/mdformat_frontmatter-2.0.10.tar.gz", hash = "sha256:decefcb4beb66cf111f17e8c0d82e60b208104c7922ec09564d05365db551bd8", size = 3958, upload-time = "2026-01-19T23:42:23.672Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/40/e61f8ed549bed3159a9677eadb89849ccca6de30eb90bf61e1b6026df96d/mdformat_frontmatter-2.0.10-py3-none-any.whl", hash = "sha256:c99f7c52de0403e39f48b6a1c2bb79a4c8ce69304a799ff0e403e3957aa3669b", size = 4636, upload-time = "2026-01-19T23:42:22.341Z" },
-]
-
-[[package]]
-name = "mdformat-gfm"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "mdformat" },
-    { name = "mdit-py-plugins" },
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stops agent-authored compact tables from being expanded with cosmetic padding.

Core `mdformat` and frontmatter support remain. The existing GFM tables are normalized once to core `mdformat`'s compact output so lint stays green without the GFM plugin.
