### PR TITLE
chore: adopt gruff and its cheapest rules (GR003, GR006)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ setup:  # Setup the development environment
 lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
+	$(call exec,uv run gruff check .)
 	$(call exec,uv run ty check --no-progress)
 	$(call exec,git ls-files "*.toml" | xargs uv run taplo fmt --check)
 	$(call exec,git ls-files "*.md" | xargs uv run mdformat --check)

--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -11,6 +11,6 @@ __version__ = importlib.metadata.version("labelme")
 
 # XXX: has to be imported before PySide6 to load dlls in order on Windows
 # https://github.com/wkentaro/labelme/issues/1564
-import onnxruntime
+import onnxruntime  # noqa: F401
 
 __all__: list[str] = []

--- a/labelme/__init__.py
+++ b/labelme/__init__.py
@@ -12,3 +12,5 @@ __version__ = importlib.metadata.version("labelme")
 # XXX: has to be imported before PySide6 to load dlls in order on Windows
 # https://github.com/wkentaro/labelme/issues/1564
 import onnxruntime
+
+__all__: list[str] = []

--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -11,3 +11,19 @@ from ._text_detection import get_bboxes_from_texts
 from ._text_detection import nms_bboxes
 from ._types import AiOutputFormat
 from ._types import AiPromptKind
+
+__all__ = [
+    "MASK_REQUIRED_SHAPE_TYPES",
+    "AiAssistProposal",
+    "AiAssistSession",
+    "AiOutputFormat",
+    "AiPromptKind",
+    "Detection",
+    "OsamSession",
+    "assign_available_group_ids",
+    "get_bboxes_from_texts",
+    "nms_bboxes",
+    "shape_to_xyxy_bbox",
+    "shapes_from_detections",
+    "suppress_detections_greedy",
+]

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -13,6 +13,8 @@ from ._shape_color import migrate_shape_color
 from ._shape_color import validate_shape_color
 from ._writer import set_overrides
 
+__all__ = ["get_user_config_file", "load_config", "set_overrides"]
+
 here = Path(__file__).resolve().parent
 
 

--- a/labelme/_utils/__init__.py
+++ b/labelme/_utils/__init__.py
@@ -15,3 +15,23 @@ from .qt import project_point_on_line
 from .qt import project_point_on_perpendicular_line
 from .shape import shape_to_mask
 from .shape import shapes_to_label
+
+__all__ = [
+    "add_actions",
+    "apply_color_theme",
+    "apply_exif_orientation",
+    "direction_angle",
+    "img_arr_to_b64",
+    "img_arr_to_data",
+    "img_b64_to_arr",
+    "img_data_to_pil",
+    "img_qt_to_arr",
+    "img_qt_to_rgb_arr",
+    "label_validator",
+    "new_action",
+    "new_icon",
+    "project_point_on_line",
+    "project_point_on_perpendicular_line",
+    "shape_to_mask",
+    "shapes_to_label",
+]

--- a/labelme/_widgets/__init__.py
+++ b/labelme/_widgets/__init__.py
@@ -13,3 +13,21 @@ from .settings_dialog import SettingsDialog
 from .tool_bar import ToolBar
 from .unique_label_qlist_widget import UniqueLabelQListWidget
 from .zoom_widget import ZoomWidget
+
+__all__ = [
+    "AiAssistedAnnotationWidget",
+    "AiTextToAnnotationWidget",
+    "BrightnessContrastDialog",
+    "Canvas",
+    "LabelDialog",
+    "LabelListWidget",
+    "LabelListWidgetItem",
+    "Palette",
+    "SettingsDialog",
+    "StatusStats",
+    "ToolBar",
+    "UniqueLabelQListWidget",
+    "ZoomWidget",
+    "download_ai_model",
+    "format_shape_label",
+]

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -2201,10 +2201,9 @@ def _reproject_oriented_rectangle_corners(
     image_size: QtCore.QSize,
     allow_out_of_bounds: bool,
 ) -> tuple[QPointF, ...]:
-    """Given a 4-corner oriented rectangle and a dragged corner, return the new
-    corner positions: the dragged corner and its two neighbors move so the shape
-    stays a parallelogram, clipped to the image unless out-of-bounds points are
-    allowed; the opposite anchor is fixed."""
+    # The dragged corner and its two neighbors move so the shape stays a
+    # parallelogram, clipped to the image unless out-of-bounds points are
+    # allowed; the opposite anchor is fixed.
     anchor = corners[(vertex_index - 2) % 4]
     edge_axis = corners[(vertex_index - 1) % 4]
     moving = pos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = ["GR003"]
+select = ["GR003", "GR006"]
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = []
+select = ["GR003"]
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
   "typos>=1.45.0",
   "yamlfix>=1.19.1",
   "towncrier>=24.8",
+  "gruff>=0.0.4",
 ]
 
 [project.scripts]
@@ -93,6 +94,9 @@ markers = [
   "network: mark a test that accesses an external network service.",
   "pixel_snapshot: mark a test that compares rendering against a stored pixel snapshot.",
 ]
+
+[tool.gruff.lint]
+select = []
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,3 @@ ignore = ["UP040"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
-
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -86,7 +86,6 @@ def _make_release_event(
 
 
 def _image_to_widget(canvas: Canvas, img_x: float, img_y: float) -> QPointF:
-    """Convert image-space coordinates to widget-space coordinates."""
     origin = canvas._compute_image_origin_offset()
     wx = (img_x + origin.x()) * canvas.scale
     wy = (img_y + origin.y()) * canvas.scale
@@ -94,7 +93,6 @@ def _image_to_widget(canvas: Canvas, img_x: float, img_y: float) -> QPointF:
 
 
 def _clear_cursor_override(canvas: Canvas) -> None:
-    """Remove any outstanding override cursor pushed by the canvas."""
     canvas._release_cursor()
 
 
@@ -416,7 +414,7 @@ def test_right_release_with_selection_copy_executes_menus_1(
 
 
 def _make_center_polygon() -> Shape:
-    """Polygon with a vertex at image-center (100, 50), others at corners."""
+    # One vertex sits at image-center (100, 50); the rest at corners.
     return Shape(
         shape_type="polygon",
         points=np.array(

--- a/uv.lock
+++ b/uv.lock
@@ -502,6 +502,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gruff"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/0e/24c140fee9989e7d7e6f5384717867842037ad6289ed82a6f2a59262d41c/gruff-0.0.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f53421c9a91e5ebe845f0ccbb02e5b449f4a72d63d7273116f04b1482eb47a4b", size = 1937646, upload-time = "2026-08-29T07:41:11.86Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9e/1b9d45affcbe2b9cfccfc90e90bce2b2c5e17e9d4b6051e2511077ffb8c9/gruff-0.0.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:225e57823c9df70b428be74118bedce5f64194969184ed69faf8f6027f90cb02", size = 1870836, upload-time = "2026-08-29T07:41:13.578Z" },
+    { url = "https://files.pythonhosted.org/packages/69/34/658ed6c931969e731ec6c6a3ba3fd5e881d72ab12756f880fb793550f6ba/gruff-0.0.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dfd760bc120e83ee902a8ba40dafcdcd654a8dc679089c1cf1583f7aec2c6ce", size = 1894000, upload-time = "2026-08-29T07:41:15.17Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d2/ca51b537863bbbe44d1582a7d30434210ec8b2222a0f929aec2f5951baac/gruff-0.0.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33c6c718d8385b600900ef5da6647d01cdfc9e67c5f58451f45568f6a0fd94ad", size = 2008931, upload-time = "2026-08-29T07:41:16.861Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/8cc8290e77fa1af663ae00283916c04c1195a7d1ae660f7666abdd294517/gruff-0.0.4-py3-none-win_amd64.whl", hash = "sha256:cbb2f381626136a81938b859ad4424e18c09599759ab50a42f86d9d35598c34d", size = 1915240, upload-time = "2026-08-29T07:41:18.333Z" },
+]
+
+[[package]]
 name = "id"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -781,6 +793,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "gruff" },
     { name = "ipython" },
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
@@ -817,6 +830,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "gruff", specifier = ">=0.0.4" },
     { name = "ipython" },
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },


### PR DESCRIPTION
Adds [gruff](https://github.com/wkentaro/gruff) to `make lint` and adopts its two cheapest rules, one commit each: GR003 (`__all__` in every package initializer) and GR006 (no docstrings on non-public defs).

Two non-obvious bits:

1. With `__all__` manifests in place, the blanket `"__init__.py" = ["F401"]` ignore becomes unnecessary — F401 treats `__all__`-listed re-exports as used. The one survivor is `import onnxruntime` in `labelme/__init__.py`, a side-effect import for Windows DLL ordering (#1564); it keeps an inline noqa.

2. The GR006 fixes delete three docstrings whose names already said everything and demote one (oriented-rectangle geometry reasoning) to an ordinary comment; no rename was needed.

Review commit by commit. No changelog fragment: lint infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>