### PR TITLE
style: adopt gruff GR002 (required-non-public-inputs)

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -230,7 +230,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._shape_clipboard = ShapeClipboard(self)
 
-        self._label_dialog = self._make_label_dialog()
+        self._label_dialog = self._make_label_dialog(label_history=None)
 
         self._prev_opened_dir = None
         self._label_list_menu_origin: QtCore.QPoint | None = None
@@ -349,7 +349,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         save = action(
             text=self.tr("&Save\n"),
-            slot=self._save_label_file,
+            slot=lambda: self._save_label_file(save_as=False),
             shortcut=shortcuts["save"],
             icon="phosphor/floppy-disk.svg",
             tip=self.tr("Save labels to file"),
@@ -508,7 +508,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         edit_mode = action(
             self.tr("Edit Shapes"),
-            lambda: self._switch_canvas_mode(edit=True),
+            lambda: self._switch_canvas_mode(edit=True, create_mode=None),
             shortcuts["edit_shape"],
             icon="phosphor/note-pencil.svg",
             tip=self.tr("Move and edit the selected shapes"),
@@ -631,7 +631,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         zoom_in = action(
             self.tr("Zoom &In"),
-            lambda _: self._add_zoom(increment=1.1),
+            lambda _: self._add_zoom(increment=1.1, pos=None),
             shortcuts["zoom_in"],
             icon="phosphor/magnifying-glass-plus.svg",
             tip=self.tr("Increase zoom level"),
@@ -639,7 +639,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         zoom_out = action(
             self.tr("&Zoom Out"),
-            lambda _: self._add_zoom(increment=0.9),
+            lambda _: self._add_zoom(increment=0.9, pos=None),
             shortcuts["zoom_out"],
             icon="phosphor/magnifying-glass-minus.svg",
             tip=self.tr("Decrease zoom level"),
@@ -1492,14 +1492,14 @@ class MainWindow(QtWidgets.QMainWindow):
     def undo_shape_edit(self) -> None:
         self._canvas_widgets.canvas.restore_last_shape()
         self._docks.label_list.clear()
-        self._load_shapes(self._canvas_widgets.canvas.shapes)
+        self._load_shapes(self._canvas_widgets.canvas.shapes, replace=True)
         self.mark_dirty()
 
     def tutorial(self) -> None:
         url = "https://github.com/labelmeai/labelme/tree/main/examples/tutorial"  # NOQA
         webbrowser.open(url)
 
-    def _on_drawing_polygon_changed(self, drawing: bool = True) -> None:
+    def _on_drawing_polygon_changed(self, drawing: bool) -> None:
         # In the middle of drawing, toggling between modes should be disabled.
         self._actions.edit_mode.setEnabled(not drawing)
         self._actions.undo_last_point.setEnabled(drawing)
@@ -1508,9 +1508,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self._actions.delete.setEnabled(not drawing)
 
-    def _switch_canvas_mode(
-        self, edit: bool = True, create_mode: str | None = None
-    ) -> None:
+    def _switch_canvas_mode(self, edit: bool, create_mode: str | None) -> None:
         self._canvas_widgets.canvas.set_editing(edit)
         if create_mode is not None:
             self._canvas_widgets.canvas.create_mode = create_mode
@@ -1576,7 +1574,7 @@ class MainWindow(QtWidgets.QMainWindow):
             label=label, existing_labels=existing_labels, policy=policy
         )
 
-    def _edit_label(self, value: object | None = None) -> None:
+    def _edit_label(self) -> None:
         items = self._docks.label_list.selected_items()
         if not items:
             logger.warning("No label is selected, so cannot edit label.")
@@ -1769,7 +1767,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._docks.label_list.remove_item(item)
         self._docks.label_list.item_dropped.connect(self._on_label_order_changed)
 
-    def _load_shapes(self, shapes: list[Shape], replace: bool = True) -> None:
+    def _load_shapes(self, shapes: list[Shape], replace: bool) -> None:
         self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
         )
@@ -1975,10 +1973,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_pan_request(self, step: QtCore.QPoint) -> None:
         # Pan moves the viewport opposite to the cursor delta so the image
         # tracks the grabbed point one-for-one in widget pixels.
-        self._move_canvas_view(step=QtCore.QPointF(step))
+        self._move_canvas_view(step=QtCore.QPointF(step), constrain_to_center=True)
 
     def _move_canvas_view(
-        self, step: QtCore.QPointF, *, constrain_to_center: bool = True
+        self, step: QtCore.QPointF, *, constrain_to_center: bool
     ) -> None:
         h_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Horizontal]
         v_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
@@ -2013,7 +2011,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self._prev_image_path = self._image_path
 
-    def _set_zoom(self, value: float, pos: QtCore.QPointF | None = None) -> None:
+    def _set_zoom(self, value: float, pos: QtCore.QPointF | None) -> None:
         if self._image_path is None:
             logger.warning("image_path is None, cannot set zoom")
             return
@@ -2045,9 +2043,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _set_zoom_to_original(self) -> None:
         self._zoom_mode = _ZoomMode.MANUAL_ZOOM
-        self._set_zoom(value=100)
+        self._set_zoom(value=100, pos=None)
 
-    def _add_zoom(self, increment: float, pos: QtCore.QPointF | None = None) -> None:
+    def _add_zoom(self, increment: float, pos: QtCore.QPointF | None) -> None:
         # Multiplicative stepping on a float widget; the QDoubleSpinBox rounds to
         # its decimal precision, so no integer ceil/floor clamping is needed.
         zoom_value = self._canvas_widgets.zoom_widget.value() * increment
@@ -2143,14 +2141,18 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             return read_label_file(filename=label_path)
         except LabelFileError as e:
-            self._show_file_open_error(path=label_path, file_kind="label", exc=e)
+            self._show_file_open_error(
+                path=label_path, file_kind="label", exc=e, extra=None
+            )
             return None
 
     def _read_image_as_annotation(self, image_path: str) -> Annotation | None:
         try:
             image_data = read_image_file(filename=image_path)
         except OSError as e:
-            self._show_file_open_error(path=image_path, file_kind="image", exc=e)
+            self._show_file_open_error(
+                path=image_path, file_kind="image", exc=e, extra=None
+            )
             return None
         return Annotation(
             image_path=os.path.basename(image_path),
@@ -2243,6 +2245,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._show_file_open_error(
                 path=image_or_label_path,
                 file_kind="image",
+                exc=None,
                 extra=extra,
             )
             return False
@@ -2264,7 +2267,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # Record one baseline state. Loading carried-forward shapes separately
         # would create a false Undo step that discards them before any edit.
         carry_prev_shapes = bool(prev_shapes) and not shapes
-        self._load_shapes(shapes=prev_shapes if carry_prev_shapes else shapes)
+        self._load_shapes(
+            shapes=prev_shapes if carry_prev_shapes else shapes, replace=True
+        )
         flags.update(annotation.flags)
         self._load_flags(flags=flags, widget=self._docks.flag_list)
         if carry_prev_shapes:
@@ -2286,7 +2291,7 @@ class MainWindow(QtWidgets.QMainWindow):
         is_initial_load = not self._viewport_states
         if target_viewport is not None:
             self._zoom_mode = target_viewport.zoom_mode
-            self._set_zoom(target_viewport.zoom_value)
+            self._set_zoom(target_viewport.zoom_value, pos=None)
         elif is_initial_load or not self._config["keep_prev_scale"]:
             self._zoom_mode = _ZoomMode.FIT_WINDOW
             self._adjust_scale()
@@ -2340,7 +2345,7 @@ class MainWindow(QtWidgets.QMainWindow):
             scale = self._fit_width_scale()
         else:
             scale = 1.0
-        self._set_zoom(value=scale * 100)
+        self._set_zoom(value=scale * 100, pos=None)
 
     def _fit_window_scale(self) -> float:
         FIT_WINDOW_SCROLLBAR_MARGIN: Final[float] = 2.0
@@ -2402,7 +2407,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     # User Dialogs #
 
-    def _open_prev_image(self, _value: bool = False) -> None:
+    def _open_prev_image(self) -> None:
         row_prev: int = self._docks.file_list.currentRow() - 1
         if row_prev < 0:
             logger.debug("there is no prev image")
@@ -2412,7 +2417,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.file_list.setCurrentRow(row_prev)
         self._docks.file_list.repaint()
 
-    def _open_next_image(self, _value: bool = False) -> None:
+    def _open_next_image(self) -> None:
         row_next: int = self._docks.file_list.currentRow() + 1
         if row_next >= self._docks.file_list.count():
             logger.debug("there is no next image")
@@ -2422,7 +2427,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.file_list.setCurrentRow(row_next)
         self._docks.file_list.repaint()
 
-    def _open_file_with_dialog(self, _value: bool = False) -> None:
+    def _open_file_with_dialog(self) -> None:
         if not self._can_continue():
             return
         formats = [
@@ -2484,7 +2489,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._refresh_file_list()
 
-    def _save_label_file(self, *, save_as: bool = False) -> None:
+    def _save_label_file(self, *, save_as: bool) -> None:
         assert not self._image.isNull(), "cannot save empty image"
 
         label_path: str | None = None
@@ -2595,7 +2600,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def _is_settings_editable(self) -> bool:
         return self._config_file is not None and not self._config_overrides
 
-    def _make_label_dialog(self, label_history: list[str] | None = None) -> LabelDialog:
+    def _make_label_dialog(self, label_history: list[str] | None) -> LabelDialog:
         return LabelDialog(
             parent=self,
             labels=self._config["labels"],
@@ -2877,7 +2882,7 @@ class MainWindow(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.StandardButton.Save,
         )
         if user_choice == QtWidgets.QMessageBox.StandardButton.Save:
-            self._save_label_file()
+            self._save_label_file(save_as=False)
             return not self._is_changed
         return user_choice == QtWidgets.QMessageBox.StandardButton.Discard
 
@@ -2891,8 +2896,8 @@ class MainWindow(QtWidgets.QMainWindow):
         *,
         path: str,
         file_kind: Literal["label", "image"],
-        exc: BaseException | None = None,
-        extra: str | None = None,
+        exc: BaseException | None,
+        extra: str | None,
     ) -> None:
         if file_kind == "label":
             message = self.tr(
@@ -2988,7 +2993,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 return
             self._import_images_from_dir(root_dir=str(Path(file_or_dir).parent))
 
-    def _open_dir_with_dialog(self, _value: bool = False) -> None:
+    def _open_dir_with_dialog(self) -> None:
         if not self._can_continue():
             return
 

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -16,6 +16,8 @@ from ._geometry import compute_oriented_rectangle_from_mask
 from ._geometry import compute_polygons_from_mask
 from ._types import AiOutputFormat
 
+_DEFAULT_POLYGON_DETAIL: Final[int] = 80
+
 
 @dataclass
 class Detection:
@@ -30,9 +32,9 @@ def _build_shape(
     shape_type: AiOutputFormat,
     points: ArrayLike,
     *,
-    mask: NDArray[np.bool_] | None = None,
-    label: str | None = None,
-    description: str | None = None,
+    mask: NDArray[np.bool_] | None,
+    label: str | None,
+    description: str | None,
 ) -> Shape:
     return Shape(
         label=label,
@@ -48,8 +50,8 @@ def _build_shapes_from_detection(
     detection: Detection,
     shape_type: AiOutputFormat,
     *,
-    image_size: tuple[int, int] | None = None,
-    polygon_detail: int = 80,
+    image_size: tuple[int, int] | None,
+    polygon_detail: int,
 ) -> list[Shape]:
     if shape_type == "rectangle":
         if detection.bbox is None:
@@ -59,6 +61,7 @@ def _build_shapes_from_detection(
             _build_shape(
                 shape_type="rectangle",
                 points=[[xmin, ymin], [xmax, ymax]],
+                mask=None,
                 label=detection.label,
                 description=detection.description,
             )
@@ -77,6 +80,7 @@ def _build_shapes_from_detection(
             _build_shape(
                 shape_type="polygon",
                 points=polygon,
+                mask=None,
                 label=detection.label,
                 description=detection.description,
             )
@@ -109,6 +113,7 @@ def _build_shapes_from_detection(
                     [circle.cx, circle.cy],
                     [circle.cx + circle.radius, circle.cy],
                 ],
+                mask=None,
                 label=detection.label,
                 description=detection.description,
             )
@@ -126,6 +131,7 @@ def _build_shapes_from_detection(
             _build_shape(
                 shape_type="oriented_rectangle",
                 points=corners,
+                mask=None,
                 label=detection.label,
                 description=detection.description,
             )
@@ -199,7 +205,10 @@ MASK_REQUIRED_SHAPE_TYPES: Final[frozenset[AiOutputFormat]] = frozenset(
     shape_type
     for shape_type in typing.get_args(AiOutputFormat)
     if not _build_shapes_from_detection(
-        detection=Detection(bbox=(0, 0, 1, 1), mask=None), shape_type=shape_type
+        detection=Detection(bbox=(0, 0, 1, 1), mask=None),
+        shape_type=shape_type,
+        image_size=None,
+        polygon_detail=_DEFAULT_POLYGON_DETAIL,
     )
 )
 
@@ -209,7 +218,7 @@ def shapes_from_detections(
     shape_type: AiOutputFormat,
     *,
     image_size: tuple[int, int] | None = None,
-    polygon_detail: int = 80,
+    polygon_detail: int = _DEFAULT_POLYGON_DETAIL,
 ) -> list[Shape]:
     shapes: list[Shape] = []
     next_group_id = 1

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import re
-from collections.abc import Callable
 from pathlib import Path
 from typing import Final
 from typing import cast
@@ -22,13 +21,11 @@ here = Path(__file__).resolve().parent
 def _update_dict(
     target_dict: dict[str, object],
     new_dict: dict[str, object],
-    validate_item: Callable[[tuple[str, ...], object], None] | None = None,
-    key_path: tuple[str, ...] = (),
+    key_path: tuple[str, ...],
 ) -> None:
     for key, value in new_dict.items():
         item_path = (*key_path, key)
-        if validate_item:
-            validate_item(item_path, value)
+        _validate_config_item(item_path, value)
         if key not in target_dict:
             raise ValueError(f"Unexpected key in config: {key}")
         if not isinstance(target_dict[key], dict):
@@ -51,7 +48,6 @@ def _update_dict(
         _update_dict(
             cast(dict[str, object], target_dict[key]),
             cast(dict[str, object], value),
-            validate_item=validate_item,
             key_path=item_path,
         )
 
@@ -195,13 +191,13 @@ def load_config(config_file: Path | None, config_overrides: dict) -> dict:
             _migrate_config_from_file(config_from_yaml=config_from_yaml)
             if "shape_color" in config_from_yaml:
                 validate_shape_color(config=config_from_yaml["shape_color"])
-            _update_dict(config, config_from_yaml, validate_item=_validate_config_item)
+            _update_dict(config, config_from_yaml, key_path=())
 
     config_overrides = copy.deepcopy(config_overrides)
     migrate_shape_color(config=config_overrides)
     if "shape_color" in config_overrides:
         validate_shape_color(config=config_overrides["shape_color"])
-    _update_dict(config, config_overrides, validate_item=_validate_config_item)
+    _update_dict(config, config_overrides, key_path=())
 
     if not config["labels"] and config["validate_label"]:
         raise ValueError("labels must be specified when validate_label is enabled")

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -519,7 +519,7 @@ class Canvas(QtWidgets.QWidget):
 
     def enterEvent(self, a0: QtCore.QEvent) -> None:
         self._apply_cursor(self._cursor)
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def leaveEvent(self, a0: QtCore.QEvent) -> None:
         if self._set_highlight(
@@ -530,11 +530,11 @@ class Canvas(QtWidgets.QWidget):
         ):
             self.update()
         self._release_cursor()
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def focusOutEvent(self, a0: QtGui.QFocusEvent) -> None:
         self._release_cursor()
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def set_editing(self, value: bool = True) -> None:
         new_mode = _CanvasMode.EDIT if value else _CanvasMode.CREATE
@@ -593,7 +593,7 @@ class Canvas(QtWidgets.QWidget):
     def _is_rotation_point_selected(self) -> bool:
         return self._hovered_rotation is not None
 
-    def _update_status(self, extra_messages: list[str] | None = None) -> None:
+    def _update_status(self, extra_messages: list[str] | None) -> None:
         messages: list[str] = []
         if self.mode == _CanvasMode.CREATE:
             messages.append(self.tr("Creating %r") % self.create_mode)
@@ -697,14 +697,14 @@ class Canvas(QtWidgets.QWidget):
         self._apply_cursor(CursorRole.DRAW)
         if self._current is None:
             self.update()
-            self._update_status()
+            self._update_status(extra_messages=None)
             return
         is_shift_pressed = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
         pos = self._project_drawing_pos_into_image(pos=pos)
         self._update_drawing_line(pos=pos, is_shift_pressed=is_shift_pressed)
         assert len(self._line.points) == len(self._line.point_labels)
         self.update()
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def _project_drawing_pos_into_image(self, pos: QPointF) -> QPointF:
         current = self._current
@@ -820,7 +820,7 @@ class Canvas(QtWidgets.QWidget):
         elif self.selected_shapes:
             self._selected_shapes_copy = [s.copy() for s in self.selected_shapes]
             self.update()
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def _continue_left_button_drag(
         self, pos: QPointF, event: QtGui.QMouseEvent
@@ -1006,7 +1006,7 @@ class Canvas(QtWidgets.QWidget):
     def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
         pos: QPointF = self.transform_widget_point_to_image(a0.position())
         self._dispatch_pointer_press(pos=pos, event=a0)
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def _dispatch_pointer_press(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         self._clear_ai_existing_shape_highlights()
@@ -1206,7 +1206,7 @@ class Canvas(QtWidgets.QWidget):
     def mouseReleaseEvent(self, a0: QtGui.QMouseEvent) -> None:
         self._dispatch_pointer_release(event=a0)
         self._commit_pending_shape_move()
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def _dispatch_pointer_release(self, event: QtGui.QMouseEvent) -> None:
         button = event.button()
@@ -1531,7 +1531,7 @@ class Canvas(QtWidgets.QWidget):
             QtGui.QPainter.RenderHint.SmoothPixmapTransform,
         ):
             painter.setRenderHint(hint)
-        painter.translate(self._compute_image_origin_offset() * self.scale)
+        painter.translate(self._compute_image_origin_offset(area=None) * self.scale)
 
     def _render_layers(self) -> tuple[Callable[[QtGui.QPainter], None], ...]:
         # Order is z-order, back-to-front.
@@ -1565,7 +1565,7 @@ class Canvas(QtWidgets.QWidget):
         if self._allow_out_of_bounds_points:
             # The cursor may be in the margin around the image, so span the whole
             # viewport instead of stopping the lines at the image edge.
-            offset = self._compute_image_origin_offset() * self.scale
+            offset = self._compute_image_origin_offset(area=None) * self.scale
             area = super().size()
             left = int(-offset.x())
             top = int(-offset.y())
@@ -1707,7 +1707,7 @@ class Canvas(QtWidgets.QWidget):
         return proposal.new_shapes
 
     def transform_widget_point_to_image(self, point: QPointF) -> QPointF:
-        origin = self._compute_image_origin_offset()
+        origin = self._compute_image_origin_offset(area=None)
         image_x = point.x() / self.scale - origin.x()
         image_y = point.y() / self.scale - origin.y()
         return QPointF(image_x, image_y)
@@ -1717,7 +1717,7 @@ class Canvas(QtWidgets.QWidget):
     ) -> QPointF:
         return (point + self._compute_image_origin_offset(area=area)) * self.scale
 
-    def _compute_image_origin_offset(self, area: QtCore.QSize | None = None) -> QPointF:
+    def _compute_image_origin_offset(self, area: QtCore.QSize | None) -> QPointF:
         if area is None:
             area = super().size()
         scaled_w = self.pixmap.width() * self.scale
@@ -1896,7 +1896,7 @@ class Canvas(QtWidgets.QWidget):
                 self._move_by_keyboard(QPointF(MOVE_SPEED, 0.0))
             elif a0.matches(QtGui.QKeySequence.StandardKey.SelectAll):
                 self.select_shapes(shapes=self.shapes[:])
-        self._update_status()
+        self._update_status(extra_messages=None)
 
     def keyReleaseEvent(self, a0: QtGui.QKeyEvent) -> None:
         modifiers = a0.modifiers()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = ["GR003", "GR004", "GR006"]
+select = ["GR002", "GR003", "GR004", "GR006"]
 
 [tool.ruff.lint]
 select = [

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -30,7 +30,7 @@ def _make_response(
     boxes: list[tuple[int, int, int, int]],
     scores: list[float],
     label_indices: list[int],
-    with_masks: bool = False,
+    with_masks: bool,
 ) -> osam.types.GenerateResponse:
     annotations = []
     for (xmin, ymin, xmax, ymax), score, label_idx in zip(
@@ -53,7 +53,7 @@ def _make_response(
 
 
 def _make_person_response(
-    texts: list[str], with_masks: bool = False
+    texts: list[str], with_masks: bool
 ) -> osam.types.GenerateResponse:
     person_idx = texts.index("person")
     return _make_response(
@@ -73,6 +73,7 @@ def _make_multi_label_response(texts: list[str]) -> osam.types.GenerateResponse:
         boxes=[(50, 30, 200, 300), (10, 150, 400, 330)],
         scores=[0.85, 0.70],
         label_indices=[person_idx, sofa_idx],
+        with_masks=False,
     )
 
 
@@ -82,6 +83,7 @@ def _make_edge_crossing_response(texts: list[str]) -> osam.types.GenerateRespons
         boxes=[(-10, 30, 50, 100)],
         scores=[0.9],
         label_indices=[0],
+        with_masks=False,
     )
 
 
@@ -111,7 +113,7 @@ def _run_text_prompt(
     qtbot: QtBot,
     text: str,
     create_mode: str,
-    score_threshold: float = 0.1,
+    score_threshold: float,
 ) -> None:
     win._switch_canvas_mode(edit=False, create_mode=create_mode)
     qtbot.wait(50)
@@ -138,7 +140,7 @@ def _run_text_prompt(
             "rectangle",
             "rectangle",
             "person",
-            _make_person_response,
+            functools.partial(_make_person_response, with_masks=False),
             {"person"},
             id="rectangle",
         ),
@@ -223,7 +225,7 @@ def test_text_prompt_creates_shapes(
             assert (shape.points <= [win._image.width(), win._image.height()]).all()
 
     out_file = str(tmp_path / "2011_000003.json")
-    win._save_label_file()
+    win._save_label_file(save_as=False)
     assert_labelfile_sanity(out_file)
 
     win._actions.undo.trigger()
@@ -249,7 +251,9 @@ def test_nms_deduplicates_existing_shapes(
     canvas = win._canvas_widgets.canvas
 
     _install_mock_session(
-        win=win, monkeypatch=monkeypatch, response_fn=_make_person_response
+        win=win,
+        monkeypatch=monkeypatch,
+        response_fn=functools.partial(_make_person_response, with_masks=False),
     )
 
     _run_text_prompt(
@@ -289,7 +293,9 @@ def test_score_threshold_filters_detections(
     canvas = win._canvas_widgets.canvas
 
     _install_mock_session(
-        win=win, monkeypatch=monkeypatch, response_fn=_make_person_response
+        win=win,
+        monkeypatch=monkeypatch,
+        response_fn=functools.partial(_make_person_response, with_masks=False),
     )
 
     _run_text_prompt(
@@ -336,7 +342,13 @@ def test_text_prompt_inference_error_surfaces_without_crashing(
         raise RuntimeError("boom")
 
     _install_mock_session(win=win, monkeypatch=monkeypatch, response_fn=_raise)
-    _run_text_prompt(win=win, qtbot=qtbot, text="person", create_mode="rectangle")
+    _run_text_prompt(
+        win=win,
+        qtbot=qtbot,
+        text="person",
+        create_mode="rectangle",
+        score_threshold=0.1,
+    )
 
     assert win.isVisible()
     assert canvas.shapes == []

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -378,7 +378,7 @@ def test_annotate_shape_types(
     if expected_num_points is not None:
         assert len(shapes[0].points) == expected_num_points
 
-    win._save_label_file()
+    win._save_label_file(save_as=False)
     assert_labelfile_sanity(out_file)
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -262,7 +262,7 @@ def test_failed_auto_save_keeps_annotation_dirty_and_allows_manual_retry(
     assert _raw_auto_save_win._actions.save_auto.isChecked()
 
     canvas = _raw_auto_save_win._canvas_widgets.canvas
-    _raw_auto_save_win._switch_canvas_mode(edit=True)
+    _raw_auto_save_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
     qtbot.keyPress(canvas, Qt.Key.Key_Right)
@@ -341,7 +341,7 @@ def test_failed_auto_save_shows_error_again_after_target_changes(
     )
 
     canvas = _raw_auto_save_win._canvas_widgets.canvas
-    _raw_auto_save_win._switch_canvas_mode(edit=True)
+    _raw_auto_save_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
     qtbot.keyPress(canvas, Qt.Key.Key_Right)

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -275,7 +275,7 @@ def test_add_point_on_edge(
     shape = next(s for s in canvas.shapes if s.label == label)
     num_points_before = len(shape.points)
 
-    annotated_win._switch_canvas_mode(edit=True)
+    annotated_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     p0, p1 = shape.points[0], shape.points[1]
@@ -408,7 +408,7 @@ def test_draw_actions_disable_only_active_mode(
         else:
             assert draw_action.isEnabled()
 
-    annotated_win._switch_canvas_mode(edit=True)
+    annotated_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
     assert canvas.mode == _CanvasMode.EDIT
 
@@ -632,7 +632,7 @@ def test_select_nonpolygon_shape(
     shape = _wait_for_shape(qtbot=qtbot, canvas=canvas, label=label)
     assert shape.shape_type == create_mode
 
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     click_pos = _shape_bounds(shape=shape).center() + QPointF(*select_offset)
@@ -731,7 +731,7 @@ def test_remove_point_blocked_at_minimum(
     shape = _wait_for_shape(qtbot=qtbot, canvas=canvas, label=label)
     assert len(shape.points) == expected_points
 
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     _click_to_remove_point(
@@ -769,7 +769,7 @@ def test_select_point_shape_by_click(
     shape = _wait_for_shape(qtbot=qtbot, canvas=canvas, label="pt")
     assert shape.shape_type == "point"
 
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     _click_to_select(

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -179,7 +179,7 @@ def test_undo_after_delete_file_does_not_restore_shapes(
     monkeypatch.setattr(win, "_confirm_deletion", lambda *args, **kwargs: True)
 
     # A prior shape edit in the same session enables the undo action.
-    win._switch_canvas_mode(edit=True)
+    win._switch_canvas_mode(edit=True, create_mode=None)
     select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
     win.delete_selected_shapes()
     qtbot.wait(50)

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -82,7 +82,7 @@ def test_restore_last_shape_via_undo(
     canvas = raw_win._canvas_widgets.canvas
 
     _draw_and_commit_polygon(qtbot=qtbot, win=raw_win, label="restore_me")
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
 
     assert len(canvas.shapes) == 1
     original_points = [
@@ -151,7 +151,7 @@ def test_first_and_subsequent_shapes_can_be_undone_and_saved(
 
     label_path = tmp_path / "manual-save.json"
     monkeypatch.setattr(raw_win, "prompt_save_file_path", lambda: str(label_path))
-    raw_win._save_label_file()
+    raw_win._save_label_file(save_as=False)
 
     with label_path.open() as f:
         assert json.load(f)["shapes"] == []
@@ -252,7 +252,7 @@ def test_save_keeps_shape_undo_disabled_while_drawing(
         "prompt_save_file_path",
         lambda: str(tmp_path / "save-while-drawing.json"),
     )
-    win._save_label_file()
+    win._save_label_file(save_as=False)
 
     assert canvas.is_drawing
     assert not win._actions.undo.isEnabled()

--- a/tests/e2e/oriented_rectangle_test.py
+++ b/tests/e2e/oriented_rectangle_test.py
@@ -69,7 +69,7 @@ def test_drag_rotation_handle_rotates_oriented_rectangle(
     original_centroid = _centroid(shape.points)
     original_edges = _edge_lengths(shape.points)
 
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     p0, p1 = original_points[0], original_points[1]
@@ -133,7 +133,7 @@ def test_drag_vertex_out_of_pixmap_clips_oriented_rectangle(
     )
     shape = next(s for s in canvas.shapes if s.label == "rect")
 
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     original_points = [QPointF(float(p[0]), float(p[1])) for p in shape.points]
@@ -191,7 +191,7 @@ def test_oriented_rectangle_disallows_add_and_remove_point(
     shape = next(s for s in canvas.shapes if s.label == "rect")
     num_points = len(shape.points)
 
-    raw_win._switch_canvas_mode(edit=True)
+    raw_win._switch_canvas_mode(edit=True, create_mode=None)
     qtbot.wait(50)
 
     # Hovering over an edge midpoint enables `add_point_to_edge` for polygons,

--- a/tests/e2e/save_format_contract_test.py
+++ b/tests/e2e/save_format_contract_test.py
@@ -299,7 +299,7 @@ def test_title_returns_to_clean_after_save(
 
     label_path = tmp_path / "2011_000003.json"
     monkeypatch.setattr(win, "prompt_save_file_path", lambda: str(label_path))
-    win._save_label_file()
+    win._save_label_file(save_as=False)
 
     assert label_path.exists()
     assert not win.windowTitle().endswith("*")

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -25,9 +25,8 @@ def _open_and_select_shape(
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    shape_index: int = 0,
-    config_overrides: dict[str, bool] | None = None,
-    output_dir: str | None = None,
+    config_overrides: dict[str, bool] | None,
+    output_dir: str | None,
 ) -> tuple[MainWindow, Canvas]:
     win = main_win(
         file_or_dir=str(data_path / "annotated/2011_000003.json"),
@@ -39,7 +38,7 @@ def _open_and_select_shape(
     canvas = win._canvas_widgets.canvas
     assert len(canvas.shapes) == 5
 
-    select_shape(qtbot=qtbot, canvas=canvas, shape_index=shape_index)
+    select_shape(qtbot=qtbot, canvas=canvas, shape_index=0)
     return win, canvas
 
 
@@ -61,7 +60,11 @@ def test_select_shape(
     pause: bool,
 ) -> None:
     win, canvas = _open_and_select_shape(
-        main_win=main_win, qtbot=qtbot, data_path=data_path
+        main_win=main_win,
+        qtbot=qtbot,
+        data_path=data_path,
+        config_overrides=None,
+        output_dir=None,
     )
 
     assert canvas.selected_shapes[0].label == "person"
@@ -95,7 +98,7 @@ def test_copy_paste_shape(
     assert len(canvas.shapes) == num_shapes_before + 1
     assert canvas.shapes[-1].label == original_label
 
-    win._save_label_file()
+    win._save_label_file(save_as=False)
     assert_labelfile_sanity(str(tmp_path / "2011_000003.json"))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
@@ -124,7 +127,7 @@ def test_duplicate_shape(
 
     assert len(canvas.shapes) == num_shapes_before + 1
 
-    win._save_label_file()
+    win._save_label_file(save_as=False)
     assert_labelfile_sanity(str(tmp_path / "2011_000003.json"))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
@@ -151,7 +154,7 @@ def test_delete_shape(
 
     assert len(canvas.shapes) == 4
 
-    win._save_label_file()
+    win._save_label_file(save_as=False)
     assert_labelfile_sanity(str(tmp_path / "2011_000003.json"))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
@@ -182,7 +185,7 @@ def test_delete_undo_shape(
     assert len(canvas.shapes) == 5
     assert canvas.shapes[0].label == "person"
 
-    win._save_label_file()
+    win._save_label_file(save_as=False)
     assert_labelfile_sanity(str(tmp_path / "2011_000003.json"))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -137,7 +137,7 @@ def test_manual_zoom_only_scrolls_the_overflowing_axis(
     pause: bool,
 ) -> None:
     _win._set_zoom_to_original()
-    _win._set_zoom(value=110)
+    _win._set_zoom(value=110, pos=None)
 
     scroll_bars = _win._canvas_widgets.scroll_bars
     qtbot.waitUntil(
@@ -173,7 +173,7 @@ def test_zoom_step_keeps_fractional_precision(
     pause: bool,
 ) -> None:
     _win._canvas_widgets.zoom_widget.setValue(105)
-    _win._add_zoom(increment=1.1)
+    _win._add_zoom(increment=1.1, pos=None)
     # 105 * 1.1 = 115.5; the old integer widget clamped this up to 116.
     assert _win._canvas_widgets.zoom_widget.value() == pytest.approx(115.5)
 
@@ -227,7 +227,7 @@ def _make_scrolled_win(
         config_overrides={"keep_prev_scale": True},
     )
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
-    win._set_zoom(value=_VIEWPORT_ZOOM)
+    win._set_zoom(value=_VIEWPORT_ZOOM, pos=None)
     scroll_values = _set_scroll_bars_to_fraction(
         qtbot=qtbot,
         win=win,
@@ -253,7 +253,7 @@ def test_navigation_restores_each_image_viewport(
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
 
     canvas = win._canvas_widgets.canvas
-    win._set_zoom(value=_VIEWPORT_ZOOM)
+    win._set_zoom(value=_VIEWPORT_ZOOM, pos=None)
     scroll_bars = win._canvas_widgets.scroll_bars
     first_scroll_values = _set_scroll_bars_to_fraction(
         qtbot=qtbot,
@@ -287,7 +287,7 @@ def test_navigation_restores_each_image_viewport(
             assert bar.value() == bar.minimum()
         assert canvas.get_view_offset().isNull()
 
-    win._set_zoom(value=250)
+    win._set_zoom(value=250, pos=None)
     second_scroll_values = _set_scroll_bars_to_fraction(
         qtbot=qtbot,
         win=win,
@@ -363,7 +363,7 @@ def test_navigation_restores_viewport_after_layout_settles(
     qtbot.waitUntil(lambda: v_bar.maximum() > 0)
     v_bar.setValue(v_bar.maximum() * 2 // 3)
     with qtbot.waitSignal(v_bar.rangeChanged):
-        win._add_zoom(increment=0.9)
+        win._add_zoom(increment=0.9, pos=None)
 
     first_image_path = win._image_path
     assert first_image_path is not None
@@ -465,7 +465,7 @@ def _make_wheel_event(
     pos: QPointF,
     angle_delta: QPoint,
     modifiers: Qt.KeyboardModifier,
-    phase: Qt.ScrollPhase = Qt.ScrollPhase.NoScrollPhase,
+    phase: Qt.ScrollPhase,
 ) -> QtGui.QWheelEvent:
     # PySide6's QWheelEvent constructor takes positional args;
     # the 8-arg form matches the modern Qt6 signature.
@@ -527,6 +527,7 @@ def test_canvas_wheel_event_dispatches_signal(
             pos=QPointF(canvas.width() / 2, canvas.height() / 2),
             angle_delta=angle_delta,
             modifiers=modifiers,
+            phase=Qt.ScrollPhase.NoScrollPhase,
         )
     )
 
@@ -619,6 +620,7 @@ def test_ctrl_wheel_keeps_image_point_under_cursor(
                 pos=canvas.mapFrom(viewport, cursor),
                 angle_delta=QPoint(0, angle_delta),
                 modifiers=Qt.KeyboardModifier.ControlModifier,
+                phase=Qt.ScrollPhase.NoScrollPhase,
             ),
         )
         qtbot.waitUntil(

--- a/tests/unit/_app_test.py
+++ b/tests/unit/_app_test.py
@@ -119,7 +119,7 @@ def _make_png_bytes(
     *,
     width: int,
     height: int,
-    image_format: QtGui.QImage.Format = QtGui.QImage.Format.Format_RGB32,
+    image_format: QtGui.QImage.Format,
 ) -> bytes:
     image = QtGui.QImage(width, height, image_format)
     image.fill(0)
@@ -132,7 +132,9 @@ def _make_png_bytes(
 def test_make_image_too_large_message_explains_allocation_limit(
     set_allocation_limit: Callable[[int], None],
 ) -> None:
-    image_data = _make_png_bytes(width=800, height=600)
+    image_data = _make_png_bytes(
+        width=800, height=600, image_format=QtGui.QImage.Format.Format_RGB32
+    )
     set_allocation_limit(1)
     assert QtGui.QImage.fromData(image_data).isNull()
 
@@ -200,7 +202,9 @@ def test_make_image_too_large_message_rounds_the_need_up(
     # 800x680 at 4 bytes/pixel needs ~2.1 MB: over a 2 MB limit, but plain
     # round() would render the contradictory "needs about 2 MB, but the
     # decode limit is 2 MB".
-    image_data = _make_png_bytes(width=800, height=680)
+    image_data = _make_png_bytes(
+        width=800, height=680, image_format=QtGui.QImage.Format.Format_RGB32
+    )
     set_allocation_limit(2)
     assert QtGui.QImage.fromData(image_data).isNull()
 
@@ -222,7 +226,9 @@ def test_make_image_too_large_message_is_none_within_allocation_limit(
 ) -> None:
     assert (
         _app._make_image_too_large_message(
-            image_data=_make_png_bytes(width=8, height=8)
+            image_data=_make_png_bytes(
+                width=8, height=8, image_format=QtGui.QImage.Format.Format_RGB32
+            )
         )
         is None
     )

--- a/tests/unit/_automation/_ai_assist_test.py
+++ b/tests/unit/_automation/_ai_assist_test.py
@@ -40,8 +40,8 @@ def install_fake_osam_session(
 def _propose(
     session: AiAssistSession,
     *,
-    prompt_kind: _ai_assist.AiPromptKind = "points",
-    existing_shapes: list[Shape] | None = None,
+    prompt_kind: _ai_assist.AiPromptKind,
+    existing_shapes: list[Shape] | None,
 ) -> AiAssistProposal:
     if prompt_kind == "box":
         points = np.zeros((2, 2))
@@ -78,7 +78,7 @@ def test_point_prompt_uses_best_answer_and_reuses_session(
     created_model_names = install_fake_osam_session(response)
     session = AiAssistSession(model_name="a", output_format="rectangle")
 
-    proposal = _propose(session)
+    proposal = _propose(session, prompt_kind="points", existing_shapes=None)
 
     assert len(proposal.new_shapes) == 1
     assert proposal.new_shapes[0].shape_type == "rectangle"
@@ -87,11 +87,11 @@ def test_point_prompt_uses_best_answer_and_reuses_session(
         [[0, 0], [10, 10]],
     )
 
-    _propose(session)
+    _propose(session, prompt_kind="points", existing_shapes=None)
     assert created_model_names == ["a"]
 
     session.model_name = "b"
-    _propose(session)
+    _propose(session, prompt_kind="points", existing_shapes=None)
     assert created_model_names == ["a", "b"]
 
 
@@ -119,9 +119,13 @@ def test_polygon_detail_controls_ai_polygon_points(
     install_fake_osam_session(response)
     session = AiAssistSession(polygon_detail=100)
 
-    maximum_detail = _propose(session).new_shapes
+    maximum_detail = _propose(
+        session, prompt_kind="points", existing_shapes=None
+    ).new_shapes
     session.polygon_detail = 80
-    balanced_detail = _propose(session).new_shapes
+    balanced_detail = _propose(
+        session, prompt_kind="points", existing_shapes=None
+    ).new_shapes
 
     assert len(maximum_detail[0].points) == 8
     assert len(balanced_detail[0].points) == 4
@@ -139,7 +143,9 @@ def test_polygon_proposal_groups_disconnected_lands(
     )
     install_fake_osam_session(response)
 
-    shapes = _propose(AiAssistSession()).new_shapes
+    shapes = _propose(
+        AiAssistSession(), prompt_kind="points", existing_shapes=None
+    ).new_shapes
 
     assert len(shapes) == 2
     assert shapes[0].group_id == shapes[1].group_id
@@ -153,7 +159,7 @@ def test_sam3_point_prompt_is_rejected_before_session_creation(
     session = AiAssistSession(model_name="sam3:latest")
 
     with pytest.raises(ValueError, match="does not support point prompts"):
-        _propose(session)
+        _propose(session, prompt_kind="points", existing_shapes=None)
 
     assert created_model_names == []
 
@@ -165,7 +171,7 @@ def test_sam3_box_prompt_reaches_session(
     created_model_names = install_fake_osam_session(response)
     session = AiAssistSession(model_name="sam3:latest")
 
-    proposal = _propose(session, prompt_kind="box")
+    proposal = _propose(session, prompt_kind="box", existing_shapes=None)
 
     assert proposal.new_shapes == []
     assert proposal.matching_existing_shapes == []
@@ -175,8 +181,8 @@ def test_sam3_box_prompt_reaches_session(
 def _annotation(
     score: float | None,
     *,
-    bbox: tuple[int, int, int, int] | None = None,
-    mask: NDArray[np.bool_] | None = None,
+    bbox: tuple[int, int, int, int] | None,
+    mask: NDArray[np.bool_] | None,
 ) -> osam.types.Annotation:
     bounding_box = (
         osam.types.BoundingBox(xmin=bbox[0], ymin=bbox[1], xmax=bbox[2], ymax=bbox[3])
@@ -201,9 +207,9 @@ def test_detections_from_annotations_empty_returns_empty() -> None:
 def test_detections_from_annotations_sorts_by_score_descending() -> None:
     detections = _detections_from_annotations(
         [
-            _annotation(score=0.2, bbox=(0, 0, 1, 1)),
-            _annotation(score=0.9, bbox=(2, 2, 3, 3)),
-            _annotation(score=0.5, bbox=(4, 4, 5, 5)),
+            _annotation(score=0.2, bbox=(0, 0, 1, 1), mask=None),
+            _annotation(score=0.9, bbox=(2, 2, 3, 3), mask=None),
+            _annotation(score=0.5, bbox=(4, 4, 5, 5), mask=None),
         ]
     )
 
@@ -217,8 +223,8 @@ def test_detections_from_annotations_sorts_by_score_descending() -> None:
 def test_detections_from_annotations_treats_missing_score_as_zero() -> None:
     detections = _detections_from_annotations(
         [
-            _annotation(score=None, bbox=(0, 0, 1, 1)),
-            _annotation(score=0.5, bbox=(2, 2, 3, 3)),
+            _annotation(score=None, bbox=(0, 0, 1, 1), mask=None),
+            _annotation(score=0.5, bbox=(2, 2, 3, 3), mask=None),
         ]
     )
 
@@ -230,14 +236,16 @@ def test_detections_from_annotations_treats_missing_score_as_zero() -> None:
 
 def test_detections_from_annotations_flattens_bounding_box() -> None:
     (detection,) = _detections_from_annotations(
-        [_annotation(score=0.5, bbox=(1, 2, 3, 4))]
+        [_annotation(score=0.5, bbox=(1, 2, 3, 4), mask=None)]
     )
 
     assert detection.bbox == (1, 2, 3, 4)
 
 
 def test_detections_from_annotations_keeps_bbox_none_without_bounding_box() -> None:
-    (detection,) = _detections_from_annotations([_annotation(score=0.5)])
+    (detection,) = _detections_from_annotations(
+        [_annotation(score=0.5, bbox=None, mask=None)]
+    )
 
     assert detection.bbox is None
     assert detection.mask is None
@@ -273,8 +281,8 @@ def test_point_prompt_reports_best_matching_existing_shape(
     response = osam.types.GenerateResponse(
         model="stub",
         annotations=[
-            _annotation(score=0.9, bbox=(20, 20, 30, 30)),
-            _annotation(score=0.8, bbox=(0, 0, 10, 10)),
+            _annotation(score=0.9, bbox=(20, 20, 30, 30), mask=None),
+            _annotation(score=0.8, bbox=(0, 0, 10, 10), mask=None),
         ],
     )
     install_fake_osam_session(response)
@@ -317,7 +325,7 @@ def test_point_prompt_reports_matching_existing_shape(
 ) -> None:
     response = osam.types.GenerateResponse(
         model="stub",
-        annotations=[_annotation(score=0.9, bbox=proposal_bbox)],
+        annotations=[_annotation(score=0.9, bbox=proposal_bbox, mask=None)],
     )
     install_fake_osam_session(response)
     existing = Shape(
@@ -326,7 +334,7 @@ def test_point_prompt_reports_matching_existing_shape(
     )
     session = AiAssistSession(output_format="rectangle")
 
-    proposal = _propose(session, existing_shapes=[existing])
+    proposal = _propose(session, existing_shapes=[existing], prompt_kind="points")
 
     assert proposal.new_shapes == []
     assert len(proposal.matching_existing_shapes) == 1
@@ -340,8 +348,8 @@ def test_sweep_suppresses_only_proposals_matching_existing_shapes(
     response = osam.types.GenerateResponse(
         model="stub",
         annotations=[
-            _annotation(score=0.9, bbox=(0, 0, 10, 10)),
-            _annotation(score=0.8, bbox=(20, 20, 30, 30)),
+            _annotation(score=0.9, bbox=(0, 0, 10, 10), mask=None),
+            _annotation(score=0.8, bbox=(20, 20, 30, 30), mask=None),
         ],
     )
     install_fake_osam_session(response)
@@ -368,7 +376,7 @@ def test_single_result_sweep_reports_matching_existing_shape(
 ) -> None:
     response = osam.types.GenerateResponse(
         model="stub",
-        annotations=[_annotation(score=0.9, bbox=(0, 0, 10, 10))],
+        annotations=[_annotation(score=0.9, bbox=(0, 0, 10, 10), mask=None)],
     )
     install_fake_osam_session(response)
     session = AiAssistSession(model_name="sam3:latest", output_format="rectangle")
@@ -391,8 +399,8 @@ def make_duplicate_sweep_session(
     response = osam.types.GenerateResponse(
         model="stub",
         annotations=[
-            _annotation(score=0.9, bbox=(0, 0, 10, 10)),
-            _annotation(score=0.8, bbox=(0, 0, 10, 10)),
+            _annotation(score=0.9, bbox=(0, 0, 10, 10), mask=None),
+            _annotation(score=0.8, bbox=(0, 0, 10, 10), mask=None),
         ],
     )
     install_fake_osam_session(response)
@@ -417,7 +425,9 @@ def test_sweep_matches_existing_shape_after_greedy_suppression(
 def test_sweep_still_applies_greedy_suppression_among_new_detections(
     duplicate_sweep_session: AiAssistSession,
 ) -> None:
-    proposal = _propose(duplicate_sweep_session, prompt_kind="box")
+    proposal = _propose(
+        duplicate_sweep_session, prompt_kind="box", existing_shapes=None
+    )
 
     assert len(proposal.new_shapes) == 1
     np.testing.assert_array_equal(

--- a/tests/unit/read_image_file_test.py
+++ b/tests/unit/read_image_file_test.py
@@ -11,18 +11,16 @@ import tifffile
 from labelme._label_file import read_image_file
 
 
-def _make_image(
-    tmp_path: Path, filename: str, mode: str = "RGB", size: tuple[int, int] = (100, 100)
-) -> Path:
+def _make_image(tmp_path: Path, filename: str, mode: str) -> Path:
     channels = 4 if mode == "RGBA" else 3
-    arr = np.random.randint(0, 255, (size[1], size[0], channels), dtype=np.uint8)
+    arr = np.random.randint(0, 255, (100, 100, channels), dtype=np.uint8)
     path = tmp_path / filename
     PIL.Image.fromarray(arr, mode=mode).save(str(path))
     return path
 
 
 def test_tiff_without_alpha_encoded_as_jpeg(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.tiff")
+    path = _make_image(tmp_path, "test.tiff", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data[:2] == b"\xff\xd8"
 
@@ -42,13 +40,13 @@ def test_corrupt_tiff_raises_os_error(tmp_path: Path) -> None:
 
 
 def test_jpeg_returns_raw_bytes(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.jpg")
+    path = _make_image(tmp_path, "test.jpg", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 
 
 def test_png_returns_raw_bytes(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.png")
+    path = _make_image(tmp_path, "test.png", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 

--- a/tests/unit/widgets/_ai_assisted_annotation_widget_test.py
+++ b/tests/unit/widgets/_ai_assisted_annotation_widget_test.py
@@ -22,7 +22,7 @@ def _make_widget(
     models: list[str],
     formats: list[AiOutputFormat],
     default_model: str,
-    details: list[int] | None = None,
+    details: list[int] | None,
 ) -> AiAssistedAnnotationWidget:
     widget = AiAssistedAnnotationWidget(
         default_model=default_model,
@@ -43,6 +43,7 @@ def test_construction_exposes_default_without_firing_callbacks(
         models=models,
         formats=formats,
         default_model="Sam2 (balanced)",
+        details=None,
     )
     assert widget.current_model_id == "sam2:latest"
     assert widget.output_format == "polygon"
@@ -58,6 +59,7 @@ def test_first_listed_default_resolves(
         models=models,
         formats=formats,
         default_model="EfficientSam (speed)",
+        details=None,
     )
     assert widget.current_model_id == "efficientsam:10m"
 
@@ -70,6 +72,7 @@ def test_unknown_default_falls_back_to_first_model(
         models=models,
         formats=formats,
         default_model="does-not-exist",
+        details=None,
     )
     assert widget.current_model_id == "efficientsam:10m"
 
@@ -82,6 +85,7 @@ def test_selecting_another_model_fires_callback(
         models=models,
         formats=formats,
         default_model="EfficientSam (speed)",
+        details=None,
     )
     widget._model_combo.setCurrentIndex(widget._model_combo.findData("sam2:latest"))
     assert models == ["sam2:latest"]
@@ -95,6 +99,7 @@ def test_selecting_another_output_format_fires_callback(
         models=models,
         formats=formats,
         default_model="EfficientSam (speed)",
+        details=None,
     )
     widget._output_format_combo.setCurrentIndex(
         widget._output_format_combo.findData("mask")

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -58,36 +58,30 @@ def _make_move_event(pos: QPointF) -> QtGui.QMouseEvent:
     )
 
 
-def _make_press_event(
-    pos: QPointF,
-    button: Qt.MouseButton = Qt.MouseButton.RightButton,
-) -> QtGui.QMouseEvent:
+def _make_press_event(pos: QPointF) -> QtGui.QMouseEvent:
     return QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseButtonPress,
         pos,
         pos,
-        button,
-        button,
+        Qt.MouseButton.RightButton,
+        Qt.MouseButton.RightButton,
         Qt.KeyboardModifier.NoModifier,
     )
 
 
-def _make_release_event(
-    pos: QPointF,
-    button: Qt.MouseButton = Qt.MouseButton.RightButton,
-) -> QtGui.QMouseEvent:
+def _make_release_event(pos: QPointF) -> QtGui.QMouseEvent:
     return QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseButtonRelease,
         pos,
         pos,
-        button,
+        Qt.MouseButton.RightButton,
         Qt.MouseButton.NoButton,
         Qt.KeyboardModifier.NoModifier,
     )
 
 
 def _image_to_widget(canvas: Canvas, img_x: float, img_y: float) -> QPointF:
-    origin = canvas._compute_image_origin_offset()
+    origin = canvas._compute_image_origin_offset(area=None)
     wx = (img_x + origin.x()) * canvas.scale
     wy = (img_y + origin.y()) * canvas.scale
     return QPointF(wx, wy)

--- a/tests/unit/widgets/_canvas_interaction/primitives_test.py
+++ b/tests/unit/widgets/_canvas_interaction/primitives_test.py
@@ -27,7 +27,7 @@ def _point(x: float, y: float) -> np.ndarray:
     return np.array([x, y], dtype=np.float64)
 
 
-def _polygon(points: list[tuple[float, float]], *, visible: bool = True) -> Shape:
+def _polygon(points: list[tuple[float, float]], *, visible: bool) -> Shape:
     return Shape(
         shape_type="polygon",
         points=np.array(points, dtype=np.float64),
@@ -42,7 +42,7 @@ def _polygon(points: list[tuple[float, float]], *, visible: bool = True) -> Shap
 
 
 def test_hit_target_frozen() -> None:
-    shape = _polygon([(0, 0), (10, 0), (10, 10)])
+    shape = _polygon([(0, 0), (10, 0), (10, 10)], visible=True)
     target = HitTarget(kind=HitKind.BODY, shape=shape, index=None)
     with pytest.raises((AttributeError, TypeError)):
         target.kind = HitKind.VERTEX  # ty: ignore[invalid-assignment]
@@ -84,7 +84,7 @@ def test_invisible_shapes_are_excluded() -> None:
 
 
 def test_visible_shape_body_hit() -> None:
-    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
     result = find_hover_target(
         shapes=[shape],
         point=_point(25.0, 25.0),
@@ -105,7 +105,7 @@ def test_visible_shape_body_hit() -> None:
 
 def test_vertex_match_beats_body() -> None:
     # Shape with vertex at (10, 10); hover exactly on vertex -> VERTEX, not BODY.
-    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
     result = find_hover_target(
         shapes=[shape],
         point=_point(10.0, 10.0),
@@ -124,8 +124,8 @@ def test_vertex_on_last_candidate_beats_body_on_first_candidate() -> None:
     # Two shapes: first (in list order) has a body at (25, 25) and its vertex
     # far away; second (examined first in reverse order) has a vertex at (10, 10).
     # Hover at (10, 10): the VERTEX on the second (topmost) shape must win.
-    body_shape = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
-    vertex_shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    body_shape = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)], visible=True)
+    vertex_shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
     # shapes=[body_shape, vertex_shape]: reverse order tries vertex_shape first.
     result = find_hover_target(
         shapes=[body_shape, vertex_shape],
@@ -144,8 +144,8 @@ def test_category_precedence_vertex_over_body_across_shapes() -> None:
     # Shape A (listed first, lower paint order): has body at center, vertex far.
     # Shape B (listed second, higher paint order, examined first): vertex at (10,10).
     # Hover at (10,10): vertex category dominates even though shape A is "first".
-    big = _polygon([(0, 0), (200, 0), (200, 200), (0, 200)])
-    small = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    big = _polygon([(0, 0), (200, 0), (200, 200), (0, 200)], visible=True)
+    small = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
     result = find_hover_target(
         shapes=[big, small],
         point=_point(10.0, 10.0),
@@ -166,7 +166,7 @@ def test_category_precedence_vertex_over_body_across_shapes() -> None:
 
 def test_edge_hit_on_polygon() -> None:
     # polygon: midpoint of top edge (10,10)-(90,10) is (50,10).
-    shape = _polygon([(10, 10), (90, 10), (90, 50), (10, 50)])
+    shape = _polygon([(10, 10), (90, 10), (90, 50), (10, 50)], visible=True)
     result = find_hover_target(
         shapes=[shape],
         point=_point(50.0, 10.0),
@@ -217,8 +217,8 @@ def test_priority_shape_is_checked_first() -> None:
     # The other shape also has vertex at (10,10).
     # Without priority, reverse order tries shape_b first (it is last in list).
     # With priority=shape_a, shape_a is tried first.
-    shape_a = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
-    shape_b = _polygon([(10, 10), (80, 10), (80, 80), (10, 80)])
+    shape_a = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
+    shape_b = _polygon([(10, 10), (80, 10), (80, 80), (10, 80)], visible=True)
     result = find_hover_target(
         shapes=[shape_b, shape_a],
         point=_point(10.0, 10.0),
@@ -234,7 +234,7 @@ def test_priority_shape_is_checked_first() -> None:
 
 def test_priority_shape_not_in_shapes_is_still_checked() -> None:
     # priority_shape need not be a member of shapes.
-    orphan = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    orphan = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
     result = find_hover_target(
         shapes=[],
         point=_point(10.0, 10.0),
@@ -250,7 +250,7 @@ def test_priority_shape_not_in_shapes_is_still_checked() -> None:
 
 def test_priority_shape_not_duplicated_in_candidates() -> None:
     # priority_shape appears in shapes; it must not be examined twice.
-    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)])
+    shape = _polygon([(10, 10), (50, 10), (50, 50), (10, 50)], visible=True)
     # Only one match expected: VERTEX at index 0.
     result = find_hover_target(
         shapes=[shape],
@@ -274,8 +274,8 @@ def test_priority_shape_not_duplicated_in_candidates() -> None:
 def test_reverse_paint_order_topmost_body_wins() -> None:
     # Two overlapping body-only shapes. The second in the list (top paint layer)
     # should be returned as the body hit.
-    shape_a = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
-    shape_b = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    shape_a = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)], visible=True)
+    shape_b = _polygon([(0, 0), (100, 0), (100, 100), (0, 100)], visible=True)
     result = find_hover_target(
         shapes=[shape_a, shape_b],
         point=_point(50.0, 50.0),

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -34,7 +34,7 @@ def _unit_square_polygon() -> Shape:
     )
 
 
-def _render(shape: Shape, *, show_label: bool, scale: float = 1.0) -> QtGui.QImage:
+def _render(shape: Shape, *, show_label: bool, scale: float) -> QtGui.QImage:
     image = QtGui.QImage(_SIZE, _SIZE, QtGui.QImage.Format.Format_ARGB32)
     image.fill(QtGui.QColor(255, 255, 255))
     painter = QtGui.QPainter(image)
@@ -125,8 +125,8 @@ def test_show_labels_draws_text_above_shape(qapp: QtGui.QGuiApplication) -> None
     # The polygon top edge sits at y=50, so the label text lands above it.
     assert (
         _diff_rows(
-            _render(shape, show_label=True),
-            _render(shape, show_label=False),
+            _render(shape, show_label=True, scale=1.0),
+            _render(shape, show_label=False, scale=1.0),
             bottom=48,
         )
         > 0
@@ -139,8 +139,8 @@ def test_empty_label_draws_no_text(qapp: QtGui.QGuiApplication) -> None:
         shape = _polygon(label=label)
         assert (
             _diff_rows(
-                _render(shape, show_label=True),
-                _render(shape, show_label=False),
+                _render(shape, show_label=True, scale=1.0),
+                _render(shape, show_label=False, scale=1.0),
                 bottom=_SIZE,
             )
             == 0
@@ -158,8 +158,8 @@ def test_point_shape_label_is_drawn(qapp: QtGui.QGuiApplication) -> None:
     )
     assert (
         _diff_rows(
-            _render(shape, show_label=True),
-            _render(shape, show_label=False),
+            _render(shape, show_label=True, scale=1.0),
+            _render(shape, show_label=False, scale=1.0),
             bottom=_SIZE,
         )
         > 0
@@ -203,7 +203,7 @@ def test_mask_outline_aligns_with_fill(qapp: QtGui.QGuiApplication) -> None:
     # The mask fill is rasterized at the correct position; the contour outline
     # must be centered on that same block, not sit a pixel off from it.
     shape = _mask_shape()
-    image = _render(shape=shape, show_label=False)
+    image = _render(shape=shape, show_label=False, scale=1.0)
     outline = _outline_center(image=image)
     assert shape.mask is not None
     ys, xs = np.nonzero(shape.mask)

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -17,39 +17,20 @@ from labelme._widgets.label_dialog import LabelQLineEdit
 # internals while these tests keep pinning observable behavior.
 
 
-def _make_dialog(
-    qtbot: QtBot,
-    text: str = "Enter object label",
-    labels: list[str] | None = None,
-    sort_labels: bool = True,
-    show_text_field: bool = True,
-    completion: str = "startswith",
-    fit_to_content: dict[str, bool] | None = None,
-    flags: dict[str, list[str]] | None = None,
-) -> LabelDialog:
-    dialog = LabelDialog(
-        text=text,
-        labels=labels,
-        sort_labels=sort_labels,
-        show_text_field=show_text_field,
-        completion=completion,
-        fit_to_content=fit_to_content,
-        flags=flags,
-    )
+def _add_dialog(qtbot: QtBot, dialog: LabelDialog) -> LabelDialog:
     qtbot.addWidget(dialog)
     return dialog
 
 
 def _run_popup(
     dialog: LabelDialog,
-    accept: bool = True,
-    at_show: Callable[[LabelDialog], None] | None = None,
-    text: str | None = None,
-    move: bool = False,
-    flags: dict[str, bool] | None = None,
-    group_id: int | None = None,
-    description: str | None = None,
-    flags_disabled: bool = False,
+    accept: bool,
+    at_show: Callable[[LabelDialog], None] | None,
+    text: str | None,
+    flags: dict[str, bool] | None,
+    group_id: int | None,
+    description: str | None,
+    flags_disabled: bool,
 ) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
     code = (
         QtWidgets.QDialog.DialogCode.Accepted
@@ -65,7 +46,9 @@ def _run_popup(
     dialog.exec = fake_exec  # ty: ignore[invalid-assignment]
     return dialog.popup(
         text=text,
-        move=move,
+        # Keeping the dialog put makes the popup deterministic under a stubbed
+        # exec(), which never shows it.
+        move=False,
         flags=flags,
         group_id=group_id,
         description=description,
@@ -151,7 +134,7 @@ def test_other_keys_edit_text_not_forwarded(qtbot: QtBot) -> None:
 
 
 def test_default_widgets_exist(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     assert isinstance(dialog.edit, LabelQLineEdit)
     assert isinstance(dialog.edit_group_id, QtWidgets.QLineEdit)
     assert isinstance(dialog.edit_description, QtWidgets.QTextEdit)
@@ -159,46 +142,48 @@ def test_default_widgets_exist(qtbot: QtBot) -> None:
 
 
 def test_default_placeholder_is_non_empty(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     assert dialog.edit.placeholderText() != ""
 
 
 def test_custom_placeholder_text(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, text="Type here")
+    dialog = _add_dialog(qtbot, LabelDialog(text="Type here"))
     assert dialog.edit.placeholderText() == "Type here"
 
 
 def test_group_id_and_description_placeholders_non_empty(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     assert dialog.edit_group_id.placeholderText() != ""
     assert dialog.edit_description.placeholderText() != ""
 
 
 def test_show_text_field_true_parents_edit_to_dialog(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, show_text_field=True)
+    dialog = _add_dialog(qtbot, LabelDialog(show_text_field=True))
     assert dialog.edit.parent() is dialog
 
 
 def test_show_text_field_false_leaves_edit_parentless(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, show_text_field=False)
+    dialog = _add_dialog(qtbot, LabelDialog(show_text_field=False))
     assert dialog.edit.parent() is None
 
 
 def test_initial_labels_listed(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["banana", "apple", "cherry"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["banana", "apple", "cherry"]))
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert set(items) == {"apple", "banana", "cherry"}
 
 
 def test_sort_labels_true_sorts(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["banana", "apple", "cherry"], sort_labels=True)
+    dialog = _add_dialog(
+        qtbot, LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=True)
+    )
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items == ["apple", "banana", "cherry"]
 
 
 def test_sort_labels_false_preserves_order_and_enables_drag(qtbot: QtBot) -> None:
-    dialog = _make_dialog(
-        qtbot, labels=["banana", "apple", "cherry"], sort_labels=False
+    dialog = _add_dialog(
+        qtbot, LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=False)
     )
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items == ["banana", "apple", "cherry"]
@@ -213,7 +198,9 @@ def test_sort_labels_false_preserves_order_and_enables_drag(qtbot: QtBot) -> Non
 def test_fit_to_content_scrollbar_policies(
     qtbot: QtBot, row_off: bool, col_off: bool
 ) -> None:
-    dialog = _make_dialog(qtbot, fit_to_content={"row": row_off, "column": col_off})
+    dialog = _add_dialog(
+        qtbot, LabelDialog(fit_to_content={"row": row_off, "column": col_off})
+    )
     always_off = QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
     if row_off:
         assert dialog.label_list.horizontalScrollBarPolicy() == always_off
@@ -227,7 +214,7 @@ def test_fit_to_content_scrollbar_policies(
 
 
 def test_completion_startswith_inline(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, completion="startswith")
+    dialog = _add_dialog(qtbot, LabelDialog(completion="startswith"))
     assert (
         dialog.edit.completer().completionMode()
         == QtWidgets.QCompleter.CompletionMode.InlineCompletion
@@ -235,7 +222,7 @@ def test_completion_startswith_inline(qtbot: QtBot) -> None:
 
 
 def test_completion_contains_popup_and_matchcontains(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, completion="contains")
+    dialog = _add_dialog(qtbot, LabelDialog(completion="contains"))
     completer = dialog.edit.completer()
     assert (
         completer.completionMode()
@@ -250,7 +237,7 @@ def test_completion_invalid_raises(qtbot: QtBot) -> None:
 
 
 def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["a", "b"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["a", "b"]))
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
 
@@ -260,28 +247,30 @@ def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
 
 
 def test_add_label_history_appends_new(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=[])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=[]))
     dialog.add_label_history("dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert "dog" in items
 
 
 def test_add_label_history_no_duplicate(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["dog"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["dog"]))
     dialog.add_label_history("dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items.count("dog") == 1
 
 
 def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["banana", "apple"], sort_labels=True)
+    dialog = _add_dialog(
+        qtbot, LabelDialog(labels=["banana", "apple"], sort_labels=True)
+    )
     dialog.add_label_history("cherry")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items == ["apple", "banana", "cherry"]
 
 
 def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["a"], sort_labels=False)
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["a"], sort_labels=False))
     dialog.add_label_history("b")
     dialog.set_predefined_labels(["a", "c"])
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
@@ -290,7 +279,7 @@ def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
 
 
 def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["a"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["a"]))
     dialog.set_predefined_labels(["a", "b", "c"])
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
@@ -301,21 +290,21 @@ def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
 
 
 def test_editing_finished_strips_whitespace(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("  hello  ")
     dialog.edit.editingFinished.emit()
     assert dialog.edit.text() == "hello"
 
 
 def test_selecting_label_sets_edit_text(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["cat", "dog"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat", "dog"]))
     item = dialog.label_list.findItems("dog", QtCore.Qt.MatchFlag.MatchExactly)[0]
     dialog.label_list.setCurrentItem(item)
     assert dialog.edit.text() == "dog"
 
 
 def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["cat"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat"]))
     dialog.label_list.setCurrentItem(
         dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
     )
@@ -329,28 +318,28 @@ def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
 
 
 def test_ok_with_text_accepts(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("car")
     _ok_button(dialog).click()
     assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_ok_with_empty_text_does_not_accept(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("")
     _ok_button(dialog).click()
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_ok_with_whitespace_text_does_not_accept(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("   ")
     _ok_button(dialog).click()
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("")
     dialog.edit.setEnabled(False)
     _ok_button(dialog).click()
@@ -358,7 +347,7 @@ def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
 
 
 def test_double_click_label_accepts(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["cat"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat"]))
     item = dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
     dialog.label_list.setCurrentItem(item)  # selection sets the edit text
     dialog.label_list.itemDoubleClicked.emit(item)
@@ -371,27 +360,27 @@ def test_double_click_label_accepts(qtbot: QtBot) -> None:
 
 
 def test_flags_shown_for_matching_label(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor", "outdoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor", "outdoor"]}))
     dialog.edit.setText("cat")
     names = {cb.text() for cb in _checkboxes(dialog)}
     assert names == {"indoor", "outdoor"}
 
 
 def test_flags_absent_for_non_matching_label(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor"]}))
     dialog.edit.setText("dog")
     assert _checkboxes(dialog) == []
 
 
 def test_flags_shown_for_prefix_match(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, flags={"car": ["fast"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"car": ["fast"]}))
     dialog.edit.setText("car_red")
     names = {cb.text() for cb in _checkboxes(dialog)}
     assert names == {"fast"}
 
 
 def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor"]}))
     dialog.edit.setText("cat")
     box = next(cb for cb in _checkboxes(dialog) if cb.text() == "indoor")
     box.setChecked(True)
@@ -401,7 +390,7 @@ def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
 
 
 def test_flag_checked_state_preserved_across_non_matching_text(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot=qtbot, flags={"^cat": ["indoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor"]}))
     dialog.edit.setText("cat")
     _checkbox(dialog=dialog, name="indoor").setChecked(True)
     dialog.edit.setText("c")  # typing over a selected label dips through "c"
@@ -411,9 +400,8 @@ def test_flag_checked_state_preserved_across_non_matching_text(qtbot: QtBot) -> 
 
 
 def test_flag_checked_state_shared_across_labels(qtbot: QtBot) -> None:
-    dialog = _make_dialog(
-        qtbot=qtbot,
-        flags={"^cat$": ["indoor"], "^dog$": ["indoor"]},
+    dialog = _add_dialog(
+        qtbot, LabelDialog(flags={"^cat$": ["indoor"], "^dog$": ["indoor"]})
     )
     dialog.edit.setText("cat")
     _checkbox(dialog=dialog, name="indoor").setChecked(True)
@@ -422,7 +410,7 @@ def test_flag_checked_state_shared_across_labels(qtbot: QtBot) -> None:
 
 
 def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot=qtbot, flags={".*": ["occluded"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={".*": ["occluded"]}))
     dialog.edit.setText("cat")
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -434,9 +422,8 @@ def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(qtbot: QtBot) -> 
 
 
 def test_flag_named_by_two_matching_patterns_shown_once(qtbot: QtBot) -> None:
-    dialog = _make_dialog(
-        qtbot=qtbot,
-        flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]},
+    dialog = _add_dialog(
+        qtbot, LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]})
     )
     dialog.edit.setText("cat")
     assert [cb.text() for cb in _checkboxes(dialog)] == ["occluded", "urgent"]
@@ -445,9 +432,8 @@ def test_flag_named_by_two_matching_patterns_shown_once(qtbot: QtBot) -> None:
 def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
     qtbot: QtBot,
 ) -> None:
-    dialog = _make_dialog(
-        qtbot=qtbot,
-        flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]},
+    dialog = _add_dialog(
+        qtbot, LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]})
     )
 
     _, flags, _, _ = _run_popup(
@@ -455,6 +441,10 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
         accept=True,
         text="cat",
         at_show=lambda d: _checkbox(dialog=d, name="occluded").setChecked(True),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert flags == {"occluded": True, "urgent": False}
 
@@ -465,9 +455,16 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
 
 
 def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, labels=["cat"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat"]))
     text, flags, group_id, description = _run_popup(
-        dialog, accept=True, text="cat", group_id=3, description="a pet"
+        dialog,
+        accept=True,
+        text="cat",
+        group_id=3,
+        description="a pet",
+        at_show=None,
+        flags=None,
+        flags_disabled=False,
     )
     assert text == "cat"
     assert group_id == 3
@@ -476,81 +473,120 @@ def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
 
 
 def test_popup_preserves_html_like_description(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     _, _, _, description = _run_popup(
-        dialog, accept=True, text="cat", description="<b>bold</b>"
+        dialog,
+        accept=True,
+        text="cat",
+        description="<b>bold</b>",
+        at_show=None,
+        flags=None,
+        group_id=None,
+        flags_disabled=False,
     )
     assert description == "<b>bold</b>"
 
 
 def test_popup_returns_all_none_on_reject(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
-    result = _run_popup(dialog, accept=False, text="cat")
+    dialog = _add_dialog(qtbot, LabelDialog())
+    result = _run_popup(
+        dialog,
+        accept=False,
+        text="cat",
+        at_show=None,
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
+    )
     assert result == (None, None, None, None)
 
 
 def test_popup_group_id_none_yields_empty_then_none(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     _, _, group_id, _ = _run_popup(
         dialog,
         accept=True,
         text="x",
         group_id=None,
         at_show=lambda d: seen.update(gid=d.edit_group_id.text()),
+        flags=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["gid"] == ""
     assert group_id is None
 
 
 def test_popup_group_id_zero_is_preserved(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot)
-    _, _, group_id, _ = _run_popup(dialog, accept=True, text="x", group_id=0)
+    dialog = _add_dialog(qtbot, LabelDialog())
+    _, _, group_id, _ = _run_popup(
+        dialog,
+        accept=True,
+        text="x",
+        group_id=0,
+        at_show=None,
+        flags=None,
+        description=None,
+        flags_disabled=False,
+    )
     assert group_id == 0
 
 
 def test_popup_sets_group_id_text_at_show(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     _run_popup(
         dialog,
         accept=True,
         text="x",
         group_id=7,
         at_show=lambda d: seen.update(gid=d.edit_group_id.text()),
+        flags=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["gid"] == "7"
 
 
 def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("preexisting")
     _run_popup(
         dialog,
         accept=True,
         text=None,
         at_show=lambda d: seen.update(t=d.edit.text()),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["t"] == "preexisting"
 
 
 def test_popup_text_none_selects_existing_edit_text(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     dialog.edit.setText("preexisting")
     _run_popup(
         dialog,
         accept=True,
         text=None,
         at_show=lambda d: seen.update(sel=d.edit.selectedText()),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["sel"] == "preexisting"
 
 
 def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
-    dialog = _make_dialog(qtbot, labels=["cat", "dog"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat", "dog"]))
     _run_popup(
         dialog,
         accept=True,
@@ -560,13 +596,17 @@ def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
             if d.label_list.currentItem()
             else None
         ),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["cur"] == "dog"
 
 
 def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
-    dialog = _make_dialog(qtbot, labels=["Cat", "Dog"])
+    dialog = _add_dialog(qtbot, LabelDialog(labels=["Cat", "Dog"]))
     _run_popup(
         dialog,
         accept=True,
@@ -576,26 +616,33 @@ def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> Non
             if d.label_list.currentItem()
             else None
         ),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["cur"] == "Cat"
 
 
 def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _make_dialog(qtbot)
+    dialog = _add_dialog(qtbot, LabelDialog())
     _run_popup(
         dialog,
         accept=True,
         text="x",
         description="hello world",
         at_show=lambda d: seen.update(desc=d.edit_description.toPlainText()),
+        flags=None,
+        group_id=None,
+        flags_disabled=False,
     )
     assert seen["desc"] == "hello world"
 
 
 def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
-    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor", "outdoor"]}))
     _run_popup(
         dialog,
         accept=True,
@@ -605,6 +652,8 @@ def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
         at_show=lambda d: seen.update(
             enabled=[cb.isEnabled() for cb in _checkboxes(d)]
         ),
+        group_id=None,
+        description=None,
     )
     assert seen["enabled"]
     assert not any(seen["enabled"])
@@ -612,7 +661,7 @@ def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
 
 def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
-    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor", "outdoor"]}))
     _run_popup(
         dialog,
         accept=True,
@@ -620,14 +669,27 @@ def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
         at_show=lambda d: seen.update(
             enabled=[cb.isEnabled() for cb in _checkboxes(d)]
         ),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["enabled"]
     assert all(seen["enabled"])
 
 
 def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
-    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor"]})
-    _run_popup(dialog, accept=True, text="cat", flags_disabled=True)
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor"]}))
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        flags_disabled=True,
+        at_show=None,
+        flags=None,
+        group_id=None,
+        description=None,
+    )
 
     seen: dict[str, list[bool]] = {}
     _run_popup(
@@ -637,6 +699,10 @@ def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
         at_show=lambda d: seen.update(
             enabled=[cb.isEnabled() for cb in _checkboxes(d)]
         ),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["enabled"]
     assert all(seen["enabled"])
@@ -646,18 +712,26 @@ def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
     qtbot: QtBot,
 ) -> None:
     seen: dict[str, bool] = {}
-    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor"]}))
     _run_popup(
         dialog,
         accept=True,
         text="cat",
         at_show=lambda d: _checkbox(d, "indoor").setChecked(True),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     _run_popup(
         dialog,
         accept=True,
         text="cat",
         at_show=lambda d: seen.update(checked=_checkbox(d, "indoor").isChecked()),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["checked"] is False
 
@@ -666,13 +740,26 @@ def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
     qtbot: QtBot,
 ) -> None:
     seen: dict[str, bool] = {}
-    dialog = _make_dialog(qtbot, flags={"^cat$": ["indoor"]})
-    _run_popup(dialog, accept=True, text="cat", flags={"indoor": True})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor"]}))
+    _run_popup(
+        dialog,
+        accept=True,
+        text="cat",
+        flags={"indoor": True},
+        at_show=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
+    )
     _run_popup(
         dialog,
         accept=True,
         text="cat",
         at_show=lambda d: seen.update(checked=_checkbox(d, "indoor").isChecked()),
+        flags=None,
+        group_id=None,
+        description=None,
+        flags_disabled=False,
     )
     assert seen["checked"] is False
 
@@ -684,13 +771,16 @@ def test_flags_disabled_survives_text_edit_rebuild(qtbot: QtBot) -> None:
         d.edit.setText("cattle")
         seen.update(enabled=[cb.isEnabled() for cb in _checkboxes(d)])
 
-    dialog = _make_dialog(qtbot, flags={"^cat": ["indoor", "outdoor"]})
+    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor", "outdoor"]}))
     _run_popup(
         dialog,
         accept=True,
         text="cat",
         flags_disabled=True,
         at_show=edit_then_inspect,
+        flags=None,
+        group_id=None,
+        description=None,
     )
     assert seen["enabled"]
     assert not any(seen["enabled"])

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -41,8 +41,8 @@ def _make_dialog(
     qtbot: QtBot,
     applied: Applied,
     overrides: dict,
-    succeed: bool = True,
-    previewed: Previewed | None = None,
+    succeed: bool,
+    previewed: Previewed | None,
 ) -> SettingsDialog:
     config = load_config(config_file=None, config_overrides=overrides)
 
@@ -66,7 +66,9 @@ def _make_dialog(
 
 @pytest.fixture
 def dialog(qtbot: QtBot, applied: Applied) -> SettingsDialog:
-    return _make_dialog(qtbot=qtbot, applied=applied, overrides={})
+    return _make_dialog(
+        qtbot=qtbot, applied=applied, overrides={}, succeed=True, previewed=None
+    )
 
 
 def test_no_apply_on_construction(dialog: SettingsDialog, applied: Applied) -> None:
@@ -101,6 +103,8 @@ def test_unbounded_integer_edit_accepts_python_ints(
         qtbot=qtbot,
         applied=applied,
         overrides={"shape_color": {"auto": {"shift": initial}}},
+        succeed=True,
+        previewed=None,
     )
     edit = dialog._editors[("shape_color", "auto", "shift")]
     assert isinstance(edit, QtWidgets.QLineEdit)
@@ -180,6 +184,7 @@ def test_shape_color_picker_applies_rgb(
         applied=applied,
         overrides={"shape_color": {"mode": "uniform"}},
         previewed=previewed,
+        succeed=True,
     )
     swatch = dialog._editors[("shape_color", "uniform", "color")]
     assert isinstance(swatch, _ColorSwatchButton)
@@ -285,7 +290,13 @@ def test_language_applies_discovered_locale(
 def test_language_unknown_code_falls_back_to_system(
     qtbot: QtBot, applied: Applied
 ) -> None:
-    dialog = _make_dialog(qtbot=qtbot, applied=applied, overrides={"language": "xx_ZZ"})
+    dialog = _make_dialog(
+        qtbot=qtbot,
+        applied=applied,
+        overrides={"language": "xx_ZZ"},
+        succeed=True,
+        previewed=None,
+    )
     combo = dialog._editors[("language",)]
     assert isinstance(combo, QtWidgets.QComboBox)
     assert combo.currentData() is None
@@ -299,6 +310,8 @@ def test_clearing_labels_is_rejected_when_validate_label_is_exact(
         qtbot=qtbot,
         applied=applied,
         overrides={"labels": ["cat"], "validate_label": "exact"},
+        succeed=True,
+        previewed=None,
     )
     warned: list[str] = []
     monkeypatch.setattr(
@@ -338,6 +351,7 @@ def test_failed_apply_reverts_checkbox(qtbot: QtBot, applied: Applied) -> None:
         applied=applied,
         overrides={"display_label_popup": True},
         succeed=False,
+        previewed=None,
     )
     checkbox = dialog._editors[("display_label_popup",)]
     assert isinstance(checkbox, QtWidgets.QCheckBox)
@@ -350,7 +364,11 @@ def test_failed_apply_reverts_checkbox(qtbot: QtBot, applied: Applied) -> None:
 
 def test_failed_apply_reverts_labels_editor(qtbot: QtBot, applied: Applied) -> None:
     dialog = _make_dialog(
-        qtbot=qtbot, applied=applied, overrides={"labels": ["cat"]}, succeed=False
+        qtbot=qtbot,
+        applied=applied,
+        overrides={"labels": ["cat"]},
+        succeed=False,
+        previewed=None,
     )
     edit = dialog._editors[("labels",)]
     assert isinstance(edit, _PlainTextEdit)
@@ -400,7 +418,9 @@ def test_navigation_elides_long_localized_names_without_squeezing_content(
     assert translator.load(str(translation_path))
     qapp.installTranslator(translator)
     try:
-        dialog = _make_dialog(qtbot=qtbot, applied=applied, overrides={})
+        dialog = _make_dialog(
+            qtbot=qtbot, applied=applied, overrides={}, succeed=True, previewed=None
+        )
         navigation = dialog._page._navigation
         long_title = "Продолжение работы между изображениями"
 
@@ -569,7 +589,9 @@ def test_large_font_uses_default_size_with_scrolling(
     large_font.setPointSize(24)
     QtWidgets.QApplication.setFont(large_font)
     try:
-        dialog = _make_dialog(qtbot=qtbot, applied=applied, overrides={})
+        dialog = _make_dialog(
+            qtbot=qtbot, applied=applied, overrides={}, succeed=True, previewed=None
+        )
         with qtbot.waitExposed(dialog):
             dialog.show()
 


### PR DESCRIPTION
Adopts gruff GR002: non-public callables lose parameter defaults — 10 parameters deleted outright (no caller varied them), 42 made required with call sites stating their values, zero suppressions.

Three non-obvious bits:

1. Five deleted parameters existed only to swallow a Qt signal argument no body used. PySide6 truncates extra signal arguments for callables with fewer parameters (verified empirically, and the codebase already relies on this for zero-arg lambdas on `triggered`); e2e passes.

2. `_make_dialog` in the label-dialog tests was a seven-parameter verbatim mirror of `LabelDialog.__init__` forwarded 1:1 across 52 call sites; it collapsed to `_add_dialog(qtbot, dialog)` with call sites constructing the dialog directly.

3. `_run_popup`'s deleted `move` parameter was silently overriding `popup()`'s own default (`False` vs `True`); the pinned value now carries a comment saying so.

Full e2e suite run in addition to unit tests since most touched signatures are Qt slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>