### PR TITLE
style: adopt ruff PLR2004 (magic-value-comparison)

### DIFF
--- a/examples/tutorial/draw_label_png.py
+++ b/examples/tutorial/draw_label_png.py
@@ -2,11 +2,15 @@
 
 import argparse
 from pathlib import Path
+from typing import Final
 
 import imgviz
 import matplotlib.pyplot as plt
 import numpy as np
 from loguru import logger
+
+# json_to_dataset stores the ignore label as 255 in the 8-bit label PNG.
+_UNLABELED_PNG_VALUE: Final = 255
 
 
 def main() -> None:
@@ -38,7 +42,7 @@ def main() -> None:
 
     label = imgviz.io.imread(args.label_png)
     label = label.astype(np.int32)
-    label[label == 255] = -1
+    label[label == _UNLABELED_PNG_VALUE] = -1
 
     unique_label_values = np.unique(label)
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -24,11 +24,19 @@ import uuid
 from pathlib import Path
 from pathlib import PureWindowsPath
 from typing import Any
+from typing import Final
 
 import numpy as np
 import PIL.Image
 import PIL.ImageDraw
 from numpy.typing import NDArray
+
+# Point counts each shape type's geometry is defined by.
+_CIRCLE_POINT_COUNT: Final = 2
+_LINE_POINT_COUNT: Final = 2
+_RECTANGLE_POINT_COUNT: Final = 2
+_ORIENTED_RECTANGLE_POINT_COUNT: Final = 4
+_MIN_POLYGON_POINT_COUNT: Final = 3
 
 
 @dataclasses.dataclass(frozen=True)
@@ -89,12 +97,16 @@ def shape_to_mask(
     draw = PIL.ImageDraw.Draw(mask)
     xy = [tuple(point) for point in points]
     if shape_type == "circle":
-        assert len(xy) == 2, "Shape of shape_type=circle must have 2 points"
+        assert len(xy) == _CIRCLE_POINT_COUNT, (
+            "Shape of shape_type=circle must have 2 points"
+        )
         (cx, cy), (px, py) = xy
         d = math.sqrt((cx - px) ** 2 + (cy - py) ** 2)
         draw.ellipse(((cx - d, cy - d), (cx + d, cy + d)), outline=1, fill=1)
     elif shape_type == "rectangle":
-        assert len(xy) == 2, "Shape of shape_type=rectangle must have 2 points"
+        assert len(xy) == _RECTANGLE_POINT_COUNT, (
+            "Shape of shape_type=rectangle must have 2 points"
+        )
         (x0, y0), (x1, y1) = xy
         draw.rectangle(
             ((min(x0, x1), min(y0, y1)), (max(x0, x1), max(y0, y1))),
@@ -102,7 +114,9 @@ def shape_to_mask(
             fill=1,
         )
     elif shape_type == "line":
-        assert len(xy) == 2, "Shape of shape_type=line must have 2 points"
+        assert len(xy) == _LINE_POINT_COUNT, (
+            "Shape of shape_type=line must have 2 points"
+        )
         draw.line(xy=xy, fill=1, width=line_width)  # ty: ignore[invalid-argument-type]
     elif shape_type == "linestrip":
         # joint="curve" rounds the joints so wide lines have no notch at turns.
@@ -113,10 +127,14 @@ def shape_to_mask(
         r = point_size
         draw.ellipse(((cx - r, cy - r), (cx + r, cy + r)), outline=1, fill=1)
     elif shape_type == "oriented_rectangle":
-        assert len(xy) == 4, "Shape of shape_type=oriented_rectangle must have 4 points"
+        assert len(xy) == _ORIENTED_RECTANGLE_POINT_COUNT, (
+            "Shape of shape_type=oriented_rectangle must have 4 points"
+        )
         draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
     elif shape_type in [None, "polygon"]:
-        assert len(xy) > 2, "Polygon must have points more than 2"
+        assert len(xy) >= _MIN_POLYGON_POINT_COUNT, (
+            "Polygon must have points more than 2"
+        )
         draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
     else:
         raise ValueError(f"shape_type={shape_type!r} is not supported.")

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2685,7 +2685,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if value is None:
             self._shape_color_preview = None
         else:
-            assert len(key_path) == 3 and key_path[0] == "shape_color"
+            SHAPE_COLOR_KEY_PATH_LENGTH: Final[int] = 3
+            assert (
+                len(key_path) == SHAPE_COLOR_KEY_PATH_LENGTH
+                and key_path[0] == "shape_color"
+            )
             # Copy only the edited section so dragging stays transient without
             # duplicating a potentially large Label map.
             preview = dict(self._config["shape_color"])

--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -10,7 +10,12 @@ import skimage
 from loguru import logger
 from numpy.typing import NDArray
 
+from .._shape import CIRCLE_POINT_COUNT
+from .._shape import MIN_POLYGON_POINT_COUNT
 from .._shape import Shape
+
+# Highest value of the mask polygonization detail slider.
+_DETAIL_MAX: Final = 100
 
 
 class Circle(NamedTuple):
@@ -37,7 +42,7 @@ def shape_to_xyxy_bbox(*, shape: Shape) -> NDArray[np.float32] | None:
     raises ValueError for shape types that have no bbox interpretation.
     """
     if shape.shape_type == "circle":
-        if len(shape.points) != 2:
+        if len(shape.points) != CIRCLE_POINT_COUNT:
             return None
         center, edge = shape.points
         radius = float(np.linalg.norm(edge - center))
@@ -85,7 +90,7 @@ def compute_oriented_rectangle_from_mask(
     if not mask.any():
         return None
     ys, xs = np.nonzero(mask)
-    if len(xs) < 3:
+    if len(xs) < MIN_POLYGON_POINT_COUNT:
         return None
     points = np.stack([xs, ys], axis=1).astype(np.float64)
     try:
@@ -165,7 +170,7 @@ def _compute_signed_area(points: NDArray[np.float64], /) -> float:
 def _compute_polygon_deviation(*, detail: int) -> float:
     # The default maps to half a pixel; the curve reserves finer control near
     # the detailed end, where small slider changes are most visible.
-    detail_loss = (100 - detail) / 20
+    detail_loss = (_DETAIL_MAX - detail) / 20
     return 0.5 * detail_loss**1.5
 
 
@@ -244,7 +249,7 @@ def _simplify_contour(
 def compute_polygons_from_mask(
     mask: NDArray[np.bool_], detail: int = 80
 ) -> list[NDArray[np.float32]]:
-    if not 0 <= detail <= 100:
+    if not 0 <= detail <= _DETAIL_MAX:
         raise ValueError(f"detail must be between 0 and 100, got {detail}")
     if not mask.any():
         logger.warning("No contour found, so returning no polygons.")
@@ -275,6 +280,6 @@ def compute_polygons_from_mask(
             detail=detail,
             mask_shape=mask.shape,
         )
-        if len(polygon) >= 3:
+        if len(polygon) >= MIN_POLYGON_POINT_COUNT:
             polygons.append(polygon)
     return polygons

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
+from .._shape import MIN_POLYGON_POINT_COUNT
 from .._shape import Shape
 from ._geometry import Circle
 from ._geometry import _round_bbox_to_int
@@ -85,7 +86,7 @@ def _build_shapes_from_detection(
                 description=detection.description,
             )
             for polygon in polygons
-            if len(polygon) >= 3
+            if len(polygon) >= MIN_POLYGON_POINT_COUNT
         ]
     if shape_type == "mask":
         if detection.bbox is None or detection.mask is None:

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -17,6 +17,8 @@ __all__ = ["get_user_config_file", "load_config", "set_overrides"]
 
 here = Path(__file__).resolve().parent
 
+_MASK_POLYGONIZATION_DETAIL_MAX: Final = 100
+
 
 def _update_dict(
     *,
@@ -56,7 +58,9 @@ def _update_dict(
 def _validate_config_item(*, key_path: tuple[str, ...], value: object) -> None:
     key = key_path[-1]
     if key_path == ("mask_polygonization", "detail") and (
-        isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 100
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= _MASK_POLYGONIZATION_DETAIL_MAX
     ):
         raise ValueError(
             "mask_polygonization.detail must be an integer between 0 and 100, "

--- a/labelme/_config/_shape_color.py
+++ b/labelme/_config/_shape_color.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
+from typing import Final
 from typing import cast
 
 from loguru import logger
+
+RGB_CHANNEL_COUNT: Final = 3
+_CHANNEL_VALUE_MAX: Final = 255
 
 
 def _is_rgb(value: object, /) -> bool:
     return (
         isinstance(value, list)
-        and len(value) == 3
+        and len(value) == RGB_CHANNEL_COUNT
         and all(
             isinstance(channel, int)
             and not isinstance(channel, bool)
-            and 0 <= channel <= 255
+            and 0 <= channel <= _CHANNEL_VALUE_MAX
             for channel in value
         )
     )

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -29,6 +29,11 @@ from ._utils.shape import ShapeDict
 
 PIL.Image.MAX_IMAGE_PIXELS = None
 
+_POINT_COORDINATE_COUNT: Final = 2
+_SINGLE_CHANNEL_NDIM: Final = 2
+_MULTI_CHANNEL_NDIM: Final = 3
+_RGB_CHANNEL_COUNT: Final = 3
+
 
 def _validate_flags(*, flags: object) -> dict[str, bool]:
     if flags is None:
@@ -86,7 +91,7 @@ def _validate_shape_semantics(
         return
     if mask is None:
         raise ValueError("mask is required for shape_type='mask'")
-    if mask.ndim != 2:
+    if mask.ndim != _SINGLE_CHANNEL_NDIM:
         raise ValueError(f"mask must decode to a 2D image, got shape {mask.shape}")
 
 
@@ -115,7 +120,7 @@ def _load_shape_json_obj(*, shape_json_obj: dict) -> ShapeDict:
         raise ValueError(f"points must be non-empty: {shape_json_obj}")
     if not all(
         isinstance(point, list)
-        and len(point) == 2
+        and len(point) == _POINT_COORDINATE_COUNT
         and all(
             isinstance(xy, int | float) and not isinstance(xy, bool) for xy in point
         )
@@ -417,12 +422,15 @@ def _imread(filename: str, /) -> PIL.Image.Image:
 def _imread_tiff(filename: str, /) -> PIL.Image.Image:
     img_arr: NDArray = tifffile.imread(filename)
 
-    if img_arr.ndim == 2:
+    if img_arr.ndim == _SINGLE_CHANNEL_NDIM:
         img_arr_normalized = _normalize_to_uint8(img_arr)
-    elif img_arr.ndim == 3:
-        if img_arr.shape[2] >= 3:
+    elif img_arr.ndim == _MULTI_CHANNEL_NDIM:
+        if img_arr.shape[2] >= _RGB_CHANNEL_COUNT:
             img_arr_normalized = np.stack(
-                [_normalize_to_uint8(img_arr[:, :, i]) for i in range(3)],
+                [
+                    _normalize_to_uint8(img_arr[:, :, i])
+                    for i in range(_RGB_CHANNEL_COUNT)
+                ],
                 axis=2,
             )
         else:

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -26,6 +26,15 @@ ShapeType: TypeAlias = Literal[
 
 POLYLINE_SHAPE_TYPES: Final[tuple[ShapeType, ...]] = ("polygon", "linestrip")
 
+# Point counts each shape type's geometry is defined by. A shape being drawn
+# holds fewer points than these until the user finishes it.
+CIRCLE_POINT_COUNT: Final = 2
+LINE_POINT_COUNT: Final = 2
+RECTANGLE_POINT_COUNT: Final = 2
+ORIENTED_RECTANGLE_POINT_COUNT: Final = 4
+MIN_LINESTRIP_POINT_COUNT: Final = 2
+MIN_POLYGON_POINT_COUNT: Final = 3
+
 
 @dataclasses.dataclass(eq=False)
 class Shape:
@@ -71,9 +80,12 @@ class Shape:
     def can_remove_point(self) -> bool:
         if not self.can_add_point():
             return False
-        if self.shape_type == "polygon" and len(self.points) <= 3:
+        if self.shape_type == "polygon" and len(self.points) <= MIN_POLYGON_POINT_COUNT:
             return False
-        if self.shape_type == "linestrip" and len(self.points) <= 2:
+        if (
+            self.shape_type == "linestrip"
+            and len(self.points) <= MIN_LINESTRIP_POINT_COUNT
+        ):
             return False
         return True
 
@@ -157,7 +169,10 @@ def nearest_rotation_point_index(
     scale: float,
     epsilon: float,
 ) -> int | None:
-    if shape.shape_type != "oriented_rectangle" or len(shape.points) != 4:
+    if (
+        shape.shape_type != "oriented_rectangle"
+        or len(shape.points) != ORIENTED_RECTANGLE_POINT_COUNT
+    ):
         return None
     handles = (shape.points + np.roll(shape.points, 1, axis=0)) / 2
     distances = np.linalg.norm((handles - point) * scale, axis=1)
@@ -165,7 +180,10 @@ def nearest_rotation_point_index(
 
 
 def get_rotation_handle(*, shape: Shape, index: int) -> npt.NDArray[np.float64]:
-    if shape.shape_type != "oriented_rectangle" or len(shape.points) != 4:
+    if (
+        shape.shape_type != "oriented_rectangle"
+        or len(shape.points) != ORIENTED_RECTANGLE_POINT_COUNT
+    ):
         raise ValueError(
             "Rotation handles are only defined for 4-point oriented rectangles, "
             f"got shape_type={shape.shape_type!r}, len(points)={len(shape.points)}"
@@ -178,7 +196,7 @@ def oriented_rectangle_center(*, shape: Shape) -> npt.NDArray[np.float64]:
         raise ValueError(
             f"Center is only defined for oriented rectangles, got {shape.shape_type!r}"
         )
-    if len(shape.points) != 4:
+    if len(shape.points) != ORIENTED_RECTANGLE_POINT_COUNT:
         raise ValueError(
             f"Oriented rectangle center requires 4 points, got {len(shape.points)}"
         )
@@ -225,7 +243,10 @@ def rotate(
             f"got {shape.shape_type!r}"
         )
     points = shape.points if source_points is None else source_points
-    if len(points) != 4 or len(shape.points) != 4:
+    if (
+        len(points) != ORIENTED_RECTANGLE_POINT_COUNT
+        or len(shape.points) != ORIENTED_RECTANGLE_POINT_COUNT
+    ):
         raise ValueError(
             "Shape rotation requires 4 points, got "
             f"len(source_points)={len(points)}, len(shape.points)={len(shape.points)}"

--- a/labelme/_utils/image.py
+++ b/labelme/_utils/image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import io
+from typing import Final
 
 import numpy as np
 import PIL.ExifTags
@@ -12,6 +13,17 @@ import PIL.Image
 import PIL.ImageOps
 from numpy.typing import NDArray
 from PySide6 import QtGui
+
+# Values of the EXIF Orientation tag, which encodes the transform needed to
+# display the stored pixels the right way up.
+_EXIF_ORIENTATION_NORMAL: Final = 1
+_EXIF_ORIENTATION_MIRROR_LEFT_TO_RIGHT: Final = 2
+_EXIF_ORIENTATION_ROTATE_180: Final = 3
+_EXIF_ORIENTATION_MIRROR_TOP_TO_BOTTOM: Final = 4
+_EXIF_ORIENTATION_MIRROR_TOP_TO_LEFT: Final = 5
+_EXIF_ORIENTATION_ROTATE_270: Final = 6
+_EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT: Final = 7
+_EXIF_ORIENTATION_ROTATE_90: Final = 8
 
 
 def img_data_to_pil(img_data: bytes) -> PIL.Image.Image:
@@ -83,29 +95,21 @@ def apply_exif_orientation(image: PIL.Image.Image) -> PIL.Image.Image:
 
     orientation = exif.get("Orientation", None)
 
-    if orientation == 1:
-        # do nothing
+    if orientation == _EXIF_ORIENTATION_NORMAL:
         return image
-    elif orientation == 2:
-        # left-to-right mirror
+    elif orientation == _EXIF_ORIENTATION_MIRROR_LEFT_TO_RIGHT:
         return PIL.ImageOps.mirror(image)
-    elif orientation == 3:
-        # rotate 180
+    elif orientation == _EXIF_ORIENTATION_ROTATE_180:
         return image.transpose(PIL.Image.ROTATE_180)
-    elif orientation == 4:
-        # top-to-bottom mirror
+    elif orientation == _EXIF_ORIENTATION_MIRROR_TOP_TO_BOTTOM:
         return PIL.ImageOps.flip(image)
-    elif orientation == 5:
-        # top-to-left mirror
+    elif orientation == _EXIF_ORIENTATION_MIRROR_TOP_TO_LEFT:
         return PIL.ImageOps.mirror(image.transpose(PIL.Image.ROTATE_270))
-    elif orientation == 6:
-        # rotate 270
+    elif orientation == _EXIF_ORIENTATION_ROTATE_270:
         return image.transpose(PIL.Image.ROTATE_270)
-    elif orientation == 7:
-        # top-to-right mirror
+    elif orientation == _EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT:
         return PIL.ImageOps.mirror(image.transpose(PIL.Image.ROTATE_90))
-    elif orientation == 8:
-        # rotate 90
+    elif orientation == _EXIF_ORIENTATION_ROTATE_90:
         return image.transpose(PIL.Image.ROTATE_90)
     else:
         return image

--- a/labelme/_utils/shape.py
+++ b/labelme/_utils/shape.py
@@ -12,6 +12,12 @@ import PIL.Image
 import PIL.ImageDraw
 from numpy.typing import NDArray
 
+from .._shape import CIRCLE_POINT_COUNT
+from .._shape import LINE_POINT_COUNT
+from .._shape import MIN_POLYGON_POINT_COUNT
+from .._shape import ORIENTED_RECTANGLE_POINT_COUNT
+from .._shape import RECTANGLE_POINT_COUNT
+
 
 class ShapeDict(TypedDict):
     label: str
@@ -35,12 +41,16 @@ def shape_to_mask(
     draw = PIL.ImageDraw.Draw(mask)
     xy = [tuple(point) for point in points]
     if shape_type == "circle":
-        assert len(xy) == 2, "Shape of shape_type=circle must have 2 points"
+        assert len(xy) == CIRCLE_POINT_COUNT, (
+            "Shape of shape_type=circle must have 2 points"
+        )
         (cx, cy), (px, py) = xy
         d = math.sqrt((cx - px) ** 2 + (cy - py) ** 2)
         draw.ellipse(((cx - d, cy - d), (cx + d, cy + d)), outline=1, fill=1)
     elif shape_type == "rectangle":
-        assert len(xy) == 2, "Shape of shape_type=rectangle must have 2 points"
+        assert len(xy) == RECTANGLE_POINT_COUNT, (
+            "Shape of shape_type=rectangle must have 2 points"
+        )
         (x0, y0), (x1, y1) = xy
         draw.rectangle(
             ((min(x0, x1), min(y0, y1)), (max(x0, x1), max(y0, y1))),
@@ -48,7 +58,9 @@ def shape_to_mask(
             fill=1,
         )
     elif shape_type == "line":
-        assert len(xy) == 2, "Shape of shape_type=line must have 2 points"
+        assert len(xy) == LINE_POINT_COUNT, (
+            "Shape of shape_type=line must have 2 points"
+        )
         draw.line(xy=xy, fill=1, width=line_width)  # ty: ignore[invalid-argument-type]
     elif shape_type == "linestrip":
         # joint="curve" rounds the joints so wide lines have no notch at turns.
@@ -59,10 +71,14 @@ def shape_to_mask(
         r = point_size
         draw.ellipse(((cx - r, cy - r), (cx + r, cy + r)), outline=1, fill=1)
     elif shape_type == "oriented_rectangle":
-        assert len(xy) == 4, "Shape of shape_type=oriented_rectangle must have 4 points"
+        assert len(xy) == ORIENTED_RECTANGLE_POINT_COUNT, (
+            "Shape of shape_type=oriented_rectangle must have 4 points"
+        )
         draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
     elif shape_type in [None, "polygon"]:
-        assert len(xy) > 2, "Polygon must have points more than 2"
+        assert len(xy) >= MIN_POLYGON_POINT_COUNT, (
+            "Polygon must have points more than 2"
+        )
         draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
     else:
         raise ValueError(f"shape_type={shape_type!r} is not supported.")

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -12,6 +12,9 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 
 from .. import _utils
+from .._shape import CIRCLE_POINT_COUNT
+from .._shape import ORIENTED_RECTANGLE_POINT_COUNT
+from .._shape import RECTANGLE_POINT_COUNT
 from .._shape import Shape
 from .._shape import get_rotation_handle
 from .._shape import nearest_edge_index
@@ -308,7 +311,7 @@ def _build_shape_points_paths(
     points = shape.points
     if shape.shape_type in ["rectangle", "mask"]:
         assert len(points) in [1, 2]
-        if len(points) == 2:
+        if len(points) == RECTANGLE_POINT_COUNT:
             paths.line.addRect(
                 QtCore.QRectF(
                     QtCore.QPointF(*(points[0] * scale)),
@@ -322,7 +325,7 @@ def _build_shape_points_paths(
                 )
     elif shape.shape_type == "oriented_rectangle":
         assert len(points) in [1, 2, 4]
-        if len(points) == 4:
+        if len(points) == ORIENTED_RECTANGLE_POINT_COUNT:
             paths.line.moveTo(QtCore.QPointF(*(points[0] * scale)))
             for i in range(len(points)):
                 paths.line.lineTo(QtCore.QPointF(*(points[i] * scale)))
@@ -340,7 +343,7 @@ def _build_shape_points_paths(
             _build_shape_oriented_rectangle_arrow_path(
                 path=paths.orientation_arrow, shape=shape, scale=scale
             )
-        elif len(points) == 2:
+        elif len(points) == CIRCLE_POINT_COUNT:
             paths.line.moveTo(QtCore.QPointF(*(points[0] * scale)))
             paths.line.lineTo(QtCore.QPointF(*(points[1] * scale)))
             for i in range(2):
@@ -349,7 +352,7 @@ def _build_shape_points_paths(
                 )
     elif shape.shape_type == "circle":
         assert len(points) in [1, 2]
-        if len(points) == 2:
+        if len(points) == CIRCLE_POINT_COUNT:
             radius = float(np.linalg.norm((points[0] - points[1]) * scale))
             paths.line.addEllipse(QtCore.QPointF(*(points[0] * scale)), radius, radius)
         for i in range(len(points)):
@@ -423,16 +426,16 @@ def _build_image_path(*, shape: Shape) -> QtGui.QPainterPath:
     points = shape.points
     out = QtGui.QPainterPath()
     if shape.shape_type in ("rectangle", "mask"):
-        if len(points) == 2:
+        if len(points) == RECTANGLE_POINT_COUNT:
             out.addRect(
                 QtCore.QRectF(QtCore.QPointF(*points[0]), QtCore.QPointF(*points[1]))
             )
     elif shape.shape_type == "circle":
-        if len(points) == 2:
+        if len(points) == CIRCLE_POINT_COUNT:
             radius = float(np.linalg.norm(points[0] - points[1]))
             out.addEllipse(QtCore.QPointF(*points[0]), radius, radius)
     elif shape.shape_type == "oriented_rectangle":
-        if len(points) == 4:
+        if len(points) == ORIENTED_RECTANGLE_POINT_COUNT:
             out.moveTo(QtCore.QPointF(*points[0]))
             for p in points[1:]:
                 out.lineTo(QtCore.QPointF(*p))

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -25,7 +25,12 @@ from .. import _ai_models
 from .. import _automation
 from .. import _shape
 from .. import _utils
+from .._shape import CIRCLE_POINT_COUNT
+from .._shape import MIN_LINESTRIP_POINT_COUNT
+from .._shape import MIN_POLYGON_POINT_COUNT
+from .._shape import ORIENTED_RECTANGLE_POINT_COUNT
 from .._shape import POLYLINE_SHAPE_TYPES
+from .._shape import RECTANGLE_POINT_COUNT
 from .._shape import Shape
 from .._shape import ShapeType
 from . import _canvas_interaction
@@ -38,6 +43,12 @@ from ._shape_render import bounds as _shape_bounds
 from ._shape_render import is_hit_by_point
 from ._shape_render import render_shape
 from .download import download_ai_model
+
+# The latest backup mirrors the current state, so an undo needs a prior one too.
+_MIN_SHAPE_BACKUPS_FOR_UNDO: Final = 2
+# The cursor supplies the closing point, so a fill preview needs one point
+# fewer than the polygon it previews.
+_MIN_POINTS_FOR_FILL_PREVIEW: Final = 2
 
 _DEFAULT_SHAPE_RGB: Final[tuple[int, int, int]] = (0, 255, 0)
 _DEFAULT_PALETTE: Final[Palette] = Palette.from_rgb(rgb=_DEFAULT_SHAPE_RGB)
@@ -500,9 +511,7 @@ class Canvas(QtWidgets.QWidget):
 
     @property
     def can_restore_shape(self) -> bool:
-        # The latest entry on the backup stack mirrors the current state, so
-        # at least one prior entry must exist for an undo to be meaningful.
-        return len(self.shape_backups) >= 2
+        return len(self.shape_backups) >= _MIN_SHAPE_BACKUPS_FOR_UNDO
 
     def restore_last_shape(self) -> None:
         # Undo coordinates with app.py::undo_shape_edit, app.py::load_shapes,
@@ -710,7 +719,10 @@ class Canvas(QtWidgets.QWidget):
     def _project_drawing_pos_into_image(self, *, pos: QPointF) -> QPointF:
         current = self._current
         assert current is not None
-        if self.create_mode == "oriented_rectangle" and len(current.points) == 4:
+        if (
+            self.create_mode == "oriented_rectangle"
+            and len(current.points) == ORIENTED_RECTANGLE_POINT_COUNT
+        ):
             # The second click only locks the orientation of the first edge,
             # not its length. The third-corner cursor drives parallelogram
             # completion through the diagonal anchor at points[0], so the
@@ -1076,7 +1088,7 @@ class Canvas(QtWidgets.QWidget):
             if current.closed:
                 self._finalize()
         elif mode == "oriented_rectangle":
-            if len(current.points) == 4:
+            if len(current.points) == ORIENTED_RECTANGLE_POINT_COUNT:
                 self._finalize()
             else:
                 assert len(current.points) == 1
@@ -1333,16 +1345,16 @@ class Canvas(QtWidgets.QWidget):
         if self.create_mode == "ai_points_to_shape":
             return True
         if self.create_mode == "linestrip":
-            return len(self._current.points) >= 2
+            return len(self._current.points) >= MIN_LINESTRIP_POINT_COUNT
         if self.create_mode == "oriented_rectangle":
             # Points 2 and 3 are seeded as duplicates of points 1 and 0 after
             # the first edge is locked; mouse movement reprojects them. Treat
             # the shape as closeable only once the third corner has moved.
             return (
-                len(self._current.points) == 4
+                len(self._current.points) == ORIENTED_RECTANGLE_POINT_COUNT
                 and self._current.points[2] != self._current.points[1]
             )
-        return len(self._current.points) >= 3
+        return len(self._current.points) >= MIN_POLYGON_POINT_COUNT
 
     def mouseDoubleClickEvent(self, _a0: QtGui.QMouseEvent) -> None:
         if self._double_click != "close":
@@ -1443,7 +1455,7 @@ class Canvas(QtWidgets.QWidget):
     def _bounded_move_oriented_rectangle_vertex(
         self, *, shape: Shape, vertex_index: int, pos: QPointF
     ) -> None:
-        assert len(shape.points) == 4
+        assert len(shape.points) == ORIENTED_RECTANGLE_POINT_COUNT
         corners = tuple(QPointF(*point) for point in shape.points)
         new_corners = _reproject_oriented_rectangle_corners(
             corners=corners,
@@ -1689,7 +1701,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _build_polygon_preview(self, *, current: _DraftShape) -> Shape:
         preview = current
-        if self._fill_drawing and len(preview.points) >= 2:
+        if self._fill_drawing and len(preview.points) >= _MIN_POINTS_FOR_FILL_PREVIEW:
             preview = preview.add_point(point=self._line.points[1], autoclose=True)
         return _draft_to_shape(preview)
 
@@ -1981,7 +1993,10 @@ class Canvas(QtWidgets.QWidget):
         current = self._current
         if current is None or current.closed:
             return
-        if self.create_mode == "oriented_rectangle" and len(current.points) == 4:
+        if (
+            self.create_mode == "oriented_rectangle"
+            and len(current.points) == ORIENTED_RECTANGLE_POINT_COUNT
+        ):
             self._unlock_oriented_rectangle_first_edge(current=current)
             self.update()
             return
@@ -2073,24 +2088,28 @@ def _is_degenerate_draft(draft: _DraftShape, /) -> bool:
     points = draft.points
     shape_type = draft.shape_type
     if shape_type == "polygon":
-        return len({(p.x(), p.y()) for p in points}) < 3
+        return len({(p.x(), p.y()) for p in points}) < MIN_POLYGON_POINT_COUNT
     if shape_type == "linestrip":
-        return len({(p.x(), p.y()) for p in points}) < 2
+        return len({(p.x(), p.y()) for p in points}) < MIN_LINESTRIP_POINT_COUNT
     if shape_type == "rectangle":
         return (
-            len(points) != 2
+            len(points) != RECTANGLE_POINT_COUNT
             or points[0].x() == points[1].x()
             or points[0].y() == points[1].y()
         )
     if shape_type in ("circle", "line"):
-        return len(points) != 2 or points[0] == points[1]
+        return len(points) != CIRCLE_POINT_COUNT or points[0] == points[1]
     if shape_type == "oriented_rectangle":
-        return len(points) != 4 or points[0] == points[1] or points[1] == points[2]
+        return (
+            len(points) != ORIENTED_RECTANGLE_POINT_COUNT
+            or points[0] == points[1]
+            or points[1] == points[2]
+        )
     return False
 
 
 def _normalize_bbox_points(*, bbox_points: Sequence[QPointF]) -> list[QPointF]:
-    if len(bbox_points) != 2:
+    if len(bbox_points) != RECTANGLE_POINT_COUNT:
         raise ValueError(f"Expected 2 points for bbox, got {len(bbox_points)}")
 
     p1, p2 = bbox_points

--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -10,6 +10,7 @@ from PySide6 import QtWidgets
 
 from .. import _locale
 from .._config import _schema as schema
+from .._config._shape_color import RGB_CHANNEL_COUNT
 from .._utils.qt import new_icon
 from ._integer_slider import IntegerSlider
 
@@ -667,7 +668,7 @@ def _build_beta_badge(*, text: str) -> QtWidgets.QLabel:
 
 
 def _parse_rgb(*, value: object) -> tuple[int, int, int]:
-    assert isinstance(value, list) and len(value) == 3
+    assert isinstance(value, list) and len(value) == RGB_CHANNEL_COUNT
     r, g, b = value
     assert isinstance(r, int) and isinstance(g, int) and isinstance(b, int)
     return r, g, b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,21 +100,26 @@ select = ["GR001", "GR002", "GR003", "GR004", "GR006"]
 
 [tool.ruff.lint]
 select = [
-  "ANN",    # flake8-annotations
-  "E",      # pycodestyle
-  "F",      # pyflakes
-  "I",      # isort
-  "UP",     # pyupgrade
-  "RUF022", # sorted __all__
-  "B006",   # mutable argument defaults
-  "RUF012", # mutable class attributes
-  "B008",   # function calls in argument defaults
-  "ARG",    # unused arguments
-  "FBT",    # boolean traps
+  "ANN",     # flake8-annotations
+  "E",       # pycodestyle
+  "F",       # pyflakes
+  "I",       # isort
+  "UP",      # pyupgrade
+  "RUF022",  # sorted __all__
+  "B006",    # mutable argument defaults
+  "RUF012",  # mutable class attributes
+  "B008",    # function calls in argument defaults
+  "ARG",     # unused arguments
+  "FBT",     # boolean traps
+  "PLR2004", # magic value comparisons
 ]
 # UP040 wants PEP 695 `type X = ...`, but our Literal aliases are enumerated at
 # runtime via typing.get_args(), which returns () for a lazy `type` alias.
 ignore = ["UP040"]
+
+[tool.ruff.lint.per-file-ignores]
+# Literal expected values are the substance of an assertion, not a magic value.
+"tests/**" = ["PLR2004"]
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
Adopts ruff's PLR2004 from gruff's recommended pairing: 63 package findings fixed for real (31 constants, zero noqa); tests are carved out via `per-file-ignores` because literal expected values are the substance of assertions.

The main win: a shared shape point-count vocabulary (`LINE_POINT_COUNT`, `RECTANGLE_POINT_COUNT`, … in `labelme/_shape.py`) now replaces ~35 scattered `== 2`-style comparisons across 6 modules.

Two deliberate leftovers:

1. The mask-polygonization detail bound `100` exists under three names (`_geometry`, `_config`, `_schema`); unifying would pull scipy into config import at startup. Left duplicated.

2. `examples/utils.py` grew its own local constants instead of importing from `labelme` — its docstring promises it never imports the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>