### PR TITLE
style: adopt gruff GR001 (explicit-non-public-input-conventions)

### DIFF
--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -44,7 +44,7 @@ class _LoggerIO(io.StringIO):
         return False
 
 
-def _setup_loguru(logger_level: str) -> None:
+def _setup_loguru(*, logger_level: str) -> None:
     logger.remove()
 
     if sys.stderr:
@@ -129,6 +129,7 @@ def _handle_exception(
     exc_type: type[BaseException],
     exc_value: BaseException,
     exc_traceback: types.TracebackType | None,
+    /,
 ) -> None:
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
@@ -176,7 +177,7 @@ class _DeprecatedAlias(argparse.Action):
         setattr(namespace, self.dest, self.const if self.nargs == 0 else values)
 
 
-def _parse_list_arg(value: str) -> list[str]:
+def _parse_list_arg(value: str, /) -> list[str]:
     if os.path.isfile(value):
         with open(value, encoding="utf-8") as f:
             return [line.strip() for line in f if line.strip()]
@@ -184,7 +185,7 @@ def _parse_list_arg(value: str) -> list[str]:
 
 
 def _resolve_config_source(
-    config_arg: str | None, default_config_file: str
+    *, config_arg: str | None, default_config_file: str
 ) -> tuple[Path | None, dict]:
     if config_arg is None:
         # A missing file is fatal only when the user asked for that file: the

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1241,7 +1241,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def _load_config(
-        self, config_file: Path | None, config_overrides: dict | None
+        self, *, config_file: Path | None, config_overrides: dict | None
     ) -> tuple[Path | None, dict]:
         try:
             config = _config.load_config(
@@ -1355,7 +1355,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def show_status_message(self, message: str, delay: int = 500) -> None:
         self.statusBar().showMessage(message, delay)
 
-    def _submit_ai_prompt(self, _: bool) -> None:
+    def _submit_ai_prompt(self, _: bool, /) -> None:
         create_mode = self._canvas_widgets.canvas.create_mode
         shape_type = _resolve_text_annotation_shape_type(
             create_mode=create_mode,
@@ -1387,7 +1387,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         except Exception as e:
             logger.opt(exception=e).error("AI text inference failed")
-            self._on_inference_failed(message=f"{type(e).__name__}: {e}")
+            self._on_inference_failed(f"{type(e).__name__}: {e}")
             return
 
         if (
@@ -1499,7 +1499,7 @@ class MainWindow(QtWidgets.QMainWindow):
         url = "https://github.com/labelmeai/labelme/tree/main/examples/tutorial"  # NOQA
         webbrowser.open(url)
 
-    def _on_drawing_polygon_changed(self, drawing: bool) -> None:
+    def _on_drawing_polygon_changed(self, drawing: bool, /) -> None:
         # In the middle of drawing, toggling between modes should be disabled.
         self._actions.edit_mode.setEnabled(not drawing)
         self._actions.undo_last_point.setEnabled(drawing)
@@ -1508,7 +1508,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self._actions.delete.setEnabled(not drawing)
 
-    def _switch_canvas_mode(self, edit: bool, create_mode: str | None) -> None:
+    def _switch_canvas_mode(self, *, edit: bool, create_mode: str | None) -> None:
         self._canvas_widgets.canvas.set_editing(edit)
         if create_mode is not None:
             self._canvas_widgets.canvas.create_mode = create_mode
@@ -1531,7 +1531,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._ai_annotation.setEnabled(not edit and create_mode in _AI_CREATE_MODES)
         self._set_point_prompt_mode(enabled=create_mode == "ai_points_to_shape")
 
-    def _highlight_ai_buttons(self, highlight: bool) -> None:
+    def _highlight_ai_buttons(self, highlight: bool, /) -> None:
         self._ai_buttons_highlighted = highlight
         BG_ALPHA: Final = 60
         BORDER_ALPHA: Final = 120
@@ -1685,6 +1685,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self,
         current_item: QtWidgets.QListWidgetItem | None,
         previous_item: QtWidgets.QListWidgetItem | None,
+        /,
     ) -> None:
         if current_item is None:
             return
@@ -1696,7 +1697,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._restore_file_list_state(item=previous_item)
 
     # React to canvas signals.
-    def _on_shape_selection_changed(self, selected_shapes: list[Shape]) -> None:
+    def _on_shape_selection_changed(self, selected_shapes: list[Shape], /) -> None:
         self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
         )
@@ -1742,6 +1743,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _get_rgb_by_label(
         self,
+        *,
         label: str,
         unique_label_list: UniqueLabelQListWidget,
     ) -> tuple[int, int, int]:
@@ -1767,7 +1769,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._docks.label_list.remove_item(item)
         self._docks.label_list.item_dropped.connect(self._on_label_order_changed)
 
-    def _load_shapes(self, shapes: list[Shape], replace: bool) -> None:
+    def _load_shapes(self, shapes: list[Shape], /, *, replace: bool) -> None:
         self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
         )
@@ -1782,6 +1784,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _load_flags(
         self,
+        *,
         flags: dict[str, bool],
         widget: QtWidgets.QListWidget,
     ) -> None:
@@ -1841,10 +1844,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 )
             return False
 
-    def _insert_shapes(self, shapes: list[Shape]) -> None:
+    def _insert_shapes(self, shapes: list[Shape], /) -> None:
         if not shapes:
             return
-        self._load_shapes(shapes=shapes, replace=False)
+        self._load_shapes(shapes, replace=False)
         self._canvas_widgets.canvas.select_shapes(shapes)
         self.mark_dirty()
 
@@ -1860,7 +1863,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if self._canvas_widgets.canvas.deselect_shape():
                 self._canvas_widgets.canvas.update()
 
-    def _on_label_item_changed(self, item: LabelListWidgetItem) -> None:
+    def _on_label_item_changed(self, item: LabelListWidgetItem, /) -> None:
         is_visible_new = item.checkState() == Qt.CheckState.Checked
 
         selected_group = (
@@ -1948,10 +1951,10 @@ class MainWindow(QtWidgets.QMainWindow):
             self.tr("AI inference produced no new annotation."), 5000
         )
 
-    def _on_inference_failed(self, message: str) -> None:
+    def _on_inference_failed(self, message: str, /) -> None:
         self.show_status_message(self.tr("AI inference failed: %s") % message, 10000)
 
-    def _on_point_prompt_rejected(self, model_name: str) -> None:
+    def _on_point_prompt_rejected(self, model_name: str, /) -> None:
         option = _ai_models.find_ai_assist_model_option(model_name=model_name)
         assert option is not None
         QtWidgets.QMessageBox.warning(
@@ -1964,19 +1967,19 @@ class MainWindow(QtWidgets.QMainWindow):
             % option.display_name,
         )
 
-    def _on_scroll_request(self, delta: int, orientation: Qt.Orientation) -> None:
+    def _on_scroll_request(self, delta: int, orientation: Qt.Orientation, /) -> None:
         units = -delta * 0.1  # natural scroll
         bar = self._canvas_widgets.scroll_bars[orientation]
         value = bar.value() + bar.singleStep() * units
         self.set_scroll_value(orientation, value)
 
-    def _on_pan_request(self, step: QtCore.QPoint) -> None:
+    def _on_pan_request(self, step: QtCore.QPoint, /) -> None:
         # Pan moves the viewport opposite to the cursor delta so the image
         # tracks the grabbed point one-for-one in widget pixels.
         self._move_canvas_view(step=QtCore.QPointF(step), constrain_to_center=True)
 
     def _move_canvas_view(
-        self, step: QtCore.QPointF, *, constrain_to_center: bool
+        self, *, step: QtCore.QPointF, constrain_to_center: bool
     ) -> None:
         h_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Horizontal]
         v_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
@@ -2011,7 +2014,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self._prev_image_path = self._image_path
 
-    def _set_zoom(self, value: float, pos: QtCore.QPointF | None) -> None:
+    def _set_zoom(self, *, value: float, pos: QtCore.QPointF | None) -> None:
         if self._image_path is None:
             logger.warning("image_path is None, cannot set zoom")
             return
@@ -2045,14 +2048,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self._zoom_mode = _ZoomMode.MANUAL_ZOOM
         self._set_zoom(value=100, pos=None)
 
-    def _add_zoom(self, increment: float, pos: QtCore.QPointF | None) -> None:
+    def _add_zoom(self, *, increment: float, pos: QtCore.QPointF | None) -> None:
         # Multiplicative stepping on a float widget; the QDoubleSpinBox rounds to
         # its decimal precision, so no integer ceil/floor clamping is needed.
         zoom_value = self._canvas_widgets.zoom_widget.value() * increment
         self._zoom_mode = _ZoomMode.MANUAL_ZOOM
         self._set_zoom(value=zoom_value, pos=pos)
 
-    def _zoom_requested(self, delta: int, pos: QtCore.QPointF) -> None:
+    def _zoom_requested(self, delta: int, pos: QtCore.QPointF, /) -> None:
         self._add_zoom(increment=1.1 if delta > 0 else 0.9, pos=pos)
 
     def set_fit_window_mode(self, value: bool = True) -> None:
@@ -2063,7 +2066,7 @@ class MainWindow(QtWidgets.QMainWindow):
         target = _ZoomMode.FIT_WIDTH if value else _ZoomMode.MANUAL_ZOOM
         self._switch_zoom_mode(target)
 
-    def _switch_zoom_mode(self, mode: _ZoomMode) -> None:
+    def _switch_zoom_mode(self, mode: _ZoomMode, /) -> None:
         self._zoom_mode = mode
         self._adjust_scale()
 
@@ -2071,7 +2074,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._actions.fit_window.setChecked(self._zoom_mode == _ZoomMode.FIT_WINDOW)
         self._actions.fit_width.setChecked(self._zoom_mode == _ZoomMode.FIT_WIDTH)
 
-    def _on_brightness_contrast_changed(self, qimage: QtGui.QImage) -> None:
+    def _on_brightness_contrast_changed(self, qimage: QtGui.QImage, /) -> None:
         self._canvas_widgets.canvas.load_pixmap(
             QtGui.QPixmap.fromImage(qimage), clear_shapes=False
         )
@@ -2137,7 +2140,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 Qt.CheckState.Checked if target else Qt.CheckState.Unchecked
             )
 
-    def _read_annotation_file(self, label_path: str) -> Annotation | None:
+    def _read_annotation_file(self, *, label_path: str) -> Annotation | None:
         try:
             return read_label_file(filename=label_path)
         except LabelFileError as e:
@@ -2146,7 +2149,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             return None
 
-    def _read_image_as_annotation(self, image_path: str) -> Annotation | None:
+    def _read_image_as_annotation(self, *, image_path: str) -> Annotation | None:
         try:
             image_data = read_image_file(filename=image_path)
         except OSError as e:
@@ -2173,7 +2176,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.file_list.repaint()
         self.setWindowTitle(self._get_window_title(dirty=self._is_changed))
 
-    def _load_file(self, image_or_label_path: str) -> bool:
+    def _load_file(self, *, image_or_label_path: str) -> bool:
         # Qt file dialogs separate with forward slashes even on Windows, while
         # the file list holds the separator of the platform, so an unnormalized
         # path would neither select its file list row nor receive the saved
@@ -2267,9 +2270,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Record one baseline state. Loading carried-forward shapes separately
         # would create a false Undo step that discards them before any edit.
         carry_prev_shapes = bool(prev_shapes) and not shapes
-        self._load_shapes(
-            shapes=prev_shapes if carry_prev_shapes else shapes, replace=True
-        )
+        self._load_shapes(prev_shapes if carry_prev_shapes else shapes, replace=True)
         flags.update(annotation.flags)
         self._load_flags(flags=flags, widget=self._docks.flag_list)
         if carry_prev_shapes:
@@ -2291,7 +2292,7 @@ class MainWindow(QtWidgets.QMainWindow):
         is_initial_load = not self._viewport_states
         if target_viewport is not None:
             self._zoom_mode = target_viewport.zoom_mode
-            self._set_zoom(target_viewport.zoom_value, pos=None)
+            self._set_zoom(value=target_viewport.zoom_value, pos=None)
         elif is_initial_load or not self._config["keep_prev_scale"]:
             self._zoom_mode = _ZoomMode.FIT_WINDOW
             self._adjust_scale()
@@ -2551,7 +2552,7 @@ class MainWindow(QtWidgets.QMainWindow):
             image_or_label_path=self._image_path, output_dir=self._output_dir
         )
 
-    def _confirm_deletion(self, message: str) -> bool:
+    def _confirm_deletion(self, *, message: str) -> bool:
         msg_box = QtWidgets.QMessageBox(self)
         msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         msg_box.setWindowTitle(self.tr("Attention"))
@@ -2600,7 +2601,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def _is_settings_editable(self) -> bool:
         return self._config_file is not None and not self._config_overrides
 
-    def _make_label_dialog(self, label_history: list[str] | None) -> LabelDialog:
+    def _make_label_dialog(self, *, label_history: list[str] | None) -> LabelDialog:
         return LabelDialog(
             parent=self,
             labels=self._config["labels"],
@@ -2615,27 +2616,22 @@ class MainWindow(QtWidgets.QMainWindow):
     def _connect_persistent_actions(self) -> None:
         for key_path, action in self._persistent_actions.items():
             action.toggled.connect(
-                lambda checked, path=key_path: self._apply_setting_change(
-                    key_path=path, value=checked
-                )
+                lambda checked, path=key_path: self._apply_setting_change(path, checked)
             )
 
-    def _on_ai_model_changed(self, model_id: str) -> None:
+    def _on_ai_model_changed(self, model_id: str, /) -> None:
         self._canvas_widgets.canvas.set_ai_model_name(model_id)
         option = _ai_models.find_ai_assist_model_option(model_name=model_id)
         assert option is not None
         model_display = option.display_name
         if self._config["ai"]["default"] == model_display:
             return
-        self._apply_setting_change(key_path=("ai", "default"), value=model_display)
+        self._apply_setting_change(("ai", "default"), model_display)
 
-    def _on_ai_polygon_detail_changed(self, detail: int) -> None:
-        self._apply_setting_change(
-            key_path=("mask_polygonization", "detail"),
-            value=detail,
-        )
+    def _on_ai_polygon_detail_changed(self, detail: int, /) -> None:
+        self._apply_setting_change(("mask_polygonization", "detail"), detail)
 
-    def _set_point_prompt_mode(self, enabled: bool) -> None:
+    def _set_point_prompt_mode(self, *, enabled: bool) -> None:
         self._ai_annotation.set_point_prompt_mode(enabled=enabled)
         if self._settings_dialog is None:
             return
@@ -2651,20 +2647,22 @@ class MainWindow(QtWidgets.QMainWindow):
                 disabled_reason=disabled_reason,
             )
 
-    def _set_setting_value(self, key_path: tuple[str, ...], value: object) -> None:
+    def _set_setting_value(self, *, key_path: tuple[str, ...], value: object) -> None:
         node: dict = self._config
         for key in key_path[:-1]:
             node = node[key]
         node[key_path[-1]] = value
 
-    def _read_setting_value(self, key_path: tuple[str, ...]) -> object:
+    def _read_setting_value(self, *, key_path: tuple[str, ...]) -> object:
         node: object = self._config
         for key in key_path:
             assert isinstance(node, dict)
             node = node[key]
         return node
 
-    def _apply_setting_change(self, key_path: tuple[str, ...], value: object) -> bool:
+    def _apply_setting_change(
+        self, key_path: tuple[str, ...], value: object, /
+    ) -> bool:
         if self._is_settings_editable and not self._try_set_overrides(
             overrides=[(key_path, value)]
         ):
@@ -2676,7 +2674,7 @@ class MainWindow(QtWidgets.QMainWindow):
         return True
 
     def _preview_shape_color(
-        self, key_path: tuple[str, ...], value: list[int] | None
+        self, key_path: tuple[str, ...], value: list[int] | None, /
     ) -> None:
         if value is None:
             self._shape_color_preview = None
@@ -2692,7 +2690,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._refresh_shape_colors()
 
     def _try_set_overrides(
-        self, overrides: list[tuple[tuple[str, ...], object]]
+        self, *, overrides: list[tuple[tuple[str, ...], object]]
     ) -> bool:
         assert self._config_file is not None
         try:
@@ -2702,7 +2700,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return False
         return True
 
-    def _sync_setting_controls(self, key_path: tuple[str, ...]) -> None:
+    def _sync_setting_controls(self, *, key_path: tuple[str, ...]) -> None:
         if self._settings_dialog is not None:
             self._settings_dialog.set_value(
                 key_path=key_path,
@@ -2710,7 +2708,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         self._apply_to_live_widgets(key_path=key_path)
 
-    def _apply_to_live_widgets(self, key_path: tuple[str, ...]) -> None:
+    def _apply_to_live_widgets(self, *, key_path: tuple[str, ...]) -> None:
         if key_path == ("color_theme",):
             # apply_color_theme -> setColorScheme emits colorSchemeChanged, which
             # drives _retheme; no explicit refresh needed here.
@@ -2956,7 +2954,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.end_move(copy=False)
         self.mark_dirty()
 
-    def _load_from_file_or_dir(self, file_or_dir: str) -> None:
+    def _load_from_file_or_dir(self, *, file_or_dir: str) -> None:
         if not file_or_dir:
             raise ValueError("file_or_dir cannot be empty")
 
@@ -2981,10 +2979,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 previous_item = file_list.currentItem()
                 with QtCore.QSignalBlocker(file_list):
                     file_list.setCurrentRow(0)
-                self._load_selected_image(
-                    current_item=file_list.currentItem(),
-                    previous_item=previous_item,
-                )
+                self._load_selected_image(file_list.currentItem(), previous_item)
                 file_list.repaint()
         else:
             # Load before swapping the File List, so a failed load leaves the
@@ -3053,7 +3048,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._docks.file_list.repaint()
                 return
 
-    def _import_images_from_dir(self, root_dir: str | None) -> None:
+    def _import_images_from_dir(self, *, root_dir: str | None) -> None:
         self._actions.open_next_img.setEnabled(True)
         self._actions.open_prev_img.setEnabled(True)
 
@@ -3090,7 +3085,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.setWindowTitle(self._get_window_title(dirty=self._is_changed))
 
-    def _update_status_stats(self, mouse_pos: QtCore.QPointF) -> None:
+    def _update_status_stats(self, mouse_pos: QtCore.QPointF, /) -> None:
         stats: list[str] = []
         stats.append(f"mode={self._canvas_widgets.canvas.mode.name}")
         stats.append(f"x={mouse_pos.x():6.1f}, y={mouse_pos.y():6.1f}")
@@ -3199,7 +3194,7 @@ def _make_image_list_item(
     return item
 
 
-def _shape_to_dict(shape: Shape) -> ShapeDict:
+def _shape_to_dict(shape: Shape, /) -> ShapeDict:
     assert shape.label is not None
     return ShapeDict(
         label=shape.label,
@@ -3280,7 +3275,7 @@ def _list_supported_image_extensions() -> tuple[str, ...]:
     )
 
 
-def _scan_image_files(root_dir: str) -> list[str]:
+def _scan_image_files(*, root_dir: str) -> list[str]:
     extensions = _list_supported_image_extensions()
 
     images: list[str] = []

--- a/labelme/_automation/_ai_assist.py
+++ b/labelme/_automation/_ai_assist.py
@@ -136,6 +136,7 @@ def _is_point_inside_detection(
 
 def _detections_from_annotations(
     annotations: list[osam.types.Annotation],
+    /,
 ) -> list[Detection]:
     if not annotations:
         logger.warning("No annotations returned")

--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -96,10 +96,10 @@ def compute_oriented_rectangle_from_mask(
         # All pixels are collinear, so no rectangle can be fit; let callers
         # fall back to the axis-aligned bbox.
         return None
-    return _min_area_rect(hull=points[hull_indices]).astype(np.float32)
+    return _min_area_rect(points[hull_indices]).astype(np.float32)
 
 
-def _min_area_rect(hull: NDArray[np.float64]) -> NDArray[np.float64]:
+def _min_area_rect(hull: NDArray[np.float64], /) -> NDArray[np.float64]:
     # Rotating calipers: the minimum-area enclosing rectangle must have one
     # side flush with an edge of the convex hull. Try each hull edge as the
     # rect orientation and keep the smallest-area candidate.
@@ -150,7 +150,7 @@ def _min_area_rect(hull: NDArray[np.float64]) -> NDArray[np.float64]:
     return best_corners
 
 
-def _compute_signed_area(points: NDArray[np.float64]) -> float:
+def _compute_signed_area(points: NDArray[np.float64], /) -> float:
     local_points = points - points[0]
     x = local_points[:, 0]
     y = local_points[:, 1]
@@ -162,7 +162,7 @@ def _compute_signed_area(points: NDArray[np.float64]) -> float:
     )
 
 
-def _compute_polygon_deviation(detail: int) -> float:
+def _compute_polygon_deviation(*, detail: int) -> float:
     # The default maps to half a pixel; the curve reserves finer control near
     # the detailed end, where small slider changes are most visible.
     detail_loss = (100 - detail) / 20
@@ -268,7 +268,7 @@ def compute_polygons_from_mask(
     for contour in contours:
         contour = contour - PAD
         raw_points = contour[:, ::-1]
-        if _compute_signed_area(points=raw_points) <= 0:
+        if _compute_signed_area(raw_points) <= 0:
             continue
         polygon = _simplify_contour(
             contour=contour,

--- a/labelme/_automation/_osam_session.py
+++ b/labelme/_automation/_osam_session.py
@@ -73,7 +73,7 @@ class OsamSession:
         )
 
     def _get_or_compute_embedding(
-        self, image: NDArray[np.uint8], image_id: str
+        self, *, image: NDArray[np.uint8], image_id: str
     ) -> osam.types.ImageEmbedding:
         for key, embedding in self._embedding_cache:
             if key == image_id:

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -29,9 +29,9 @@ class Detection:
 
 
 def _build_shape(
+    *,
     shape_type: AiOutputFormat,
     points: ArrayLike,
-    *,
     mask: NDArray[np.bool_] | None,
     label: str | None,
     description: str | None,
@@ -47,9 +47,9 @@ def _build_shape(
 
 
 def _build_shapes_from_detection(
+    *,
     detection: Detection,
     shape_type: AiOutputFormat,
-    *,
     image_size: tuple[int, int] | None,
     polygon_detail: int,
 ) -> list[Shape]:
@@ -140,6 +140,7 @@ def _build_shapes_from_detection(
 
 
 def _oriented_rectangle_for_detection(
+    *,
     detection: Detection,
 ) -> NDArray[np.float32] | None:
     if detection.mask is not None:
@@ -178,7 +179,7 @@ def _fit_oriented_rectangle_to_image(
     )
 
 
-def _circle_for_detection(detection: Detection) -> Circle | None:
+def _circle_for_detection(*, detection: Detection) -> Circle | None:
     if detection.mask is not None:
         circle = compute_circle_from_mask(mask=detection.mask)
         if circle is not None:

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -19,13 +19,14 @@ here = Path(__file__).resolve().parent
 
 
 def _update_dict(
+    *,
     target_dict: dict[str, object],
     new_dict: dict[str, object],
     key_path: tuple[str, ...],
 ) -> None:
     for key, value in new_dict.items():
         item_path = (*key_path, key)
-        _validate_config_item(item_path, value)
+        _validate_config_item(key_path=item_path, value=value)
         if key not in target_dict:
             raise ValueError(f"Unexpected key in config: {key}")
         if not isinstance(target_dict[key], dict):
@@ -46,13 +47,13 @@ def _update_dict(
                 f"but got {type(value).__name__}: {value!r}"
             )
         _update_dict(
-            cast(dict[str, object], target_dict[key]),
-            cast(dict[str, object], value),
+            target_dict=cast(dict[str, object], target_dict[key]),
+            new_dict=cast(dict[str, object], value),
             key_path=item_path,
         )
 
 
-def _validate_config_item(key_path: tuple[str, ...], value: object) -> None:
+def _validate_config_item(*, key_path: tuple[str, ...], value: object) -> None:
     key = key_path[-1]
     if key_path == ("mask_polygonization", "detail") and (
         isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 100
@@ -75,7 +76,7 @@ def _validate_config_item(key_path: tuple[str, ...], value: object) -> None:
             )
 
 
-def _migrate_config_from_file(config_from_yaml: dict) -> None:
+def _migrate_config_from_file(*, config_from_yaml: dict) -> None:
     migrate_shape_color(config=config_from_yaml)
     keep_prev_brightness: bool = config_from_yaml.pop("keep_prev_brightness", False)
     keep_prev_contrast: bool = config_from_yaml.pop("keep_prev_contrast", False)
@@ -191,13 +192,13 @@ def load_config(config_file: Path | None, config_overrides: dict) -> dict:
             _migrate_config_from_file(config_from_yaml=config_from_yaml)
             if "shape_color" in config_from_yaml:
                 validate_shape_color(config=config_from_yaml["shape_color"])
-            _update_dict(config, config_from_yaml, key_path=())
+            _update_dict(target_dict=config, new_dict=config_from_yaml, key_path=())
 
     config_overrides = copy.deepcopy(config_overrides)
     migrate_shape_color(config=config_overrides)
     if "shape_color" in config_overrides:
         validate_shape_color(config=config_overrides["shape_color"])
-    _update_dict(config, config_overrides, key_path=())
+    _update_dict(target_dict=config, new_dict=config_overrides, key_path=())
 
     if not config["labels"] and config["validate_label"]:
         raise ValueError("labels must be specified when validate_label is enabled")

--- a/labelme/_config/_shape_color.py
+++ b/labelme/_config/_shape_color.py
@@ -5,7 +5,7 @@ from typing import cast
 from loguru import logger
 
 
-def _is_rgb(value: object) -> bool:
+def _is_rgb(value: object, /) -> bool:
     return (
         isinstance(value, list)
         and len(value) == 3

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -22,7 +22,7 @@ _DEFAULT_CONFIG: Final = _yaml.safe_load(
 )
 
 
-def _default_value(key_path: Sequence[str]) -> object:
+def _default_value(*, key_path: Sequence[str]) -> object:
     node: object = _DEFAULT_CONFIG
     for key in key_path:
         if not isinstance(node, dict) or key not in node:
@@ -31,7 +31,7 @@ def _default_value(key_path: Sequence[str]) -> object:
     return node
 
 
-def _assign(doc: CommentedMap, key_path: Sequence[str], value: object) -> None:
+def _assign(*, doc: CommentedMap, key_path: Sequence[str], value: object) -> None:
     node = doc
     for key in key_path[:-1]:
         if key in node and not isinstance(node[key], dict):
@@ -49,7 +49,7 @@ def _assign(doc: CommentedMap, key_path: Sequence[str], value: object) -> None:
     node[key_path[-1]] = value
 
 
-def _prune(doc: CommentedMap, key_path: Sequence[str]) -> None:
+def _prune(*, doc: CommentedMap, key_path: Sequence[str]) -> None:
     head, *rest = key_path
     if head not in doc:
         return
@@ -63,7 +63,7 @@ def _prune(doc: CommentedMap, key_path: Sequence[str]) -> None:
         del doc[head]
 
 
-def _atomic_write(config_file: Path, content: str) -> None:
+def _atomic_write(*, config_file: Path, content: str) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=config_file.parent, prefix=f"{config_file.name}.", suffix=".tmp"
     )

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -30,7 +30,7 @@ from ._utils.shape import ShapeDict
 PIL.Image.MAX_IMAGE_PIXELS = None
 
 
-def _validate_flags(flags: object) -> dict[str, bool]:
+def _validate_flags(*, flags: object) -> dict[str, bool]:
     if flags is None:
         return {}
     if not isinstance(flags, dict):
@@ -90,7 +90,7 @@ def _validate_shape_semantics(
         raise ValueError(f"mask must decode to a 2D image, got shape {mask.shape}")
 
 
-def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
+def _load_shape_json_obj(*, shape_json_obj: dict) -> ShapeDict:
     SHAPE_KEYS: Final[set[str]] = {
         "label",
         "points",
@@ -178,7 +178,7 @@ def _load_shape_json_obj(shape_json_obj: dict) -> ShapeDict:
     return loaded
 
 
-def _dump_shape_to_json_obj(shape: ShapeDict) -> dict[str, Any]:
+def _dump_shape_to_json_obj(*, shape: ShapeDict) -> dict[str, Any]:
     json_obj: dict[str, Any] = dict(shape["other_data"])
     json_obj.update(
         label=shape["label"],
@@ -241,9 +241,9 @@ def read_image_file(filename: str) -> bytes:
         raise OSError(f"failed to read image {filename!r}: {e}") from e
 
 
-def _read_image_file(filename: str) -> bytes:
+def _read_image_file(*, filename: str) -> bytes:
     t_start = time.time()
-    image_pil = _imread(filename=filename)
+    image_pil = _imread(filename)
 
     oriented: PIL.Image.Image = _utils.apply_exif_orientation(image=image_pil)
     ext = Path(filename).suffix.lower()
@@ -363,7 +363,9 @@ def write_label_file(
         payload: dict[str, Any] = {
             "version": __version__,
             "flags": dict(annotation.flags) if annotation.flags else {},
-            "shapes": [_dump_shape_to_json_obj(shape) for shape in annotation.shapes],
+            "shapes": [
+                _dump_shape_to_json_obj(shape=shape) for shape in annotation.shapes
+            ],
             "imagePath": annotation.image_path,
             "imageData": image_data_b64,
             "imageHeight": image_height,
@@ -399,7 +401,7 @@ def write_label_file(
 _DISPLAYABLE_MODES: Final = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
 
 
-def _imread(filename: str) -> PIL.Image.Image:
+def _imread(filename: str, /) -> PIL.Image.Image:
     ext: str = Path(filename).suffix.lower()
     try:
         image_pil = PIL.Image.open(filename)
@@ -412,7 +414,7 @@ def _imread(filename: str) -> PIL.Image.Image:
         raise
 
 
-def _imread_tiff(filename: str) -> PIL.Image.Image:
+def _imread_tiff(filename: str, /) -> PIL.Image.Image:
     img_arr: NDArray = tifffile.imread(filename)
 
     if img_arr.ndim == 2:
@@ -431,7 +433,7 @@ def _imread_tiff(filename: str) -> PIL.Image.Image:
     return PIL.Image.fromarray(img_arr_normalized)
 
 
-def _normalize_to_uint8(arr: NDArray) -> NDArray[np.uint8]:
+def _normalize_to_uint8(arr: NDArray, /) -> NDArray[np.uint8]:
     arr = arr.astype(np.float64)
     finite = arr[np.isfinite(arr)]
     if finite.size == 0:

--- a/labelme/_widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/_widgets/_ai_assisted_annotation_widget.py
@@ -55,6 +55,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
     def _init_ui(
         self,
+        *,
         default_model: str,
         polygon_detail: int,
         on_model_changed: Callable[[str], None],

--- a/labelme/_widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/_widgets/_ai_text_to_annotation_widget.py
@@ -31,9 +31,9 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
         parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
-        self._init_ui(on_submit)
+        self._init_ui(on_submit=on_submit)
 
-    def _init_ui(self, on_submit: Callable[[bool], None]) -> None:
+    def _init_ui(self, *, on_submit: Callable[[bool], None]) -> None:
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(2)

--- a/labelme/_widgets/_integer_slider.py
+++ b/labelme/_widgets/_integer_slider.py
@@ -46,6 +46,6 @@ class IntegerSlider(QtWidgets.QWidget):
         self._slider.setValue(value)
         self._value_label.setNum(self._slider.value())
 
-    def _on_value_changed(self, value: int) -> None:
+    def _on_value_changed(self, value: int, /) -> None:
         self._value_label.setNum(value)
         self.value_changed.emit(value)

--- a/labelme/_widgets/brightness_contrast_dialog.py
+++ b/labelme/_widgets/brightness_contrast_dialog.py
@@ -44,7 +44,7 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         self.img = img
 
     def _add_slider_row(
-        self, grid: QtWidgets.QGridLayout, row: int, title: str
+        self, *, grid: QtWidgets.QGridLayout, row: int, title: str
     ) -> QtWidgets.QSlider:
         slider = QtWidgets.QSlider(Qt.Orientation.Horizontal)
         slider.setRange(0, 3 * self._base_value)
@@ -63,7 +63,7 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         grid.addWidget(value_label, row, 2)
         return slider
 
-    def _format_factor(self, value: int) -> str:
+    def _format_factor(self, value: int, /) -> str:
         return f"{value / self._base_value:.2f}"
 
     def apply(self) -> None:

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -81,7 +81,7 @@ class _DraftShape:
         )
 
 
-def _draft_to_shape(draft: _DraftShape) -> Shape:
+def _draft_to_shape(draft: _DraftShape, /) -> Shape:
     return Shape(
         shape_type=draft.shape_type,
         points=np.array([[p.x(), p.y()] for p in draft.points], dtype=np.float64),
@@ -90,7 +90,7 @@ def _draft_to_shape(draft: _DraftShape) -> Shape:
     )
 
 
-def _shape_to_draft(shape: Shape) -> _DraftShape:
+def _shape_to_draft(shape: Shape, /) -> _DraftShape:
     return _DraftShape(
         shape_type=shape.shape_type,
         points=tuple(QPointF(*point) for point in shape.points),
@@ -323,7 +323,7 @@ class Canvas(QtWidgets.QWidget):
     def set_point_size(self, point_size: int) -> None:
         self._point_size = point_size
 
-    def _resolve_palette(self, label: str | None) -> Palette:
+    def _resolve_palette(self, label: str | None, /) -> Palette:
         if label is None or self._color_resolver is None:
             return _DEFAULT_PALETTE
         # Auto colors depend on the live label ordering, so the palette cannot
@@ -339,12 +339,12 @@ class Canvas(QtWidgets.QWidget):
     def set_draft_palette(self, palette: Palette) -> None:
         self._draft_palette = palette
 
-    def _highlight_vertex(self, index: int, mode: Literal["move", "near"]) -> None:
+    def _highlight_vertex(self, *, index: int, mode: Literal["move", "near"]) -> None:
         self._highlight = VertexHighlight(index=index, mode=mode)
         self._rotation_highlight = None
 
     def _highlight_rotation_point(
-        self, index: int, mode: Literal["move", "near"]
+        self, *, index: int, mode: Literal["move", "near"]
     ) -> None:
         self._rotation_highlight = VertexHighlight(index=index, mode=mode)
         self._highlight = None
@@ -353,7 +353,7 @@ class Canvas(QtWidgets.QWidget):
         self._highlight = None
         self._rotation_highlight = None
 
-    def _render_context(self, shape: Shape, *, highlighted: bool) -> ShapeRenderContext:
+    def _render_context(self, *, shape: Shape, highlighted: bool) -> ShapeRenderContext:
         selected = shape in self.selected_shapes
         return ShapeRenderContext(
             scale=self.scale,
@@ -490,7 +490,7 @@ class Canvas(QtWidgets.QWidget):
         )
         return proposal
 
-    def _report_inference_failure(self, error: Exception) -> None:
+    def _report_inference_failure(self, *, error: Exception) -> None:
         self._ai_inference_failed = True
         logger.opt(exception=error).error("AI inference failed")
         self.inference_failed.emit(f"{type(error).__name__}: {error}")
@@ -558,6 +558,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _set_highlight(
         self,
+        *,
         hovered_shape: Shape | None,
         hovered_edge: int | None,
         hovered_vertex: int | None,
@@ -593,7 +594,7 @@ class Canvas(QtWidgets.QWidget):
     def _is_rotation_point_selected(self) -> bool:
         return self._hovered_rotation is not None
 
-    def _update_status(self, extra_messages: list[str] | None) -> None:
+    def _update_status(self, *, extra_messages: list[str] | None) -> None:
         messages: list[str] = []
         if self.mode == _CanvasMode.CREATE:
             messages.append(self.tr("Creating %r") % self.create_mode)
@@ -662,7 +663,7 @@ class Canvas(QtWidgets.QWidget):
         self._prev_move_point = pos
         self._dispatch_pointer_move(pos=pos, event=a0)
 
-    def _dispatch_pointer_move(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
+    def _dispatch_pointer_move(self, *, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         if self._pan_anchor is not None:
             self._advance_pan(event=event)
             return
@@ -678,7 +679,7 @@ class Canvas(QtWidgets.QWidget):
             return
         self._refresh_hover_state(pos=pos)
 
-    def _advance_pan(self, event: QtGui.QMouseEvent) -> None:
+    def _advance_pan(self, *, event: QtGui.QMouseEvent) -> None:
         assert self._pan_anchor is not None
         # Use screen coordinates so the anchor does not drift when our own
         # pan emit shifts the canvas widget under the scroll area — a
@@ -688,7 +689,7 @@ class Canvas(QtWidgets.QWidget):
         self._pan_anchor = cursor
         self.pan_request.emit(QPoint(int(step.x()), int(step.y())))
 
-    def _track_drawing_cursor(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
+    def _track_drawing_cursor(self, *, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         desired_line_shape_type = _CREATE_MODE_TO_SHAPE_TYPE[self.create_mode]
         if self._line.shape_type != desired_line_shape_type:
             self._line = dataclasses.replace(
@@ -706,7 +707,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
         self._update_status(extra_messages=None)
 
-    def _project_drawing_pos_into_image(self, pos: QPointF) -> QPointF:
+    def _project_drawing_pos_into_image(self, *, pos: QPointF) -> QPointF:
         current = self._current
         assert current is not None
         if self.create_mode == "oriented_rectangle" and len(current.points) == 4:
@@ -727,7 +728,7 @@ class Canvas(QtWidgets.QWidget):
             return self._current.points[MOVING_CORNER_INDEX]
         if self._should_constrain_to_pixmap(pos):
             return _compute_intersection_edges_image(
-                current.points[-1], pos, image_size=self.pixmap.size()
+                p1=current.points[-1], p2=pos, image_size=self.pixmap.size()
             )
         if not self._cursor_should_snap_to_polygon_origin(pos=pos):
             return pos
@@ -735,7 +736,7 @@ class Canvas(QtWidgets.QWidget):
         self._highlight_vertex(index=0, mode="near")
         return current.points[0]
 
-    def _cursor_should_snap_to_polygon_origin(self, pos: QPointF) -> bool:
+    def _cursor_should_snap_to_polygon_origin(self, *, pos: QPointF) -> bool:
         if not self._snapping:
             return False
         if self.create_mode != "polygon":
@@ -751,14 +752,14 @@ class Canvas(QtWidgets.QWidget):
             epsilon=self._epsilon,
         )
 
-    def _refresh_hover_state(self, pos: QPointF) -> None:
+    def _refresh_hover_state(self, *, pos: QPointF) -> None:
         status_messages: list[str] = []
         self._highlight_hover_shape(pos=pos, status_messages=status_messages)
         self.vertex_selected.emit(self._hovered_vertex is not None)
         self.edge_selected.emit(self._hovered_edge is not None)
         self._update_status(extra_messages=status_messages)
 
-    def _update_drawing_line(self, pos: QPointF, is_shift_pressed: bool) -> QPointF:
+    def _update_drawing_line(self, *, pos: QPointF, is_shift_pressed: bool) -> QPointF:
         current = self._current
         assert current is not None
         mode = self.create_mode
@@ -808,7 +809,7 @@ class Canvas(QtWidgets.QWidget):
             )
         return pos
 
-    def _continue_right_button_drag(self, pos: QPointF) -> None:
+    def _continue_right_button_drag(self, *, pos: QPointF) -> None:
         if self._selected_shapes_copy:
             self._apply_cursor(CursorRole.MOVE)
             self._drag_shapes(
@@ -823,7 +824,7 @@ class Canvas(QtWidgets.QWidget):
         self._update_status(extra_messages=None)
 
     def _continue_left_button_drag(
-        self, pos: QPointF, event: QtGui.QMouseEvent
+        self, *, pos: QPointF, event: QtGui.QMouseEvent
     ) -> None:
         is_shift_pressed = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
         if self._is_vertex_selected():
@@ -836,7 +837,7 @@ class Canvas(QtWidgets.QWidget):
             return
         self._drag_selected_shapes(pos=pos)
 
-    def _drag_hovered_vertex(self, pos: QPointF, is_shift_pressed: bool) -> None:
+    def _drag_hovered_vertex(self, *, pos: QPointF, is_shift_pressed: bool) -> None:
         assert self._hovered_vertex is not None
         assert self.hovered_shape is not None
         self._bounded_move_vertex(
@@ -848,7 +849,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
         self._is_moving_shape = True
 
-    def _drag_hovered_rotation_point(self, pos: QPointF) -> None:
+    def _drag_hovered_rotation_point(self, *, pos: QPointF) -> None:
         assert self.hovered_shape is not None
         assert len(self._rotation_original_points) > 0, (
             "_capture_rotation_anchors must be called before dragging"
@@ -879,7 +880,7 @@ class Canvas(QtWidgets.QWidget):
         )
         self._rotation_original_points = self.hovered_shape.points.copy()
 
-    def _drag_selected_shapes(self, pos: QPointF) -> None:
+    def _drag_selected_shapes(self, *, pos: QPointF) -> None:
         self._apply_cursor(CursorRole.MOVE)
         self._drag_shapes(
             shapes=self.selected_shapes, cursor=pos, constrain_cursor=True
@@ -887,7 +888,9 @@ class Canvas(QtWidgets.QWidget):
         self.update()
         self._is_moving_shape = True
 
-    def _highlight_hover_shape(self, pos: QPointF, status_messages: list[str]) -> None:
+    def _highlight_hover_shape(
+        self, *, pos: QPointF, status_messages: list[str]
+    ) -> None:
         target = _canvas_interaction.find_hover_target(
             shapes=self.shapes,
             point=np.array([pos.x(), pos.y()]),
@@ -1008,7 +1011,9 @@ class Canvas(QtWidgets.QWidget):
         self._dispatch_pointer_press(pos=pos, event=a0)
         self._update_status(extra_messages=None)
 
-    def _dispatch_pointer_press(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
+    def _dispatch_pointer_press(
+        self, *, pos: QPointF, event: QtGui.QMouseEvent
+    ) -> None:
         self._clear_ai_existing_shape_highlights()
         button = event.button()
         if button == Qt.MouseButton.LeftButton:
@@ -1022,7 +1027,7 @@ class Canvas(QtWidgets.QWidget):
         ):
             self._begin_pan(event=event)
 
-    def _press_left(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
+    def _press_left(self, *, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         is_shift_pressed = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
         if self.mode == _CanvasMode.CREATE:
             self._press_left_while_drawing(
@@ -1034,6 +1039,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _press_left_while_drawing(
         self,
+        *,
         pos: QPointF,
         event: QtGui.QMouseEvent,
         is_shift_pressed: bool,
@@ -1057,7 +1063,7 @@ class Canvas(QtWidgets.QWidget):
         return True
 
     def _extend_current_shape(
-        self, current: _DraftShape, event: QtGui.QMouseEvent
+        self, *, current: _DraftShape, event: QtGui.QMouseEvent
     ) -> None:
         mode = self.create_mode
         modifiers = event.modifiers()
@@ -1100,7 +1106,7 @@ class Canvas(QtWidgets.QWidget):
             if modifiers & Qt.KeyboardModifier.ControlModifier:
                 self._finalize()
 
-    def _lock_oriented_rectangle_first_edge(self, current: _DraftShape) -> None:
+    def _lock_oriented_rectangle_first_edge(self, *, current: _DraftShape) -> None:
         first_corner = self._line.points[0]
         second_corner = self._line.points[1]
         self._current = dataclasses.replace(
@@ -1117,7 +1123,7 @@ class Canvas(QtWidgets.QWidget):
             self._line, points=(second_corner,) + self._line.points[1:]
         )
 
-    def _unlock_oriented_rectangle_first_edge(self, current: _DraftShape) -> None:
+    def _unlock_oriented_rectangle_first_edge(self, *, current: _DraftShape) -> None:
         anchor = current.points[0]
         self._current = dataclasses.replace(
             current, points=(anchor,), point_labels=(current.point_labels[0],)
@@ -1126,6 +1132,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _start_new_shape(
         self,
+        *,
         pos: QPointF,
         event: QtGui.QMouseEvent,
         is_shift_pressed: bool,
@@ -1160,7 +1167,9 @@ class Canvas(QtWidgets.QWidget):
         self.drawing_polygon.emit(True)
         self.update()
 
-    def _press_left_while_editing(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
+    def _press_left_while_editing(
+        self, *, pos: QPointF, event: QtGui.QMouseEvent
+    ) -> None:
         modifiers = event.modifiers()
         if self._maybe_modify_polygon_topology(modifiers=modifiers):
             # remove_selected_point already repainted; just consume the press.
@@ -1174,7 +1183,7 @@ class Canvas(QtWidgets.QWidget):
         self._prev_point = pos
         self.update()
 
-    def _maybe_modify_polygon_topology(self, modifiers: Qt.KeyboardModifier) -> bool:
+    def _maybe_modify_polygon_topology(self, *, modifiers: Qt.KeyboardModifier) -> bool:
         # Returns True only when the press is consumed as a terminal edit (a point
         # removal), so the caller skips point selection and starts no drag. Adding
         # a point intentionally falls through so the new vertex can be dragged.
@@ -1187,7 +1196,7 @@ class Canvas(QtWidgets.QWidget):
             return self.remove_selected_point()
         return False
 
-    def _press_right(self, pos: QPointF, event: QtGui.QMouseEvent) -> None:
+    def _press_right(self, *, pos: QPointF, event: QtGui.QMouseEvent) -> None:
         if _should_reselect_on_right_press(
             selected_shapes=self.selected_shapes, hovered_shape=self.hovered_shape
         ):
@@ -1199,7 +1208,7 @@ class Canvas(QtWidgets.QWidget):
             self.update()
         self._prev_point = pos
 
-    def _begin_pan(self, event: QtGui.QMouseEvent) -> None:
+    def _begin_pan(self, *, event: QtGui.QMouseEvent) -> None:
         self._apply_cursor(CursorRole.GRAB)
         self._pan_anchor = QPointF(self.mapToGlobal(event.position().toPoint()))
 
@@ -1208,7 +1217,7 @@ class Canvas(QtWidgets.QWidget):
         self._commit_pending_shape_move()
         self._update_status(extra_messages=None)
 
-    def _dispatch_pointer_release(self, event: QtGui.QMouseEvent) -> None:
+    def _dispatch_pointer_release(self, *, event: QtGui.QMouseEvent) -> None:
         button = event.button()
         if button == Qt.MouseButton.RightButton:
             self._release_right(event=event)
@@ -1219,7 +1228,7 @@ class Canvas(QtWidgets.QWidget):
         if button == Qt.MouseButton.MiddleButton:
             self._finish_pan()
 
-    def _release_right(self, event: QtGui.QMouseEvent) -> None:
+    def _release_right(self, *, event: QtGui.QMouseEvent) -> None:
         menu = self.context_menus.menu_for(
             has_selection=len(self._selected_shapes_copy) > 0
         )
@@ -1347,7 +1356,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
 
     def _select_shape_point(
-        self, point: QPointF, multiple_selection_mode: bool
+        self, point: QPointF, /, *, multiple_selection_mode: bool
     ) -> None:
         if self._hovered_vertex is not None:
             assert self.hovered_shape is not None
@@ -1375,7 +1384,7 @@ class Canvas(QtWidgets.QWidget):
             self._hovered_shape_is_selected = False
         self._record_drag_anchor(shapes=self.selected_shapes, click=point)
 
-    def _find_shape_at_point(self, point: QPointF) -> Shape | None:
+    def _find_shape_at_point(self, point: QPointF, /) -> Shape | None:
         query = np.array([point.x(), point.y()])
         for shape in reversed(self.shapes):
             if shape.visible and is_hit_by_point(
@@ -1388,7 +1397,7 @@ class Canvas(QtWidgets.QWidget):
                 return shape
         return None
 
-    def _record_drag_anchor(self, shapes: list[Shape], click: QPointF) -> None:
+    def _record_drag_anchor(self, *, shapes: list[Shape], click: QPointF) -> None:
         if not shapes:
             self._drag_anchor = (QPointF(), QRectF())
             return
@@ -1397,6 +1406,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _bounded_move_vertex(
         self,
+        *,
         shape: Shape,
         vertex_index: int,
         pos: QPointF,
@@ -1418,7 +1428,9 @@ class Canvas(QtWidgets.QWidget):
 
         if self._should_constrain_to_pixmap(pos):
             pos = _compute_intersection_edges_image(
-                QPointF(*shape.points[vertex_index]), pos, image_size=self.pixmap.size()
+                p1=QPointF(*shape.points[vertex_index]),
+                p2=pos,
+                image_size=self.pixmap.size(),
             )
 
         if is_shift_pressed and shape.shape_type == "rectangle":
@@ -1429,7 +1441,7 @@ class Canvas(QtWidgets.QWidget):
         shape.move_vertex(i=vertex_index, pos=(pos.x(), pos.y()))
 
     def _bounded_move_oriented_rectangle_vertex(
-        self, shape: Shape, vertex_index: int, pos: QPointF
+        self, *, shape: Shape, vertex_index: int, pos: QPointF
     ) -> None:
         assert len(shape.points) == 4
         corners = tuple(QPointF(*point) for point in shape.points)
@@ -1444,7 +1456,7 @@ class Canvas(QtWidgets.QWidget):
             shape.move_vertex(i=i, pos=(corner.x(), corner.y()))
 
     def _drag_shapes(
-        self, shapes: list[Shape], cursor: QPointF, constrain_cursor: bool
+        self, *, shapes: list[Shape], cursor: QPointF, constrain_cursor: bool
     ) -> bool:
         if constrain_cursor and self._should_constrain_to_pixmap(cursor):
             return False
@@ -1525,7 +1537,7 @@ class Canvas(QtWidgets.QWidget):
         finally:
             painter.end()
 
-    def _setup_world_transform(self, painter: QtGui.QPainter) -> None:
+    def _setup_world_transform(self, *, painter: QtGui.QPainter) -> None:
         for hint in (
             QtGui.QPainter.RenderHint.Antialiasing,
             QtGui.QPainter.RenderHint.SmoothPixmapTransform,
@@ -1545,7 +1557,7 @@ class Canvas(QtWidgets.QWidget):
             self._draw_ai_existing_match_layer,
         )
 
-    def _draw_pixmap_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_pixmap_layer(self, painter: QtGui.QPainter, /) -> None:
         target = QtCore.QRectF(
             0.0,
             0.0,
@@ -1554,7 +1566,7 @@ class Canvas(QtWidgets.QWidget):
         )
         painter.drawPixmap(target, self.pixmap, QtCore.QRectF(self.pixmap.rect()))
 
-    def _draw_crosshair_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_crosshair_layer(self, painter: QtGui.QPainter, /) -> None:
         cursor: QPointF | None = self._prev_move_point
         if not self._should_draw_crosshair(cursor=cursor):
             return
@@ -1578,7 +1590,7 @@ class Canvas(QtWidgets.QWidget):
         painter.drawLine(left, cy, right, cy)
         painter.drawLine(cx, top, cx, bottom)
 
-    def _should_draw_crosshair(self, cursor: QPointF | None) -> bool:
+    def _should_draw_crosshair(self, *, cursor: QPointF | None) -> bool:
         if self.mode != _CanvasMode.CREATE:
             return False
         if not self._crosshair[self._create_mode]:
@@ -1587,7 +1599,7 @@ class Canvas(QtWidgets.QWidget):
             return False
         return not self._should_constrain_to_pixmap(cursor)
 
-    def _draw_committed_shapes_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_committed_shapes_layer(self, painter: QtGui.QPainter, /) -> None:
         for shape in self.shapes:
             if not shape.visible:
                 continue
@@ -1596,14 +1608,14 @@ class Canvas(QtWidgets.QWidget):
             )
             render_shape(painter=painter, shape=shape, context=context)
 
-    def _draw_active_shape_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_active_shape_layer(self, painter: QtGui.QPainter, /) -> None:
         if self._current is None:
             return
         assert len(self._line.points) == len(self._line.point_labels)
         self._render_draft(painter=painter, draft=self._current, highlighted=True)
         self._render_draft(painter=painter, draft=self._line, highlighted=False)
 
-    def _draw_drag_copy_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_drag_copy_layer(self, painter: QtGui.QPainter, /) -> None:
         for copy_shape in self._selected_shapes_copy:
             context = ShapeRenderContext(
                 scale=self.scale,
@@ -1618,7 +1630,7 @@ class Canvas(QtWidgets.QWidget):
             )
             render_shape(painter=painter, shape=copy_shape, context=context)
 
-    def _draw_preview_overlay_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_preview_overlay_layer(self, painter: QtGui.QPainter, /) -> None:
         previews = self._build_preview_shapes()
         if not previews:
             return
@@ -1631,7 +1643,7 @@ class Canvas(QtWidgets.QWidget):
         for preview in previews:
             render_shape(painter=painter, shape=preview, context=context)
 
-    def _draw_ai_existing_match_layer(self, painter: QtGui.QPainter) -> None:
+    def _draw_ai_existing_match_layer(self, painter: QtGui.QPainter, /) -> None:
         AI_EXISTING_MATCH_PALETTE: Final[Palette] = Palette(
             line=QtGui.QColor(255, 170, 0),
             fill=QtGui.QColor(255, 170, 0, 64),
@@ -1655,7 +1667,7 @@ class Canvas(QtWidgets.QWidget):
             render_shape(painter=painter, shape=shape, context=context)
 
     def _render_draft(
-        self, painter: QtGui.QPainter, draft: _DraftShape, highlighted: bool
+        self, *, painter: QtGui.QPainter, draft: _DraftShape, highlighted: bool
     ) -> None:
         shape = _draft_to_shape(draft)
         context = self._draft_render_context(
@@ -1675,13 +1687,13 @@ class Canvas(QtWidgets.QWidget):
             return self._build_ai_points_preview(current=self._current)
         return []
 
-    def _build_polygon_preview(self, current: _DraftShape) -> Shape:
+    def _build_polygon_preview(self, *, current: _DraftShape) -> Shape:
         preview = current
         if self._fill_drawing and len(preview.points) >= 2:
             preview = preview.add_point(point=self._line.points[1], autoclose=True)
         return _draft_to_shape(preview)
 
-    def _build_ai_points_preview(self, current: _DraftShape) -> list[Shape]:
+    def _build_ai_points_preview(self, *, current: _DraftShape) -> list[Shape]:
         if not _ai_models.supports_point_prompts(model_name=self.get_ai_model_name()):
             return []
         preview = current.add_point(
@@ -1717,7 +1729,7 @@ class Canvas(QtWidgets.QWidget):
     ) -> QPointF:
         return (point + self._compute_image_origin_offset(area=area)) * self.scale
 
-    def _compute_image_origin_offset(self, area: QtCore.QSize | None) -> QPointF:
+    def _compute_image_origin_offset(self, *, area: QtCore.QSize | None) -> QPointF:
         if area is None:
             area = super().size()
         scaled_w = self.pixmap.width() * self.scale
@@ -1729,7 +1741,7 @@ class Canvas(QtWidgets.QWidget):
     def is_out_of_pixmap(self, p: QPointF) -> bool:
         return _is_out_of_image(p, self.pixmap.size())
 
-    def _should_constrain_to_pixmap(self, point: QPointF) -> bool:
+    def _should_constrain_to_pixmap(self, point: QPointF, /) -> bool:
         return not self._allow_out_of_bounds_points and self.is_out_of_pixmap(point)
 
     def _finalize(self) -> None:
@@ -1861,7 +1873,7 @@ class Canvas(QtWidgets.QWidget):
             self.scroll_request.emit(delta.y(), Qt.Orientation.Vertical)
         a0.accept()
 
-    def _move_by_keyboard(self, offset: QPointF) -> None:
+    def _move_by_keyboard(self, *, offset: QPointF) -> None:
         if not self.selected_shapes:
             return
         self._drag_shapes(
@@ -1887,13 +1899,13 @@ class Canvas(QtWidgets.QWidget):
                 self._snapping = False
         elif self.mode == _CanvasMode.EDIT:
             if key == Qt.Key.Key_Up:
-                self._move_by_keyboard(QPointF(0.0, -MOVE_SPEED))
+                self._move_by_keyboard(offset=QPointF(0.0, -MOVE_SPEED))
             elif key == Qt.Key.Key_Down:
-                self._move_by_keyboard(QPointF(0.0, MOVE_SPEED))
+                self._move_by_keyboard(offset=QPointF(0.0, MOVE_SPEED))
             elif key == Qt.Key.Key_Left:
-                self._move_by_keyboard(QPointF(-MOVE_SPEED, 0.0))
+                self._move_by_keyboard(offset=QPointF(-MOVE_SPEED, 0.0))
             elif key == Qt.Key.Key_Right:
-                self._move_by_keyboard(QPointF(MOVE_SPEED, 0.0))
+                self._move_by_keyboard(offset=QPointF(MOVE_SPEED, 0.0))
             elif a0.matches(QtGui.QKeySequence.StandardKey.SelectAll):
                 self.select_shapes(shapes=self.shapes[:])
         self._update_status(extra_messages=None)
@@ -2016,7 +2028,7 @@ class Canvas(QtWidgets.QWidget):
         shape.visible = value
         self.update()
 
-    def _apply_cursor(self, role: CursorRole) -> None:
+    def _apply_cursor(self, role: CursorRole, /) -> None:
         if role == self._cursor:
             return
         shape = _canvas_interaction.cursor_shape_for(role=role)
@@ -2057,7 +2069,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
 
 
-def _is_degenerate_draft(draft: _DraftShape) -> bool:
+def _is_degenerate_draft(draft: _DraftShape, /) -> bool:
     points = draft.points
     shape_type = draft.shape_type
     if shape_type == "polygon":
@@ -2077,7 +2089,7 @@ def _is_degenerate_draft(draft: _DraftShape) -> bool:
     return False
 
 
-def _normalize_bbox_points(bbox_points: Sequence[QPointF]) -> list[QPointF]:
+def _normalize_bbox_points(*, bbox_points: Sequence[QPointF]) -> list[QPointF]:
     if len(bbox_points) != 2:
         raise ValueError(f"Expected 2 points for bbox, got {len(bbox_points)}")
 
@@ -2089,7 +2101,7 @@ def _normalize_bbox_points(bbox_points: Sequence[QPointF]) -> list[QPointF]:
     return [QPointF(xmin, ymin), QPointF(xmax, ymax)]
 
 
-def _snap_cursor_pos_for_square(pos: QPointF, opposite_vertex: QPointF) -> QPointF:
+def _snap_cursor_pos_for_square(*, pos: QPointF, opposite_vertex: QPointF) -> QPointF:
     pos_from_opposite: QPointF = pos - opposite_vertex
     square_size: float = min(abs(pos_from_opposite.x()), abs(pos_from_opposite.y()))
     return opposite_vertex + QPointF(
@@ -2099,7 +2111,7 @@ def _snap_cursor_pos_for_square(pos: QPointF, opposite_vertex: QPointF) -> QPoin
 
 
 def _compute_intersection_edges_image(
-    p1: QPointF, p2: QPointF, image_size: QtCore.QSize
+    *, p1: QPointF, p2: QPointF, image_size: QtCore.QSize
 ) -> QPointF:
     width = image_size.width()
     height = image_size.height()
@@ -2137,7 +2149,7 @@ def _compute_intersection_edges_image(
 
 
 def _should_reselect_on_right_press(
-    selected_shapes: list[Shape], hovered_shape: Shape | None
+    *, selected_shapes: list[Shape], hovered_shape: Shape | None
 ) -> bool:
     if not selected_shapes:
         return True
@@ -2147,7 +2159,7 @@ def _should_reselect_on_right_press(
 
 
 def _pick_pending_moved_shape(
-    is_moving_shape: bool, hovered_shape: Shape | None, shapes: list[Shape]
+    *, is_moving_shape: bool, hovered_shape: Shape | None, shapes: list[Shape]
 ) -> Shape | None:
     if not is_moving_shape:
         return None
@@ -2184,7 +2196,7 @@ def _project_oriented_rectangle_corners(
     return perp, para
 
 
-def _is_out_of_image(point: QPointF, image_size: QtCore.QSize) -> bool:
+def _is_out_of_image(point: QPointF, image_size: QtCore.QSize, /) -> bool:
     return (
         point.x() < 0
         or point.y() < 0

--- a/labelme/_widgets/download.py
+++ b/labelme/_widgets/download.py
@@ -65,7 +65,7 @@ class _DownloadThread(QThread):
             self.error.emit(e)
 
 
-def _format_bytes(n: int) -> str:
+def _format_bytes(n: int, /) -> str:
     UNIT: Final = 1024
     value = float(n)
     # Advance a tier when the value rounds up to a full UNIT, so the display

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -170,7 +170,7 @@ class LabelDialog(QtWidgets.QDialog):
     def label_history(self) -> list[str]:
         return self._label_history[:]
 
-    def _make_completer(self, completion: str) -> QtWidgets.QCompleter:
+    def _make_completer(self, *, completion: str) -> QtWidgets.QCompleter:
         if completion == "startswith":
             completer = QtWidgets.QCompleter(self.label_list.model())
             completer.setCompletionMode(
@@ -194,12 +194,13 @@ class LabelDialog(QtWidgets.QDialog):
         self,
         current: QtWidgets.QListWidgetItem | None,
         previous: QtWidgets.QListWidgetItem | None,
+        /,
     ) -> None:
         if current is None:
             return
         self.edit.setText(current.text())
 
-    def _on_item_double_clicked(self, item: QtWidgets.QListWidgetItem) -> None:
+    def _on_item_double_clicked(self, item: QtWidgets.QListWidgetItem, /) -> None:
         self.label_list.setCurrentItem(item)
         self._on_ok_clicked()
 
@@ -218,7 +219,7 @@ class LabelDialog(QtWidgets.QDialog):
                 widget.setParent(None)
                 widget.deleteLater()
 
-    def _update_flags(self, text: str) -> None:
+    def _update_flags(self, text: str, /) -> None:
         self._flag_states.update(self._collect_flags())
         flags: dict[str, bool] = {}
         for pattern, flag_keys in self._flags_spec.items():
@@ -312,7 +313,7 @@ class LabelDialog(QtWidgets.QDialog):
 
         return None, None, None, None
 
-    def _set_flag_checkboxes(self, flags: dict[str, bool]) -> None:
+    def _set_flag_checkboxes(self, *, flags: dict[str, bool]) -> None:
         self._clear_flag_checkboxes()
         for key, checked in flags.items():
             checkbox = QtWidgets.QCheckBox(key)
@@ -340,14 +341,14 @@ class LabelDialog(QtWidgets.QDialog):
         if self._fit_to_content["column"]:
             self.label_list.setMinimumWidth(self.label_list.sizeHintForColumn(0) + 2)
 
-    def _move_within_screen(self, target: QtCore.QPoint) -> None:
+    def _move_within_screen(self, target: QtCore.QPoint, /) -> None:
         self.adjustSize()
         # setGeometry() anchors the client area, unlike move() which anchors the
         # window frame: the content corner lands at target, not the title bar's.
         self.setGeometry(QtCore.QRect(target, self.size()))
         self._clamp_within_screen(target)
 
-    def _clamp_within_screen(self, target: QtCore.QPoint) -> None:
+    def _clamp_within_screen(self, target: QtCore.QPoint, /) -> None:
         screen = (
             QtGui.QGuiApplication.screenAt(target)
             or QtGui.QGuiApplication.primaryScreen()

--- a/labelme/_widgets/label_list_widget.py
+++ b/labelme/_widgets/label_list_widget.py
@@ -247,7 +247,7 @@ class LabelListWidget(QtWidgets.QListView):
         )
 
     def _resolve_item(
-        self, index: QtCore.QPersistentModelIndex
+        self, *, index: QtCore.QPersistentModelIndex
     ) -> LabelListWidgetItem | None:
         if not index.isValid():
             return None
@@ -275,12 +275,13 @@ class LabelListWidget(QtWidgets.QListView):
         self,
         selected: QtCore.QItemSelection,
         deselected: QtCore.QItemSelection,
+        /,
     ) -> None:
         selected_items = [self._model.itemFromIndex(i) for i in selected.indexes()]
         deselected_items = [self._model.itemFromIndex(i) for i in deselected.indexes()]
         self.item_selection_changed.emit(selected_items, deselected_items)
 
-    def _on_item_double_clicked(self, index: QtCore.QModelIndex) -> None:
+    def _on_item_double_clicked(self, index: QtCore.QModelIndex, /) -> None:
         self.item_double_clicked.emit(self._model.itemFromIndex(index))
 
     def selected_items(self) -> list[LabelListWidgetItem]:

--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -164,7 +164,7 @@ class _SettingsPage(QtWidgets.QWidget):
             + self._content.minimumSizeHint().width()
         )
 
-    def _scroll_to_group(self, index: int) -> None:
+    def _scroll_to_group(self, index: int, /) -> None:
         if not 0 <= index < len(self._groups):
             return
         group = self._groups[index]
@@ -178,7 +178,7 @@ class _SettingsPage(QtWidgets.QWidget):
         with QtCore.QSignalBlocker(self._navigation):
             self._navigation.setCurrentRow(index)
 
-    def _sync_navigation_to_scroll(self, value: int) -> None:
+    def _sync_navigation_to_scroll(self, value: int, /) -> None:
         if self._scrolling_to_group:
             return
         viewport = self._scroll_area.viewport()
@@ -320,7 +320,7 @@ class SettingsDialog(QtWidgets.QDialog):
         item.setEnabled(enabled)
         item.setToolTip("" if enabled else disabled_reason)
 
-    def _read_value(self, key_path: tuple[str, ...]) -> object:
+    def _read_value(self, *, key_path: tuple[str, ...]) -> object:
         node: object = self._config
         for key in key_path:
             if not isinstance(node, dict):
@@ -329,7 +329,7 @@ class SettingsDialog(QtWidgets.QDialog):
         return node
 
     def _build_group(
-        self, title: str, settings: list[schema.Setting]
+        self, *, title: str, settings: list[schema.Setting]
     ) -> QtWidgets.QGroupBox:
         group_box = QtWidgets.QGroupBox(title)
         group_box.setFlat(True)
@@ -361,7 +361,7 @@ class SettingsDialog(QtWidgets.QDialog):
         return group_box
 
     def _build_label_cell(
-        self, setting: schema.Setting, editor: QtWidgets.QWidget
+        self, *, setting: schema.Setting, editor: QtWidgets.QWidget
     ) -> QtWidgets.QWidget:
         label = QtWidgets.QLabel(self.tr(setting.label))
         label.setBuddy(editor)
@@ -397,8 +397,8 @@ class SettingsDialog(QtWidgets.QDialog):
         cell_layout.addWidget(note)
         return cell
 
-    def _create_editor(self, setting: schema.Setting) -> QtWidgets.QWidget:
-        value = self._read_value(setting.key_path)
+    def _create_editor(self, *, setting: schema.Setting) -> QtWidgets.QWidget:
+        value = self._read_value(key_path=setting.key_path)
         if setting.kind == "bool":
             check = QtWidgets.QCheckBox()
             self._set_editor_value(editor=check, value=value)
@@ -464,7 +464,9 @@ class SettingsDialog(QtWidgets.QDialog):
         if setting.kind == "color":
             swatch = _ColorSwatchButton()
             self._set_editor_value(editor=swatch, value=value)
-            swatch.clicked.connect(lambda: self._pick_color(setting.key_path, swatch))
+            swatch.clicked.connect(
+                lambda: self._pick_color(key_path=setting.key_path, swatch=swatch)
+            )
             return swatch
         if setting.kind == "str_list":
             edit = _PlainTextEdit()
@@ -483,6 +485,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
     def _create_combo(
         self,
+        *,
         setting: schema.Setting,
         value: object,
         items: Sequence[tuple[str, object]],
@@ -498,13 +501,15 @@ class SettingsDialog(QtWidgets.QDialog):
         )
         return combo
 
-    def _apply_combo(self, setting: schema.Setting, combo: QtWidgets.QComboBox) -> None:
+    def _apply_combo(
+        self, *, setting: schema.Setting, combo: QtWidgets.QComboBox
+    ) -> None:
         self._apply(setting.key_path, combo.currentData())
         if setting.key_path == ("shape_color", "mode"):
             self._sync_shape_color_mode()
 
     def _apply_integer_edit(
-        self, key_path: tuple[str, ...], edit: QtWidgets.QLineEdit
+        self, *, key_path: tuple[str, ...], edit: QtWidgets.QLineEdit
     ) -> None:
         try:
             value = int(edit.text())
@@ -515,7 +520,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self._apply(key_path, value)
 
     def _pick_color(
-        self, key_path: tuple[str, ...], swatch: _ColorSwatchButton
+        self, *, key_path: tuple[str, ...], swatch: _ColorSwatchButton
     ) -> None:
         picker = QtWidgets.QColorDialog(
             parent=self, currentColor=QtGui.QColor(*swatch.get_rgb())
@@ -534,6 +539,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
     def _preview_color(
         self,
+        *,
         key_path: tuple[str, ...],
         swatch: _ColorSwatchButton,
         color: QtGui.QColor,
@@ -542,7 +548,7 @@ class SettingsDialog(QtWidgets.QDialog):
         swatch.set_rgb(rgb)
         self._preview_shape_color(key_path, list(rgb))
 
-    def _set_editor_value(self, editor: QtWidgets.QWidget, value: object) -> None:
+    def _set_editor_value(self, *, editor: QtWidgets.QWidget, value: object) -> None:
         if isinstance(editor, QtWidgets.QCheckBox):
             editor.setChecked(bool(value))
         elif isinstance(editor, QtWidgets.QComboBox):
@@ -560,7 +566,7 @@ class SettingsDialog(QtWidgets.QDialog):
         elif isinstance(editor, _ColorSwatchButton):
             editor.set_rgb(_parse_rgb(value=value))
 
-    def _apply(self, key_path: tuple[str, ...], value: object) -> bool:
+    def _apply(self, key_path: tuple[str, ...], value: object, /) -> bool:
         editor = self._editors[key_path]
         if isinstance(editor, QtWidgets.QComboBox):
             model = editor.model()
@@ -578,10 +584,10 @@ class SettingsDialog(QtWidgets.QDialog):
         self._revert_editor(key_path=key_path)
         return False
 
-    def _revert_editor(self, key_path: tuple[str, ...]) -> None:
-        self.set_value(key_path=key_path, value=self._read_value(key_path))
+    def _revert_editor(self, *, key_path: tuple[str, ...]) -> None:
+        self.set_value(key_path=key_path, value=self._read_value(key_path=key_path))
 
-    def _on_labels_edited(self, edit: _PlainTextEdit) -> None:
+    def _on_labels_edited(self, *, edit: _PlainTextEdit) -> None:
         labels = _parse_str_list(edit=edit)
         validate_combo = self._editors.get(("validate_label",))
         if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = ["GR002", "GR003", "GR004", "GR006"]
+select = ["GR001", "GR002", "GR003", "GR004", "GR006"]
 
 [tool.ruff.lint]
 select = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,7 @@ def close_or_pause(
         widget.close()
 
 
-def _create_annotated_nested(data_path: Path) -> None:
+def _create_annotated_nested(*, data_path: Path) -> None:
     dst_dir: Path = data_path / "annotated_nested"
     dst_dir.mkdir()
 

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -26,6 +26,7 @@ _AI_TEXT_MODEL: Final = "yoloworld:latest"
 
 
 def _make_response(
+    *,
     texts: list[str],
     boxes: list[tuple[int, int, int, int]],
     scores: list[float],
@@ -53,7 +54,7 @@ def _make_response(
 
 
 def _make_person_response(
-    texts: list[str], with_masks: bool
+    *, texts: list[str], with_masks: bool
 ) -> osam.types.GenerateResponse:
     person_idx = texts.index("person")
     return _make_response(
@@ -65,7 +66,7 @@ def _make_person_response(
     )
 
 
-def _make_multi_label_response(texts: list[str]) -> osam.types.GenerateResponse:
+def _make_multi_label_response(*, texts: list[str]) -> osam.types.GenerateResponse:
     person_idx = texts.index("person")
     sofa_idx = texts.index("sofa")
     return _make_response(
@@ -77,7 +78,7 @@ def _make_multi_label_response(texts: list[str]) -> osam.types.GenerateResponse:
     )
 
 
-def _make_edge_crossing_response(texts: list[str]) -> osam.types.GenerateResponse:
+def _make_edge_crossing_response(*, texts: list[str]) -> osam.types.GenerateResponse:
     return _make_response(
         texts=texts,
         boxes=[(-10, 30, 50, 100)],
@@ -88,6 +89,7 @@ def _make_edge_crossing_response(texts: list[str]) -> osam.types.GenerateRespons
 
 
 def _install_mock_session(
+    *,
     win: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
     response_fn: Callable[..., osam.types.GenerateResponse],

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -32,6 +32,7 @@ _VERTICES: Final[tuple[tuple[float, float], ...]] = (
 
 @pytest.fixture()
 def _auto_save_win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -48,6 +49,7 @@ def _auto_save_win(
 
 @pytest.fixture()
 def _raw_auto_save_win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -37,7 +37,7 @@ _TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
 _SHAPE_INDEX: Final[int] = 0
 
 
-def _find_edge_midpoint_clear_of_vertices(canvas: Canvas, shape: Shape) -> QPointF:
+def _find_edge_midpoint_clear_of_vertices(*, canvas: Canvas, shape: Shape) -> QPointF:
     # Hovering prefers a vertex over an edge within epsilon/scale of it, so the
     # middle of a short edge stops being hoverable once a smaller screen scales
     # the image down. Take the edge midpoint standing farthest from any vertex.
@@ -66,6 +66,7 @@ def _find_edge_midpoint_clear_of_vertices(canvas: Canvas, shape: Shape) -> QPoin
 
 
 def _hover_and_drag(
+    *,
     qtbot: QtBot,
     canvas: Canvas,
     start_image_pos: QPointF,
@@ -85,6 +86,7 @@ def _hover_and_drag(
 
 
 def _cancel_label(
+    *,
     qtbot: QtBot,
     label_dialog: LabelDialog,
 ) -> None:
@@ -94,7 +96,7 @@ def _cancel_label(
     )
 
 
-def _wait_for_shape(qtbot: QtBot, canvas: Canvas, label: str) -> Shape:
+def _wait_for_shape(*, qtbot: QtBot, canvas: Canvas, label: str) -> Shape:
     result: list[Shape] = []
 
     def created() -> None:
@@ -109,6 +111,7 @@ def _wait_for_shape(qtbot: QtBot, canvas: Canvas, label: str) -> Shape:
 
 
 def _click_to_remove_point(
+    *,
     qtbot: QtBot,
     canvas: Canvas,
     vertex: QPointF,
@@ -126,6 +129,7 @@ def _click_to_remove_point(
 
 
 def _save_and_check(
+    *,
     win: MainWindow,
     tmp_path: Path,
 ) -> None:
@@ -746,7 +750,7 @@ def test_remove_point_blocked_at_minimum(
     close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)
 
 
-def _click_to_select(qtbot: QtBot, canvas: Canvas, image_pos: QPointF) -> None:
+def _click_to_select(*, qtbot: QtBot, canvas: Canvas, image_pos: QPointF) -> None:
     pos = image_to_widget_pos(canvas=canvas, image_pos=image_pos)
     hover_widget_pos(qtbot=qtbot, canvas=canvas, pos=pos)
     qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=pos)

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -45,14 +45,14 @@ _TRIANGLE_FRACTIONS: Final[tuple[tuple[float, float], ...]] = (
 )
 
 
-def _pin_canvas_for_snapshot(qtbot: QtBot, canvas: Canvas) -> None:
+def _pin_canvas_for_snapshot(*, qtbot: QtBot, canvas: Canvas) -> None:
     canvas.setFixedSize(_RENDER_WIDTH, _RENDER_HEIGHT)
     canvas.scale = _RENDER_SCALE
     canvas.update()
     qtbot.wait(_PAINT_SETTLE_MS)
 
 
-def _render_canvas_offscreen(canvas: Canvas) -> QImage:
+def _render_canvas_offscreen(*, canvas: Canvas) -> QImage:
     image = QImage(_RENDER_WIDTH, _RENDER_HEIGHT, QImage.Format.Format_ARGB32)
     image.fill(_BACKGROUND_COLOR)
     painter = QPainter(image)
@@ -70,7 +70,7 @@ def _render_canvas_offscreen(canvas: Canvas) -> QImage:
     return image
 
 
-def _qimage_to_numpy(image: QImage) -> np.ndarray:
+def _qimage_to_numpy(image: QImage, /) -> np.ndarray:
     assert image.format() == QImage.Format.Format_ARGB32
     width = image.width()
     height = image.height()
@@ -82,12 +82,12 @@ def _qimage_to_numpy(image: QImage) -> np.ndarray:
     return arr[:, :width, :].copy()
 
 
-def _save_snapshot(path: Path, image: QImage) -> None:
+def _save_snapshot(*, path: Path, image: QImage) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     image.save(str(path))
 
 
-def _assert_matches_snapshot(actual: QImage, snapshot_path: Path) -> None:
+def _assert_matches_snapshot(*, actual: QImage, snapshot_path: Path) -> None:
     TOLERANCE_MAX_DIFF: Final[int] = 1
     TOLERANCE_PASSING_FRACTION: Final[float] = 0.995
     if not snapshot_path.exists():
@@ -115,6 +115,7 @@ def _assert_matches_snapshot(actual: QImage, snapshot_path: Path) -> None:
 
 
 def _check_or_update_snapshot(
+    *,
     canvas: Canvas,
     snapshot_path: Path,
     update_snapshots: bool,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -52,7 +52,7 @@ def image_to_widget_pos(canvas: Canvas, image_pos: QPointF) -> QPoint:
 
 @pytest.fixture(autouse=True)
 def _isolated_qtsettings(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Generator[None, None, None]:
     settings_file = tmp_path / "qtsettings.ini"
     settings: QSettings = QSettings(str(settings_file), QSettings.Format.IniFormat)
@@ -63,12 +63,12 @@ def _isolated_qtsettings(
 
 
 @pytest.fixture(autouse=True)
-def _stub_setup_loguru(monkeypatch: pytest.MonkeyPatch) -> None:
+def _stub_setup_loguru(*, monkeypatch: pytest.MonkeyPatch) -> None:
     # main() configures loguru with a file handler using enqueue=True, which
     # spawns a multiprocessing.Queue (semaphores → file descriptors). Calling
     # main() per test leaks FDs faster than GC reclaims them and exhausts the
     # worker's ulimit. Tests don't need file logging, so stub it out.
-    monkeypatch.setattr("labelme.__main__._setup_loguru", lambda logger_level: None)
+    monkeypatch.setattr("labelme.__main__._setup_loguru", lambda *, logger_level: None)
 
 
 MainWinFactory = Callable[..., MainWindow]

--- a/tests/e2e/delete_confirmation_test.py
+++ b/tests/e2e/delete_confirmation_test.py
@@ -10,6 +10,7 @@ from .conftest import MainWinFactory
 
 def _exec_clicking_role(
     role: QtWidgets.QMessageBox.ButtonRole,
+    /,
 ) -> Callable[[QtWidgets.QMessageBox], int]:
     def _exec(msg_box: QtWidgets.QMessageBox) -> int:
         for button in msg_box.buttons():

--- a/tests/e2e/drag_and_drop_test.py
+++ b/tests/e2e/drag_and_drop_test.py
@@ -19,13 +19,13 @@ from ..conftest import close_or_pause
 from .conftest import MainWinFactory
 
 
-def _make_drop_mime(paths: list[Path]) -> QMimeData:
+def _make_drop_mime(*, paths: list[Path]) -> QMimeData:
     mime = QMimeData()
     mime.setUrls([QUrl.fromLocalFile(str(p)) for p in paths])
     return mime
 
 
-def _drag_enter_accepted(win: MainWindow, mime: QMimeData) -> bool:
+def _drag_enter_accepted(*, win: MainWindow, mime: QMimeData) -> bool:
     event = QDragEnterEvent(
         QPoint(0, 0),
         Qt.DropAction.CopyAction,
@@ -37,7 +37,7 @@ def _drag_enter_accepted(win: MainWindow, mime: QMimeData) -> bool:
     return event.isAccepted()
 
 
-def _send_drop(win: MainWindow, mime: QMimeData) -> None:
+def _send_drop(*, win: MainWindow, mime: QMimeData) -> None:
     event = QDropEvent(
         QPointF(0, 0),
         Qt.DropAction.CopyAction,

--- a/tests/e2e/file_dialog_actions_test.py
+++ b/tests/e2e/file_dialog_actions_test.py
@@ -47,47 +47,47 @@ def loaded_win(
     return win
 
 
-def _open_file_dialog_return(paths: _Paths) -> tuple[str, str]:
+def _open_file_dialog_return(paths: _Paths, /) -> tuple[str, str]:
     return (str(paths.next_image), "")
 
 
-def _open_dir_dialog_return(paths: _Paths) -> str:
+def _open_dir_dialog_return(paths: _Paths, /) -> str:
     return str(paths.annotated_dir)
 
 
-def _save_file_dialog_return(paths: _Paths) -> tuple[str, str]:
+def _save_file_dialog_return(paths: _Paths, /) -> tuple[str, str]:
     return (str(paths.save_path), "")
 
 
-def _new_output_dir_dialog_return(paths: _Paths) -> str:
+def _new_output_dir_dialog_return(paths: _Paths, /) -> str:
     paths.new_output_dir.mkdir(exist_ok=True)
     return str(paths.new_output_dir)
 
 
-def _trigger_open_file(win: MainWindow) -> None:
+def _trigger_open_file(win: MainWindow, /) -> None:
     win._open_file_with_dialog()
 
 
-def _trigger_open_dir(win: MainWindow) -> None:
+def _trigger_open_dir(win: MainWindow, /) -> None:
     win._open_dir_with_dialog()
 
 
-def _trigger_save_as(win: MainWindow) -> None:
+def _trigger_save_as(win: MainWindow, /) -> None:
     win._save_label_file(save_as=True)
 
 
-def _trigger_change_output_dir(win: MainWindow) -> None:
+def _trigger_change_output_dir(win: MainWindow, /) -> None:
     win.prompt_output_dir()
 
 
-def _verify_open_file(win: MainWindow, paths: _Paths) -> bool:
+def _verify_open_file(win: MainWindow, paths: _Paths, /) -> bool:
     return (
         win._image_path is not None
         and Path(win._image_path).resolve() == paths.next_image.resolve()
     )
 
 
-def _verify_open_dir(win: MainWindow, paths: _Paths) -> bool:
+def _verify_open_dir(win: MainWindow, paths: _Paths, /) -> bool:
     return (
         win._docks.file_list.count() > 0
         and win._image_path is not None
@@ -95,11 +95,11 @@ def _verify_open_dir(win: MainWindow, paths: _Paths) -> bool:
     )
 
 
-def _verify_save_as(_win: MainWindow, paths: _Paths) -> bool:
+def _verify_save_as(_win: MainWindow, paths: _Paths, /) -> bool:
     return paths.save_path.exists()
 
 
-def _verify_change_output_dir(win: MainWindow, paths: _Paths) -> bool:
+def _verify_change_output_dir(win: MainWindow, paths: _Paths, /) -> bool:
     return win._output_dir == paths.new_output_dir
 
 

--- a/tests/e2e/file_loading_test.py
+++ b/tests/e2e/file_loading_test.py
@@ -166,7 +166,7 @@ def test_MainWindow_reports_size_when_image_exceeds_decode_limit(
 
     set_allocation_limit(1)
 
-    raw_win._load_file(str(image_path))
+    raw_win._load_file(image_or_label_path=str(image_path))
 
     assert len(critical_messages) == 1
     assert "800x600" in critical_messages[0]
@@ -236,7 +236,7 @@ def test_MainWindow_rejects_malformed_shapes_before_installing_any(
             }
         )
     )
-    raw_win._load_file(str(label_path))
+    raw_win._load_file(image_or_label_path=str(label_path))
 
     assert len(critical_messages) == 1
     assert str(label_path) in critical_messages[0]

--- a/tests/e2e/file_search_test.py
+++ b/tests/e2e/file_search_test.py
@@ -27,7 +27,7 @@ def test_file_search_filters_loaded_images_without_changing_active_annotation(
     scan_calls: list[str] = []
     scan_image_files = labelme._app._scan_image_files
 
-    def _track_scan_image_files(root_dir: str) -> list[str]:
+    def _track_scan_image_files(*, root_dir: str) -> list[str]:
         scan_calls.append(root_dir)
         return scan_image_files(root_dir=root_dir)
 
@@ -65,7 +65,7 @@ def test_file_search_filters_loaded_images_without_changing_active_annotation(
         continue_checks.append(True)
         return can_continue()
 
-    def _track_load_file(image_or_label_path: str) -> None:
+    def _track_load_file(*, image_or_label_path: str) -> None:
         load_calls.append(image_or_label_path)
         load_file(image_or_label_path=image_or_label_path)
 

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -26,7 +26,7 @@ _CLOSE_POLYGON_CLICK: Final = _VERTICES[0]
 _draw_triangle = partial(draw_triangle, vertices=_VERTICES)
 
 
-def _check_flag(label_dialog: LabelDialog, name: str) -> None:
+def _check_flag(*, label_dialog: LabelDialog, name: str) -> None:
     for cb in label_dialog.findChildren(QCheckBox):
         if cb.text() == name:
             cb.setChecked(True)
@@ -35,6 +35,7 @@ def _check_flag(label_dialog: LabelDialog, name: str) -> None:
 
 
 def _enter_label(
+    *,
     qtbot: QtBot,
     label_dialog: LabelDialog,
     name: str,

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -24,7 +24,7 @@ _CLOSE_POLYGON_CLICK: Final = _VERTICES[0]
 _draw_triangle = partial(draw_triangle, vertices=_VERTICES)
 
 
-def _label_list_texts(label_list: QtWidgets.QListWidget) -> list[str]:
+def _label_list_texts(*, label_list: QtWidgets.QListWidget) -> list[str]:
     texts: list[str] = []
     for i in range(label_list.count()):
         item = label_list.item(i)

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -21,6 +21,7 @@ from .conftest import submit_label_dialog
 
 
 def _draw_polygon(
+    *,
     qtbot: QtBot,
     win: MainWindow,
     canvas: Canvas,

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -29,6 +29,7 @@ _draw_and_commit_polygon = partial(draw_and_commit_polygon, vertices=_VERTICES)
 
 
 def _schedule_capture_then_cancel(
+    *,
     label_dialog: LabelDialog,
     captured: list[str],
 ) -> None:

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -18,13 +18,13 @@ from .conftest import image_to_widget_pos
 _DRAG_OFFSET_PX: Final[int] = 40
 
 
-def _diagonal_drag_endpoints(canvas: Canvas) -> tuple[QPoint, QPoint]:
+def _diagonal_drag_endpoints(*, canvas: Canvas) -> tuple[QPoint, QPoint]:
     start = QPoint(canvas.width() // 2, canvas.height() // 2)
     end = QPoint(start.x() + _DRAG_OFFSET_PX, start.y() + _DRAG_OFFSET_PX)
     return start, end
 
 
-def _zoom_until_overflow(canvas: Canvas) -> None:
+def _zoom_until_overflow(*, canvas: Canvas) -> None:
     # Mutates canvas.scale directly to bypass the public zoom path because
     # this fixture only needs to force overflow; if the zoom pipeline gains
     # additional side effects relevant to a test, route through that instead.

--- a/tests/e2e/oriented_rectangle_test.py
+++ b/tests/e2e/oriented_rectangle_test.py
@@ -20,16 +20,18 @@ from .conftest import image_to_widget_pos
 from .conftest import submit_label_dialog
 
 
-def _centroid(points: np.ndarray) -> QPointF:
+def _centroid(points: np.ndarray, /) -> QPointF:
     return QPointF(float(points[:, 0].mean()), float(points[:, 1].mean()))
 
 
-def _edge_lengths(points: np.ndarray) -> list[float]:
+def _edge_lengths(points: np.ndarray, /) -> list[float]:
     n = len(points)
     return [float(np.linalg.norm(points[(i + 1) % n] - points[i])) for i in range(n)]
 
 
-def _vertex_displacements(actual: np.ndarray, original: list[QPointF]) -> list[float]:
+def _vertex_displacements(
+    *, actual: np.ndarray, original: list[QPointF]
+) -> list[float]:
     return [
         math.hypot(float(actual[i][0]) - o.x(), float(actual[i][1]) - o.y())
         for i, o in enumerate(original)
@@ -37,6 +39,7 @@ def _vertex_displacements(actual: np.ndarray, original: list[QPointF]) -> list[f
 
 
 def _draw_oriented_rectangle(
+    *,
     qtbot: QtBot,
     win: MainWindow,
     label: str,

--- a/tests/e2e/save_format_contract_test.py
+++ b/tests/e2e/save_format_contract_test.py
@@ -268,9 +268,9 @@ def test_open_json_with_missing_image_shows_error_and_recovers(
         json.dump(json_data, f)
 
     QTimer.singleShot(0, lambda: dismiss_active_modal(qtbot=qtbot))
-    raw_win._load_file(str(missing_image_json))
+    raw_win._load_file(image_or_label_path=str(missing_image_json))
 
-    raw_win._load_file(str(data_path / _RAW_FILE_NAME))
+    raw_win._load_file(image_or_label_path=str(data_path / _RAW_FILE_NAME))
     qtbot.waitUntil(lambda: raw_win._annotation is not None, timeout=5_000)
 
     close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -22,7 +22,7 @@ from ..conftest import close_or_pause
 from .conftest import MainWinFactory
 
 
-def _set_flag_checked(win: MainWindow, name: str) -> None:
+def _set_flag_checked(*, win: MainWindow, name: str) -> None:
     flag_list = win._docks.flag_list
     flag_list.blockSignals(True)  # avoid mark_dirty; we test only the flag refresh
     try:
@@ -37,7 +37,7 @@ def _set_flag_checked(win: MainWindow, name: str) -> None:
         flag_list.blockSignals(False)
 
 
-def _open_settings_dialog(win: MainWindow) -> SettingsDialog:
+def _open_settings_dialog(*, win: MainWindow) -> SettingsDialog:
     win._open_settings()
     dialog = win._settings_dialog
     assert dialog is not None
@@ -310,7 +310,7 @@ def test_flags_setting_refreshes_flag_dock_live(
     assert win._read_flag_dock_states() == {"occluded": False, "truncated": False}
     assert not win._is_changed  # a settings-driven refresh must not dirty the image
 
-    _set_flag_checked(win, "occluded")
+    _set_flag_checked(win=win, name="occluded")
     flags_editor.setPlainText("occluded\ntruncated\nblurry")
     flags_editor.commit()
 
@@ -400,7 +400,7 @@ def test_setting_controls_revert_when_write_fails(
     # Refuse the save at the boundary a read-only config directory would;
     # injecting the failure keeps it reachable on Windows and as root, where
     # a read-only directory does not block writes.
-    def _refuse_write(config_file: Path, content: str) -> None:
+    def _refuse_write(*, config_file: Path, content: str) -> None:
         raise PermissionError(f"injected write failure: {config_file}")
 
     monkeypatch.setattr(_writer, "_atomic_write", _refuse_write)

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -22,6 +22,7 @@ from .conftest import show_window_and_wait_for_imagedata
 
 
 def _open_and_select_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -43,6 +44,7 @@ def _open_and_select_shape(
 
 
 def _delete_selected_shape(
+    *,
     win: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,

--- a/tests/e2e/unsaved_changes_dialog_test.py
+++ b/tests/e2e/unsaved_changes_dialog_test.py
@@ -42,6 +42,7 @@ def _intercept_question(
 
 @pytest.fixture()
 def _raw_win_no_autosave(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -58,6 +59,7 @@ def _raw_win_no_autosave(
 
 @pytest.fixture()
 def _dir_win_no_autosave(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -26,6 +26,7 @@ _VIEWPORT_ZOOM: Final[int] = 300
 
 @pytest.fixture()
 def _win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -181,6 +182,7 @@ def test_zoom_step_keeps_fractional_precision(
 
 
 def _set_scroll_bars_to_fraction(
+    *,
     qtbot: QtBot,
     win: MainWindow,
     numerator: int,
@@ -199,6 +201,7 @@ def _set_scroll_bars_to_fraction(
 
 
 def _wait_for_viewport(
+    *,
     qtbot: QtBot,
     win: MainWindow,
     scroll_values: dict[Qt.Orientation, int],
@@ -218,6 +221,7 @@ def _wait_for_viewport(
 
 @pytest.fixture(name="scrolled_win")
 def _make_scrolled_win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -462,6 +466,7 @@ def test_close_and_open_restores_viewport(
 
 
 def _make_wheel_event(
+    *,
     pos: QPointF,
     angle_delta: QPoint,
     modifiers: Qt.KeyboardModifier,

--- a/tests/unit/_automation/_ai_assist_test.py
+++ b/tests/unit/_automation/_ai_assist_test.py
@@ -39,6 +39,7 @@ def install_fake_osam_session(
 
 def _propose(
     session: AiAssistSession,
+    /,
     *,
     prompt_kind: _ai_assist.AiPromptKind,
     existing_shapes: list[Shape] | None,
@@ -179,8 +180,8 @@ def test_sam3_box_prompt_reaches_session(
 
 
 def _annotation(
-    score: float | None,
     *,
+    score: float | None,
     bbox: tuple[int, int, int, int] | None,
     mask: NDArray[np.bool_] | None,
 ) -> osam.types.Annotation:

--- a/tests/unit/_automation/_osam_session_test.py
+++ b/tests/unit/_automation/_osam_session_test.py
@@ -67,7 +67,7 @@ def install_fake_model(
     return _install
 
 
-def _run_point(session: OsamSession, image_id: str) -> None:
+def _run_point(session: OsamSession, /, *, image_id: str) -> None:
     session.run(
         image=_IMAGE,
         image_id=image_id,

--- a/tests/unit/_automation/_text_detection_test.py
+++ b/tests/unit/_automation/_text_detection_test.py
@@ -29,6 +29,7 @@ def _make_annotation(*, with_mask: bool) -> osam.types.Annotation:
 
 def _get_bboxes(
     response: osam.types.GenerateResponse,
+    /,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, list[NDArray[np.bool_]] | None]:
     return get_bboxes_from_texts(
         session=_FakeOsamSession(response),  # ty: ignore[invalid-argument-type]

--- a/tests/unit/_config/api_test.py
+++ b/tests/unit/_config/api_test.py
@@ -9,7 +9,7 @@ import pytest
 from labelme import _config
 
 
-def _steer_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+def _steer_home(*, monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
     monkeypatch.setenv("HOME", str(home))
     # ntpath.expanduser ignores HOME, so without this the test would read and
     # write the real user profile on Windows.
@@ -71,14 +71,14 @@ def test_migrate_removes_logger_level(tmp_path: Path) -> None:
 )
 def test_migrate_ai_model_name(input_name: str, expected_name: str) -> None:
     config: dict = {"ai": {"default": input_name}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config["ai"]["default"] == expected_name
 
 
 @pytest.mark.parametrize("model_name", [True, 42, ["Sam"]])
 def test_migrate_tolerates_non_string_ai_default(model_name: object) -> None:
     config: dict = {"ai": {"default": model_name}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config["ai"]["default"] == model_name
 
 
@@ -124,21 +124,21 @@ _POLYGON_TO_SHAPE_RENAMES: Final = {
 )
 def test_migrate_polygon_shortcut_to_shape(old_key: str, new_key: str) -> None:
     config = {"shortcuts": {old_key: "Ctrl+X"}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert old_key not in config["shortcuts"]
     assert config["shortcuts"][new_key] == "Ctrl+X"
 
 
 def test_migrate_polygon_shortcuts_no_shortcuts_key() -> None:
     config = {}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert "shortcuts" not in config
 
 
 @pytest.mark.parametrize("section", ["shortcuts", "ai"])
 def test_migrate_tolerates_empty_section(section: str) -> None:
     config = {section: None}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config[section] is None
 
 
@@ -160,7 +160,7 @@ def test_load_config_empty_section_keeps_defaults(
 @pytest.mark.parametrize("section", ["shortcuts", "ai"])
 def test_migrate_leaves_malformed_section_for_merge_to_report(section: str) -> None:
     config = {section: "oops"}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config[section] == "oops"
 
 
@@ -183,7 +183,7 @@ def test_migrate_polygon_shortcut_drops_old_key_when_new_key_exists(
     old_key: str, new_key: str
 ) -> None:
     config = {"shortcuts": {old_key: "Ctrl+X", new_key: "Ctrl+Y"}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config["shortcuts"][new_key] == "Ctrl+Y"
     assert old_key not in config["shortcuts"]
 
@@ -207,7 +207,7 @@ def test_load_config_tolerates_both_polygon_and_shape_shortcuts(
 
 def test_migrate_removes_add_point_to_edge_shortcut() -> None:
     config = {"shortcuts": {"add_point_to_edge": "Ctrl+X"}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert "add_point_to_edge" not in config["shortcuts"]
 
 
@@ -234,7 +234,7 @@ def test_migrate_ai_crosshair_keys_to_ai_points_to_shape(
     ai_polygon: bool, ai_mask: bool, expected: bool
 ) -> None:
     config = {"canvas": {"crosshair": {"ai_polygon": ai_polygon, "ai_mask": ai_mask}}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     crosshair = config["canvas"]["crosshair"]
     assert "ai_polygon" not in crosshair
     assert "ai_mask" not in crosshair
@@ -245,7 +245,7 @@ def test_migrate_ai_crosshair_keeps_explicit_ai_points_to_shape() -> None:
     config = {
         "canvas": {"crosshair": {"ai_polygon": True, "ai_points_to_shape": False}}
     }
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     crosshair = config["canvas"]["crosshair"]
     assert "ai_polygon" not in crosshair
     assert crosshair["ai_points_to_shape"] is False
@@ -262,7 +262,7 @@ def test_load_config_tolerates_legacy_ai_crosshair_keys(tmp_path: Path) -> None:
 
 def test_migrate_leaves_malformed_crosshair_for_merge_to_report() -> None:
     config = {"canvas": {"crosshair": "oops"}}
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config["canvas"]["crosshair"] == "oops"
 
 
@@ -292,7 +292,7 @@ def test_migrate_keep_prev_brightness_contrast(
     old_config: dict[str, bool], expected: dict[str, bool]
 ) -> None:
     config = old_config.copy()
-    _config._migrate_config_from_file(config)
+    _config._migrate_config_from_file(config_from_yaml=config)
     assert config == expected
 
 

--- a/tests/unit/_config/schema_test.py
+++ b/tests/unit/_config/schema_test.py
@@ -17,7 +17,7 @@ def default_config() -> dict:
     return load_config(config_file=None, config_overrides={})
 
 
-def _resolve(config: dict, key_path: tuple[str, ...]) -> object:
+def _resolve(*, config: dict, key_path: tuple[str, ...]) -> object:
     node: object = config
     for key in key_path:
         assert isinstance(node, dict), key_path
@@ -26,7 +26,7 @@ def _resolve(config: dict, key_path: tuple[str, ...]) -> object:
     return node
 
 
-def _ids(settings: tuple[Setting, ...]) -> list[str]:
+def _ids(settings: tuple[Setting, ...], /) -> list[str]:
     return [".".join(setting.key_path) for setting in settings]
 
 

--- a/tests/unit/_config/writer_test.py
+++ b/tests/unit/_config/writer_test.py
@@ -12,7 +12,7 @@ from labelme import _config
 from labelme import _yaml
 
 
-def _parse(config_file: Path) -> dict | None:
+def _parse(config_file: Path, /) -> dict | None:
     return _yaml.safe_load(config_file.read_text(encoding="utf-8"))
 
 

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -67,7 +67,7 @@ def annotated_dst(data_path: Path, tmp_path: Path) -> Path:
     return tmp_path / "2011_000003.json"
 
 
-def _dump_json(path: Path, raw: dict[str, Any]) -> None:
+def _dump_json(*, path: Path, raw: dict[str, Any]) -> None:
     with open(path, "w") as f:
         json.dump(raw, f)
 

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -11,7 +11,7 @@ from labelme._shape import Shape
 from labelme._shape import ShapeType
 
 
-def _make_oriented_rectangle(points: list[tuple[float, float]]) -> Shape:
+def _make_oriented_rectangle(points: list[tuple[float, float]], /) -> Shape:
     return Shape(
         shape_type="oriented_rectangle",
         points=np.array(points, dtype=np.float64),

--- a/tests/unit/examples/utils_test.py
+++ b/tests/unit/examples/utils_test.py
@@ -15,7 +15,9 @@ from examples import utils
 _SOURCE_MODES: Final = ["RGB", "RGBA", "LA", "L", "P"]
 
 
-def _mask_shape(points: list[list[float]], mask: NDArray[np.bool_]) -> dict[str, Any]:
+def _mask_shape(
+    *, points: list[list[float]], mask: NDArray[np.bool_]
+) -> dict[str, Any]:
     return dict(
         label="car",
         points=points,
@@ -94,7 +96,7 @@ def test_shapes_to_label_mask_keeps_integer_bbox_extent() -> None:
     assert np.array_equal(cls > 0, painted)
 
 
-def _encode_png(img_pil: PIL.Image.Image) -> bytes:
+def _encode_png(img_pil: PIL.Image.Image, /) -> bytes:
     buf = io.BytesIO()
     img_pil.save(buf, format="PNG")
     return buf.getvalue()

--- a/tests/unit/read_image_file_test.py
+++ b/tests/unit/read_image_file_test.py
@@ -11,7 +11,7 @@ import tifffile
 from labelme._label_file import read_image_file
 
 
-def _make_image(tmp_path: Path, filename: str, mode: str) -> Path:
+def _make_image(tmp_path: Path, /, *, filename: str, mode: str) -> Path:
     channels = 4 if mode == "RGBA" else 3
     arr = np.random.randint(0, 255, (100, 100, channels), dtype=np.uint8)
     path = tmp_path / filename
@@ -20,13 +20,13 @@ def _make_image(tmp_path: Path, filename: str, mode: str) -> Path:
 
 
 def test_tiff_without_alpha_encoded_as_jpeg(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.tiff", mode="RGB")
+    path = _make_image(tmp_path, filename="test.tiff", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data[:2] == b"\xff\xd8"
 
 
 def test_tiff_with_alpha_encoded_as_png(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.tiff", mode="RGBA")
+    path = _make_image(tmp_path, filename="test.tiff", mode="RGBA")
     data = read_image_file(filename=str(path))
     assert data[:4] == b"\x89PNG"
 
@@ -40,13 +40,13 @@ def test_corrupt_tiff_raises_os_error(tmp_path: Path) -> None:
 
 
 def test_jpeg_returns_raw_bytes(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.jpg", mode="RGB")
+    path = _make_image(tmp_path, filename="test.jpg", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 
 
 def test_png_returns_raw_bytes(tmp_path: Path) -> None:
-    path = _make_image(tmp_path, "test.png", mode="RGB")
+    path = _make_image(tmp_path, filename="test.png", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 

--- a/tests/unit/utils/image_test.py
+++ b/tests/unit/utils/image_test.py
@@ -90,7 +90,7 @@ def test_img_qt_to_arr_copies_source_buffer() -> None:
     np.testing.assert_array_equal(arr[0, 0], [30, 20, 10, 255])
 
 
-def _make_jpeg_with_red_marker(orientation: int) -> PIL.Image.Image:
+def _make_jpeg_with_red_marker(*, orientation: int) -> PIL.Image.Image:
     # Round-trip through JPEG so apply_exif_orientation can read the EXIF
     # Orientation tag; pin quality so the red marker stays the brightest pixel.
     ORIENTATION_TAG: Final = 274  # EXIF Orientation tag (0x0112)
@@ -105,7 +105,7 @@ def _make_jpeg_with_red_marker(orientation: int) -> PIL.Image.Image:
     return PIL.Image.open(buf)
 
 
-def _find_brightest_red_rowcol(image: PIL.Image.Image) -> tuple[int, int]:
+def _find_brightest_red_rowcol(image: PIL.Image.Image, /) -> tuple[int, int]:
     red = np.asarray(image)[:, :, 0]
     row, col = np.unravel_index(red.argmax(), red.shape)
     return int(row), int(col)

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -146,7 +146,7 @@ def test_new_icon_with_path_that_includes_subdir(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _set_window_text(app: QtWidgets.QApplication, color: QtGui.QColor) -> None:
+def _set_window_text(app: QtWidgets.QApplication, /, *, color: QtGui.QColor) -> None:
     palette = app.palette()
     palette.setColor(
         QtGui.QPalette.ColorGroup.Normal, QtGui.QPalette.ColorRole.WindowText, color
@@ -159,7 +159,7 @@ def test_tinted_svg_engine_renders_window_text_color(
 ) -> None:
     original = qapp.palette()
     try:
-        _set_window_text(qapp, QtGui.QColor(255, 0, 0))
+        _set_window_text(qapp, color=QtGui.QColor(255, 0, 0))
         svg = (
             b'<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4">'
             b'<rect width="4" height="4" fill="currentColor"/></svg>'
@@ -204,9 +204,9 @@ def test_new_icon_tints_monochrome_icon_to_palette(
     original = qapp.palette()
     try:
         icon = new_icon("phosphor/polygon.svg")  # authored with fill="currentColor"
-        _set_window_text(qapp, QtGui.QColor(255, 0, 0))
+        _set_window_text(qapp, color=QtGui.QColor(255, 0, 0))
         red = icon.pixmap(QtCore.QSize(24, 24)).toImage()
-        _set_window_text(qapp, QtGui.QColor(0, 0, 255))
+        _set_window_text(qapp, color=QtGui.QColor(0, 0, 255))
         blue = icon.pixmap(QtCore.QSize(24, 24)).toImage()
         assert red != blue
     finally:
@@ -217,9 +217,9 @@ def test_new_icon_keeps_accent_icon_fixed(qapp: QtWidgets.QApplication) -> None:
     original = qapp.palette()
     try:
         icon = new_icon("phosphor/floppy-disk.svg")  # baked accent color, not tinted
-        _set_window_text(qapp, QtGui.QColor(255, 0, 0))
+        _set_window_text(qapp, color=QtGui.QColor(255, 0, 0))
         a = icon.pixmap(QtCore.QSize(24, 24)).toImage()
-        _set_window_text(qapp, QtGui.QColor(0, 255, 0))
+        _set_window_text(qapp, color=QtGui.QColor(0, 255, 0))
         b = icon.pixmap(QtCore.QSize(24, 24)).toImage()
         assert a == b
     finally:

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -105,7 +105,7 @@ def test_shapes_to_label_groups_instances_by_label_and_group_id() -> None:
     assert ins[17, 17] == 1  # same (label, group_id) as the first -> same instance
 
 
-def _mask_shape(points: list[list[float]], mask: NDArray[np.bool_]) -> ShapeDict:
+def _mask_shape(*, points: list[list[float]], mask: NDArray[np.bool_]) -> ShapeDict:
     return ShapeDict(
         label="car",
         points=points,

--- a/tests/unit/widgets/_ai_assisted_annotation_widget_test.py
+++ b/tests/unit/widgets/_ai_assisted_annotation_widget_test.py
@@ -18,6 +18,7 @@ def formats() -> list[AiOutputFormat]:
 
 
 def _make_widget(
+    *,
     qtbot: QtBot,
     models: list[str],
     formats: list[AiOutputFormat],

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -47,7 +47,7 @@ def canvas(qtbot: QtBot) -> Canvas:
     return c
 
 
-def _make_move_event(pos: QPointF) -> QtGui.QMouseEvent:
+def _make_move_event(*, pos: QPointF) -> QtGui.QMouseEvent:
     return QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseMove,
         pos,
@@ -58,7 +58,7 @@ def _make_move_event(pos: QPointF) -> QtGui.QMouseEvent:
     )
 
 
-def _make_press_event(pos: QPointF) -> QtGui.QMouseEvent:
+def _make_press_event(*, pos: QPointF) -> QtGui.QMouseEvent:
     return QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseButtonPress,
         pos,
@@ -69,7 +69,7 @@ def _make_press_event(pos: QPointF) -> QtGui.QMouseEvent:
     )
 
 
-def _make_release_event(pos: QPointF) -> QtGui.QMouseEvent:
+def _make_release_event(*, pos: QPointF) -> QtGui.QMouseEvent:
     return QtGui.QMouseEvent(
         QtCore.QEvent.Type.MouseButtonRelease,
         pos,
@@ -80,14 +80,14 @@ def _make_release_event(pos: QPointF) -> QtGui.QMouseEvent:
     )
 
 
-def _image_to_widget(canvas: Canvas, img_x: float, img_y: float) -> QPointF:
+def _image_to_widget(*, canvas: Canvas, img_x: float, img_y: float) -> QPointF:
     origin = canvas._compute_image_origin_offset(area=None)
     wx = (img_x + origin.x()) * canvas.scale
     wy = (img_y + origin.y()) * canvas.scale
     return QPointF(wx, wy)
 
 
-def _clear_cursor_override(canvas: Canvas) -> None:
+def _clear_cursor_override(*, canvas: Canvas) -> None:
     canvas._release_cursor()
 
 

--- a/tests/unit/widgets/_canvas_interaction/primitives_test.py
+++ b/tests/unit/widgets/_canvas_interaction/primitives_test.py
@@ -23,11 +23,11 @@ _SCALE: Final[float] = 1.0
 _POINT_SIZE: Final[int] = 8
 
 
-def _point(x: float, y: float) -> np.ndarray:
+def _point(x: float, y: float, /) -> np.ndarray:
     return np.array([x, y], dtype=np.float64)
 
 
-def _polygon(points: list[tuple[float, float]], *, visible: bool) -> Shape:
+def _polygon(points: list[tuple[float, float]], /, *, visible: bool) -> Shape:
     return Shape(
         shape_type="polygon",
         points=np.array(points, dtype=np.float64),

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -17,7 +17,7 @@ from labelme._widgets._shape_render import render_shape
 _SIZE: Final = 200
 
 
-def _polygon(label: str | None) -> Shape:
+def _polygon(*, label: str | None) -> Shape:
     return Shape(
         label=label,
         shape_type="polygon",
@@ -34,7 +34,7 @@ def _unit_square_polygon() -> Shape:
     )
 
 
-def _render(shape: Shape, *, show_label: bool, scale: float) -> QtGui.QImage:
+def _render(*, shape: Shape, show_label: bool, scale: float) -> QtGui.QImage:
     image = QtGui.QImage(_SIZE, _SIZE, QtGui.QImage.Format.Format_ARGB32)
     image.fill(QtGui.QColor(255, 255, 255))
     painter = QtGui.QPainter(image)
@@ -54,7 +54,7 @@ def _render(shape: Shape, *, show_label: bool, scale: float) -> QtGui.QImage:
     return image
 
 
-def _diff_rows(a: QtGui.QImage, b: QtGui.QImage, *, bottom: int) -> int:
+def _diff_rows(*, a: QtGui.QImage, b: QtGui.QImage, bottom: int) -> int:
     # Only the label text differs between renders; everything else (outline,
     # vertices) is identical, so the per-pixel diff isolates the text. Restrict
     # to rows above the shape top edge to assert the text is anchored there.
@@ -66,7 +66,7 @@ def _diff_rows(a: QtGui.QImage, b: QtGui.QImage, *, bottom: int) -> int:
     return count
 
 
-def _shape(shape_type: ShapeType, points: list[list[float]]) -> Shape:
+def _shape(*, shape_type: ShapeType, points: list[list[float]]) -> Shape:
     return Shape(
         label="a",
         shape_type=shape_type,
@@ -125,8 +125,8 @@ def test_show_labels_draws_text_above_shape(qapp: QtGui.QGuiApplication) -> None
     # The polygon top edge sits at y=50, so the label text lands above it.
     assert (
         _diff_rows(
-            _render(shape, show_label=True, scale=1.0),
-            _render(shape, show_label=False, scale=1.0),
+            a=_render(shape=shape, show_label=True, scale=1.0),
+            b=_render(shape=shape, show_label=False, scale=1.0),
             bottom=48,
         )
         > 0
@@ -139,8 +139,8 @@ def test_empty_label_draws_no_text(qapp: QtGui.QGuiApplication) -> None:
         shape = _polygon(label=label)
         assert (
             _diff_rows(
-                _render(shape, show_label=True, scale=1.0),
-                _render(shape, show_label=False, scale=1.0),
+                a=_render(shape=shape, show_label=True, scale=1.0),
+                b=_render(shape=shape, show_label=False, scale=1.0),
                 bottom=_SIZE,
             )
             == 0
@@ -158,8 +158,8 @@ def test_point_shape_label_is_drawn(qapp: QtGui.QGuiApplication) -> None:
     )
     assert (
         _diff_rows(
-            _render(shape, show_label=True, scale=1.0),
-            _render(shape, show_label=False, scale=1.0),
+            a=_render(shape=shape, show_label=True, scale=1.0),
+            b=_render(shape=shape, show_label=False, scale=1.0),
             bottom=_SIZE,
         )
         > 0
@@ -182,7 +182,7 @@ def _mask_shape() -> Shape:
     )
 
 
-def _outline_center(image: QtGui.QImage) -> tuple[float, float]:
+def _outline_center(*, image: QtGui.QImage) -> tuple[float, float]:
     # Restrict to the central window so the bbox rect at the edges does not
     # contaminate the mask block's outline; the opaque line color isolates the
     # outline from the semi-transparent fill blended over the white canvas.
@@ -223,15 +223,15 @@ def test_label_anchor_tracks_scale(qapp: QtGui.QGuiApplication) -> None:
     # into the band above y=24 rather than staying near y=48.
     assert (
         _diff_rows(
-            _render(shape, show_label=True, scale=0.5),
-            _render(shape, show_label=False, scale=0.5),
+            a=_render(shape=shape, show_label=True, scale=0.5),
+            b=_render(shape=shape, show_label=False, scale=0.5),
             bottom=24,
         )
         > 0
     )
 
 
-def _hit(shape: Shape, point: tuple[float, float]) -> bool:
+def _hit(*, shape: Shape, point: tuple[float, float]) -> bool:
     return is_hit_by_point(
         shape=shape,
         point=np.array(point, dtype=np.float64),
@@ -246,8 +246,8 @@ def test_line_is_hit_near_its_segment() -> None:
         shape_type="line",
         points=np.array([[0, 0], [100, 0]], dtype=np.float64),
     )
-    assert _hit(shape, (50, 2)) is True
-    assert _hit(shape, (50, 20)) is False
+    assert _hit(shape=shape, point=(50, 2)) is True
+    assert _hit(shape=shape, point=(50, 20)) is False
 
 
 def test_linestrip_hit_ignores_phantom_closing_edge() -> None:
@@ -256,10 +256,10 @@ def test_linestrip_hit_ignores_phantom_closing_edge() -> None:
         points=np.array([[0, 0], [100, 0], [100, 100]], dtype=np.float64),
     )
     # Near a real segment (the bottom edge) is a hit.
-    assert _hit(shape, (50, 2)) is True
+    assert _hit(shape=shape, point=(50, 2)) is True
     # The diagonal from the last point back to the first is never drawn, so a
     # click on it must not register as a hit.
-    assert _hit(shape, (50, 50)) is False
+    assert _hit(shape=shape, point=(50, 50)) is False
 
 
 def test_points_shape_is_never_body_hit() -> None:
@@ -267,7 +267,7 @@ def test_points_shape_is_never_body_hit() -> None:
         shape_type="points",
         points=np.array([[10, 10], [20, 20]], dtype=np.float64),
     )
-    assert _hit(shape, (10, 10)) is False
+    assert _hit(shape=shape, point=(10, 10)) is False
 
 
 def test_point_shape_hit_within_radius() -> None:
@@ -276,13 +276,13 @@ def test_point_shape_hit_within_radius() -> None:
         points=np.array([[10, 10]], dtype=np.float64),
     )
     # point_size / 2 == 4, so a point 2px away hits and one 10px away misses.
-    assert _hit(shape, (10, 12)) is True
-    assert _hit(shape, (10, 20)) is False
+    assert _hit(shape=shape, point=(10, 12)) is True
+    assert _hit(shape=shape, point=(10, 20)) is False
 
 
 def test_empty_point_shape_is_not_hit() -> None:
     shape = Shape(shape_type="point")
-    assert _hit(shape, (0, 0)) is False
+    assert _hit(shape=shape, point=(0, 0)) is False
 
 
 def test_mask_shape_hit_reads_the_translated_pixel() -> None:
@@ -294,15 +294,15 @@ def test_mask_shape_hit_reads_the_translated_pixel() -> None:
         mask=mask,
     )
     # The mask origin is the bbox top-left (10, 10), so mask[2, 3] is at (13, 12).
-    assert _hit(shape, (13, 12)) is True
+    assert _hit(shape=shape, point=(13, 12)) is True
     # Inside the bbox but where the mask is False.
-    assert _hit(shape, (11, 11)) is False
+    assert _hit(shape=shape, point=(11, 11)) is False
     # Outside the mask array bounds is guarded to a miss.
-    assert _hit(shape, (5, 5)) is False
-    assert _hit(shape, (100, 100)) is False
+    assert _hit(shape=shape, point=(5, 5)) is False
+    assert _hit(shape=shape, point=(100, 100)) is False
 
 
 def test_polygon_hit_uses_path_containment() -> None:
     shape = _unit_square_polygon()
-    assert _hit(shape, (5, 5)) is True
-    assert _hit(shape, (50, 50)) is False
+    assert _hit(shape=shape, point=(5, 5)) is True
+    assert _hit(shape=shape, point=(50, 50)) is False

--- a/tests/unit/widgets/brightness_contrast_dialog/alpha_test.py
+++ b/tests/unit/widgets/brightness_contrast_dialog/alpha_test.py
@@ -21,7 +21,7 @@ def rgba_img() -> PIL.Image.Image:
 
 
 def _make_dialog(
-    qtbot: QtBot, img: PIL.Image.Image
+    *, qtbot: QtBot, img: PIL.Image.Image
 ) -> tuple[BrightnessContrastDialog, list[NDArray[np.uint8]]]:
     captured: list[NDArray[np.uint8]] = []
     dialog = BrightnessContrastDialog(

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -64,7 +64,7 @@ def test_propose_ai_shapes_passes_rgb_image_to_model(
     np.testing.assert_array_equal(captured_images[0][0, 0], [10, 20, 30])
 
 
-def _make_oriented_rectangle(corners: list[tuple[float, float]]) -> Shape:
+def _make_oriented_rectangle(*, corners: list[tuple[float, float]]) -> Shape:
     return Shape(
         shape_type="oriented_rectangle",
         points=np.array(corners, dtype=np.float64),
@@ -507,7 +507,7 @@ def test_shape_visibility_survives_backup_and_restore(canvas: Canvas) -> None:
     assert canvas.shapes[0].visible is False
 
 
-def _make_rectangle(label: str | None) -> Shape:
+def _make_rectangle(*, label: str | None) -> Shape:
     return Shape(
         label=label,
         shape_type="rectangle",

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -17,12 +17,13 @@ from labelme._widgets.label_dialog import LabelQLineEdit
 # internals while these tests keep pinning observable behavior.
 
 
-def _add_dialog(qtbot: QtBot, dialog: LabelDialog) -> LabelDialog:
+def _add_dialog(qtbot: QtBot, /, *, dialog: LabelDialog) -> LabelDialog:
     qtbot.addWidget(dialog)
     return dialog
 
 
 def _run_popup(
+    *,
     dialog: LabelDialog,
     accept: bool,
     at_show: Callable[[LabelDialog], None] | None,
@@ -56,17 +57,17 @@ def _run_popup(
     )
 
 
-def _checkboxes(dialog: LabelDialog) -> list[QtWidgets.QCheckBox]:
+def _checkboxes(dialog: LabelDialog, /) -> list[QtWidgets.QCheckBox]:
     return dialog.findChildren(QtWidgets.QCheckBox)
 
 
-def _checkbox(dialog: LabelDialog, name: str) -> QtWidgets.QCheckBox:
+def _checkbox(*, dialog: LabelDialog, name: str) -> QtWidgets.QCheckBox:
     matches = [cb for cb in _checkboxes(dialog) if cb.text() == name]
     assert matches, f"no checkbox named {name!r}"
     return matches[0]
 
 
-def _ok_button(dialog: LabelDialog) -> QtWidgets.QPushButton:
+def _ok_button(dialog: LabelDialog, /) -> QtWidgets.QPushButton:
     box = dialog.findChild(QtWidgets.QDialogButtonBox)
     assert box is not None
     button = box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
@@ -134,7 +135,7 @@ def test_other_keys_edit_text_not_forwarded(qtbot: QtBot) -> None:
 
 
 def test_default_widgets_exist(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     assert isinstance(dialog.edit, LabelQLineEdit)
     assert isinstance(dialog.edit_group_id, QtWidgets.QLineEdit)
     assert isinstance(dialog.edit_description, QtWidgets.QTextEdit)
@@ -142,40 +143,43 @@ def test_default_widgets_exist(qtbot: QtBot) -> None:
 
 
 def test_default_placeholder_is_non_empty(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     assert dialog.edit.placeholderText() != ""
 
 
 def test_custom_placeholder_text(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(text="Type here"))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(text="Type here"))
     assert dialog.edit.placeholderText() == "Type here"
 
 
 def test_group_id_and_description_placeholders_non_empty(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     assert dialog.edit_group_id.placeholderText() != ""
     assert dialog.edit_description.placeholderText() != ""
 
 
 def test_show_text_field_true_parents_edit_to_dialog(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(show_text_field=True))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(show_text_field=True))
     assert dialog.edit.parent() is dialog
 
 
 def test_show_text_field_false_leaves_edit_parentless(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(show_text_field=False))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(show_text_field=False))
     assert dialog.edit.parent() is None
 
 
 def test_initial_labels_listed(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["banana", "apple", "cherry"]))
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(labels=["banana", "apple", "cherry"])
+    )
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert set(items) == {"apple", "banana", "cherry"}
 
 
 def test_sort_labels_true_sorts(qtbot: QtBot) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=True)
+        qtbot,
+        dialog=LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=True),
     )
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items == ["apple", "banana", "cherry"]
@@ -183,7 +187,8 @@ def test_sort_labels_true_sorts(qtbot: QtBot) -> None:
 
 def test_sort_labels_false_preserves_order_and_enables_drag(qtbot: QtBot) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=False)
+        qtbot,
+        dialog=LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=False),
     )
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items == ["banana", "apple", "cherry"]
@@ -199,7 +204,7 @@ def test_fit_to_content_scrollbar_policies(
     qtbot: QtBot, row_off: bool, col_off: bool
 ) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(fit_to_content={"row": row_off, "column": col_off})
+        qtbot, dialog=LabelDialog(fit_to_content={"row": row_off, "column": col_off})
     )
     always_off = QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
     if row_off:
@@ -214,7 +219,7 @@ def test_fit_to_content_scrollbar_policies(
 
 
 def test_completion_startswith_inline(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(completion="startswith"))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(completion="startswith"))
     assert (
         dialog.edit.completer().completionMode()
         == QtWidgets.QCompleter.CompletionMode.InlineCompletion
@@ -222,7 +227,7 @@ def test_completion_startswith_inline(qtbot: QtBot) -> None:
 
 
 def test_completion_contains_popup_and_matchcontains(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(completion="contains"))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(completion="contains"))
     completer = dialog.edit.completer()
     assert (
         completer.completionMode()
@@ -237,7 +242,7 @@ def test_completion_invalid_raises(qtbot: QtBot) -> None:
 
 
 def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["a", "b"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a", "b"]))
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
 
@@ -247,14 +252,14 @@ def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
 
 
 def test_add_label_history_appends_new(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=[]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=[]))
     dialog.add_label_history("dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert "dog" in items
 
 
 def test_add_label_history_no_duplicate(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["dog"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["dog"]))
     dialog.add_label_history("dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items.count("dog") == 1
@@ -262,7 +267,7 @@ def test_add_label_history_no_duplicate(qtbot: QtBot) -> None:
 
 def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(labels=["banana", "apple"], sort_labels=True)
+        qtbot, dialog=LabelDialog(labels=["banana", "apple"], sort_labels=True)
     )
     dialog.add_label_history("cherry")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
@@ -270,7 +275,7 @@ def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
 
 
 def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["a"], sort_labels=False))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a"], sort_labels=False))
     dialog.add_label_history("b")
     dialog.set_predefined_labels(["a", "c"])
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
@@ -279,7 +284,7 @@ def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
 
 
 def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["a"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a"]))
     dialog.set_predefined_labels(["a", "b", "c"])
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
@@ -290,21 +295,21 @@ def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
 
 
 def test_editing_finished_strips_whitespace(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("  hello  ")
     dialog.edit.editingFinished.emit()
     assert dialog.edit.text() == "hello"
 
 
 def test_selecting_label_sets_edit_text(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat", "dog"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog"]))
     item = dialog.label_list.findItems("dog", QtCore.Qt.MatchFlag.MatchExactly)[0]
     dialog.label_list.setCurrentItem(item)
     assert dialog.edit.text() == "dog"
 
 
 def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
     dialog.label_list.setCurrentItem(
         dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
     )
@@ -318,28 +323,28 @@ def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
 
 
 def test_ok_with_text_accepts(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("car")
     _ok_button(dialog).click()
     assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_ok_with_empty_text_does_not_accept(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("")
     _ok_button(dialog).click()
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_ok_with_whitespace_text_does_not_accept(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("   ")
     _ok_button(dialog).click()
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("")
     dialog.edit.setEnabled(False)
     _ok_button(dialog).click()
@@ -347,7 +352,7 @@ def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
 
 
 def test_double_click_label_accepts(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
     item = dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
     dialog.label_list.setCurrentItem(item)  # selection sets the edit text
     dialog.label_list.itemDoubleClicked.emit(item)
@@ -360,27 +365,29 @@ def test_double_click_label_accepts(qtbot: QtBot) -> None:
 
 
 def test_flags_shown_for_matching_label(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor", "outdoor"]}))
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor", "outdoor"]})
+    )
     dialog.edit.setText("cat")
     names = {cb.text() for cb in _checkboxes(dialog)}
     assert names == {"indoor", "outdoor"}
 
 
 def test_flags_absent_for_non_matching_label(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"]}))
     dialog.edit.setText("dog")
     assert _checkboxes(dialog) == []
 
 
 def test_flags_shown_for_prefix_match(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"car": ["fast"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"car": ["fast"]}))
     dialog.edit.setText("car_red")
     names = {cb.text() for cb in _checkboxes(dialog)}
     assert names == {"fast"}
 
 
 def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     dialog.edit.setText("cat")
     box = next(cb for cb in _checkboxes(dialog) if cb.text() == "indoor")
     box.setChecked(True)
@@ -390,7 +397,7 @@ def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
 
 
 def test_flag_checked_state_preserved_across_non_matching_text(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     dialog.edit.setText("cat")
     _checkbox(dialog=dialog, name="indoor").setChecked(True)
     dialog.edit.setText("c")  # typing over a selected label dips through "c"
@@ -401,7 +408,7 @@ def test_flag_checked_state_preserved_across_non_matching_text(qtbot: QtBot) -> 
 
 def test_flag_checked_state_shared_across_labels(qtbot: QtBot) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(flags={"^cat$": ["indoor"], "^dog$": ["indoor"]})
+        qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"], "^dog$": ["indoor"]})
     )
     dialog.edit.setText("cat")
     _checkbox(dialog=dialog, name="indoor").setChecked(True)
@@ -410,7 +417,7 @@ def test_flag_checked_state_shared_across_labels(qtbot: QtBot) -> None:
 
 
 def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={".*": ["occluded"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={".*": ["occluded"]}))
     dialog.edit.setText("cat")
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -423,7 +430,8 @@ def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(qtbot: QtBot) -> 
 
 def test_flag_named_by_two_matching_patterns_shown_once(qtbot: QtBot) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]})
+        qtbot,
+        dialog=LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]}),
     )
     dialog.edit.setText("cat")
     assert [cb.text() for cb in _checkboxes(dialog)] == ["occluded", "urgent"]
@@ -433,7 +441,8 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
     qtbot: QtBot,
 ) -> None:
     dialog = _add_dialog(
-        qtbot, LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]})
+        qtbot,
+        dialog=LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]}),
     )
 
     _, flags, _, _ = _run_popup(
@@ -455,9 +464,9 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
 
 
 def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
     text, flags, group_id, description = _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         group_id=3,
@@ -473,9 +482,9 @@ def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
 
 
 def test_popup_preserves_html_like_description(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _, _, _, description = _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         description="<b>bold</b>",
@@ -488,9 +497,9 @@ def test_popup_preserves_html_like_description(qtbot: QtBot) -> None:
 
 
 def test_popup_returns_all_none_on_reject(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     result = _run_popup(
-        dialog,
+        dialog=dialog,
         accept=False,
         text="cat",
         at_show=None,
@@ -504,9 +513,9 @@ def test_popup_returns_all_none_on_reject(qtbot: QtBot) -> None:
 
 def test_popup_group_id_none_yields_empty_then_none(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _, _, group_id, _ = _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="x",
         group_id=None,
@@ -520,9 +529,9 @@ def test_popup_group_id_none_yields_empty_then_none(qtbot: QtBot) -> None:
 
 
 def test_popup_group_id_zero_is_preserved(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _, _, group_id, _ = _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="x",
         group_id=0,
@@ -536,9 +545,9 @@ def test_popup_group_id_zero_is_preserved(qtbot: QtBot) -> None:
 
 def test_popup_sets_group_id_text_at_show(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="x",
         group_id=7,
@@ -552,10 +561,10 @@ def test_popup_sets_group_id_text_at_show(qtbot: QtBot) -> None:
 
 def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("preexisting")
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text=None,
         at_show=lambda d: seen.update(t=d.edit.text()),
@@ -569,10 +578,10 @@ def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
 
 def test_popup_text_none_selects_existing_edit_text(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("preexisting")
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text=None,
         at_show=lambda d: seen.update(sel=d.edit.selectedText()),
@@ -586,9 +595,9 @@ def test_popup_text_none_selects_existing_edit_text(qtbot: QtBot) -> None:
 
 def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["cat", "dog"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog"]))
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="dog",
         at_show=lambda d: seen.update(
@@ -606,9 +615,9 @@ def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
 
 def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
-    dialog = _add_dialog(qtbot, LabelDialog(labels=["Cat", "Dog"]))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["Cat", "Dog"]))
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         at_show=lambda d: seen.update(
@@ -626,9 +635,9 @@ def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> Non
 
 def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
-    dialog = _add_dialog(qtbot, LabelDialog())
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="x",
         description="hello world",
@@ -642,9 +651,11 @@ def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
 
 def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor", "outdoor"]}))
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
+    )
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         flags={"indoor": True},
@@ -661,9 +672,11 @@ def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
 
 def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor", "outdoor"]}))
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
+    )
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         at_show=lambda d: seen.update(
@@ -679,9 +692,9 @@ def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
 
 
 def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         flags_disabled=True,
@@ -693,7 +706,7 @@ def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
 
     seen: dict[str, list[bool]] = {}
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         at_show=lambda d: seen.update(
@@ -712,22 +725,24 @@ def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
     qtbot: QtBot,
 ) -> None:
     seen: dict[str, bool] = {}
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"]}))
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
-        at_show=lambda d: _checkbox(d, "indoor").setChecked(True),
+        at_show=lambda d: _checkbox(dialog=d, name="indoor").setChecked(True),
         flags=None,
         group_id=None,
         description=None,
         flags_disabled=False,
     )
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
-        at_show=lambda d: seen.update(checked=_checkbox(d, "indoor").isChecked()),
+        at_show=lambda d: seen.update(
+            checked=_checkbox(dialog=d, name="indoor").isChecked()
+        ),
         flags=None,
         group_id=None,
         description=None,
@@ -740,9 +755,9 @@ def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
     qtbot: QtBot,
 ) -> None:
     seen: dict[str, bool] = {}
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat$": ["indoor"]}))
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"]}))
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         flags={"indoor": True},
@@ -752,10 +767,12 @@ def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
         flags_disabled=False,
     )
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
-        at_show=lambda d: seen.update(checked=_checkbox(d, "indoor").isChecked()),
+        at_show=lambda d: seen.update(
+            checked=_checkbox(dialog=d, name="indoor").isChecked()
+        ),
         flags=None,
         group_id=None,
         description=None,
@@ -771,9 +788,11 @@ def test_flags_disabled_survives_text_edit_rebuild(qtbot: QtBot) -> None:
         d.edit.setText("cattle")
         seen.update(enabled=[cb.isEnabled() for cb in _checkboxes(d)])
 
-    dialog = _add_dialog(qtbot, LabelDialog(flags={"^cat": ["indoor", "outdoor"]}))
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
+    )
     _run_popup(
-        dialog,
+        dialog=dialog,
         accept=True,
         text="cat",
         flags_disabled=True,

--- a/tests/unit/widgets/label_dialog/screen_fit_test.py
+++ b/tests/unit/widgets/label_dialog/screen_fit_test.py
@@ -7,7 +7,7 @@ from pytestqt.qtbot import QtBot
 from labelme._widgets.label_dialog import LabelDialog
 
 
-def _make_dialog(qtbot: QtBot, flag_count: int) -> LabelDialog:
+def _make_dialog(qtbot: QtBot, /, *, flag_count: int) -> LabelDialog:
     flags = {f"flag_{i:02d}": False for i in range(flag_count)}
     dialog = LabelDialog(labels=["cat"], flags={".*": list(flags)})
     qtbot.addWidget(dialog)
@@ -15,7 +15,7 @@ def _make_dialog(qtbot: QtBot, flag_count: int) -> LabelDialog:
     return dialog
 
 
-def _checkbox_gaps(dialog: LabelDialog) -> list[int]:
+def _checkbox_gaps(dialog: LabelDialog, /) -> list[int]:
     tops = [checkbox.y() for checkbox in dialog._flag_checkboxes.values()]
     return [bottom - top for top, bottom in zip(tops, tops[1:])]
 

--- a/tests/unit/widgets/label_dialog/updates_test.py
+++ b/tests/unit/widgets/label_dialog/updates_test.py
@@ -6,7 +6,7 @@ from pytestqt.qtbot import QtBot
 from labelme._widgets.label_dialog import LabelDialog
 
 
-def _labels(dialog: LabelDialog) -> set[str]:
+def _labels(dialog: LabelDialog, /) -> set[str]:
     label_list = dialog.label_list
     return {label_list.item(i).text() for i in range(label_list.count())}
 

--- a/tests/unit/widgets/label_list_widget_test.py
+++ b/tests/unit/widgets/label_list_widget_test.py
@@ -17,6 +17,7 @@ from labelme._widgets.label_list_widget import format_shape_label
 
 
 def _paint_item(
+    *,
     delegate: QtWidgets.QAbstractItemDelegate,
     item: LabelListWidgetItem,
     option: QtWidgets.QStyleOptionViewItem,
@@ -31,7 +32,9 @@ def _paint_item(
     return image
 
 
-def _pixels_with_color(image: QtGui.QImage, color: QtGui.QColor) -> list[QtCore.QPoint]:
+def _pixels_with_color(
+    *, image: QtGui.QImage, color: QtGui.QColor
+) -> list[QtCore.QPoint]:
     return [
         QtCore.QPoint(x, y)
         for x in range(image.width())
@@ -146,14 +149,16 @@ def selected_pair(
     return item_a, item_b
 
 
-def _item_center(widget: LabelListWidget, item: LabelListWidgetItem) -> QtCore.QPoint:
+def _item_center(
+    *, widget: LabelListWidget, item: LabelListWidgetItem
+) -> QtCore.QPoint:
     model = widget.model()
     assert model is not None
     return widget.visualRect(model.index(item.row(), 0)).center()
 
 
 def _press_on_item(
-    qtbot: QtBot, widget: LabelListWidget, item: LabelListWidgetItem
+    *, qtbot: QtBot, widget: LabelListWidget, item: LabelListWidgetItem
 ) -> None:
     qtbot.mousePress(
         widget.viewport(),
@@ -262,7 +267,7 @@ def test_format_shape_label(shape: Shape, expected: str) -> None:
     assert format_shape_label(shape=shape) == expected
 
 
-def _model_texts(model: _ItemModel) -> list[str]:
+def _model_texts(model: _ItemModel, /) -> list[str]:
     return [model.item(row).text() for row in range(model.rowCount())]
 
 

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -25,7 +25,7 @@ def applied() -> Applied:
     return []
 
 
-def _preferred_width(dialog: SettingsDialog) -> int:
+def _preferred_width(dialog: SettingsDialog, /) -> int:
     # The width the dialog opens at on an unconstrained screen: its page held
     # out of sideways scrolling plus its own chrome, never below the default.
     page = dialog._page
@@ -38,6 +38,7 @@ def _preferred_width(dialog: SettingsDialog) -> int:
 
 
 def _make_dialog(
+    *,
     qtbot: QtBot,
     applied: Applied,
     overrides: dict,

--- a/tests/unit/widgets/tool_bar_test.py
+++ b/tests/unit/widgets/tool_bar_test.py
@@ -15,7 +15,7 @@ from labelme._widgets.tool_bar import ToolBar
 _EXT_BUTTON_NAME: Final = "qt_toolbar_ext_button"
 
 
-def _user_buttons(toolbar: ToolBar) -> list[QtWidgets.QToolButton]:
+def _user_buttons(toolbar: ToolBar, /) -> list[QtWidgets.QToolButton]:
     return [
         b
         for b in toolbar.findChildren(QtWidgets.QToolButton)
@@ -23,7 +23,7 @@ def _user_buttons(toolbar: ToolBar) -> list[QtWidgets.QToolButton]:
     ]
 
 
-def _make_action(text: str) -> QtGui.QAction:
+def _make_action(text: str, /) -> QtGui.QAction:
     # Create without a parent so the action outlives any ephemeral container.
     return QtGui.QAction(text)
 

--- a/tools/update_translate.py
+++ b/tools/update_translate.py
@@ -23,7 +23,7 @@ def _setup_logging() -> None:
     )
 
 
-def _log_tool_version(tool: str) -> None:
+def _log_tool_version(tool: str, /) -> None:
     version: str = (
         subprocess.check_output([tool, "-version"], stderr=subprocess.STDOUT)
         .decode()
@@ -33,7 +33,7 @@ def _log_tool_version(tool: str) -> None:
 
 
 def _build_catalogs(
-    source_files: list[Path], ts_paths: list[Path], out_dir: Path, quiet: bool
+    *, source_files: list[Path], ts_paths: list[Path], out_dir: Path, quiet: bool
 ) -> None:
     targets: list[Path] = []
     for ts_path in ts_paths:
@@ -69,7 +69,7 @@ def _build_catalogs(
             raise RuntimeError(f"pyside6-lrelease did not produce {qm_path}")
 
 
-def _find_problems(ts_paths: list[Path], rebuilt_dir: Path) -> list[str]:
+def _find_problems(*, ts_paths: list[Path], rebuilt_dir: Path) -> list[str]:
     problems: list[str] = []
     for ts_path in ts_paths:
         rebuilt_ts: Path = rebuilt_dir / ts_path.name


### PR DESCRIPTION
Adopts gruff GR001: every fixed input to a non-public callable becomes positional-only or keyword-only — 499 findings, ~256 functions, mechanical sweep with one convention: keyword-only by default, positional-only for Qt slots, callbacks invoked positionally, and short value transformers.

Three non-obvious bits:

1. Functions stored in `Callable[...]`-typed attributes had to be positional-only — `Callable` cannot express keyword-only parameters. This made several annotations honest.

2. Every bare `.connect(self._x)` reference was audited against its new signature: no bare-connected slot has keyword-only parameters, so no `TypeError` hides behind a Qt signal tests don't exercise.

3. `@pytest.fixture` functions are keyword-only by necessity (pytest injects by name) — the rule flags them, but the fix direction is forced.

Both test suites pass; e2e run because slot signatures changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>