### PR TITLE
style: enable ruff RUF022, B006, RUF012, B008

### DIFF
--- a/labelme/_widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/_widgets/_ai_text_to_annotation_widget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import ClassVar
 
 from PySide6 import QtCore
 from PySide6 import QtGui
@@ -10,7 +11,7 @@ from ._info_button import InfoButton
 
 
 class AiTextToAnnotationWidget(QtWidgets.QWidget):
-    _available_models: list[tuple[str, str]] = [
+    _available_models: ClassVar[list[tuple[str, str]]] = [
         ("sam3:latest", "SAM3 (smart)"),
         ("yoloworld:latest", "YOLO-World (fast)"),
     ]

--- a/labelme/_widgets/label_list_widget.py
+++ b/labelme/_widgets/label_list_widget.py
@@ -27,6 +27,9 @@ def format_shape_label(shape: Shape) -> str:
     return text
 
 
+_INVALID_MODEL_INDEX: Final = QtCore.QModelIndex()
+
+
 class TrailingColorDotDelegate(QtWidgets.QStyledItemDelegate):
     _DOT: Final = " ●"
 
@@ -137,7 +140,7 @@ class _ItemModel(QtGui.QStandardItemModel):
         row: int,
         count: int,
         parent: QtCore.QModelIndex
-        | QtCore.QPersistentModelIndex = QtCore.QModelIndex(),
+        | QtCore.QPersistentModelIndex = _INVALID_MODEL_INDEX,
     ) -> bool:
         ret = super().removeRows(row, count, parent)
         self.item_dropped.emit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ select = [
   "RUF022", # sorted __all__
   "B006",   # mutable argument defaults
   "RUF012", # mutable class attributes
+  "B008",   # function calls in argument defaults
 ]
 # UP040 wants PEP 695 `type X = ...`, but our Literal aliases are enumerated at
 # runtime via typing.get_args(), which returns () for a lazy `type` alias.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
   "I",      # isort
   "UP",     # pyupgrade
   "RUF022", # sorted __all__
+  "B006",   # mutable argument defaults
 ]
 # UP040 wants PEP 695 `type X = ...`, but our Literal aliases are enumerated at
 # runtime via typing.get_args(), which returns () for a lazy `type` alias.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,12 @@ select = ["GR003", "GR006"]
 
 [tool.ruff.lint]
 select = [
-  "ANN", # flake8-annotations
-  "E",   # pycodestyle
-  "F",   # pyflakes
-  "I",   # isort
-  "UP",  # pyupgrade
+  "ANN",    # flake8-annotations
+  "E",      # pycodestyle
+  "F",      # pyflakes
+  "I",      # isort
+  "UP",     # pyupgrade
+  "RUF022", # sorted __all__
 ]
 # UP040 wants PEP 695 `type X = ...`, but our Literal aliases are enumerated at
 # runtime via typing.get_args(), which returns () for a lazy `type` alias.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ select = [
   "UP",     # pyupgrade
   "RUF022", # sorted __all__
   "B006",   # mutable argument defaults
+  "RUF012", # mutable class attributes
 ]
 # UP040 wants PEP 695 `type X = ...`, but our Literal aliases are enumerated at
 # runtime via typing.get_args(), which returns () for a lazy `type` alias.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Callable
 from collections.abc import Generator
 from pathlib import Path
+from typing import Final
 
 import pytest
 from PySide6 import QtGui
@@ -23,6 +24,8 @@ from labelme.__main__ import main
 from labelme._app import MainWindow
 from labelme._widgets.canvas import Canvas
 from labelme._widgets.label_dialog import LabelDialog
+
+_DEFAULT_WINDOW_SIZE: Final = QSize(800, 600)
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -100,7 +103,7 @@ def main_win(
         config_file: str | Path | None = None,
         config_overrides: dict | None = None,
         output_dir: str | Path | None = None,
-        size: QSize | None = QSize(800, 600),
+        size: QSize | None = _DEFAULT_WINDOW_SIZE,
     ) -> MainWindow:
         argv = ["labelme"]
 


### PR DESCRIPTION
Enables the four cheapest rules of gruff's recommended ruff pairing, one commit each. RUF022 and B006 were already clean and just lock in guarantees; RUF012 and B008 needed three small fixes.

One non-obvious bit: the B008 fix hoists `QModelIndex()` and `QSize(800, 600)` argument defaults into module-level `Final` singletons. Sharing a `QModelIndex` across calls is safe — it is an invalid-index sentinel Qt only reads; the `QSize` is only read by the fixture that resizes the window.

Review commit by commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>