### PR TITLE
style: adopt gruff GR004 (final-constants)

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -73,7 +73,7 @@ class _ZoomMode(enum.Enum):
 
 
 _TextToAnnotationCreateMode: TypeAlias = Literal["polygon", "rectangle"]
-_AI_CREATE_MODES: tuple[str, ...] = (
+_AI_CREATE_MODES: Final[tuple[str, ...]] = (
     "ai_points_to_shape",
     "ai_box_to_shape",
 )
@@ -1031,7 +1031,7 @@ class MainWindow(QtWidgets.QMainWindow):
         #
         # Bump this when dock/toolbar layout changes to reset window state
         # for users upgrading from an older version.
-        SETTINGS_VERSION: int = 1
+        SETTINGS_VERSION: Final[int] = 1
         if self._window_state.value("settingsVersion", 0, type=int) != SETTINGS_VERSION:
             self._reset_layout()
             self._window_state.setValue("settingsVersion", SETTINGS_VERSION)

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -4,6 +4,7 @@ import copy
 import re
 from collections.abc import Callable
 from pathlib import Path
+from typing import Final
 from typing import cast
 
 from loguru import logger
@@ -122,7 +123,7 @@ def _migrate_config_from_file(config_from_yaml: dict) -> None:
         ai["default"] = model_name_new
 
     # Migrate polygon shortcut keys to shape
-    _POLYGON_TO_SHAPE_RENAMES = {
+    _POLYGON_TO_SHAPE_RENAMES: Final = {
         "edit_polygon": "edit_shape",
         "delete_polygon": "delete_shape",
         "duplicate_polygon": "duplicate_shape",

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -91,7 +91,7 @@ def _validate_shape_semantics(
 
 
 def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
-    SHAPE_KEYS: set[str] = {
+    SHAPE_KEYS: Final[set[str]] = {
         "label",
         "points",
         "group_id",
@@ -396,7 +396,7 @@ def write_label_file(
         raise LabelFileWriteError(f"failed to write {filename!r}: {e}") from e
 
 
-_DISPLAYABLE_MODES = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
+_DISPLAYABLE_MODES: Final = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
 
 
 def _imread(filename: str) -> PIL.Image.Image:

--- a/labelme/_shape_color.py
+++ b/labelme/_shape_color.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from typing import Final
+
 import imgviz
 import numpy as np
 from numpy.typing import NDArray
 
-_LABEL_COLORMAP: NDArray[np.uint8] = imgviz.label_colormap()
+_LABEL_COLORMAP: Final[NDArray[np.uint8]] = imgviz.label_colormap()
 
 
 def resolve_shape_color(

--- a/labelme/_utils/qt.py
+++ b/labelme/_utils/qt.py
@@ -15,15 +15,15 @@ from PySide6 import QtWidgets
 
 _ICONS_DIR: Final = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons")
 _DEFAULT_ICON_SUFFIX: Final = ".png"
+_SCHEME_BY_THEME: Final = {
+    "system": QtCore.Qt.ColorScheme.Unknown,
+    "light": QtCore.Qt.ColorScheme.Light,
+    "dark": QtCore.Qt.ColorScheme.Dark,
+}
 
 
 def apply_color_theme(theme: str) -> None:
-    scheme_by_theme: Final = {
-        "system": QtCore.Qt.ColorScheme.Unknown,
-        "light": QtCore.Qt.ColorScheme.Light,
-        "dark": QtCore.Qt.ColorScheme.Dark,
-    }
-    scheme = scheme_by_theme.get(theme, QtCore.Qt.ColorScheme.Unknown)
+    scheme = _SCHEME_BY_THEME.get(theme, QtCore.Qt.ColorScheme.Unknown)
     QtGui.QGuiApplication.styleHints().setColorScheme(scheme)
 
 

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -99,7 +99,7 @@ def _shape_to_draft(shape: Shape) -> _DraftShape:
     )
 
 
-MOVE_SPEED: float = 5.0
+MOVE_SPEED: Final[float] = 5.0
 
 _CreateMode = Literal[
     "polygon",

--- a/labelme/_widgets/zoom_widget.py
+++ b/labelme/_widgets/zoom_widget.py
@@ -9,9 +9,9 @@ _ZOOM_LEVEL_LABEL: Final = "Zoom Level"
 
 
 class ZoomWidget(QtWidgets.QDoubleSpinBox):
-    PERCENT_MAX: int = 1000
-    PERCENT_DECIMALS: int = 1
-    PERCENT_SUFFIX: str = " %"
+    PERCENT_MAX: Final[int] = 1000
+    PERCENT_DECIMALS: Final[int] = 1
+    PERCENT_SUFFIX: Final[str] = " %"
 
     def __init__(self) -> None:
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = ["GR003", "GR006"]
+select = ["GR003", "GR004", "GR006"]
 
 [tool.ruff.lint]
 select = [

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -4,6 +4,7 @@ import functools
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Final
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -21,7 +22,7 @@ from .conftest import show_window_and_wait_for_imagedata
 if TYPE_CHECKING:
     from labelme._app import MainWindow
 
-_AI_TEXT_MODEL = "yoloworld:latest"
+_AI_TEXT_MODEL: Final = "yoloworld:latest"
 
 
 def _make_response(

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Final
 
 import pytest
 from PySide6.QtCore import QPoint
@@ -20,7 +21,7 @@ from .conftest import MainWinFactory
 from .conftest import show_window_and_wait_for_imagedata
 
 # Smallest available model (~40MB) to keep download and inference fast
-_AI_MODEL = "efficientsam:10m"
+_AI_MODEL: Final = "efficientsam:10m"
 
 
 @pytest.mark.gui

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -163,9 +163,9 @@ def test_add_label_history_dedups_repeated_labels_and_keeps_sorted(
     label_list = win._label_dialog.label_list
     assert _label_list_texts(label_list=label_list) == ["cat"]
 
-    triangle_zebra: Final = ((0.10, 0.10), (0.25, 0.10), (0.25, 0.25))
-    triangle_cat: Final = ((0.40, 0.10), (0.55, 0.10), (0.55, 0.25))
-    triangle_ant: Final = ((0.70, 0.10), (0.85, 0.10), (0.85, 0.25))
+    triangle_zebra = ((0.10, 0.10), (0.25, 0.10), (0.25, 0.25))
+    triangle_cat = ((0.40, 0.10), (0.55, 0.10), (0.55, 0.25))
+    triangle_ant = ((0.70, 0.10), (0.85, 0.10), (0.85, 0.25))
 
     draw_and_commit_polygon(
         qtbot=qtbot, win=win, label="zebra", vertices=triangle_zebra

--- a/tests/e2e/status_bar_messages_test.py
+++ b/tests/e2e/status_bar_messages_test.py
@@ -64,7 +64,7 @@ def test_save_does_not_emit_transient_status_message(
     tmp_path: Path,
     pause: bool,
 ) -> None:
-    json_basename: Final[str] = "2011_000003.json"
+    json_basename = "2011_000003.json"
     NO_TEMP_MESSAGE_TIMEOUT_MS: Final[int] = 3000
     win = main_win(
         file_or_dir=str(data_path / "annotated" / json_basename),

--- a/tests/unit/_automation/_osam_session_test.py
+++ b/tests/unit/_automation/_osam_session_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Final
 
 import numpy as np
 import osam
@@ -9,9 +10,9 @@ from numpy.typing import NDArray
 
 from labelme._automation._osam_session import OsamSession
 
-_IMAGE: NDArray[np.uint8] = np.zeros((2, 3, 3), dtype=np.uint8)
-_POINTS: NDArray[np.floating] = np.array([[1.0, 2.0]])
-_POINT_LABELS: NDArray[np.intp] = np.array([1])
+_IMAGE: Final[NDArray[np.uint8]] = np.zeros((2, 3, 3), dtype=np.uint8)
+_POINTS: Final[NDArray[np.floating]] = np.array([[1.0, 2.0]])
+_POINT_LABELS: Final[NDArray[np.intp]] = np.array([1])
 
 
 class _FakeModelRegistry:

--- a/tests/unit/_config/api_test.py
+++ b/tests/unit/_config/api_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -104,7 +105,7 @@ def test_load_config_rejects_invalid_polygon_detail(
         _config.load_config(config_file=config_file, config_overrides={})
 
 
-_POLYGON_TO_SHAPE_RENAMES = {
+_POLYGON_TO_SHAPE_RENAMES: Final = {
     "edit_polygon": "edit_shape",
     "delete_polygon": "delete_shape",
     "duplicate_polygon": "duplicate_shape",

--- a/tests/unit/_config/schema_test.py
+++ b/tests/unit/_config/schema_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from typing import Final
 
 import pytest
 
@@ -29,10 +30,10 @@ def _ids(settings: tuple[Setting, ...]) -> list[str]:
     return [".".join(setting.key_path) for setting in settings]
 
 
-_ENUM_SETTINGS = tuple(s for s in SETTINGS if s.kind == "enum")
-_BOOL_SETTINGS = tuple(s for s in SETTINGS if s.kind == "bool")
-_COLOR_SETTINGS = tuple(s for s in SETTINGS if s.kind == "color")
-_INT_SETTINGS = tuple(s for s in SETTINGS if s.kind == "int")
+_ENUM_SETTINGS: Final = tuple(s for s in SETTINGS if s.kind == "enum")
+_BOOL_SETTINGS: Final = tuple(s for s in SETTINGS if s.kind == "bool")
+_COLOR_SETTINGS: Final = tuple(s for s in SETTINGS if s.kind == "color")
+_INT_SETTINGS: Final = tuple(s for s in SETTINGS if s.kind == "int")
 
 
 @pytest.mark.parametrize("setting", SETTINGS, ids=_ids(SETTINGS))

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import Final
 
 import numpy as np
 import pytest
@@ -16,11 +17,11 @@ from labelme._widgets.canvas import Canvas
 from labelme._widgets.canvas import _DraftShape
 
 # Default epsilon in Canvas (screen-pixel hit radius).
-_EPSILON: float = 10.0
+_EPSILON: Final[float] = 10.0
 
 # Pixmap dimensions used across all tests.
-_W: int = 200
-_H: int = 100
+_W: Final[int] = 200
+_H: Final[int] = 100
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/widgets/_canvas_interaction/primitives_test.py
+++ b/tests/unit/widgets/_canvas_interaction/primitives_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Final
+
 import numpy as np
 import pytest
 from PySide6.QtCore import Qt
@@ -16,9 +18,9 @@ from labelme._widgets._canvas_interaction import find_hover_target
 from labelme._widgets._canvas_interaction import is_within_pick_threshold
 
 # Shared test constants
-_EPSILON: float = 10.0
-_SCALE: float = 1.0
-_POINT_SIZE: int = 8
+_EPSILON: Final[float] = 10.0
+_SCALE: Final[float] = 1.0
+_POINT_SIZE: Final[int] = 8
 
 
 def _point(x: float, y: float) -> np.ndarray:

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Final
+
 import numpy as np
 import pytest
 from PySide6 import QtGui
@@ -12,7 +14,7 @@ from labelme._widgets._shape_render import bounds
 from labelme._widgets._shape_render import is_hit_by_point
 from labelme._widgets._shape_render import render_shape
 
-_SIZE = 200
+_SIZE: Final = 200
 
 
 def _polygon(label: str | None) -> Shape:

--- a/tests/unit/widgets/brightness_contrast_dialog/i18n_test.py
+++ b/tests/unit/widgets/brightness_contrast_dialog/i18n_test.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Final
 from xml.etree import ElementTree
 
 import PIL.Image
@@ -19,8 +20,8 @@ from labelme import _locale
 from labelme._widgets import brightness_contrast_dialog
 from labelme._widgets.brightness_contrast_dialog import BrightnessContrastDialog
 
-_LOCALE = "ja_JP"
-_SLIDER_LABELS = ("Brightness:", "Contrast:")
+_LOCALE: Final = "ja_JP"
+_SLIDER_LABELS: Final = ("Brightness:", "Contrast:")
 
 
 @pytest.fixture()

--- a/tests/unit/widgets/tool_bar_test.py
+++ b/tests/unit/widgets/tool_bar_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Final
+
 import pytest
 from PySide6 import QtGui
 from PySide6 import QtWidgets
@@ -10,7 +12,7 @@ from labelme._widgets.tool_bar import ToolBar
 
 # Qt automatically adds an internal extension/overflow button to every QToolBar.
 # Filter it out when counting user-added buttons.
-_EXT_BUTTON_NAME = "qt_toolbar_ext_button"
+_EXT_BUTTON_NAME: Final = "qt_toolbar_ext_button"
 
 
 def _user_buttons(toolbar: ToolBar) -> list[QtWidgets.QToolButton]:

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -1,10 +1,11 @@
 import re
 import tomllib
 from pathlib import Path
+from typing import Final
 
 from ruamel.yaml import YAML
 
-_REPO_ROOT = Path(__file__).parents[1]
+_REPO_ROOT: Final = Path(__file__).parents[1]
 
 
 def test_test_matrix_covers_every_supported_python_version() -> None:


### PR DESCRIPTION
Adopts gruff GR004: uppercase constants get `Final`, `Final` bindings get UPPER_SNAKE_CASE. Mechanical sweep, 36 findings.

Two judgment calls:

1. Four `Final`-annotated per-test locals (`triangle_zebra`, `json_basename`, …) dropped `Final` instead of being screaming-cased — they are fixture data, not constants.

2. `scheme_by_theme` in `labelme/_utils/qt.py` was a lookup table rebuilt on every call; it moved to module scope as `_SCHEME_BY_THEME: Final` next to that file's existing constants rather than becoming an uppercase local. Enum member access needs no `QApplication`, so import-time construction is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>