### PR TITLE
style: adopt gruff GR005 (explicit-public-input-conventions)

### DIFF
--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -146,7 +146,7 @@ def main() -> None:
             label = shape["label"]
             group_id = shape.get("group_id")
             shape_type = shape.get("shape_type", "polygon")
-            mask = utils.shape_to_mask(img.shape[:2], points, shape_type)
+            mask = utils.shape_to_mask(img.shape[:2], points, shape_type=shape_type)
 
             if group_id is None:
                 group_id = uuid.uuid1()

--- a/examples/tutorial/draw_json.py
+++ b/examples/tutorial/draw_json.py
@@ -27,7 +27,11 @@ def main() -> None:
         else:
             label_value = len(label_name_to_value)
             label_name_to_value[label_name] = label_value
-    lbl, _ = utils.shapes_to_label(img.shape, label_file.shapes, label_name_to_value)
+    lbl, _ = utils.shapes_to_label(
+        img_shape=img.shape,
+        shapes=label_file.shapes,
+        label_name_to_value=label_name_to_value,
+    )
 
     label_names: list[str] = [""] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():

--- a/examples/tutorial/export_json.py
+++ b/examples/tutorial/export_json.py
@@ -37,7 +37,11 @@ def main() -> None:
         else:
             label_value = len(label_name_to_value)
             label_name_to_value[label_name] = label_value
-    lbl, _ = utils.shapes_to_label(image.shape, label_file.shapes, label_name_to_value)
+    lbl, _ = utils.shapes_to_label(
+        img_shape=image.shape,
+        shapes=label_file.shapes,
+        label_name_to_value=label_name_to_value,
+    )
 
     label_names: list[str] = [""] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -45,7 +45,7 @@ class LabeledImage:
     shapes: list[dict[str, Any]]
 
 
-def load_label_file(filename: str) -> LabeledImage:
+def load_label_file(filename: str, /) -> LabeledImage:
     with open(filename, encoding="utf-8") as f:
         data = json.load(f)
 
@@ -71,24 +71,26 @@ def load_label_file(filename: str) -> LabeledImage:
     return LabeledImage(image_data=image_data, shapes=shapes)
 
 
-def img_data_to_arr(img_data: bytes) -> NDArray[np.uint8]:
+def img_data_to_arr(img_data: bytes, /) -> NDArray[np.uint8]:
     return np.array(PIL.Image.open(io.BytesIO(img_data)))
 
 
-def decode_img_data_as_rgb(img_data: bytes) -> NDArray[np.uint8]:
+def decode_img_data_as_rgb(img_data: bytes, /) -> NDArray[np.uint8]:
     # Converting at the PIL level rather than on the decoded array resolves a
     # palette image against its palette instead of reading the indices as
     # intensities, and drops the alpha channel that JPEG cannot represent.
     return np.array(PIL.Image.open(io.BytesIO(img_data)).convert("RGB"))
 
 
-def img_b64_to_arr(img_b64: str | bytes) -> NDArray[np.uint8]:
+def img_b64_to_arr(img_b64: str | bytes, /) -> NDArray[np.uint8]:
     return img_data_to_arr(base64.b64decode(img_b64))
 
 
 def shape_to_mask(
     img_shape: tuple[int, ...],
     points: list[list[float]],
+    /,
+    *,
     shape_type: str | None = None,
     line_width: int = 10,
     point_size: int = 5,
@@ -142,6 +144,7 @@ def shape_to_mask(
 
 
 def shapes_to_label(
+    *,
     img_shape: tuple[int, ...],
     shapes: list[dict[str, Any]],
     label_name_to_value: dict[str, int],
@@ -191,7 +194,7 @@ def shapes_to_label(
                     y_start - y1 : y_stop - y1, x_start - x1 : x_stop - x1
                 ]
         else:
-            mask = shape_to_mask(img_shape[:2], points, shape_type)
+            mask = shape_to_mask(img_shape[:2], points, shape_type=shape_type)
 
         cls[mask] = cls_id
         ins[mask] = ins_id

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -31,7 +31,7 @@ _LOGGER_LEVELS: Final = ("debug", "info", "warning", "error", "critical")
 
 
 class _LoggerIO(io.StringIO):
-    def write(self, s: AnyStr) -> int:
+    def write(self, s: AnyStr, /) -> int:
         assert isinstance(s, str)
         if stripped_s := s.strip():
             logger.debug(stripped_s)
@@ -159,12 +159,16 @@ class _DeprecatedAlias(argparse.Action):
     argparse matched (including abbreviations) warns and points back to it.
     """
 
-    def __call__(
+    # argparse invokes the action positionally, but its stub leaves the
+    # parameters positional-or-keyword, so the narrower spelling reads as an
+    # incompatible override.
+    def __call__(  # ty: ignore[invalid-method-override]
         self,
         parser: argparse.ArgumentParser,  # noqa: ARG002 -- fixed by the base class
         namespace: argparse.Namespace,
         values: object,
         option_string: str | None = None,
+        /,
     ) -> None:
         canonical = self.option_strings[0]
         if option_string is not None and option_string != canonical:

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -214,6 +214,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def __init__(
         self,
+        *,
         config_file: Path | None = None,
         config_overrides: dict | None = None,
         file_or_dir: str | None = None,
@@ -228,7 +229,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._config_overrides = config_overrides or {}
         self._shape_color_preview = None
 
-        self._shape_clipboard = ShapeClipboard(self)
+        self._shape_clipboard = ShapeClipboard(parent=self)
 
         self._label_dialog = self._make_label_dialog(label_history=None)
 
@@ -265,13 +266,13 @@ class MainWindow(QtWidgets.QMainWindow):
             parent=self,
         )
         self._canvas_widgets.canvas.set_ai_model_name(
-            self._ai_annotation.current_model_id
+            model_name=self._ai_annotation.current_model_id
         )
         self._canvas_widgets.canvas.set_ai_output_format(
             self._ai_annotation.output_format
         )
         self._canvas_widgets.canvas.set_ai_polygon_detail(
-            self._config["mask_polygonization"]["detail"]
+            detail=self._config["mask_polygonization"]["detail"]
         )
         self._ai_annotation.setEnabled(False)
         self._ai_buttons_highlighted = False
@@ -425,61 +426,61 @@ class MainWindow(QtWidgets.QMainWindow):
             checked=self._config["keep_prev_brightness_contrast"],
         )
         delete = action(
-            self.tr("Delete Shapes"),
-            self.delete_selected_shapes,
-            shortcuts["delete_shape"],
+            text=self.tr("Delete Shapes"),
+            slot=self.delete_selected_shapes,
+            shortcut=shortcuts["delete_shape"],
             icon="phosphor/trash.svg",
             tip=self.tr("Delete the selected shapes"),
             enabled=False,
         )
         edit = action(
-            self.tr("&Edit Label"),
-            self._edit_label,
-            shortcuts["edit_label"],
+            text=self.tr("&Edit Label"),
+            slot=self._edit_label,
+            shortcut=shortcuts["edit_label"],
             icon="phosphor/note-pencil.svg",
             tip=self.tr("Modify the label of the selected shape"),
             enabled=False,
         )
         duplicate = action(
-            self.tr("Duplicate Shapes"),
-            lambda: self._insert_shapes(
+            text=self.tr("Duplicate Shapes"),
+            slot=lambda: self._insert_shapes(
                 [s.copy() for s in self._canvas_widgets.canvas.selected_shapes]
             ),
-            shortcuts["duplicate_shape"],
+            shortcut=shortcuts["duplicate_shape"],
             icon="phosphor/copy.svg",
             tip=self.tr("Create a duplicate of the selected shapes"),
             enabled=False,
         )
         copy = action(
-            self.tr("Copy Shapes"),
-            lambda: self._shape_clipboard.store(
-                self._canvas_widgets.canvas.selected_shapes
+            text=self.tr("Copy Shapes"),
+            slot=lambda: self._shape_clipboard.store(
+                shapes=self._canvas_widgets.canvas.selected_shapes
             ),
-            shortcuts["copy_shape"],
-            "copy_clipboard",
-            self.tr("Copy selected shapes to clipboard"),
+            shortcut=shortcuts["copy_shape"],
+            icon="copy_clipboard",
+            tip=self.tr("Copy selected shapes to clipboard"),
             enabled=False,
         )
         paste = action(
-            self.tr("Paste Shapes"),
-            lambda: self._insert_shapes(self._shape_clipboard.paste()),
-            shortcuts["paste_shape"],
-            "paste",
-            self.tr("Paste copied shapes"),
+            text=self.tr("Paste Shapes"),
+            slot=lambda: self._insert_shapes(self._shape_clipboard.paste()),
+            shortcut=shortcuts["paste_shape"],
+            icon="paste",
+            tip=self.tr("Paste copied shapes"),
             enabled=False,
         )
         undo_last_point = action(
-            self.tr("Undo last point"),
-            self._canvas_widgets.canvas.undo_last_point,
-            shortcuts["undo_last_point"],
+            text=self.tr("Undo last point"),
+            slot=self._canvas_widgets.canvas.undo_last_point,
+            shortcut=shortcuts["undo_last_point"],
             icon="phosphor/arrow-u-up-left.svg",
             tip=self.tr("Undo last drawn point"),
             enabled=False,
         )
         undo = action(
-            self.tr("Undo\n"),
-            self.undo_shape_edit,
-            shortcuts["undo"],
+            text=self.tr("Undo\n"),
+            slot=self.undo_shape_edit,
+            shortcut=shortcuts["undo"],
             icon="phosphor/arrow-u-up-left.svg",
             tip=self.tr("Undo last add and edit of shape"),
             enabled=False,
@@ -507,9 +508,9 @@ class MainWindow(QtWidgets.QMainWindow):
             enabled=False,
         )
         edit_mode = action(
-            self.tr("Edit Shapes"),
-            lambda: self._switch_canvas_mode(edit=True, create_mode=None),
-            shortcuts["edit_shape"],
+            text=self.tr("Edit Shapes"),
+            slot=lambda: self._switch_canvas_mode(edit=True, create_mode=None),
+            shortcut=shortcuts["edit_shape"],
             icon="phosphor/note-pencil.svg",
             tip=self.tr("Move and edit the selected shapes"),
             enabled=False,
@@ -565,21 +566,25 @@ class MainWindow(QtWidgets.QMainWindow):
             enabled=False,
         )
         create_ai_points_to_shape_mode = action(
-            self.tr("AI-Points"),
-            lambda: self._switch_canvas_mode(
+            text=self.tr("AI-Points"),
+            slot=lambda: self._switch_canvas_mode(
                 edit=False, create_mode="ai_points_to_shape"
             ),
-            None,
-            "ai-points.svg",
-            self.tr("Click points to segment object. Ctrl+LeftClick ends creation."),
+            shortcut=None,
+            icon="ai-points.svg",
+            tip=self.tr(
+                "Click points to segment object. Ctrl+LeftClick ends creation."
+            ),
             enabled=False,
         )
         create_ai_box_to_shape_mode = action(
-            self.tr("AI-Box"),
-            lambda: self._switch_canvas_mode(edit=False, create_mode="ai_box_to_shape"),
-            None,
-            "ai-box.svg",
-            self.tr("Draw a bounding box to segment object."),
+            text=self.tr("AI-Box"),
+            slot=lambda: self._switch_canvas_mode(
+                edit=False, create_mode="ai_box_to_shape"
+            ),
+            shortcut=None,
+            icon="ai-box.svg",
+            tip=self.tr("Draw a bounding box to segment object."),
             enabled=False,
         )
         open_next_img = action(
@@ -604,51 +609,51 @@ class MainWindow(QtWidgets.QMainWindow):
             checked=self._config["keep_prev_scale"],
         )
         fit_window = action(
-            self.tr("&Fit Window"),
-            self.set_fit_window_mode,
-            shortcuts["fit_window"],
+            text=self.tr("&Fit Window"),
+            slot=self.set_fit_window_mode,
+            shortcut=shortcuts["fit_window"],
             icon="phosphor/frame-corners.svg",
             tip=self.tr("Zoom follows window size"),
             checkable=True,
             enabled=False,
         )
         fit_width = action(
-            self.tr("Fit &Width"),
-            self.set_fit_width_mode,
-            shortcuts["fit_width"],
+            text=self.tr("Fit &Width"),
+            slot=self.set_fit_width_mode,
+            shortcut=shortcuts["fit_width"],
             icon="frame-arrows-horizontal.svg",
             tip=self.tr("Zoom follows window width"),
             checkable=True,
             enabled=False,
         )
         brightness_contrast = action(
-            self.tr("&Brightness Contrast"),
-            self.open_brightness_contrast_dialog,
-            None,
-            "brightness-contrast.svg",
-            self.tr("Adjust brightness and contrast"),
+            text=self.tr("&Brightness Contrast"),
+            slot=self.open_brightness_contrast_dialog,
+            shortcut=None,
+            icon="brightness-contrast.svg",
+            tip=self.tr("Adjust brightness and contrast"),
             enabled=False,
         )
         zoom_in = action(
-            self.tr("Zoom &In"),
-            lambda _: self._add_zoom(increment=1.1, pos=None),
-            shortcuts["zoom_in"],
+            text=self.tr("Zoom &In"),
+            slot=lambda _: self._add_zoom(increment=1.1, pos=None),
+            shortcut=shortcuts["zoom_in"],
             icon="phosphor/magnifying-glass-plus.svg",
             tip=self.tr("Increase zoom level"),
             enabled=False,
         )
         zoom_out = action(
-            self.tr("&Zoom Out"),
-            lambda _: self._add_zoom(increment=0.9, pos=None),
-            shortcuts["zoom_out"],
+            text=self.tr("&Zoom Out"),
+            slot=lambda _: self._add_zoom(increment=0.9, pos=None),
+            shortcut=shortcuts["zoom_out"],
             icon="phosphor/magnifying-glass-minus.svg",
             tip=self.tr("Decrease zoom level"),
             enabled=False,
         )
         zoom_org = action(
-            self.tr("&Original size"),
-            self._set_zoom_to_original,
-            shortcuts["zoom_to_original"],
+            text=self.tr("&Original size"),
+            slot=self._set_zoom_to_original,
+            shortcut=shortcuts["zoom_to_original"],
             icon="phosphor/image-square.svg",
             tip=self.tr("Zoom to original size"),
             enabled=False,
@@ -670,25 +675,25 @@ class MainWindow(QtWidgets.QMainWindow):
             value=self._config["canvas"]["fill_drawing"]
         )
         hide_all = action(
-            self.tr("&Hide\nShapes"),
-            functools.partial(self.toggle_shape_visibility, value=False),
-            shortcuts["hide_all_shapes"],
+            text=self.tr("&Hide\nShapes"),
+            slot=functools.partial(self.toggle_shape_visibility, value=False),
+            shortcut=shortcuts["hide_all_shapes"],
             icon="phosphor/eye.svg",
             tip=self.tr("Hide all shapes"),
             enabled=False,
         )
         show_all = action(
-            self.tr("&Show\nShapes"),
-            functools.partial(self.toggle_shape_visibility, value=True),
-            shortcuts["show_all_shapes"],
+            text=self.tr("&Show\nShapes"),
+            slot=functools.partial(self.toggle_shape_visibility, value=True),
+            shortcut=shortcuts["show_all_shapes"],
             icon="phosphor/eye.svg",
             tip=self.tr("Show all shapes"),
             enabled=False,
         )
         toggle_all = action(
-            self.tr("&Toggle\nShapes"),
-            functools.partial(self.toggle_shape_visibility, value=None),
-            shortcuts["toggle_all_shapes"],
+            text=self.tr("&Toggle\nShapes"),
+            slot=functools.partial(self.toggle_shape_visibility, value=None),
+            shortcut=shortcuts["toggle_all_shapes"],
             icon="phosphor/eye.svg",
             tip=self.tr("Toggle all shapes"),
             enabled=False,
@@ -854,8 +859,8 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         open_config.setMenuRole(QtGui.QAction.MenuRole.PreferencesRole)
         help_ = action(
-            self.tr("&Tutorial"),
-            self.tutorial,
+            text=self.tr("&Tutorial"),
+            slot=self.tutorial,
             icon="phosphor/question.svg",
             tip=self.tr("Show tutorial page"),
         )
@@ -865,7 +870,9 @@ class MainWindow(QtWidgets.QMainWindow):
         view_menu = self.menu(self.tr("&View"))
         help_menu = self.menu(self.tr("&Help"))
         label_menu = QtWidgets.QMenu()
-        _utils.add_actions(label_menu, (self._actions.edit, self._actions.delete))
+        _utils.add_actions(
+            widget=label_menu, actions=(self._actions.edit, self._actions.delete)
+        )
         self._docks.label_list.setContextMenuPolicy(
             Qt.ContextMenuPolicy.CustomContextMenu
         )
@@ -874,8 +881,8 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
         _utils.add_actions(
-            file_menu,
-            (
+            widget=file_menu,
+            actions=(
                 self._actions.open,
                 self._actions.open_next_img,
                 self._actions.open_prev_img,
@@ -893,10 +900,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 quit_,
             ),
         )
-        _utils.add_actions(help_menu, (help_, self._actions.about))
+        _utils.add_actions(widget=help_menu, actions=(help_, self._actions.about))
         _utils.add_actions(
-            view_menu,
-            (
+            widget=view_menu,
+            actions=(
                 self._docks.flag_dock.toggleViewAction(),
                 self._docks.label_dock.toggleViewAction(),
                 self._docks.shape_dock.toggleViewAction(),
@@ -924,14 +931,14 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
         _utils.add_actions(
-            self._canvas_widgets.canvas.context_menus.without_selection,
-            self._actions.context_menu,
+            widget=self._canvas_widgets.canvas.context_menus.without_selection,
+            actions=self._actions.context_menu,
         )
         _utils.add_actions(
-            self._canvas_widgets.canvas.context_menus.with_selection,
-            (
-                action("&Copy here", self.copy_shape),
-                action("&Move here", self.move_shape),
+            widget=self._canvas_widgets.canvas.context_menus.with_selection,
+            actions=(
+                action(text="&Copy here", slot=self.copy_shape),
+                action(text="&Move here", slot=self.move_shape),
             ),
         )
 
@@ -1084,13 +1091,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 "allow_out_of_bounds_points"
             ],
         )
-        canvas.set_point_size(self._config["shape"]["point_size"])
+        canvas.set_point_size(point_size=self._config["shape"]["point_size"])
         canvas.set_show_labels(value=self._config["shape"]["show_labels"])
         canvas.set_ai_existing_shape_suppression(
             enabled=self._config["ai"]["suppress_existing_shape_matches"]
         )
         canvas.set_draft_palette(
-            Palette(
+            palette=Palette(
                 line=QtGui.QColor(*self._config["shape"]["line_color"]),
                 fill=QtGui.QColor(*self._config["shape"]["fill_color"]),
                 select_line=QtGui.QColor(*self._config["shape"]["select_line_color"]),
@@ -1100,7 +1107,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         )
         canvas.set_color_resolver(
-            lambda label: self._get_rgb_by_label(
+            resolver=lambda label: self._get_rgb_by_label(
                 label=label, unique_label_list=self._docks.unique_label_list
             )
         )
@@ -1134,7 +1141,7 @@ class MainWindow(QtWidgets.QMainWindow):
         canvas.point_prompt_rejected.connect(self._on_point_prompt_rejected)
         canvas.degenerate_shape_rejected.connect(
             lambda: self.show_status_message(
-                self.tr("Shape had no area; nothing created."), 5000
+                self.tr("Shape had no area; nothing created."), delay=5000
             )
         )
         canvas.shape_moved.connect(self.mark_dirty)
@@ -1274,11 +1281,13 @@ class MainWindow(QtWidgets.QMainWindow):
     def menu(
         self,
         title: str,
+        /,
+        *,
         actions: tuple[QtGui.QAction | QtWidgets.QMenu | None, ...] | None = None,
     ) -> QtWidgets.QMenu:
         menu = self.menuBar().addMenu(title)
         if actions:
-            _utils.add_actions(menu, actions)
+            _utils.add_actions(widget=menu, actions=actions)
         return menu
 
     # Support Functions
@@ -1289,8 +1298,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def populate_mode_actions(self) -> None:
         self._canvas_widgets.canvas.context_menus.without_selection.clear()
         _utils.add_actions(
-            self._canvas_widgets.canvas.context_menus.without_selection,
-            self._actions.context_menu,
+            widget=self._canvas_widgets.canvas.context_menus.without_selection,
+            actions=self._actions.context_menu,
         )
         self._menus.edit.clear()
         actions = (
@@ -1298,7 +1307,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._actions.edit_mode,
             *self._actions.edit_menu,
         )
-        _utils.add_actions(self._menus.edit, actions)
+        _utils.add_actions(widget=self._menus.edit, actions=actions)
 
     def _get_window_title(self, *, dirty: bool) -> str:
         file_list = self._docks.file_list
@@ -1352,7 +1361,7 @@ class MainWindow(QtWidgets.QMainWindow):
         for action in (*self._actions.zoom, *self._actions.on_load_active):
             action.setEnabled(value)
 
-    def show_status_message(self, message: str, delay: int = 500) -> None:
+    def show_status_message(self, message: str, /, *, delay: int = 500) -> None:
         self.statusBar().showMessage(message, delay)
 
     def _submit_ai_prompt(self, _: bool, /) -> None:  # noqa: FBT001 -- submit callback receives the Qt clicked flag
@@ -1381,7 +1390,7 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             boxes, scores, labels, masks = _automation.get_bboxes_from_texts(
                 session=self._text_osam_session,
-                image=_utils.img_qt_to_rgb_arr(img_qt=self._image),
+                image=_utils.img_qt_to_rgb_arr(self._image),
                 image_id=str(hash(self._image_path)),
                 texts=texts,
             )
@@ -1553,7 +1562,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     if isinstance(widget, QtWidgets.QToolButton):
                         widget.setStyleSheet(style)
 
-    def show_label_list_menu(self, point: QtCore.QPoint) -> None:
+    def show_label_list_menu(self, point: QtCore.QPoint, /) -> None:
         self._label_list_menu_origin = self._docks.label_list.mapToGlobal(point)
         try:
             # PySide6 type QMenu.exec() argument too narrowly
@@ -1561,7 +1570,7 @@ class MainWindow(QtWidgets.QMainWindow):
         finally:
             self._label_list_menu_origin = None
 
-    def validate_label(self, label: str) -> bool:
+    def validate_label(self, *, label: str) -> bool:
         policy = self._config["validate_label"]
         if policy is None:
             return True
@@ -1636,10 +1645,10 @@ class MainWindow(QtWidgets.QMainWindow):
             assert description is None
             return
 
-        if not self.validate_label(text):
+        if not self.validate_label(label=text):
             self.show_error_message(
-                self.tr("Invalid label"),
-                self.tr("Invalid label '{}' with validation type '{}'").format(
+                title=self.tr("Invalid label"),
+                message=self.tr("Invalid label '{}' with validation type '{}'").format(
                     text, self._config["validate_label"]
                 ),
             )
@@ -1665,11 +1674,11 @@ class MainWindow(QtWidgets.QMainWindow):
                 unique_label_list=self._docks.unique_label_list,
             )
             item.set_label(
-                text=format_shape_label(shape),
+                text=format_shape_label(shape=shape),
                 color=fill_rgb,
             )
             self.mark_dirty()
-            if self._docks.unique_label_list.find_label_item(shape.label) is None:
+            if self._docks.unique_label_list.find_label_item(label=shape.label) is None:
                 self._docks.unique_label_list.add_label_item(
                     label=shape.label,
                     color=self._get_rgb_by_label(
@@ -1704,9 +1713,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._docks.label_list.clearSelection()
         self._canvas_widgets.canvas.selected_shapes = selected_shapes
         for shape in self._canvas_widgets.canvas.selected_shapes:
-            item = self._docks.label_list.find_item_by_shape(shape)
-            self._docks.label_list.select_item(item)
-            self._docks.label_list.scroll_to_item(item)
+            item = self._docks.label_list.find_item_by_shape(shape=shape)
+            self._docks.label_list.select_item(item=item)
+            self._docks.label_list.scroll_to_item(item=item)
         self._docks.label_list.item_selection_changed.connect(
             self._label_selection_changed
         )
@@ -1716,11 +1725,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self._actions.copy.setEnabled(n_selected)
         self._actions.edit.setEnabled(n_selected)
 
-    def add_label(self, shape: Shape) -> None:
+    def add_label(self, *, shape: Shape) -> None:
         assert shape.label is not None
         label_list_item = LabelListWidgetItem(shape=shape)
-        self._docks.label_list.add_item(label_list_item)
-        if self._docks.unique_label_list.find_label_item(shape.label) is None:
+        self._docks.label_list.add_item(item=label_list_item)
+        if self._docks.unique_label_list.find_label_item(label=shape.label) is None:
             self._docks.unique_label_list.add_label_item(
                 label=shape.label,
                 color=self._get_rgb_by_label(
@@ -1728,7 +1737,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     unique_label_list=self._docks.unique_label_list,
                 ),
             )
-        self._label_dialog.add_label_history(shape.label)
+        self._label_dialog.add_label_history(label=shape.label)
         for action in self._actions.on_shapes_present:
             action.setEnabled(True)
 
@@ -1737,7 +1746,7 @@ class MainWindow(QtWidgets.QMainWindow):
             unique_label_list=self._docks.unique_label_list,
         )
         label_list_item.set_label(
-            text=format_shape_label(shape),
+            text=format_shape_label(shape=shape),
             color=fill_rgb,
         )
 
@@ -1747,7 +1756,7 @@ class MainWindow(QtWidgets.QMainWindow):
         label: str,
         unique_label_list: UniqueLabelQListWidget,
     ) -> tuple[int, int, int]:
-        item = unique_label_list.find_label_item(label)
+        item = unique_label_list.find_label_item(label=label)
         label_index: int = (
             unique_label_list.indexFromItem(item).row()
             if item
@@ -1762,11 +1771,11 @@ class MainWindow(QtWidgets.QMainWindow):
             label_index=label_index,
         )
 
-    def remove_labels(self, shapes: list[Shape]) -> None:
+    def remove_labels(self, *, shapes: list[Shape]) -> None:
         self._docks.label_list.item_dropped.disconnect(self._on_label_order_changed)
         for shape in shapes:
-            item = self._docks.label_list.find_item_by_shape(shape)
-            self._docks.label_list.remove_item(item)
+            item = self._docks.label_list.find_item_by_shape(shape=shape)
+            self._docks.label_list.remove_item(item=item)
         self._docks.label_list.item_dropped.connect(self._on_label_order_changed)
 
     def _load_shapes(self, shapes: list[Shape], /, *, replace: bool) -> None:
@@ -1775,7 +1784,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         shape: Shape
         for shape in shapes:
-            self.add_label(shape)
+            self.add_label(shape=shape)
         self._docks.label_list.clearSelection()
         self._docks.label_list.item_selection_changed.connect(
             self._label_selection_changed
@@ -1799,7 +1808,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             widget.addItem(item)
 
-    def save_labels(self, label_path: str, *, show_error: bool = True) -> bool:
+    def save_labels(self, *, label_path: str, show_error: bool = True) -> bool:
         shapes = [
             _shape_to_dict(s)
             for item in self._docks.label_list
@@ -1840,7 +1849,8 @@ class MainWindow(QtWidgets.QMainWindow):
         except (LabelFileError, OSError, ValueError) as e:
             if show_error:
                 self.show_error_message(
-                    self.tr("Error saving label data"), self.tr("<b>%s</b>") % e
+                    title=self.tr("Error saving label data"),
+                    message=self.tr("<b>%s</b>") % e,
                 )
             return False
 
@@ -1848,7 +1858,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not shapes:
             return
         self._load_shapes(shapes, replace=False)
-        self._canvas_widgets.canvas.select_shapes(shapes)
+        self._canvas_widgets.canvas.select_shapes(shapes=shapes)
         self.mark_dirty()
 
     def _label_selection_changed(self) -> None:
@@ -1858,7 +1868,7 @@ class MainWindow(QtWidgets.QMainWindow):
             assert shape is not None
             selected_shapes.append(shape)
         if selected_shapes:
-            self._canvas_widgets.canvas.select_shapes(selected_shapes)
+            self._canvas_widgets.canvas.select_shapes(shapes=selected_shapes)
         else:
             if self._canvas_widgets.canvas.deselect_shape():
                 self._canvas_widgets.canvas.update()
@@ -1921,10 +1931,10 @@ class MainWindow(QtWidgets.QMainWindow):
             if not text:
                 self._label_dialog.edit.setText(previous_text)
 
-        if text and not self.validate_label(text):
+        if text and not self.validate_label(label=text):
             self.show_error_message(
-                self.tr("Invalid label"),
-                self.tr("Invalid label '{}' with validation type '{}'").format(
+                title=self.tr("Invalid label"),
+                message=self.tr("Invalid label '{}' with validation type '{}'").format(
                     text, self._config["validate_label"]
                 ),
             )
@@ -1932,12 +1942,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if text:
             self._docks.label_list.clearSelection()
             assert isinstance(flags, dict)
-            shapes = self._canvas_widgets.canvas.set_last_label(text, flags)
+            shapes = self._canvas_widgets.canvas.set_last_label(text=text, flags=flags)
             for shape in shapes:
                 if group_id is not None or shape.group_id is None:
                     shape.group_id = group_id
                 shape.description = description
-                self.add_label(shape)
+                self.add_label(shape=shape)
             self._actions.edit_mode.setEnabled(True)
             self._actions.undo_last_point.setEnabled(False)
             self._actions.undo.setEnabled(True)
@@ -1948,11 +1958,13 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_inference_produced_no_shapes(self) -> None:
         self.show_status_message(
-            self.tr("AI inference produced no new annotation."), 5000
+            self.tr("AI inference produced no new annotation."), delay=5000
         )
 
     def _on_inference_failed(self, message: str, /) -> None:
-        self.show_status_message(self.tr("AI inference failed: %s") % message, 10000)
+        self.show_status_message(
+            self.tr("AI inference failed: %s") % message, delay=10000
+        )
 
     def _on_point_prompt_rejected(self, model_name: str, /) -> None:
         option = _ai_models.find_ai_assist_model_option(model_name=model_name)
@@ -1971,7 +1983,7 @@ class MainWindow(QtWidgets.QMainWindow):
         units = -delta * 0.1  # natural scroll
         bar = self._canvas_widgets.scroll_bars[orientation]
         value = bar.value() + bar.singleStep() * units
-        self.set_scroll_value(orientation, value)
+        self.set_scroll_value(orientation=orientation, value=value)
 
     def _on_pan_request(self, step: QtCore.QPoint, /) -> None:
         # Pan moves the viewport opposite to the cursor delta so the image
@@ -1985,8 +1997,12 @@ class MainWindow(QtWidgets.QMainWindow):
         v_bar = self._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
         h_old = h_bar.value()
         v_old = v_bar.value()
-        self.set_scroll_value(Qt.Orientation.Horizontal, h_bar.value() - step.x())
-        self.set_scroll_value(Qt.Orientation.Vertical, v_bar.value() - step.y())
+        self.set_scroll_value(
+            orientation=Qt.Orientation.Horizontal, value=h_bar.value() - step.x()
+        )
+        self.set_scroll_value(
+            orientation=Qt.Orientation.Vertical, value=v_bar.value() - step.y()
+        )
         # Scrollbars take the movement they can; the render offset carries any
         # clamped remainder without changing canvas geometry.
         self._canvas_widgets.canvas.pan_view(
@@ -1997,7 +2013,7 @@ class MainWindow(QtWidgets.QMainWindow):
             constrain_to_center=constrain_to_center,
         )
 
-    def set_scroll_value(self, orientation: Qt.Orientation, value: float) -> None:
+    def set_scroll_value(self, *, orientation: Qt.Orientation, value: float) -> None:
         self._canvas_widgets.scroll_bars[orientation].setValue(int(value))
 
     def _remember_current_viewport(self) -> None:
@@ -2058,11 +2074,11 @@ class MainWindow(QtWidgets.QMainWindow):
     def _zoom_requested(self, delta: int, pos: QtCore.QPointF, /) -> None:
         self._add_zoom(increment=1.1 if delta > 0 else 0.9, pos=pos)
 
-    def set_fit_window_mode(self, value: bool = True) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
+    def set_fit_window_mode(self, value: bool = True, /) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
         target = _ZoomMode.FIT_WINDOW if value else _ZoomMode.MANUAL_ZOOM
         self._switch_zoom_mode(target)
 
-    def set_fit_width_mode(self, value: bool = True) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
+    def set_fit_width_mode(self, value: bool = True, /) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
         target = _ZoomMode.FIT_WIDTH if value else _ZoomMode.MANUAL_ZOOM
         self._switch_zoom_mode(target)
 
@@ -2076,12 +2092,13 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_brightness_contrast_changed(self, qimage: QtGui.QImage, /) -> None:
         self._canvas_widgets.canvas.load_pixmap(
-            QtGui.QPixmap.fromImage(qimage), clear_shapes=False
+            pixmap=QtGui.QPixmap.fromImage(qimage), clear_shapes=False
         )
 
     def open_brightness_contrast_dialog(
         self,
         _value: bool,  # noqa: FBT001 -- QAction.triggered slot
+        /,
         *,
         is_initial_load: bool = False,
     ) -> None:
@@ -2109,8 +2126,8 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         assert self._annotation is not None
         dialog = BrightnessContrastDialog(
-            _utils.img_data_to_pil(self._annotation.image_data),
-            self._on_brightness_contrast_changed,
+            img=_utils.img_data_to_pil(self._annotation.image_data),
+            callback=self._on_brightness_contrast_changed,
             parent=self,
         )
 
@@ -2200,8 +2217,8 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         if not QtCore.QFile.exists(image_or_label_path):
             self.show_error_message(
-                self.tr("Error opening file"),
-                self.tr("No such file: <b>%s</b>") % image_or_label_path,
+                title=self.tr("Error opening file"),
+                message=self.tr("No such file: <b>%s</b>") % image_or_label_path,
             )
             return False
         # assumes same name, but json extension
@@ -2267,7 +2284,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._label_file_path = label_file_path
         self._image = image
         t0 = time.time()
-        self._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
+        self._canvas_widgets.canvas.load_pixmap(pixmap=QtGui.QPixmap.fromImage(image))
         logger.debug("Loaded pixmap in {:.0f}ms", (time.time() - t0) * 1000)
         flags = {k: False for k in self._config["flags"] or []}
         # Record one baseline state. Loading carried-forward shapes separately
@@ -2326,7 +2343,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         return True
 
-    def resizeEvent(self, a0: QtGui.QResizeEvent) -> None:
+    def resizeEvent(self, a0: QtGui.QResizeEvent, /) -> None:
         if (
             self._canvas_widgets.canvas
             and not self._image.isNull()
@@ -2385,7 +2402,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._window_state.remove(WINDOW_LAYOUT_KEY)
         self.restoreState(self._default_state)
 
-    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+    def closeEvent(self, a0: QtGui.QCloseEvent, /) -> None:
         if not self._can_continue():
             a0.ignore()
             return
@@ -2393,7 +2410,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._window_state.setValue(WINDOW_POSITION_KEY, self.pos())
         self._window_state.setValue(WINDOW_LAYOUT_KEY, self.saveState())
 
-    def dragEnterEvent(self, a0: QtGui.QDragEnterEvent) -> None:
+    def dragEnterEvent(self, a0: QtGui.QDragEnterEvent, /) -> None:
         extensions = _list_supported_image_extensions()
         if a0.mimeData().hasUrls():
             items = [i.toLocalFile() for i in a0.mimeData().urls()]
@@ -2402,7 +2419,7 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             a0.ignore()
 
-    def dropEvent(self, a0: QtGui.QDropEvent) -> None:
+    def dropEvent(self, a0: QtGui.QDropEvent, /) -> None:
         if not self._can_continue():
             a0.ignore()
             return
@@ -2410,7 +2427,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # list holds the separator of the platform, so an unnormalized drop
         # would list an image the directory scan already listed a second time.
         items = [os.path.normpath(i.toLocalFile()) for i in a0.mimeData().urls()]
-        self.import_dropped_image_files(items)
+        self.import_dropped_image_files(image_files=items)
 
     # User Dialogs #
 
@@ -2453,7 +2470,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if image_or_label_path:
             self._load_from_file_or_dir(file_or_dir=image_or_label_path)
 
-    def prompt_output_dir(self, _value: bool = False) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
+    def prompt_output_dir(self, _value: bool = False, /) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
         default_output_dir: str
         if self._output_dir is not None:
             default_output_dir = str(self._output_dir)
@@ -2538,7 +2555,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         return label_path
 
-    def close_file(self, _value: bool = False) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
+    def close_file(self, _value: bool = False, /) -> None:  # noqa: FBT001, FBT002 -- QAction.triggered slot
         if not self._can_continue():
             return
         self._remember_current_viewport()
@@ -2626,7 +2643,7 @@ class MainWindow(QtWidgets.QMainWindow):
             )
 
     def _on_ai_model_changed(self, model_id: str, /) -> None:
-        self._canvas_widgets.canvas.set_ai_model_name(model_id)
+        self._canvas_widgets.canvas.set_ai_model_name(model_name=model_id)
         option = _ai_models.find_ai_assist_model_option(model_name=model_id)
         assert option is not None
         model_display = option.display_name
@@ -2738,7 +2755,7 @@ class MainWindow(QtWidgets.QMainWindow):
         elif key_path == ("mask_polygonization", "detail"):
             detail = self._config["mask_polygonization"]["detail"]
             self._ai_annotation.set_polygon_detail(detail)
-            self._canvas_widgets.canvas.set_ai_polygon_detail(detail)
+            self._canvas_widgets.canvas.set_ai_polygon_detail(detail=detail)
         elif key_path == ("canvas", "allow_out_of_bounds_points"):
             canvas = self._canvas_widgets.canvas
             canvas.set_allow_out_of_bounds_points(
@@ -2752,7 +2769,9 @@ class MainWindow(QtWidgets.QMainWindow):
             # from loaded/created shapes via add_label_history) is preserved, while
             # a removed predefined label drops from suggestions unless it was used
             # this session.
-            self._label_dialog.set_predefined_labels(self._config["labels"] or [])
+            self._label_dialog.set_predefined_labels(
+                labels=self._config["labels"] or []
+            )
             # The Label List dock is append-only (a shape's label stays after the
             # shape is deleted), so add new predefined labels and leave removed
             # ones until restart.
@@ -2811,7 +2830,7 @@ class MainWindow(QtWidgets.QMainWindow):
             shape = item.shape()
             assert shape is not None and shape.label is not None
             item.set_label(
-                text=format_shape_label(shape),
+                text=format_shape_label(shape=shape),
                 color=self._get_rgb_by_label(
                     label=shape.label, unique_label_list=unique_labels
                 ),
@@ -2894,7 +2913,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return not self._is_changed
         return user_choice == QtWidgets.QMessageBox.StandardButton.Discard
 
-    def show_error_message(self, title: str, message: str) -> int:
+    def show_error_message(self, *, title: str, message: str) -> int:
         return QtWidgets.QMessageBox.critical(
             self, title, f"<p><b>{title}</b></p>{message}"
         )
@@ -2933,9 +2952,9 @@ class MainWindow(QtWidgets.QMainWindow):
             and len(self._canvas_widgets.canvas.hovered_shape.points) == 0
         ):
             self._canvas_widgets.canvas.delete_shape(
-                self._canvas_widgets.canvas.hovered_shape
+                shape=self._canvas_widgets.canvas.hovered_shape
             )
-            self.remove_labels([self._canvas_widgets.canvas.hovered_shape])
+            self.remove_labels(shapes=[self._canvas_widgets.canvas.hovered_shape])
             if self.has_no_shapes():
                 for action in self._actions.on_shapes_present:
                     action.setEnabled(False)
@@ -2947,7 +2966,7 @@ class MainWindow(QtWidgets.QMainWindow):
         ).format(len(self._canvas_widgets.canvas.selected_shapes))
         if not self._confirm_deletion(message=msg):
             return
-        self.remove_labels(self._canvas_widgets.canvas.delete_selected())
+        self.remove_labels(shapes=self._canvas_widgets.canvas.delete_selected())
         self.mark_dirty()
         if self.has_no_shapes():
             for action in self._actions.on_shapes_present:
@@ -2956,7 +2975,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def copy_shape(self) -> None:
         self._canvas_widgets.canvas.end_move(copy=True)
         for shape in self._canvas_widgets.canvas.selected_shapes:
-            self.add_label(shape)
+            self.add_label(shape=shape)
         self._docks.label_list.clearSelection()
         self.mark_dirty()
 
@@ -3031,7 +3050,7 @@ class MainWindow(QtWidgets.QMainWindow):
             lst.append(item.text())
         return lst
 
-    def import_dropped_image_files(self, image_files: list[str]) -> None:
+    def import_dropped_image_files(self, *, image_files: list[str]) -> None:
         extensions = _list_supported_image_extensions()
         already_loaded = set(self._loaded_image_paths)
         new_files = [

--- a/labelme/_automation/_ai_assist.py
+++ b/labelme/_automation/_ai_assist.py
@@ -33,6 +33,7 @@ class AiAssistSession:
 
     def __init__(
         self,
+        *,
         model_name: str = "sam2:latest",
         output_format: AiOutputFormat = "polygon",
         polygon_detail: int = 80,

--- a/labelme/_automation/_geometry.py
+++ b/labelme/_automation/_geometry.py
@@ -70,7 +70,7 @@ def shape_to_xyxy_bbox(*, shape: Shape) -> NDArray[np.float32] | None:
     return np.array([xmin, ymin, xmax, ymax], dtype=np.float32)
 
 
-def compute_circle_from_mask(mask: NDArray[np.bool_]) -> Circle | None:
+def compute_circle_from_mask(*, mask: NDArray[np.bool_]) -> Circle | None:
     if not mask.any():
         return None
     ys, xs = np.nonzero(mask)
@@ -85,6 +85,7 @@ def compute_circle_from_mask(mask: NDArray[np.bool_]) -> Circle | None:
 
 
 def compute_oriented_rectangle_from_mask(
+    *,
     mask: NDArray[np.bool_],
 ) -> NDArray[np.float32] | None:
     if not mask.any():
@@ -247,7 +248,7 @@ def _simplify_contour(
 
 
 def compute_polygons_from_mask(
-    mask: NDArray[np.bool_], detail: int = 80
+    *, mask: NDArray[np.bool_], detail: int = 80
 ) -> list[NDArray[np.float32]]:
     if not 0 <= detail <= _DETAIL_MAX:
         raise ValueError(f"detail must be between 0 and 100, got {detail}")

--- a/labelme/_automation/_osam_session.py
+++ b/labelme/_automation/_osam_session.py
@@ -15,6 +15,7 @@ class OsamSession:
 
     def __init__(
         self,
+        *,
         model_name: str = "sam2:latest",
         embedding_cache_size: int = 3,
     ) -> None:
@@ -30,6 +31,7 @@ class OsamSession:
 
     def run(
         self,
+        *,
         image: NDArray[np.uint8],
         image_id: str,
         points: NDArray[np.floating] | None = None,

--- a/labelme/_automation/_shape_builders.py
+++ b/labelme/_automation/_shape_builders.py
@@ -216,9 +216,9 @@ MASK_REQUIRED_SHAPE_TYPES: Final[frozenset[AiOutputFormat]] = frozenset(
 
 
 def shapes_from_detections(
+    *,
     detections: list[Detection],
     shape_type: AiOutputFormat,
-    *,
     image_size: tuple[int, int] | None = None,
     polygon_detail: int = _DEFAULT_POLYGON_DETAIL,
 ) -> list[Shape]:

--- a/labelme/_automation/_text_detection.py
+++ b/labelme/_automation/_text_detection.py
@@ -9,7 +9,7 @@ from ._osam_session import OsamSession
 
 
 def get_bboxes_from_texts(
-    session: OsamSession, image: np.ndarray, image_id: str, texts: list[str]
+    *, session: OsamSession, image: np.ndarray, image_id: str, texts: list[str]
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, list[NDArray[np.bool_]] | None]:
     logger.debug(
         f"Requesting with model={session.model_name!r}, "
@@ -59,6 +59,7 @@ def get_bboxes_from_texts(
 
 
 def nms_bboxes(
+    *,
     boxes: np.ndarray,
     scores: np.ndarray,
     labels: np.ndarray,

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -184,7 +184,7 @@ def get_user_config_file(*, create_if_missing: bool = True) -> str:
     return str(user_config_path)
 
 
-def load_config(config_file: Path | None, config_overrides: dict) -> dict:
+def load_config(*, config_file: Path | None, config_overrides: dict) -> dict:
     config: dict
     with open(here / "default_config.yaml", encoding="utf-8") as f:
         config = _yaml.safe_load(f)

--- a/labelme/_config/_writer.py
+++ b/labelme/_config/_writer.py
@@ -77,7 +77,7 @@ def _atomic_write(*, config_file: Path, content: str) -> None:
 
 
 def set_overrides(
-    config_file: Path, overrides: Sequence[tuple[Sequence[str], object]]
+    *, config_file: Path, overrides: Sequence[tuple[Sequence[str], object]]
 ) -> None:
     yaml = YAML()
     yaml.preserve_quotes = True

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -233,11 +233,11 @@ _RESERVED_TOP_LEVEL_KEYS: Final[tuple[str, ...]] = (
 )
 
 
-def is_label_file_path(filename: str) -> bool:
+def is_label_file_path(*, filename: str) -> bool:
     return Path(filename).suffix.lower() == LABEL_FILE_SUFFIX
 
 
-def read_image_file(filename: str) -> bytes:
+def read_image_file(*, filename: str) -> bytes:
     try:
         return _read_image_file(filename=filename)
     except OSError:
@@ -250,7 +250,7 @@ def _read_image_file(*, filename: str) -> bytes:
     t_start = time.time()
     image_pil = _imread(filename)
 
-    oriented: PIL.Image.Image = _utils.apply_exif_orientation(image=image_pil)
+    oriented: PIL.Image.Image = _utils.apply_exif_orientation(image_pil)
     ext = Path(filename).suffix.lower()
     if oriented is image_pil and ext in (".jpg", ".jpeg", ".png"):
         with open(filename, "rb") as f:
@@ -291,7 +291,7 @@ def _check_image_dimensions(
         isinstance(expected_width, bool) or not isinstance(expected_width, int)
     ):
         raise TypeError(f"imageWidth must be int: {expected_width}")
-    actual_w, actual_h = _utils.img_data_to_pil(img_data=image_data).size
+    actual_w, actual_h = _utils.img_data_to_pil(image_data).size
     if expected_height is not None and expected_height != actual_h:
         raise ValueError(
             f"imageHeight mismatch: declared={expected_height}, actual={actual_h}"
@@ -302,7 +302,7 @@ def _check_image_dimensions(
         )
 
 
-def read_label_file(filename: str) -> Annotation:
+def read_label_file(*, filename: str) -> Annotation:
     try:
         with open(filename, encoding="utf-8") as f:
             raw: dict[str, Any] = json.load(f)
@@ -348,9 +348,9 @@ def read_label_file(filename: str) -> Annotation:
 
 
 def write_label_file(
+    *,
     filename: str,
     annotation: Annotation,
-    *,
     image_height: int | None,
     image_width: int | None,
     save_image_data: bool,

--- a/labelme/_label_flags.py
+++ b/labelme/_label_flags.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 
 def compile_label_flags(
+    *,
     label_flags: dict[str, list[str]] | None,
 ) -> dict[re.Pattern[str], list[str]]:
     # The patterns arrive unvalidated from ~/.labelmerc or --label-flags, so

--- a/labelme/_locale.py
+++ b/labelme/_locale.py
@@ -18,7 +18,7 @@ def available_translation_locales() -> list[str]:
     )
 
 
-def is_valid_language(code: object) -> bool:
+def is_valid_language(code: object, /) -> bool:
     if code is None or code == SOURCE_LOCALE:
         return True
     return code in available_translation_locales()

--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -65,7 +65,7 @@ class Shape:
     def can_add_point(self) -> bool:
         return self.shape_type in POLYLINE_SHAPE_TYPES
 
-    def insert_point(self, i: int, point: npt.ArrayLike, label: int = 1) -> None:
+    def insert_point(self, *, i: int, point: npt.ArrayLike, label: int = 1) -> None:
         if not self.can_add_point():
             logger.warning(
                 "Cannot add point to: shape_type={!r}, len(points)={:d}",
@@ -89,7 +89,7 @@ class Shape:
             return False
         return True
 
-    def remove_point(self, i: int) -> None:
+    def remove_point(self, *, i: int) -> None:
         if not self.can_remove_point():
             logger.warning(
                 "Cannot remove point from: shape_type={!r}, len(points)={:d}",
@@ -100,10 +100,10 @@ class Shape:
         self.points = np.delete(self.points, i, axis=0)
         self.point_labels = np.delete(self.point_labels, i)
 
-    def move_vertex(self, i: int, pos: npt.ArrayLike) -> None:
+    def move_vertex(self, *, i: int, pos: npt.ArrayLike) -> None:
         self.points[i] = np.asarray(pos, dtype=np.float64).reshape(2)
 
-    def translate(self, offset: npt.ArrayLike) -> None:
+    def translate(self, *, offset: npt.ArrayLike) -> None:
         self.points = self.points + np.asarray(offset, dtype=np.float64).reshape(2)
 
     def copy(self) -> Shape:

--- a/labelme/_shape_clipboard.py
+++ b/labelme/_shape_clipboard.py
@@ -10,11 +10,11 @@ from ._shape import Shape
 class ShapeClipboard(QtCore.QObject):
     availability_changed = QtCore.Signal(bool)
 
-    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+    def __init__(self, *, parent: QtCore.QObject | None = None) -> None:
         super().__init__(parent)
         self._buffer: tuple[Shape, ...] = ()
 
-    def store(self, shapes: Iterable[Shape]) -> None:
+    def store(self, *, shapes: Iterable[Shape]) -> None:
         snapshot = tuple(shape.copy() for shape in shapes)
         had_content = bool(self._buffer)
         self._buffer = snapshot

--- a/labelme/_utils/image.py
+++ b/labelme/_utils/image.py
@@ -26,42 +26,42 @@ _EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT: Final = 7
 _EXIF_ORIENTATION_ROTATE_90: Final = 8
 
 
-def img_data_to_pil(img_data: bytes) -> PIL.Image.Image:
+def img_data_to_pil(img_data: bytes, /) -> PIL.Image.Image:
     return PIL.Image.open(io.BytesIO(img_data))
 
 
-def img_data_to_arr(img_data: bytes) -> NDArray[np.uint8]:
+def img_data_to_arr(img_data: bytes, /) -> NDArray[np.uint8]:
     img_pil = img_data_to_pil(img_data)
     img_arr = np.array(img_pil)
     return img_arr
 
 
-def img_b64_to_arr(img_b64: str | bytes) -> NDArray[np.uint8]:
+def img_b64_to_arr(img_b64: str | bytes, /) -> NDArray[np.uint8]:
     img_data = base64.b64decode(img_b64)
     img_arr = img_data_to_arr(img_data)
     return img_arr
 
 
-def img_pil_to_data(img_pil: PIL.Image.Image) -> bytes:
+def img_pil_to_data(img_pil: PIL.Image.Image, /) -> bytes:
     f = io.BytesIO()
     img_pil.save(f, format="PNG")
     img_data = f.getvalue()
     return img_data
 
 
-def img_arr_to_b64(img_arr: NDArray[np.uint8]) -> str:
+def img_arr_to_b64(img_arr: NDArray[np.uint8], /) -> str:
     img_data = img_arr_to_data(img_arr)
     img_b64 = base64.b64encode(img_data).decode("utf-8")
     return img_b64
 
 
-def img_arr_to_data(img_arr: NDArray[np.uint8]) -> bytes:
+def img_arr_to_data(img_arr: NDArray[np.uint8], /) -> bytes:
     img_pil = PIL.Image.fromarray(img_arr)
     img_data = img_pil_to_data(img_pil)
     return img_data
 
 
-def img_qt_to_arr(img_qt: QtGui.QImage) -> NDArray[np.uint8]:
+def img_qt_to_arr(img_qt: QtGui.QImage, /) -> NDArray[np.uint8]:
     w, h, d = img_qt.size().width(), img_qt.size().height(), img_qt.depth()
     channels = d // 8
     # bits() spans bytesPerLine() * height; Qt aligns each scanline to a 4-byte
@@ -72,17 +72,15 @@ def img_qt_to_arr(img_qt: QtGui.QImage) -> NDArray[np.uint8]:
     return rows[:, : w * channels].reshape((h, w, channels))
 
 
-def img_qt_to_rgb_arr(img_qt: QtGui.QImage) -> NDArray[np.uint8]:
+def img_qt_to_rgb_arr(img_qt: QtGui.QImage, /) -> NDArray[np.uint8]:
     # The raw-memory conversion above yields BGRA on little-endian for the
     # 32-bit formats Qt loads images as; force RGB888 first (byte-order
     # defined on every platform) so callers that feed vision models get
     # true RGB.
-    return img_qt_to_arr(
-        img_qt=img_qt.convertToFormat(QtGui.QImage.Format.Format_RGB888)
-    )
+    return img_qt_to_arr(img_qt.convertToFormat(QtGui.QImage.Format.Format_RGB888))
 
 
-def apply_exif_orientation(image: PIL.Image.Image) -> PIL.Image.Image:
+def apply_exif_orientation(image: PIL.Image.Image, /) -> PIL.Image.Image:
     try:
         exif = image._getexif()  # ty: ignore[unresolved-attribute]
     except AttributeError:

--- a/labelme/_utils/qt.py
+++ b/labelme/_utils/qt.py
@@ -22,7 +22,7 @@ _SCHEME_BY_THEME: Final = {
 }
 
 
-def apply_color_theme(theme: str) -> None:
+def apply_color_theme(*, theme: str) -> None:
     scheme = _SCHEME_BY_THEME.get(theme, QtCore.Qt.ColorScheme.Unknown)
     QtGui.QGuiApplication.styleHints().setColorScheme(scheme)
 
@@ -69,7 +69,7 @@ class _TintedSvgIconEngine(QtGui.QIconEngine):
         return pixmap
 
     def pixmap(
-        self, size: QtCore.QSize, mode: QtGui.QIcon.Mode, _state: QtGui.QIcon.State
+        self, size: QtCore.QSize, mode: QtGui.QIcon.Mode, _state: QtGui.QIcon.State, /
     ) -> QtGui.QPixmap:
         # Copy so neither callers nor Qt's scaledPixmap (which sets a device pixel
         # ratio on the result) mutate the shared cached pixmap.
@@ -82,6 +82,7 @@ class _TintedSvgIconEngine(QtGui.QIconEngine):
         rect: QtCore.QRect,
         mode: QtGui.QIcon.Mode,
         _state: QtGui.QIcon.State,
+        /,
     ) -> None:
         # Render at device pixels so the icon stays crisp on HiDPI/Retina screens,
         # where rect is in device-independent coordinates. Copy before stamping the
@@ -109,7 +110,7 @@ class _TintedSvgIconEngine(QtGui.QIconEngine):
         return _TintedSvgIconEngine(svg=self._svg)
 
 
-def new_icon(name: str) -> QtGui.QIcon:
+def new_icon(name: str, /) -> QtGui.QIcon:
     if not os.path.splitext(name)[1]:
         name = name + _DEFAULT_ICON_SUFFIX
     path = os.path.join(_ICONS_DIR, name)
@@ -123,12 +124,13 @@ def new_icon(name: str) -> QtGui.QIcon:
 
 def new_action(
     parent: QtWidgets.QWidget,
+    /,
+    *,
     text: str = "",
     slot: Callable[..., object] | None = None,
     shortcut: str | list[str] | tuple[str, ...] | None = None,
     icon: str | None = None,
     tip: str | None = None,
-    *,
     checkable: bool = False,
     enabled: bool = True,
     checked: bool = False,
@@ -154,6 +156,7 @@ def new_action(
 
 
 def add_actions(
+    *,
     widget: QtWidgets.QMenu | QtWidgets.QToolBar,
     actions: Sequence[QtGui.QAction | QtWidgets.QMenu | None],
 ) -> None:

--- a/labelme/_utils/shape.py
+++ b/labelme/_utils/shape.py
@@ -33,6 +33,8 @@ class ShapeDict(TypedDict):
 def shape_to_mask(
     img_shape: tuple[int, ...],
     points: list[list[float]],
+    /,
+    *,
     shape_type: str | None = None,
     line_width: int = 10,
     point_size: int = 5,
@@ -86,6 +88,7 @@ def shape_to_mask(
 
 
 def shapes_to_label(
+    *,
     img_shape: tuple[int, ...],
     shapes: list[ShapeDict],
     label_name_to_value: dict[str, int],
@@ -136,7 +139,7 @@ def shapes_to_label(
                     y_start - y1 : y_stop - y1, x_start - x1 : x_stop - x1
                 ]
         else:
-            mask = shape_to_mask(img_shape[:2], points, shape_type)
+            mask = shape_to_mask(img_shape[:2], points, shape_type=shape_type)
 
         cls[mask] = cls_id
         ins[mask] = ins_id

--- a/labelme/_widgets/_ai_assisted_annotation_widget.py
+++ b/labelme/_widgets/_ai_assisted_annotation_widget.py
@@ -24,6 +24,7 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
     def __init__(
         self,
+        *,
         default_model: str,
         polygon_detail: int,
         on_model_changed: Callable[[str], None],
@@ -156,13 +157,13 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
 
         self.setMaximumWidth(200)
 
-    def set_current_model(self, model_display: str) -> None:
+    def set_current_model(self, *, model_display: str) -> None:
         index = self._model_combo.findText(model_display)
         if index < 0 or self._model_combo.currentIndex() == index:
             return
         self._model_combo.setCurrentIndex(index)
 
-    def set_polygon_detail(self, detail: int) -> None:
+    def set_polygon_detail(self, detail: int, /) -> None:
         with QtCore.QSignalBlocker(self._polygon_detail_slider):
             self._polygon_detail_slider.set_value(detail)
 
@@ -174,12 +175,12 @@ class AiAssistedAnnotationWidget(QtWidgets.QWidget):
             assert item is not None
             item.setEnabled(not enabled or option.supports_point_prompts)
 
-    def setEnabled(self, a0: bool) -> None:  # noqa: FBT001 -- QWidget.setEnabled override
+    def setEnabled(self, a0: bool, /) -> None:  # noqa: FBT001 -- QWidget.setEnabled override
         self._body.setEnabled(a0)
         self._polygon_detail_button.setEnabled(a0)
         self.hover_highlight_requested.emit(False)  # noqa: FBT003 -- Qt signal payload is positional
 
-    def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent) -> bool:
+    def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent, /) -> bool:
         if a0 in (self, self._body) and not self._body.isEnabled():
             if a1.type() == QtCore.QEvent.Type.Enter:
                 QtWidgets.QToolTip.showText(

--- a/labelme/_widgets/_ai_text_to_annotation_widget.py
+++ b/labelme/_widgets/_ai_text_to_annotation_widget.py
@@ -27,6 +27,7 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
 
     def __init__(
         self,
+        *,
         on_submit: Callable[[bool], None],
         parent: QtWidgets.QWidget | None = None,
     ) -> None:
@@ -148,10 +149,10 @@ class AiTextToAnnotationWidget(QtWidgets.QWidget):
     def get_iou_threshold(self) -> float:
         return self._iou_spinbox.value()
 
-    def setEnabled(self, a0: bool) -> None:  # noqa: FBT001 -- QWidget.setEnabled override
+    def setEnabled(self, a0: bool, /) -> None:  # noqa: FBT001 -- QWidget.setEnabled override
         self._body.setEnabled(a0)
 
-    def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent) -> bool:
+    def eventFilter(self, a0: QtCore.QObject, a1: QtCore.QEvent, /) -> bool:
         if a0 == self._body and not self._body.isEnabled():
             if a1.type() == QtCore.QEvent.Type.Enter:
                 QtWidgets.QToolTip.showText(

--- a/labelme/_widgets/_canvas_interaction.py
+++ b/labelme/_widgets/_canvas_interaction.py
@@ -130,7 +130,7 @@ assert set(_CURSOR_SHAPE_MAP) == set(CursorRole), (
 )
 
 
-def cursor_shape_for(role: CursorRole) -> Qt.CursorShape:
+def cursor_shape_for(role: CursorRole, /) -> Qt.CursorShape:
     return _CURSOR_SHAPE_MAP[role]
 
 

--- a/labelme/_widgets/_info_button.py
+++ b/labelme/_widgets/_info_button.py
@@ -8,7 +8,9 @@ from .._utils.qt import new_icon
 
 
 class InfoButton(QtWidgets.QToolButton):
-    def __init__(self, tooltip: str, parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(
+        self, *, tooltip: str, parent: QtWidgets.QWidget | None = None
+    ) -> None:
         super().__init__(parent=parent)
         self.setIcon(new_icon("phosphor/info.svg"))
         self.setIconSize(QtCore.QSize(16, 16))
@@ -27,6 +29,6 @@ class InfoButton(QtWidgets.QToolButton):
         self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
         self.setToolTip(tooltip)
 
-    def enterEvent(self, a0: QtGui.QEnterEvent) -> None:
+    def enterEvent(self, a0: QtGui.QEnterEvent, /) -> None:
         super().enterEvent(a0)
         QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), self.toolTip())

--- a/labelme/_widgets/_integer_slider.py
+++ b/labelme/_widgets/_integer_slider.py
@@ -34,7 +34,7 @@ class IntegerSlider(QtWidgets.QWidget):
         self._slider.valueChanged.connect(self._on_value_changed)
         self.set_value(value)
 
-    def setAccessibleName(self, name: str) -> None:
+    def setAccessibleName(self, name: str, /) -> None:
         super().setAccessibleName(name)
         self._slider.setAccessibleName(name)
 
@@ -42,7 +42,7 @@ class IntegerSlider(QtWidgets.QWidget):
     def value(self) -> int:
         return self._slider.value()
 
-    def set_value(self, value: int) -> None:
+    def set_value(self, value: int, /) -> None:
         self._slider.setValue(value)
         self._value_label.setNum(self._slider.value())
 

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -56,7 +56,7 @@ class Palette:
     hvertex_fill: QtGui.QColor
 
     @classmethod
-    def from_rgb(cls, rgb: tuple[int, int, int]) -> Palette:
+    def from_rgb(cls, rgb: tuple[int, int, int], /) -> Palette:
         r, g, b = rgb
         return cls(
             line=QtGui.QColor(r, g, b),
@@ -83,7 +83,7 @@ class ShapeRenderContext:
 
 
 def render_shape(
-    painter: QtGui.QPainter, shape: Shape, context: ShapeRenderContext
+    *, painter: QtGui.QPainter, shape: Shape, context: ShapeRenderContext
 ) -> None:
     if shape.mask is None and len(shape.points) == 0:
         return

--- a/labelme/_widgets/brightness_contrast_dialog.py
+++ b/labelme/_widgets/brightness_contrast_dialog.py
@@ -16,6 +16,7 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
 
     def __init__(
         self,
+        *,
         img: PIL.Image.Image,
         callback: Callable[[QImage], None],
         parent: QtWidgets.QWidget | None = None,

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -51,7 +51,7 @@ _MIN_SHAPE_BACKUPS_FOR_UNDO: Final = 2
 _MIN_POINTS_FOR_FILL_PREVIEW: Final = 2
 
 _DEFAULT_SHAPE_RGB: Final[tuple[int, int, int]] = (0, 255, 0)
-_DEFAULT_PALETTE: Final[Palette] = Palette.from_rgb(rgb=_DEFAULT_SHAPE_RGB)
+_DEFAULT_PALETTE: Final[Palette] = Palette.from_rgb(_DEFAULT_SHAPE_RGB)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -74,7 +74,7 @@ class _DraftShape:
         return dataclasses.replace(self, closed=False)
 
     def add_point(
-        self, point: QPointF, label: int = 1, *, autoclose: bool = False
+        self, point: QPointF, /, *, label: int = 1, autoclose: bool = False
     ) -> _DraftShape:
         if autoclose and self.points and self.points[0] == point:
             return dataclasses.replace(self, closed=True)
@@ -296,7 +296,7 @@ class Canvas(QtWidgets.QWidget):
     def set_allow_out_of_bounds_points(self, *, value: bool) -> None:
         self._allow_out_of_bounds_points = value
 
-    def pan_view(self, step: QPointF, *, constrain_to_center: bool = True) -> None:
+    def pan_view(self, *, step: QPointF, constrain_to_center: bool = True) -> None:
         viewport = self._scroll_viewport()
         if viewport is None:
             return
@@ -327,11 +327,11 @@ class Canvas(QtWidgets.QWidget):
         return QPointF(self._view_offset)
 
     def set_color_resolver(
-        self, resolver: Callable[[str], tuple[int, int, int]]
+        self, *, resolver: Callable[[str], tuple[int, int, int]]
     ) -> None:
         self._color_resolver = resolver
 
-    def set_point_size(self, point_size: int) -> None:
+    def set_point_size(self, *, point_size: int) -> None:
         self._point_size = point_size
 
     def _resolve_palette(self, label: str | None, /) -> Palette:
@@ -343,11 +343,11 @@ class Canvas(QtWidgets.QWidget):
         # resolution into one lookup per distinct label per frame.
         palette = self._palette_cache.get(label)
         if palette is None:
-            palette = Palette.from_rgb(rgb=self._color_resolver(label))
+            palette = Palette.from_rgb(self._color_resolver(label))
             self._palette_cache[label] = palette
         return palette
 
-    def set_draft_palette(self, palette: Palette) -> None:
+    def set_draft_palette(self, *, palette: Palette) -> None:
         self._draft_palette = palette
 
     def _highlight_vertex(self, *, index: int, mode: Literal["move", "near"]) -> None:
@@ -406,7 +406,7 @@ class Canvas(QtWidgets.QWidget):
         return self._create_mode
 
     @create_mode.setter
-    def create_mode(self, value: str) -> None:
+    def create_mode(self, value: str, /) -> None:
         if value not in typing.get_args(_CreateMode):
             raise ValueError(f"Unsupported create_mode: {value}")
         new_mode = cast(_CreateMode, value)
@@ -448,19 +448,21 @@ class Canvas(QtWidgets.QWidget):
     def get_ai_model_name(self) -> str:
         return self._ai_assist_session.model_name
 
-    def set_ai_model_name(self, model_name: str) -> None:
+    def set_ai_model_name(self, *, model_name: str) -> None:
         if self._ai_assist_session.model_name == model_name:
             return
         self._ai_assist_session.model_name = model_name
         self._clear_ai_existing_shape_highlights()
 
-    def set_ai_output_format(self, output_format: _automation.AiOutputFormat) -> None:
+    def set_ai_output_format(
+        self, output_format: _automation.AiOutputFormat, /
+    ) -> None:
         if self._ai_assist_session.output_format == output_format:
             return
         self._ai_assist_session.output_format = output_format
         self._clear_ai_existing_shape_highlights()
 
-    def set_ai_polygon_detail(self, detail: int) -> None:
+    def set_ai_polygon_detail(self, *, detail: int) -> None:
         if self._ai_assist_session.polygon_detail == detail:
             return
         self._ai_assist_session.polygon_detail = detail
@@ -479,7 +481,7 @@ class Canvas(QtWidgets.QWidget):
         points: Sequence[QPointF],
         point_labels: Sequence[int],
     ) -> _automation.AiAssistProposal:
-        image: np.ndarray = _utils.img_qt_to_rgb_arr(img_qt=self.pixmap.toImage())
+        image: np.ndarray = _utils.img_qt_to_rgb_arr(self.pixmap.toImage())
         proposal = self._ai_assist_session.propose_shapes(
             image=image,
             image_id=str(self._pixmap_hash),
@@ -526,11 +528,11 @@ class Canvas(QtWidgets.QWidget):
         self.selected_shapes.clear()
         self.update()
 
-    def enterEvent(self, _a0: QtCore.QEvent) -> None:
+    def enterEvent(self, _a0: QtCore.QEvent, /) -> None:
         self._apply_cursor(self._cursor)
         self._update_status(extra_messages=None)
 
-    def leaveEvent(self, _a0: QtCore.QEvent) -> None:
+    def leaveEvent(self, _a0: QtCore.QEvent, /) -> None:
         if self._set_highlight(
             hovered_shape=None,
             hovered_edge=None,
@@ -541,7 +543,7 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self._update_status(extra_messages=None)
 
-    def focusOutEvent(self, _a0: QtGui.QFocusEvent) -> None:
+    def focusOutEvent(self, _a0: QtGui.QFocusEvent, /) -> None:
         self._release_cursor()
         self._update_status(extra_messages=None)
 
@@ -663,7 +665,7 @@ class Canvas(QtWidgets.QWidget):
             return self.tr("Click third corner to close oriented rectangle")
         return self.tr("Click to add point")
 
-    def mouseMoveEvent(self, a0: QtGui.QMouseEvent) -> None:
+    def mouseMoveEvent(self, a0: QtGui.QMouseEvent, /) -> None:
         try:
             pos = self.transform_widget_point_to_image(a0.position())
         except AttributeError:
@@ -991,7 +993,7 @@ class Canvas(QtWidgets.QWidget):
         point = self._prev_move_point
         if shape is None or index is None or point is None:
             return
-        shape.insert_point(index, (point.x(), point.y()))
+        shape.insert_point(i=index, point=(point.x(), point.y()))
         self._highlight_vertex(index=index, mode="move")
         self.hovered_shape = shape
         self._hovered_vertex = index
@@ -1005,7 +1007,7 @@ class Canvas(QtWidgets.QWidget):
         index = self._last_hovered_vertex
         if shape is None or index is None or not shape.can_remove_point():
             return False
-        shape.remove_point(index)
+        shape.remove_point(i=index)
         self._clear_highlight_state()
         # Drop the hovered vertex and selection so the press that deleted the
         # point cannot also drag the adjacent vertex (#968) or the whole shape.
@@ -1018,7 +1020,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
         return True
 
-    def mousePressEvent(self, a0: QtGui.QMouseEvent) -> None:
+    def mousePressEvent(self, a0: QtGui.QMouseEvent, /) -> None:
         pos: QPointF = self.transform_widget_point_to_image(a0.position())
         self._dispatch_pointer_press(pos=pos, event=a0)
         self._update_status(extra_messages=None)
@@ -1224,7 +1226,7 @@ class Canvas(QtWidgets.QWidget):
         self._apply_cursor(CursorRole.GRAB)
         self._pan_anchor = QPointF(self.mapToGlobal(event.position().toPoint()))
 
-    def mouseReleaseEvent(self, a0: QtGui.QMouseEvent) -> None:
+    def mouseReleaseEvent(self, a0: QtGui.QMouseEvent, /) -> None:
         self._dispatch_pointer_release(event=a0)
         self._commit_pending_shape_move()
         self._update_status(extra_messages=None)
@@ -1356,14 +1358,14 @@ class Canvas(QtWidgets.QWidget):
             )
         return len(self._current.points) >= MIN_POLYGON_POINT_COUNT
 
-    def mouseDoubleClickEvent(self, _a0: QtGui.QMouseEvent) -> None:
+    def mouseDoubleClickEvent(self, _a0: QtGui.QMouseEvent, /) -> None:
         if self._double_click != "close":
             return
         if not self._can_close_shape():
             return
         self._finalize()
 
-    def select_shapes(self, shapes: list[Shape]) -> None:
+    def select_shapes(self, *, shapes: list[Shape]) -> None:
         self.selection_changed.emit(shapes)
         self.update()
 
@@ -1522,7 +1524,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
         return removed
 
-    def delete_shape(self, shape: Shape) -> None:
+    def delete_shape(self, *, shape: Shape) -> None:
         if shape in self.selected_shapes:
             self.selected_shapes.remove(shape)
         self.shapes = [s for s in self.shapes if s is not shape]
@@ -1530,7 +1532,7 @@ class Canvas(QtWidgets.QWidget):
         self._set_ai_existing_shape_highlights(shapes=[])
         self.update()
 
-    def paintEvent(self, a0: QtGui.QPaintEvent) -> None:
+    def paintEvent(self, a0: QtGui.QPaintEvent, /) -> None:
         if self.pixmap.isNull():
             super().paintEvent(a0)
             return
@@ -1702,14 +1704,14 @@ class Canvas(QtWidgets.QWidget):
     def _build_polygon_preview(self, *, current: _DraftShape) -> Shape:
         preview = current
         if self._fill_drawing and len(preview.points) >= _MIN_POINTS_FOR_FILL_PREVIEW:
-            preview = preview.add_point(point=self._line.points[1], autoclose=True)
+            preview = preview.add_point(self._line.points[1], autoclose=True)
         return _draft_to_shape(preview)
 
     def _build_ai_points_preview(self, *, current: _DraftShape) -> list[Shape]:
         if not _ai_models.supports_point_prompts(model_name=self.get_ai_model_name()):
             return []
         preview = current.add_point(
-            point=self._line.points[1],
+            self._line.points[1],
             label=self._line.point_labels[1],
         )
         try:
@@ -1730,14 +1732,14 @@ class Canvas(QtWidgets.QWidget):
         self._set_ai_existing_shape_highlights(shapes=proposal.matching_existing_shapes)
         return proposal.new_shapes
 
-    def transform_widget_point_to_image(self, point: QPointF) -> QPointF:
+    def transform_widget_point_to_image(self, point: QPointF, /) -> QPointF:
         origin = self._compute_image_origin_offset(area=None)
         image_x = point.x() / self.scale - origin.x()
         image_y = point.y() / self.scale - origin.y()
         return QPointF(image_x, image_y)
 
     def transform_image_point_to_widget(
-        self, point: QPointF, *, area: QtCore.QSize | None = None
+        self, point: QPointF, /, *, area: QtCore.QSize | None = None
     ) -> QPointF:
         return (point + self._compute_image_origin_offset(area=area)) * self.scale
 
@@ -1750,7 +1752,7 @@ class Canvas(QtWidgets.QWidget):
         slack_h = max(area.height() - scaled_h, 0.0)
         return (QPointF(slack_w, slack_h) / 2.0 + self._view_offset) / self.scale
 
-    def is_out_of_pixmap(self, p: QPointF) -> bool:
+    def is_out_of_pixmap(self, p: QPointF, /) -> bool:
         return _is_out_of_image(p, self.pixmap.size())
 
     def _should_constrain_to_pixmap(self, point: QPointF, /) -> bool:
@@ -1862,7 +1864,7 @@ class Canvas(QtWidgets.QWidget):
     def minimumSizeHint(self) -> QtCore.QSize:
         return self._compute_canvas_size()
 
-    def wheelEvent(self, a0: QtGui.QWheelEvent) -> None:
+    def wheelEvent(self, a0: QtGui.QWheelEvent, /) -> None:
         self._clear_ai_existing_shape_highlights()
         mods: Qt.KeyboardModifier = a0.modifiers()
         delta: QPoint = a0.angleDelta()
@@ -1896,7 +1898,7 @@ class Canvas(QtWidgets.QWidget):
         self.update()
         self._is_moving_shape = True
 
-    def keyPressEvent(self, a0: QtGui.QKeyEvent) -> None:
+    def keyPressEvent(self, a0: QtGui.QKeyEvent, /) -> None:
         self._clear_ai_existing_shape_highlights()
         modifiers = a0.modifiers()
         key = a0.key()
@@ -1922,7 +1924,7 @@ class Canvas(QtWidgets.QWidget):
                 self.select_shapes(shapes=self.shapes[:])
         self._update_status(extra_messages=None)
 
-    def keyReleaseEvent(self, a0: QtGui.QKeyEvent) -> None:
+    def keyReleaseEvent(self, a0: QtGui.QKeyEvent, /) -> None:
         modifiers = a0.modifiers()
         if self.mode == _CanvasMode.CREATE:
             if not modifiers:
@@ -1942,7 +1944,7 @@ class Canvas(QtWidgets.QWidget):
 
                 self._is_moving_shape = False
 
-    def set_last_label(self, text: str, flags: dict[str, bool]) -> list[Shape]:
+    def set_last_label(self, *, text: str, flags: dict[str, bool]) -> list[Shape]:
         if not text:
             raise ValueError("text must not be empty")
         shapes = []
@@ -2019,8 +2021,8 @@ class Canvas(QtWidgets.QWidget):
         self._clear_highlight_state()
         self._set_ai_existing_shape_highlights(shapes=[])
 
-    def load_pixmap(self, pixmap: QtGui.QPixmap, *, clear_shapes: bool = True) -> None:
-        pixmap_arr = _utils.img_qt_to_arr(img_qt=pixmap.toImage())
+    def load_pixmap(self, *, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
+        pixmap_arr = _utils.img_qt_to_arr(pixmap.toImage())
         self.pixmap = pixmap
         self._pixmap_hash = hash(pixmap_arr.tobytes())
         # A new image is a fresh inference context that should surface its own
@@ -2031,13 +2033,13 @@ class Canvas(QtWidgets.QWidget):
             self.shapes = []
         self.update()
 
-    def load_shapes(self, shapes: list[Shape], *, replace: bool = True) -> None:
+    def load_shapes(self, *, shapes: list[Shape], replace: bool = True) -> None:
         self.shapes = list(shapes) if replace else self.shapes + list(shapes)
         self.backup_shapes()
         self._reset_interaction_state()
         self.update()
 
-    def set_shape_visible(self, shape: Shape, *, value: bool) -> None:
+    def set_shape_visible(self, *, shape: Shape, value: bool) -> None:
         if shape.visible == value:
             return
         shape.visible = value
@@ -2046,7 +2048,7 @@ class Canvas(QtWidgets.QWidget):
     def _apply_cursor(self, role: CursorRole, /) -> None:
         if role == self._cursor:
             return
-        shape = _canvas_interaction.cursor_shape_for(role=role)
+        shape = _canvas_interaction.cursor_shape_for(role)
         # Push on first apply; swap the top of the stack we already own afterwards.
         if self._cursor == CursorRole.DEFAULT:
             QtWidgets.QApplication.setOverrideCursor(shape)

--- a/labelme/_widgets/download.py
+++ b/labelme/_widgets/download.py
@@ -23,7 +23,7 @@ class _DownloadThread(QThread):
     succeeded = Signal()
     error = Signal(Exception)
 
-    def __init__(self, model_type: type[osam.types.Model], parent: QWidget) -> None:
+    def __init__(self, *, model_type: type[osam.types.Model], parent: QWidget) -> None:
         super().__init__(parent)
         self._model_type = model_type
         self._total_files = sum(
@@ -79,7 +79,7 @@ def _format_bytes(n: int, /) -> str:
     return f"{value:.1f} TB"
 
 
-def download_ai_model(model_name: str, parent: QWidget) -> bool:
+def download_ai_model(*, model_name: str, parent: QWidget) -> bool:
     model_type = osam.apis.get_model_type_by_name(model_name)
 
     if model_type.get_size() is not None:

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -20,14 +20,14 @@ _FLAGS_SCROLL_MAX_HEIGHT: Final[int] = 150
 class LabelQLineEdit(QtWidgets.QLineEdit):
     """QLineEdit that forwards Up/Down key events to a paired list widget."""
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(self, *, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
         self.list_widget: QtWidgets.QListWidget | None = None
 
-    def set_list_widget(self, list_widget: QtWidgets.QListWidget) -> None:
+    def set_list_widget(self, *, list_widget: QtWidgets.QListWidget) -> None:
         self.list_widget = list_widget
 
-    def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
+    def keyPressEvent(self, event: QtGui.QKeyEvent, /) -> None:
         key = event.key()
         if key in (QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down):
             if self.list_widget is not None:
@@ -41,10 +41,10 @@ class LabelDialog(QtWidgets.QDialog):
 
     def __init__(
         self,
+        *,
         text: str = _PLACEHOLDER_TEXT,
         parent: QtWidgets.QWidget | None = None,
         labels: list[str] | None = None,
-        *,
         sort_labels: bool = True,
         show_text_field: bool = True,
         completion: str = "startswith",
@@ -111,7 +111,7 @@ class LabelDialog(QtWidgets.QDialog):
         # Set up completer bound to label_list's model
         completer = self._make_completer(completion=completion)
         self.edit.setCompleter(completer)
-        self.edit.set_list_widget(self.label_list)
+        self.edit.set_list_widget(list_widget=self.label_list)
 
         # Button box
         button_box = QtWidgets.QDialogButtonBox(
@@ -230,7 +230,7 @@ class LabelDialog(QtWidgets.QDialog):
                 flags[key] = self._flag_states.get(key, False)
         self._set_flag_checkboxes(flags=flags)
 
-    def add_label_history(self, label: str) -> None:
+    def add_label_history(self, *, label: str) -> None:
         if label not in self._label_history:
             self._label_history.append(label)
 
@@ -239,7 +239,7 @@ class LabelDialog(QtWidgets.QDialog):
             if self._sort_labels:
                 self.label_list.sortItems()
 
-    def set_predefined_labels(self, labels: list[str]) -> None:
+    def set_predefined_labels(self, *, labels: list[str]) -> None:
         history_extras = [h for h in self._label_history if h not in labels]
         all_labels = list(dict.fromkeys(labels)) + history_extras
 
@@ -252,8 +252,8 @@ class LabelDialog(QtWidgets.QDialog):
 
     def popup(
         self,
-        text: str | None = None,
         *,
+        text: str | None = None,
         move: bool = True,
         position: QtCore.QPoint | None = None,
         flags: dict[str, bool] | None = None,

--- a/labelme/_widgets/label_list_widget.py
+++ b/labelme/_widgets/label_list_widget.py
@@ -16,7 +16,7 @@ from .._shape import Shape
 LABEL_COLOR_ROLE: Final = Qt.ItemDataRole.UserRole.value + 1
 
 
-def format_shape_label(shape: Shape) -> str:
+def format_shape_label(*, shape: Shape) -> str:
     assert shape.label is not None
     text = shape.label
     if shape.group_id is not None:
@@ -37,6 +37,7 @@ class TrailingColorDotDelegate(QtWidgets.QStyledItemDelegate):
         self,
         option: QtWidgets.QStyleOptionViewItem,
         index: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
+        /,
     ) -> QtCore.QSize:
         size = super().sizeHint(option, index)
         if isinstance(index.data(LABEL_COLOR_ROLE), QtGui.QColor):
@@ -50,6 +51,7 @@ class TrailingColorDotDelegate(QtWidgets.QStyledItemDelegate):
         painter: QtGui.QPainter,
         option: QtWidgets.QStyleOptionViewItem,
         index: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
+        /,
     ) -> None:
         color = index.data(LABEL_COLOR_ROLE)
         if not isinstance(color, QtGui.QColor):
@@ -97,10 +99,10 @@ class TrailingColorDotDelegate(QtWidgets.QStyledItemDelegate):
 
 
 class LabelListWidgetItem(QtGui.QStandardItem):
-    def __init__(self, text: str | None = None, shape: Shape | None = None) -> None:
+    def __init__(self, *, text: str | None = None, shape: Shape | None = None) -> None:
         super().__init__()
         self.setText(text or "")
-        self.set_shape(shape)
+        self.set_shape(shape=shape)
 
         self.setCheckable(True)
         self.setCheckState(
@@ -115,10 +117,10 @@ class LabelListWidgetItem(QtGui.QStandardItem):
         item.setData(self.data(LABEL_COLOR_ROLE), LABEL_COLOR_ROLE)
         return item
 
-    def set_shape(self, shape: Shape | None) -> None:
+    def set_shape(self, *, shape: Shape | None) -> None:
         self.setData(shape, Qt.ItemDataRole.UserRole)
 
-    def set_label(self, text: str, color: tuple[int, int, int]) -> None:
+    def set_label(self, *, text: str, color: tuple[int, int, int]) -> None:
         self.setText(text)
         self.setData(QtGui.QColor(*color), LABEL_COLOR_ROLE)
 
@@ -139,9 +141,10 @@ class _ItemModel(QtGui.QStandardItemModel):
         self,
         row: int,
         count: int,
+        /,
         parent: QtCore.QModelIndex
         | QtCore.QPersistentModelIndex = _INVALID_MODEL_INDEX,
-    ) -> bool:
+    ) -> bool:  # noqa: GR005 -- PySide6 declares `parent` positional-or-keyword
         ret = super().removeRows(row, count, parent)
         self.item_dropped.emit()
         return ret
@@ -153,6 +156,7 @@ class _ItemModel(QtGui.QStandardItemModel):
         row: int,
         column: int,
         parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
+        /,
     ) -> bool:
         # NOTE: By default, PyQt will overwrite items when dropped on them, so we need
         # to adjust the row/parent to insert after the item instead.
@@ -202,7 +206,7 @@ class LabelListWidget(QtWidgets.QListView):
 
         self._press_snapshot: tuple[_ItemSnapshot, ...] = ()
 
-    def mousePressEvent(self, e: QtGui.QMouseEvent) -> None:
+    def mousePressEvent(self, e: QtGui.QMouseEvent, /) -> None:
         self._press_snapshot = tuple(
             _ItemSnapshot(
                 index=QtCore.QPersistentModelIndex(self._model.indexFromItem(item)),
@@ -212,7 +216,7 @@ class LabelListWidget(QtWidgets.QListView):
         )
         super().mousePressEvent(e)
 
-    def mouseReleaseEvent(self, e: QtGui.QMouseEvent) -> None:
+    def mouseReleaseEvent(self, e: QtGui.QMouseEvent, /) -> None:
         super().mouseReleaseEvent(e)
 
         # Restore the multi-selection only when a checkbox toggle collapsed it.
@@ -256,7 +260,7 @@ class LabelListWidget(QtWidgets.QListView):
     def __len__(self) -> int:
         return self._model.rowCount()
 
-    def __getitem__(self, i: int) -> LabelListWidgetItem:
+    def __getitem__(self, i: int, /) -> LabelListWidgetItem:
         return cast(LabelListWidgetItem, self._model.item(i))
 
     def __iter__(self) -> Iterator[LabelListWidgetItem]:
@@ -290,25 +294,25 @@ class LabelListWidget(QtWidgets.QListView):
             for i in self.selectedIndexes()
         ]
 
-    def scroll_to_item(self, item: LabelListWidgetItem) -> None:
+    def scroll_to_item(self, *, item: LabelListWidgetItem) -> None:
         self.scrollTo(self._model.indexFromItem(item))
 
-    def add_item(self, item: LabelListWidgetItem) -> None:
+    def add_item(self, *, item: LabelListWidgetItem) -> None:
         if not isinstance(item, LabelListWidgetItem):
             raise TypeError("item must be LabelListWidgetItem")
         self._model.setItem(self._model.rowCount(), 0, item)
 
-    def remove_item(self, item: LabelListWidgetItem) -> None:
+    def remove_item(self, *, item: LabelListWidgetItem) -> None:
         index = self._model.indexFromItem(item)
         self._model.removeRows(index.row(), 1)
 
-    def select_item(self, item: LabelListWidgetItem) -> None:
+    def select_item(self, *, item: LabelListWidgetItem) -> None:
         index = self._model.indexFromItem(item)
         self.selectionModel().select(
             index, QtCore.QItemSelectionModel.SelectionFlag.Select
         )
 
-    def find_item_by_shape(self, shape: Shape) -> LabelListWidgetItem:
+    def find_item_by_shape(self, *, shape: Shape) -> LabelListWidgetItem:
         for row in range(self._model.rowCount()):
             item = self._model.item(row, 0)
             item = cast(LabelListWidgetItem, item)

--- a/labelme/_widgets/settings_dialog.py
+++ b/labelme/_widgets/settings_dialog.py
@@ -34,7 +34,7 @@ class _PlainTextEdit(QtWidgets.QPlainTextEdit):
         self.mark_committed()
         self.editing_finished.emit()
 
-    def focusOutEvent(self, e: QtGui.QFocusEvent) -> None:
+    def focusOutEvent(self, e: QtGui.QFocusEvent, /) -> None:
         super().focusOutEvent(e)
         self.commit()
 
@@ -50,7 +50,7 @@ class _ColorSwatchButton(QtWidgets.QPushButton):
     def get_rgb(self) -> tuple[int, int, int]:
         return self._rgb
 
-    def set_rgb(self, rgb: tuple[int, int, int]) -> None:
+    def set_rgb(self, rgb: tuple[int, int, int], /) -> None:
         self._rgb = rgb
         r, g, b = rgb
         self.setToolTip(
@@ -62,7 +62,7 @@ class _ColorSwatchButton(QtWidgets.QPushButton):
         self.setIcon(QtGui.QIcon(swatch))
         self.setIconSize(swatch.size())
 
-    def set_accessible_note(self, note: str) -> None:
+    def set_accessible_note(self, note: str, /) -> None:
         self._accessible_note = note
         self._update_accessible_description()
 
@@ -76,6 +76,7 @@ class _ColorSwatchButton(QtWidgets.QPushButton):
 class _SettingsPage(QtWidgets.QWidget):
     def __init__(
         self,
+        *,
         groups: Sequence[tuple[str, QtGui.QIcon, QtWidgets.QGroupBox]],
     ) -> None:
         super().__init__()
@@ -202,6 +203,7 @@ class _SettingsPage(QtWidgets.QWidget):
 class SettingsDialog(QtWidgets.QDialog):
     def __init__(
         self,
+        *,
         config: dict,
         apply_setting: ApplySetting,
         preview_shape_color: PreviewShapeColor,
@@ -296,7 +298,7 @@ class SettingsDialog(QtWidgets.QDialog):
         # nothing, so treat them like Close and flush pending edits.
         self.accept()
 
-    def set_value(self, key_path: tuple[str, ...], value: object) -> None:
+    def set_value(self, *, key_path: tuple[str, ...], value: object) -> None:
         editor = self._editors[key_path]
         with QtCore.QSignalBlocker(editor):
             self._set_editor_value(editor=editor, value=value)
@@ -305,9 +307,9 @@ class SettingsDialog(QtWidgets.QDialog):
 
     def set_choice_enabled(
         self,
+        *,
         key_path: tuple[str, ...],
         value: object,
-        *,
         enabled: bool,
         disabled_reason: str,
     ) -> None:

--- a/labelme/_widgets/tool_bar.py
+++ b/labelme/_widgets/tool_bar.py
@@ -18,6 +18,7 @@ _VERTICAL_SEPARATOR_STYLE: Final = (
 class ToolBar(QtWidgets.QToolBar):
     def __init__(
         self,
+        *,
         title: str,
         actions: list[QtGui.QAction | None],
         orientation: Qt.Orientation = Qt.Orientation.Horizontal,
@@ -45,12 +46,12 @@ class ToolBar(QtWidgets.QToolBar):
         if orientation == Qt.Orientation.Vertical:
             self.setStyleSheet(_VERTICAL_SEPARATOR_STYLE)
 
-        add_actions(self, actions)
+        add_actions(widget=self, actions=actions)
 
         if orientation == Qt.Orientation.Vertical:
             self._equalize_button_widths()
 
-    def addAction(self, action: QtGui.QAction) -> None:  # ty: ignore[invalid-method-override]
+    def addAction(self, action: QtGui.QAction, /) -> None:  # ty: ignore[invalid-method-override]
         if isinstance(action, QtWidgets.QWidgetAction):
             super().addAction(action)
             return

--- a/labelme/_widgets/unique_label_qlist_widget.py
+++ b/labelme/_widgets/unique_label_qlist_widget.py
@@ -9,31 +9,31 @@ from .label_list_widget import TrailingColorDotDelegate
 
 
 class _EscapableQListWidget(QtWidgets.QListWidget):
-    def keyPressEvent(self, keyEvent: QtGui.QKeyEvent) -> None:
+    def keyPressEvent(self, keyEvent: QtGui.QKeyEvent, /) -> None:
         super().keyPressEvent(keyEvent)
         if keyEvent.key() == Qt.Key.Key_Escape:
             self.clearSelection()
 
 
 class UniqueLabelQListWidget(_EscapableQListWidget):
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(self, *, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent=parent)
         self.setItemDelegate(TrailingColorDotDelegate(parent=self))
 
-    def mousePressEvent(self, mouseEvent: QtGui.QMouseEvent) -> None:
+    def mousePressEvent(self, mouseEvent: QtGui.QMouseEvent, /) -> None:
         super().mousePressEvent(mouseEvent)
         if not self.indexAt(mouseEvent.position().toPoint()).isValid():
             self.clearSelection()
 
-    def find_label_item(self, label: str) -> QtWidgets.QListWidgetItem | None:
+    def find_label_item(self, *, label: str) -> QtWidgets.QListWidgetItem | None:
         for row in range(self.count()):
             item = self.item(row)
             if item and item.data(Qt.ItemDataRole.UserRole) == label:
                 return item
         return None
 
-    def add_label_item(self, label: str, color: tuple[int, int, int]) -> None:
-        if self.find_label_item(label):
+    def add_label_item(self, *, label: str, color: tuple[int, int, int]) -> None:
+        if self.find_label_item(label=label):
             raise ValueError(f"Item for label '{label}' already exists")
 
         item = QtWidgets.QListWidgetItem()

--- a/labelme/_yaml.py
+++ b/labelme/_yaml.py
@@ -6,7 +6,7 @@ from typing import Any
 from ruamel.yaml import YAML
 
 
-def safe_load(stream: str | IO[str]) -> Any:  # noqa: ANN401
+def safe_load(stream: str | IO[str], /) -> Any:  # noqa: ANN401
     # A fresh instance per call, not a shared one: ruamel's load() appends to
     # YAML().doc_infos and never clears it, so a long-lived instance leaks.
     return YAML(typ="safe").load(stream)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,9 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = ["GR001", "GR002", "GR003", "GR004", "GR006"]
+select = ["GR001", "GR002", "GR003", "GR004", "GR005", "GR006"]
+# The tests migration lands in the next commit.
+per-file-ignores = { "tests/**" = ["GR005"] }
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ select = [
   "FBT",     # boolean traps
   "PLR2004", # magic value comparisons
 ]
+# Keep ruff from flagging gruff's GR noqa codes as unknown.
+external = ["GR"]
 # UP040 wants PEP 695 `type X = ...`, but our Literal aliases are enumerated at
 # runtime via typing.get_args(), which returns () for a lazy `type` alias.
 ignore = ["UP040"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,6 @@ markers = [
 
 [tool.gruff.lint]
 select = ["GR001", "GR002", "GR003", "GR004", "GR005", "GR006"]
-# The tests migration lands in the next commit.
-per-file-ignores = { "tests/**" = ["GR005"] }
 
 [tool.ruff.lint]
 select = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from pytestqt.qtbot import QtBot
 import labelme._utils
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
+def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: GR005 -- pluggy calls hooks positionally
     parser.addoption(
         "--pause",
         action="store_true",
@@ -48,13 +48,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_configure(config: pytest.Config) -> None:
+def pytest_configure(config: pytest.Config) -> None:  # noqa: GR005 -- pluggy calls hooks positionally
     if not config.getoption("--headed"):
         os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 
 @pytest.fixture()
 def close_failed_download_dialog(
+    *,
     qapp: QApplication,  # noqa: ARG001 -- a fixture cannot use usefixtures
 ) -> Generator[None, None, None]:
     timer = QTimer()
@@ -75,14 +76,14 @@ def close_failed_download_dialog(
 
 
 @pytest.fixture()
-def pause(request: pytest.FixtureRequest) -> bool:
+def pause(*, request: pytest.FixtureRequest) -> bool:
     return request.config.getoption("--pause", default=False)
 
 
 @pytest.fixture()
-def use_widget_color_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
+def use_widget_color_dialog(*, monkeypatch: pytest.MonkeyPatch) -> None:
     class WidgetColorDialog(QColorDialog):
-        def __init__(self, parent: QWidget, *, currentColor: QColor) -> None:
+        def __init__(self, *, parent: QWidget, currentColor: QColor) -> None:
             super().__init__(parent=parent, currentColor=currentColor)
             self.setOption(QColorDialog.ColorDialogOption.DontUseNativeDialog)
 
@@ -90,7 +91,7 @@ def use_widget_color_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture()
-def update_snapshots(request: pytest.FixtureRequest) -> bool:
+def update_snapshots(*, request: pytest.FixtureRequest) -> bool:
     return request.config.getoption("--update-snapshots")
 
 
@@ -102,6 +103,7 @@ def snapshot_dir() -> Path:
 
 @pytest.fixture()
 def set_allocation_limit(
+    *,
     qapp: QApplication,  # noqa: ARG001 -- a fixture cannot use usefixtures
 ) -> Iterator[Callable[[int], None]]:
     original_limit = QImageReader.allocationLimit()
@@ -109,7 +111,7 @@ def set_allocation_limit(
     QImageReader.setAllocationLimit(original_limit)
 
 
-def assert_labelfile_sanity(filename: str) -> None:
+def assert_labelfile_sanity(filename: str, /) -> None:
     label_path = Path(filename)
     assert label_path.exists()
 
@@ -167,7 +169,7 @@ def _create_annotated_nested(*, data_path: Path) -> None:
 
 
 @pytest.fixture(scope="function")
-def data_path(tmp_path: Path) -> Path:
+def data_path(*, tmp_path: Path) -> Path:
     data_path: Path = tmp_path / "data"
     shutil.copytree(Path(__file__).parent / "data", data_path)
 

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -183,12 +183,12 @@ def _run_text_prompt(
     ],
 )
 def test_text_prompt_creates_shapes(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
     create_mode: str,
     expected_shape_type: AiOutputFormat,
@@ -243,11 +243,11 @@ def test_text_prompt_creates_shapes(
 
 @pytest.mark.gui
 def test_nms_deduplicates_existing_shapes(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     input_file = str(data_path / "raw/2011_000003.jpg")
@@ -286,11 +286,11 @@ def test_nms_deduplicates_existing_shapes(
 
 @pytest.mark.gui
 def test_score_threshold_filters_detections(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     input_file = str(data_path / "raw/2011_000003.jpg")
@@ -333,11 +333,11 @@ def test_score_threshold_filters_detections(
 
 @pytest.mark.gui
 def test_text_prompt_inference_error_surfaces_without_crashing(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     # A model error during text-to-annotation inference must not crash the app:
@@ -367,10 +367,10 @@ def test_text_prompt_inference_error_surfaces_without_crashing(
 
 @pytest.mark.gui
 def test_canvas_inference_failed_signal_surfaces_status_message(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     # The hover-preview path emits inference_failed from inside paintEvent, so

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -326,7 +326,7 @@ def test_annotate_shape_types(
 
     label = "test_shape"
     canvas = win._canvas_widgets.canvas
-    canvas.set_ai_model_name(_AI_MODEL)
+    canvas.set_ai_model_name(model_name=_AI_MODEL)
     if ai_output_format is not None:
         canvas.set_ai_output_format(ai_output_format)
 

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -26,10 +26,10 @@ _AI_MODEL: Final = "efficientsam:10m"
 
 @pytest.mark.gui
 def test_labeling_ai_lands_preserves_generated_group(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(config_overrides={"auto_save": False})
@@ -53,16 +53,16 @@ def test_labeling_ai_lands_preserves_generated_group(
 
 
 @pytest.fixture()
-def ai_model_combo(raw_win: MainWindow) -> QComboBox:
+def ai_model_combo(*, raw_win: MainWindow) -> QComboBox:
     return raw_win._ai_annotation._model_combo
 
 
 @pytest.mark.gui
 def test_ai_points_mode_disables_sam3(
+    *,
     raw_win: MainWindow,
     ai_model_combo: QComboBox,
     qtbot: QtBot,
-    *,
     pause: bool,
 ) -> None:
     sam3_index = ai_model_combo.findData("sam3:latest")
@@ -78,11 +78,11 @@ def test_ai_points_mode_disables_sam3(
 
 @pytest.mark.gui
 def test_ai_points_mode_keeps_selected_sam3_and_rejects_click(
+    *,
     raw_win: MainWindow,
     ai_model_combo: QComboBox,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     warnings: list[tuple[str, str]] = []
@@ -299,11 +299,11 @@ def test_ai_points_mode_keeps_selected_sam3_and_rejects_click(
 )
 @pytest.mark.usefixtures("close_failed_download_dialog")
 def test_annotate_shape_types(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
     create_mode: str,
     setup_clicks: list[tuple[float, float]],

--- a/tests/e2e/auto_save_test.py
+++ b/tests/e2e/auto_save_test.py
@@ -66,10 +66,10 @@ def _raw_auto_save_win(
 
 @pytest.mark.gui
 def test_auto_save_on_shape_move(
+    *,
     qtbot: QtBot,
     _auto_save_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     label_file = tmp_path / Path(_TEST_FILE_NAME).name
@@ -95,6 +95,7 @@ def test_auto_save_on_shape_move(
 
 @pytest.mark.gui
 def test_enabling_auto_save_on_dirty_annotation_clears_dirty_state(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     main_win: MainWinFactory,
     qtbot: QtBot,
@@ -154,10 +155,10 @@ def test_enabling_auto_save_on_dirty_annotation_clears_dirty_state(
 
 @pytest.mark.gui
 def test_auto_save_on_undo(
+    *,
     qtbot: QtBot,
     _auto_save_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     label_file = tmp_path / Path(_TEST_FILE_NAME).name
@@ -191,10 +192,10 @@ def test_auto_save_on_undo(
 
 @pytest.mark.gui
 def test_auto_save_on_undo_of_first_shape(
+    *,
     qtbot: QtBot,
     _raw_auto_save_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     label_file = tmp_path / f"{Path(_RAW_FILE_NAME).stem}.json"
@@ -225,11 +226,11 @@ def test_auto_save_on_undo_of_first_shape(
 
 @pytest.mark.gui
 def test_failed_auto_save_keeps_annotation_dirty_and_allows_manual_retry(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_auto_save_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     label_file = tmp_path / f"{Path(_RAW_FILE_NAME).stem}.json"
@@ -320,11 +321,11 @@ def test_failed_auto_save_keeps_annotation_dirty_and_allows_manual_retry(
 
 @pytest.mark.gui
 def test_failed_auto_save_shows_error_again_after_target_changes(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_auto_save_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     errors_shown: list[bool] = []

--- a/tests/e2e/brightness_contrast_test.py
+++ b/tests/e2e/brightness_contrast_test.py
@@ -13,9 +13,9 @@ from ..conftest import close_or_pause
 
 @pytest.mark.gui
 def test_brightness_contrast_dialog(
+    *,
     annotated_win: MainWindow,
     qtbot: QtBot,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -140,10 +140,10 @@ def _save_and_check(
 
 @pytest.mark.gui
 def test_move_shape_by_drag(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -169,10 +169,10 @@ def test_move_shape_by_drag(
 
 @pytest.mark.gui
 def test_move_vertex_by_drag(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -207,9 +207,9 @@ def test_move_vertex_by_drag(
     ],
 )
 def test_move_shape_by_arrow_key(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
     key: int,
     expected_dx: float,
@@ -234,9 +234,9 @@ def test_move_shape_by_arrow_key(
 
 @pytest.mark.gui
 def test_select_all_shapes_from_canvas(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -255,10 +255,10 @@ def test_select_all_shapes_from_canvas(
 
 @pytest.mark.gui
 def test_add_point_on_edge(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -310,10 +310,10 @@ def test_add_point_on_edge(
 
 @pytest.mark.gui
 def test_add_point_via_context_menu_action(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -338,10 +338,10 @@ def test_add_point_via_context_menu_action(
 
 @pytest.mark.gui
 def test_remove_point_from_shape(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -363,10 +363,10 @@ def test_remove_point_from_shape(
 @pytest.mark.gui
 @pytest.mark.parametrize("remove_index", [1, 4])
 def test_remove_point_does_not_drag_adjacent(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
     remove_index: int,
 ) -> None:
@@ -404,9 +404,9 @@ def test_remove_point_does_not_drag_adjacent(
 
 @pytest.mark.gui
 def test_draw_actions_disable_only_active_mode(
+    *,
     annotated_win: MainWindow,
     qtbot: QtBot,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -433,9 +433,9 @@ def test_draw_actions_disable_only_active_mode(
 
 @pytest.mark.gui
 def test_cancel_drawing_with_escape(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -461,10 +461,10 @@ def test_cancel_drawing_with_escape(
 
 @pytest.mark.gui
 def test_undo_last_point_while_drawing(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -510,10 +510,10 @@ def test_undo_last_point_while_drawing(
 
 @pytest.mark.gui
 def test_finalize_polygon_with_enter(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -543,10 +543,10 @@ def test_finalize_polygon_with_enter(
 
 @pytest.mark.gui
 def test_undo_shape_creation(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -624,10 +624,10 @@ def test_undo_shape_creation(
     ],
 )
 def test_select_nonpolygon_shape(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
     create_mode: str,
     setup_click: tuple[float, float],
@@ -668,9 +668,9 @@ def test_select_nonpolygon_shape(
 
 @pytest.mark.gui
 def test_cancel_label_reopens_shape(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -724,10 +724,10 @@ def test_cancel_label_reopens_shape(
     ],
 )
 def test_remove_point_blocked_at_minimum(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
     create_mode: str,
     setup_clicks: list[tuple[float, float]],
@@ -775,9 +775,9 @@ def _click_to_select(*, qtbot: QtBot, canvas: Canvas, image_pos: QPointF) -> Non
 
 @pytest.mark.gui
 def test_select_point_shape_by_click(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -806,10 +806,10 @@ def test_select_point_shape_by_click(
 
 @pytest.mark.gui
 def test_right_click_on_shape_opens_context_menu(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -843,11 +843,11 @@ def test_right_click_on_shape_opens_context_menu(
 
 @pytest.mark.gui
 def test_select_mask_shape_by_click(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     # Mask cells are indexed pixel-for-pixel from points[0]; clicking inside

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -129,10 +129,10 @@ def _check_or_update_snapshot(
 
 @pytest.mark.gui
 def test_snapshot_empty_canvas(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     snapshot_dir: Path,
-    *,
     update_snapshots: bool,
     pause: bool,
 ) -> None:
@@ -151,10 +151,10 @@ def test_snapshot_empty_canvas(
 
 @pytest.mark.gui
 def test_snapshot_shapes_unselected(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     snapshot_dir: Path,
-    *,
     update_snapshots: bool,
     pause: bool,
 ) -> None:
@@ -174,10 +174,10 @@ def test_snapshot_shapes_unselected(
 
 @pytest.mark.gui
 def test_snapshot_one_polygon_selected(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     snapshot_dir: Path,
-    *,
     update_snapshots: bool,
     pause: bool,
 ) -> None:
@@ -199,10 +199,10 @@ def test_snapshot_one_polygon_selected(
 
 @pytest.mark.gui
 def test_snapshot_polygon_mid_draw(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     snapshot_dir: Path,
-    *,
     update_snapshots: bool,
     pause: bool,
 ) -> None:
@@ -242,10 +242,10 @@ def test_snapshot_polygon_mid_draw(
 
 @pytest.mark.gui
 def test_snapshot_after_polygon_commit(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     snapshot_dir: Path,
-    *,
     update_snapshots: bool,
     pause: bool,
 ) -> None:

--- a/tests/e2e/config_test.py
+++ b/tests/e2e/config_test.py
@@ -18,8 +18,8 @@ from .conftest import MainWinFactory
     ],
 )
 def test_MainWindow_config(
-    main_win: MainWinFactory,
     *,
+    main_win: MainWinFactory,
     with_config_file: bool,
     qtbot: QtBot,
     tmp_path: Path,
@@ -52,10 +52,10 @@ def test_MainWindow_config(
 
 @pytest.mark.gui
 def test_MainWindow_config_load_error_falls_back(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     # Malformed YAML makes load_config raise a non-ValueError (a yaml

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -28,7 +28,7 @@ from labelme._widgets.label_dialog import LabelDialog
 _DEFAULT_WINDOW_SIZE: Final = QSize(800, 600)
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:  # noqa: GR005 -- pluggy calls hooks positionally
     # The reference pixels are rendered on Linux, and Qt rendering can differ
     # across platforms. Gating on the marker here keeps one plain `make test`
     # correct on every OS, locally and in CI.
@@ -41,11 +41,11 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 
 @pytest.fixture(scope="session")
-def session_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def session_home(*, tmp_path_factory: pytest.TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("home")
 
 
-def image_to_widget_pos(canvas: Canvas, image_pos: QPointF) -> QPoint:
+def image_to_widget_pos(*, canvas: Canvas, image_pos: QPointF) -> QPoint:
     widget_pos = canvas.transform_image_point_to_widget(image_pos)
     return QPoint(int(widget_pos.x()), int(widget_pos.y()))
 
@@ -78,19 +78,19 @@ class _QAppProxy:
     """Proxy that returns the existing QApplication from constructor calls
     and forwards static/class method access to the real QApplication class."""
 
-    def __init__(self, existing_app: QApplication) -> None:
+    def __init__(self, *, existing_app: QApplication) -> None:
         self._app = existing_app
 
-    def __call__(self, _argv: list[str]) -> QApplication:
+    def __call__(self, _argv: list[str], /) -> QApplication:
         return self._app
 
-    def __getattr__(self, name: str) -> object:
+    def __getattr__(self, name: str, /) -> object:
         return getattr(QApplication, name)
 
 
 @pytest.fixture()
 def main_win(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, session_home: Path
+    *, qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, session_home: Path
 ) -> Generator[MainWinFactory, None, None]:
     created: list[MainWindow] = []
 
@@ -135,7 +135,9 @@ def main_win(
         app = QApplication.instance()
         assert isinstance(app, QApplication)
 
-        monkeypatch.setattr("labelme.__main__.QtWidgets.QApplication", _QAppProxy(app))
+        monkeypatch.setattr(
+            "labelme.__main__.QtWidgets.QApplication", _QAppProxy(existing_app=app)
+        )
         monkeypatch.setattr(app, "exec", lambda: 0)
 
         existing = set(w for w in app.topLevelWidgets() if isinstance(w, MainWindow))
@@ -163,7 +165,7 @@ def main_win(
             pass
 
 
-def hover_widget_pos(qtbot: QtBot, canvas: Canvas, pos: QPoint) -> None:
+def hover_widget_pos(*, qtbot: QtBot, canvas: Canvas, pos: QPoint) -> None:
     # The offscreen Qt platform dedupes mouseMove events that match the
     # current cursor position, which suppresses hover-state refresh after a
     # click that landed on the same pixel. Nudging to (0, 0) first guarantees
@@ -175,6 +177,7 @@ def hover_widget_pos(qtbot: QtBot, canvas: Canvas, pos: QPoint) -> None:
 
 
 def click_canvas_fraction(
+    *,
     qtbot: QtBot,
     canvas: Canvas,
     xy: tuple[float, float],
@@ -193,6 +196,7 @@ def click_canvas_fraction(
 
 
 def drag_canvas(
+    *,
     qtbot: QtBot,
     canvas: Canvas,
     button: Qt.MouseButton,
@@ -219,6 +223,7 @@ def drag_canvas(
 
 
 def schedule_on_dialog(
+    *,
     label_dialog: LabelDialog,
     action: Callable[[], None],
 ) -> None:
@@ -232,6 +237,7 @@ def schedule_on_dialog(
 
 
 def submit_label_dialog(
+    *,
     qtbot: QtBot,
     label_dialog: LabelDialog,
     label: str,
@@ -246,6 +252,7 @@ def submit_label_dialog(
 
 
 def draw_triangle(
+    *,
     qtbot: QtBot,
     win: MainWindow,
     vertices: tuple[tuple[float, float], ...],
@@ -258,6 +265,7 @@ def draw_triangle(
 
 
 def draw_and_commit_polygon(
+    *,
     qtbot: QtBot,
     win: MainWindow,
     label: str,
@@ -281,7 +289,7 @@ def draw_and_commit_polygon(
     qtbot.waitUntil(shape_committed, timeout=timeout)
 
 
-def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
+def select_shape(*, qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
     points = canvas.shapes[shape_index].points
     centroid = QPointF(float(points[:, 0].mean()), float(points[:, 1].mean()))
     pos = image_to_widget_pos(canvas=canvas, image_pos=centroid)
@@ -292,7 +300,7 @@ def select_shape(qtbot: QtBot, canvas: Canvas, shape_index: int = 0) -> None:
     assert len(canvas.selected_shapes) == 1
 
 
-def show_window_and_wait_for_imagedata(qtbot: QtBot, win: MainWindow) -> None:
+def show_window_and_wait_for_imagedata(*, qtbot: QtBot, win: MainWindow) -> None:
     win.show()
 
     def check_image_data() -> None:
@@ -301,7 +309,7 @@ def show_window_and_wait_for_imagedata(qtbot: QtBot, win: MainWindow) -> None:
     qtbot.waitUntil(check_image_data)
 
 
-def dismiss_active_modal(qtbot: QtBot, timeout: int = 3000) -> None:
+def dismiss_active_modal(*, qtbot: QtBot, timeout: int = 3000) -> None:
     qtbot.waitUntil(
         lambda: QApplication.activeModalWidget() is not None,
         timeout=timeout,
@@ -313,6 +321,7 @@ def dismiss_active_modal(qtbot: QtBot, timeout: int = 3000) -> None:
 
 @pytest.fixture()
 def annotated_win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -328,6 +337,7 @@ def annotated_win(
 
 @pytest.fixture()
 def raw_win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -342,7 +352,7 @@ def raw_win(
 
 
 @pytest.fixture()
-def critical_messages(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+def critical_messages(*, monkeypatch: pytest.MonkeyPatch) -> list[str]:
     messages: list[str] = []
 
     def capture_critical(

--- a/tests/e2e/delete_confirmation_test.py
+++ b/tests/e2e/delete_confirmation_test.py
@@ -24,6 +24,7 @@ def _exec_clicking_role(
 
 @pytest.mark.gui
 def test_confirm_deletion_defaults_to_cancel(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -44,6 +45,7 @@ def test_confirm_deletion_defaults_to_cancel(
 
 @pytest.mark.gui
 def test_confirm_deletion_returns_true_when_delete_clicked(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -60,6 +62,7 @@ def test_confirm_deletion_returns_true_when_delete_clicked(
 
 @pytest.mark.gui
 def test_confirm_deletion_returns_false_when_cancel_clicked(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/e2e/drag_and_drop_test.py
+++ b/tests/e2e/drag_and_drop_test.py
@@ -50,10 +50,10 @@ def _send_drop(*, win: MainWindow, mime: QMimeData) -> None:
 
 @pytest.mark.gui
 def test_drop_image_files_loads_them(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win()
@@ -80,10 +80,10 @@ def test_drop_image_files_loads_them(
 
 @pytest.mark.gui
 def test_dropped_image_files_respect_active_search_filter(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(config_overrides={"file_search": r"000003\.jpg$"})
@@ -111,10 +111,10 @@ def test_dropped_image_files_respect_active_search_filter(
 
 @pytest.mark.gui
 def test_opening_annotation_file_clears_loaded_directory_images(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     annotated_dir = data_path / "annotated"
@@ -138,11 +138,11 @@ def test_opening_annotation_file_clears_loaded_directory_images(
 
 @pytest.mark.gui
 def test_drag_enter_rejects_non_image_and_keeps_state(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     original_title = raw_win.windowTitle()

--- a/tests/e2e/file_dialog_actions_test.py
+++ b/tests/e2e/file_dialog_actions_test.py
@@ -25,7 +25,7 @@ class _Paths:
 
 
 @pytest.fixture()
-def paths(data_path: Path, tmp_path: Path) -> _Paths:
+def paths(*, data_path: Path, tmp_path: Path) -> _Paths:
     return _Paths(
         annotated_dir=data_path / "annotated",
         next_image=data_path / "raw" / "2011_000006.jpg",
@@ -36,6 +36,7 @@ def paths(data_path: Path, tmp_path: Path) -> _Paths:
 
 @pytest.fixture()
 def loaded_win(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -138,11 +139,11 @@ def _verify_change_output_dir(win: MainWindow, paths: _Paths, /) -> bool:
     ],
 )
 def test_action_via_qfile_dialog(
+    *,
     qtbot: QtBot,
     loaded_win: MainWindow,
     paths: _Paths,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
     dialog_method: str,
     dialog_return: Callable[[_Paths], tuple[str, str] | str],
@@ -165,11 +166,11 @@ def test_action_via_qfile_dialog(
 
 @pytest.mark.gui
 def test_open_file_dialog_normalizes_the_reported_path(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(file_or_dir=str(data_path / "raw"))

--- a/tests/e2e/file_list_focus_test.py
+++ b/tests/e2e/file_list_focus_test.py
@@ -14,10 +14,10 @@ from .conftest import show_window_and_wait_for_imagedata
 
 @pytest.mark.gui
 def test_arrow_keys_walk_file_list_across_loads(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(file_or_dir=str(data_path / "annotated"))
@@ -41,10 +41,10 @@ def test_arrow_keys_walk_file_list_across_loads(
 
 @pytest.mark.gui
 def test_canvas_takes_focus_when_file_list_has_none(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(file_or_dir=str(data_path / "annotated"))

--- a/tests/e2e/file_loading_test.py
+++ b/tests/e2e/file_loading_test.py
@@ -607,12 +607,12 @@ def test_failed_load_of_dropped_image_preserves_current_session(
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
     annotation_before = win._annotation
 
-    win.import_dropped_image_files([str(existing_image)])
+    win.import_dropped_image_files(image_files=[str(existing_image)])
     assert win._image_path == str(current_image)
 
     corrupt_image = tmp_path / "dropped.jpg"
     corrupt_image.write_bytes(b"not an image")
-    win.import_dropped_image_files([str(corrupt_image)])
+    win.import_dropped_image_files(image_files=[str(corrupt_image)])
 
     qtbot.waitUntil(lambda: len(critical_messages) == 1)
     assert win._image_path == str(current_image)

--- a/tests/e2e/file_loading_test.py
+++ b/tests/e2e/file_loading_test.py
@@ -23,10 +23,10 @@ from .conftest import show_window_and_wait_for_imagedata
 
 @pytest.mark.gui
 def test_MainWindow_open_img(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     image_file: str = str(data_path / "raw/2011_000003.jpg")
@@ -38,10 +38,10 @@ def test_MainWindow_open_img(
 
 @pytest.mark.gui
 def test_MainWindow_open_json(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     json_files: list[str] = [
@@ -62,11 +62,11 @@ def test_MainWindow_open_json(
 @pytest.mark.gui
 @pytest.mark.parametrize("scenario", ["raw", "annotated", "annotated_nested"])
 def test_MainWindow_open_dir(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     scenario: Literal["raw", "annotated", "annotated_nested"],
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     directory: str
@@ -126,11 +126,11 @@ def test_MainWindow_open_dir(
 
 @pytest.mark.gui
 def test_reopening_directory_preserves_session_when_first_image_fails(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -156,12 +156,12 @@ def test_reopening_directory_preserves_session_when_first_image_fails(
 
 @pytest.mark.gui
 def test_MainWindow_reports_size_when_image_exceeds_decode_limit(
+    *,
     raw_win: MainWindow,
     qtbot: QtBot,
     tmp_path: Path,
     critical_messages: list[str],
     set_allocation_limit: Callable[[int], None],
-    *,
     pause: bool,
 ) -> None:
     image_path = tmp_path / "too_large.png"
@@ -214,6 +214,7 @@ def test_MainWindow_reports_size_when_image_exceeds_decode_limit(
     ids=["unknown-shape-type", "invalid-point-count", "missing-mask"],
 )
 def test_MainWindow_rejects_malformed_shapes_before_installing_any(
+    *,
     raw_win: MainWindow,
     critical_messages: list[str],
     data_path: Path,
@@ -252,7 +253,7 @@ def test_MainWindow_rejects_malformed_shapes_before_installing_any(
 
 
 @pytest.fixture
-def create_annotated_session_image(data_path: Path, tmp_path: Path) -> Path:
+def create_annotated_session_image(*, data_path: Path, tmp_path: Path) -> Path:
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     image_path = session_dir / "01-current.jpg"
@@ -268,7 +269,7 @@ def create_annotated_session_image(data_path: Path, tmp_path: Path) -> Path:
 
 @pytest.fixture
 def choose_candidate_output_dir(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    *, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> Path:
     candidate_dir = tmp_path / "candidate"
     candidate_dir.mkdir()
@@ -293,12 +294,12 @@ def choose_candidate_output_dir(
     ],
 )
 def test_failed_navigation_preserves_current_session(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
     failure: str,
     navigation: str,
@@ -367,11 +368,11 @@ def test_failed_navigation_preserves_current_session(
 
 @pytest.mark.gui
 def test_failed_navigation_restores_selected_source_item(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -401,10 +402,10 @@ def test_failed_navigation_restores_selected_source_item(
 
 @pytest.mark.gui
 def test_direct_image_open_preserves_source_selection(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     create_annotated_session_image: Path,
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -442,11 +443,11 @@ def test_direct_image_open_preserves_source_selection(
 
 @pytest.mark.gui
 def test_failed_navigation_restores_filtered_out_selection(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -471,12 +472,12 @@ def test_failed_navigation_restores_filtered_out_selection(
 
 @pytest.mark.gui
 def test_failed_navigation_refreshes_title_after_saving(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -507,12 +508,12 @@ def test_failed_navigation_refreshes_title_after_saving(
 @pytest.mark.gui
 @pytest.mark.parametrize("hide_active_image", [False, True])
 def test_prompt_output_dir_rejects_corrupt_annotation(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     create_annotated_session_image: Path,
     choose_candidate_output_dir: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
     hide_active_image: bool,
 ) -> None:
@@ -548,11 +549,11 @@ def test_prompt_output_dir_rejects_corrupt_annotation(
 
 @pytest.mark.gui
 def test_prompt_output_dir_loads_candidate_before_committing(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     create_annotated_session_image: Path,
     choose_candidate_output_dir: Path,
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -586,13 +587,13 @@ def test_prompt_output_dir_loads_candidate_before_committing(
 
 @pytest.mark.gui
 def test_failed_load_of_dropped_image_preserves_current_session(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image
@@ -626,13 +627,13 @@ def test_failed_load_of_dropped_image_preserves_current_session(
 
 @pytest.mark.gui
 def test_open_dir_with_failing_first_image_keeps_other_images_reachable(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
     create_annotated_session_image: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     current_image = create_annotated_session_image

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -16,9 +16,9 @@ from .conftest import show_window_and_wait_for_imagedata
 
 @pytest.mark.gui
 def test_close_file(
+    *,
     annotated_win: MainWindow,
     qtbot: QtBot,
-    *,
     pause: bool,
 ) -> None:
     assert annotated_win._annotation is not None
@@ -36,10 +36,10 @@ def test_close_file(
 
 @pytest.mark.gui
 def test_delete_label_file(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -70,10 +70,10 @@ def test_delete_label_file(
 
 @pytest.mark.gui
 def test_delete_label_file_keeps_image(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -104,11 +104,11 @@ def test_delete_label_file_keeps_image(
 
 @pytest.mark.gui
 def test_delete_file_respects_output_dir(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -146,11 +146,11 @@ def test_delete_file_respects_output_dir(
 
 @pytest.mark.gui
 def test_current_label_file_path_prefers_opened_file(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     opened_path = data_path / "annotated/2011_000003.json"
@@ -169,10 +169,10 @@ def test_current_label_file_path_prefers_opened_file(
 
 @pytest.mark.gui
 def test_undo_after_delete_file_does_not_restore_shapes(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/e2e/file_search_test.py
+++ b/tests/e2e/file_search_test.py
@@ -16,11 +16,11 @@ from .conftest import show_window_and_wait_for_imagedata
 
 @pytest.mark.gui
 def test_file_search_filters_loaded_images_without_changing_active_annotation(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     image_dir = data_path / "annotated_nested/images"

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -58,10 +58,10 @@ def _enter_label(
     ],
 )
 def test_label_flags_applied_to_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     flag_to_toggle: str | None,
     expected_flags: dict[str, bool],
@@ -101,10 +101,10 @@ def test_label_flags_applied_to_shape(
 
 @pytest.mark.gui
 def test_enabled_flags_shown_in_label_list(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -144,10 +144,10 @@ def test_enabled_flags_shown_in_label_list(
 
 @pytest.mark.gui
 def test_flags_survive_retyping_the_label(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -201,11 +201,11 @@ def test_flags_survive_retyping_the_label(
 
 @pytest.mark.gui
 def test_flags_survive_save_reload_roundtrip(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(

--- a/tests/e2e/label_dialog_flags_test.py
+++ b/tests/e2e/label_dialog_flags_test.py
@@ -179,7 +179,7 @@ def test_flags_survive_retyping_the_label(
     item = next(
         it for it in label_list if (s := it.shape()) is not None and s.label == "cat"
     )
-    label_list.select_item(item)
+    label_list.select_item(item=item)
     schedule_on_dialog(
         label_dialog=label_dialog,
         action=partial(

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -35,10 +35,10 @@ def _label_list_texts(*, label_list: QtWidgets.QListWidget) -> list[str]:
 
 @pytest.mark.gui
 def test_blank_input_keeps_dialog_open(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(file_or_dir=str(data_path / _RAW_FILE))
@@ -70,11 +70,11 @@ def test_blank_input_keeps_dialog_open(
 
 @pytest.mark.gui
 def test_validate_label_exact_rejects_unknown_label(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -112,10 +112,10 @@ def test_validate_label_exact_rejects_unknown_label(
 
 @pytest.mark.gui
 def test_arrow_keys_in_label_edit_navigate_label_list(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -153,10 +153,10 @@ def test_arrow_keys_in_label_edit_navigate_label_list(
 
 @pytest.mark.gui
 def test_add_label_history_dedups_repeated_labels_and_keeps_sorted(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -190,10 +190,10 @@ def test_add_label_history_dedups_repeated_labels_and_keeps_sorted(
 
 @pytest.mark.gui
 def test_label_completer_autocompletes_typed_prefix(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -231,10 +231,10 @@ def test_label_completer_autocompletes_typed_prefix(
 
 @pytest.mark.gui
 def test_trailing_whitespace_label_is_stripped(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -90,7 +90,7 @@ def test_click_label_list_entry_selects_canvas_shape(
     expected_shape = first_item.shape()
     assert expected_shape is not None
 
-    label_list.select_item(first_item)
+    label_list.select_item(item=first_item)
     qtbot.waitUntil(lambda: expected_shape in canvas.selected_shapes)
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
@@ -287,8 +287,8 @@ def test_edit_label_multi_shape_mismatch_disables_text_field(
     )
 
     label_list.clearSelection()
-    label_list.select_item(label_list[0])
-    label_list.select_item(label_list[3])
+    label_list.select_item(item=label_list[0])
+    label_list.select_item(item=label_list[3])
 
     edit_disabled_during_popup: list[bool] = []
 

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -49,9 +49,9 @@ def _draw_polygon(
 
 @pytest.mark.gui
 def test_draw_shape_appears_in_label_list(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     win = raw_win
@@ -71,9 +71,9 @@ def test_draw_shape_appears_in_label_list(
 
 @pytest.mark.gui
 def test_click_label_list_entry_selects_canvas_shape(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     win = annotated_win
@@ -98,9 +98,9 @@ def test_click_label_list_entry_selects_canvas_shape(
 
 @pytest.mark.gui
 def test_click_canvas_shape_selects_label_list_entry(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     win = annotated_win
@@ -122,9 +122,9 @@ def test_click_canvas_shape_selects_label_list_entry(
 
 @pytest.mark.gui
 def test_rename_via_label_dialog_updates_shape_and_list(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     win = annotated_win
@@ -158,10 +158,10 @@ def test_rename_via_label_dialog_updates_shape_and_list(
 
 @pytest.mark.gui
 def test_delete_shape_removes_label_list_entry(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win = annotated_win
@@ -183,6 +183,7 @@ def test_delete_shape_removes_label_list_entry(
 
 @pytest.fixture()
 def annotated_with_labels(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
@@ -199,9 +200,9 @@ def annotated_with_labels(
 
 @pytest.mark.gui
 def test_edit_label_cancel_keeps_labels(
+    *,
     qtbot: QtBot,
     annotated_with_labels: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     win = annotated_with_labels
@@ -230,10 +231,10 @@ def test_edit_label_cancel_keeps_labels(
     indirect=True,
 )
 def test_edit_label_invalid_label_keeps_labels_and_shows_error(
+    *,
     qtbot: QtBot,
     annotated_with_labels: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win = annotated_with_labels
@@ -269,9 +270,9 @@ def test_edit_label_invalid_label_keeps_labels_and_shows_error(
 
 @pytest.mark.gui
 def test_edit_label_multi_shape_mismatch_disables_text_field(
+    *,
     qtbot: QtBot,
     annotated_with_labels: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     # Mismatched labels make `_edit_label` disable the text field while the
@@ -308,10 +309,10 @@ def test_edit_label_multi_shape_mismatch_disables_text_field(
 
 @pytest.mark.gui
 def test_open_different_file_repopulates_label_list(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(file_or_dir=str(data_path / "annotated"))

--- a/tests/e2e/last_label_and_restore_test.py
+++ b/tests/e2e/last_label_and_restore_test.py
@@ -41,7 +41,7 @@ def _schedule_capture_then_cancel(
 
 
 @pytest.fixture()
-def discard_unsaved_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+def discard_unsaved_changes(*, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         QMessageBox,
         "question",
@@ -51,9 +51,9 @@ def discard_unsaved_changes(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.gui
 def test_last_label_memo(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -76,10 +76,10 @@ def test_last_label_memo(
 
 @pytest.mark.gui
 def test_restore_last_shape_via_undo(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -112,12 +112,12 @@ def test_restore_last_shape_via_undo(
 
 @pytest.mark.gui
 def test_first_and_subsequent_shapes_can_be_undone_and_saved(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     raw_win = main_win(
@@ -166,11 +166,11 @@ def test_first_and_subsequent_shapes_can_be_undone_and_saved(
 @pytest.mark.gui
 @pytest.mark.usefixtures("discard_unsaved_changes")
 def test_undo_not_enabled_after_opening_image_with_shapes_carried_forward(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -201,11 +201,11 @@ def test_undo_not_enabled_after_opening_image_with_shapes_carried_forward(
 @pytest.mark.parametrize("image_dir", ["raw", "annotated"])
 @pytest.mark.usefixtures("discard_unsaved_changes")
 def test_navigation_disables_undo_for_clean_image_history(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     data_path: Path,
     image_dir: str,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -232,12 +232,12 @@ def test_navigation_disables_undo_for_clean_image_history(
 
 @pytest.mark.gui
 def test_save_keeps_shape_undo_disabled_while_drawing(
+    *,
     qtbot: QtBot,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -41,9 +41,9 @@ def _zoom_until_overflow(*, canvas: Canvas) -> None:
 
 @pytest.mark.gui
 def test_middle_drag_emits_pan_request_with_widget_pixel_delta(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -72,9 +72,9 @@ def test_middle_drag_emits_pan_request_with_widget_pixel_delta(
 
 @pytest.mark.gui
 def test_middle_drag_no_pan_when_image_fits_viewport(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -106,9 +106,9 @@ def test_middle_drag_no_pan_when_image_fits_viewport(
 
 @pytest.mark.gui
 def test_middle_drag_recenters_fitting_image_after_focal_zoom(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas

--- a/tests/e2e/navigation_test.py
+++ b/tests/e2e/navigation_test.py
@@ -14,10 +14,10 @@ from .conftest import show_window_and_wait_for_imagedata
 
 @pytest.mark.gui
 def test_image_navigation_while_selecting_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(file_or_dir=str(data_path / "annotated"))

--- a/tests/e2e/oriented_rectangle_test.py
+++ b/tests/e2e/oriented_rectangle_test.py
@@ -56,9 +56,9 @@ def _draw_oriented_rectangle(
 
 @pytest.mark.gui
 def test_drag_rotation_handle_rotates_oriented_rectangle(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -115,9 +115,9 @@ def test_drag_rotation_handle_rotates_oriented_rectangle(
 
 @pytest.mark.gui
 def test_drag_vertex_out_of_pixmap_clips_oriented_rectangle(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas
@@ -182,9 +182,9 @@ def test_drag_vertex_out_of_pixmap_clips_oriented_rectangle(
 
 @pytest.mark.gui
 def test_oriented_rectangle_disallows_add_and_remove_point(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = raw_win._canvas_widgets.canvas

--- a/tests/e2e/save_error_handling_test.py
+++ b/tests/e2e/save_error_handling_test.py
@@ -16,12 +16,12 @@ _RAW_FILE_NAME: Final[str] = "raw/2011_000003.jpg"
 
 @pytest.mark.gui
 def test_save_labels_reports_filesystem_failure_without_crashing(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(

--- a/tests/e2e/save_format_contract_test.py
+++ b/tests/e2e/save_format_contract_test.py
@@ -31,11 +31,11 @@ _DEFAULT_TRIANGLE: Final[tuple[tuple[float, float], ...]] = (
 @pytest.mark.gui
 @pytest.mark.parametrize("with_image_data", [True, False])
 def test_save_image_data_field_matches_config(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
     with_image_data: bool,
 ) -> None:
@@ -71,13 +71,13 @@ def test_save_image_data_field_matches_config(
 
 @pytest.mark.gui
 def test_save_falls_back_to_an_absolute_image_path_across_drives(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
     critical_messages: list[str],
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -127,11 +127,11 @@ def test_save_falls_back_to_an_absolute_image_path_across_drives(
 
 @pytest.mark.gui
 def test_round_trip_polygon_preserves_points(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     raw_win: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     label = "rt_polygon"
@@ -172,11 +172,11 @@ def test_round_trip_polygon_preserves_points(
 
 @pytest.mark.gui
 def test_round_trip_mask_shape_via_fixture(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     mask_arr = np.zeros((4, 4), dtype=np.uint8)
@@ -252,11 +252,11 @@ def test_round_trip_mask_shape_via_fixture(
 
 @pytest.mark.gui
 def test_open_json_with_missing_image_shows_error_and_recovers(
+    *,
     qtbot: QtBot,
     raw_win: MainWindow,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     missing_image_json = tmp_path / "missing_image.json"
@@ -283,12 +283,12 @@ def test_open_json_with_missing_image_shows_error_and_recovers(
 
 @pytest.mark.gui
 def test_title_returns_to_clean_after_save(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -46,7 +46,7 @@ def _open_settings_dialog(*, win: MainWindow) -> SettingsDialog:
 
 
 @pytest.fixture
-def editable_config_file(tmp_path: Path) -> Path:
+def editable_config_file(*, tmp_path: Path) -> Path:
     config_file = tmp_path / "labelmerc.yaml"
     config_file.write_text("auto_save: true\n")
     return config_file
@@ -54,6 +54,7 @@ def editable_config_file(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def settings_with_label_history(
+    *,
     main_win: MainWinFactory,
     editable_config_file: Path,
 ) -> tuple[MainWindow, SettingsDialog]:
@@ -64,10 +65,10 @@ def settings_with_label_history(
 
 @pytest.mark.gui
 def test_startup_syncs_first_ai_model_without_rewriting_config(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
 ) -> None:
     original_config = "ai:\n  default: EfficientSam (speed)\nauto_save: true\n"
@@ -83,10 +84,10 @@ def test_startup_syncs_first_ai_model_without_rewriting_config(
 
 @pytest.mark.gui
 def test_startup_applies_existing_shape_suppression_override(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
 ) -> None:
     original_config = "ai:\n  suppress_existing_shape_matches: true\n"
@@ -102,7 +103,7 @@ def test_startup_applies_existing_shape_suppression_override(
 
 @pytest.mark.gui
 def test_settings_dialog_opens_when_editable(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
 
@@ -116,7 +117,7 @@ def test_settings_dialog_opens_when_editable(
 
 @pytest.mark.gui
 def test_setting_change_persists_and_applies(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
 
@@ -149,11 +150,11 @@ def test_setting_change_persists_and_applies(
 @pytest.mark.gui
 @pytest.mark.usefixtures("use_widget_color_dialog")
 def test_shape_color_picker_previews_and_persists_only_on_accept(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -227,7 +228,7 @@ def test_shape_color_picker_previews_and_persists_only_on_accept(
 
 @pytest.mark.gui
 def test_show_labels_toggle_applies_to_canvas(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     canvas = win._canvas_widgets.canvas
@@ -248,10 +249,10 @@ def test_show_labels_toggle_applies_to_canvas(
 
 @pytest.mark.gui
 def test_existing_shape_suppression_toggle_applies_to_canvas(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(config_file=editable_config_file)
@@ -277,9 +278,9 @@ def test_existing_shape_suppression_toggle_applies_to_canvas(
 
 @pytest.mark.gui
 def test_label_edit_preserves_label_history(
+    *,
     settings_with_label_history: tuple[MainWindow, SettingsDialog],
     qtbot: QtBot,
-    *,
     pause: bool,
 ) -> None:
     win, dialog = settings_with_label_history
@@ -300,7 +301,7 @@ def test_label_edit_preserves_label_history(
 
 @pytest.mark.gui
 def test_flags_setting_refreshes_flag_dock_live(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
 
@@ -329,10 +330,10 @@ def test_flags_setting_refreshes_flag_dock_live(
 
 @pytest.mark.gui
 def test_clearing_labels_is_rejected_when_validate_label_is_exact(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -375,10 +376,10 @@ def test_clearing_labels_is_rejected_when_validate_label_is_exact(
 
 @pytest.mark.gui
 def test_setting_controls_revert_when_write_fails(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     tmp_path: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -433,10 +434,10 @@ def test_setting_controls_revert_when_write_fails(
 
 @pytest.mark.gui
 def test_settings_dialog_is_deleted_when_opening_text_editor(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -457,7 +458,7 @@ def test_settings_dialog_is_deleted_when_opening_text_editor(
 
 @pytest.mark.gui
 def test_settings_disabled_with_cli_overrides(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(
         config_file=editable_config_file, config_overrides={"labels": ["bird"]}
@@ -472,7 +473,7 @@ def test_settings_disabled_with_cli_overrides(
 
 @pytest.mark.gui
 def test_keep_prev_dialog_toggle_checks_menu_action(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     assert not win._actions.toggle_keep_prev_mode.isChecked()
@@ -505,10 +506,10 @@ def test_keep_prev_dialog_toggle_checks_menu_action(
     ],
 )
 def test_menu_toggle_persists_and_syncs_settings_dialog(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
     action_name: str,
     key_path: tuple[str, ...],
@@ -536,7 +537,7 @@ def test_menu_toggle_persists_and_syncs_settings_dialog(
 
 @pytest.mark.gui
 def test_fill_drawing_dialog_toggle_applies_to_canvas(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     canvas = win._canvas_widgets.canvas
@@ -558,7 +559,7 @@ def test_fill_drawing_dialog_toggle_applies_to_canvas(
 
 @pytest.mark.gui
 def test_fill_drawing_menu_toggle_applies_with_cli_overrides(
-    main_win: MainWinFactory, qtbot: QtBot, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, pause: bool
 ) -> None:
     win = main_win(config_overrides={"canvas": {"fill_drawing": True}})
     canvas = win._canvas_widgets.canvas
@@ -574,10 +575,10 @@ def test_fill_drawing_menu_toggle_applies_with_cli_overrides(
 
 @pytest.mark.gui
 def test_sort_labels_dialog_toggle_rebuilds_label_dialog(
+    *,
     settings_with_label_history: tuple[MainWindow, SettingsDialog],
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
 ) -> None:
     win, dialog = settings_with_label_history
@@ -605,10 +606,10 @@ def test_sort_labels_dialog_toggle_rebuilds_label_dialog(
 
 @pytest.mark.gui
 def test_show_label_text_field_dialog_toggle_rebuilds_label_dialog(
+    *,
     settings_with_label_history: tuple[MainWindow, SettingsDialog],
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
 ) -> None:
     win, dialog = settings_with_label_history
@@ -629,10 +630,10 @@ def test_show_label_text_field_dialog_toggle_rebuilds_label_dialog(
 
 @pytest.mark.gui
 def test_label_completion_dialog_change_rebuilds_label_dialog(
+    *,
     settings_with_label_history: tuple[MainWindow, SettingsDialog],
     qtbot: QtBot,
     editable_config_file: Path,
-    *,
     pause: bool,
 ) -> None:
     win, dialog = settings_with_label_history
@@ -658,7 +659,7 @@ def test_label_completion_dialog_change_rebuilds_label_dialog(
 
 @pytest.mark.gui
 def test_ai_default_dialog_change_syncs_dock_combo(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     assert win._config["ai"]["default"] == "Sam2 (balanced)"
@@ -683,7 +684,7 @@ def test_ai_default_dialog_change_syncs_dock_combo(
 
 @pytest.mark.gui
 def test_ai_model_choices_follow_point_prompt_mode(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     win._switch_canvas_mode(edit=False, create_mode="ai_points_to_shape")
@@ -725,7 +726,7 @@ def test_ai_model_choices_follow_point_prompt_mode(
 
 @pytest.mark.gui
 def test_ai_dock_change_persists_and_syncs_settings_dialog(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     dialog = _open_settings_dialog(win=win)
@@ -748,7 +749,7 @@ def test_ai_dock_change_persists_and_syncs_settings_dialog(
 
 @pytest.mark.gui
 def test_polygon_detail_popover_and_settings_stay_in_sync(
-    main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, editable_config_file: Path, pause: bool
 ) -> None:
     win = main_win(config_file=editable_config_file)
     dialog = _open_settings_dialog(win=win)

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -136,8 +136,8 @@ def test_setting_change_persists_and_applies(
     assert win._config["labels"] == ["cat", "dog"]
     assert win._label_dialog is label_dialog_before  # updated in place, not rebuilt
     unique_label_list = win._docks.unique_label_list
-    assert unique_label_list.find_label_item("cat") is not None
-    assert unique_label_list.find_label_item("dog") is not None
+    assert unique_label_list.find_label_item(label="cat") is not None
+    assert unique_label_list.find_label_item(label="dog") is not None
 
     persisted = safe_load(editable_config_file.read_text())
     assert persisted["display_label_popup"] is False

--- a/tests/e2e/shape_editing_test.py
+++ b/tests/e2e/shape_editing_test.py
@@ -56,10 +56,10 @@ def _delete_selected_shape(
 
 @pytest.mark.gui
 def test_select_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win, canvas = _open_and_select_shape(
@@ -77,11 +77,11 @@ def test_select_shape(
 
 @pytest.mark.gui
 def test_copy_paste_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win, canvas = _open_and_select_shape(
@@ -110,11 +110,11 @@ def test_copy_paste_shape(
 
 @pytest.mark.gui
 def test_duplicate_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win, canvas = _open_and_select_shape(
@@ -140,11 +140,11 @@ def test_duplicate_shape(
 
 @pytest.mark.gui
 def test_delete_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -168,12 +168,12 @@ def test_delete_shape(
 
 @pytest.mark.gui
 def test_delete_undo_shape(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     win, canvas = _open_and_select_shape(
@@ -200,10 +200,10 @@ def test_delete_undo_shape(
 
 @pytest.mark.gui
 def test_right_drag_copy_here_duplicates_shape(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas

--- a/tests/e2e/smoke_test.py
+++ b/tests/e2e/smoke_test.py
@@ -11,7 +11,7 @@ from .conftest import MainWinFactory
 
 @pytest.mark.gui
 def test_MainWindow_open(
-    main_win: MainWinFactory, qtbot: QtBot, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, pause: bool
 ) -> None:
     win = main_win()
 
@@ -20,7 +20,7 @@ def test_MainWindow_open(
 
 @pytest.mark.gui
 def test_file_search_config_regex_filters_on_startup(
-    main_win: MainWinFactory, qtbot: QtBot, data_path: Path, *, pause: bool
+    *, main_win: MainWinFactory, qtbot: QtBot, data_path: Path, pause: bool
 ) -> None:
     raw_dir = data_path / "raw"
     all_images = list(raw_dir.glob("*.jpg"))

--- a/tests/e2e/status_bar_messages_test.py
+++ b/tests/e2e/status_bar_messages_test.py
@@ -39,10 +39,10 @@ def _wait_for_status_message_containing(
 
 @pytest.mark.gui
 def test_status_bar_shows_loaded_message_after_opening(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     file_path = str(data_path / "raw" / "2011_000003.jpg")
@@ -59,11 +59,11 @@ def test_status_bar_shows_loaded_message_after_opening(
 
 @pytest.mark.gui
 def test_save_does_not_emit_transient_status_message(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     json_basename = "2011_000003.json"
@@ -92,10 +92,10 @@ def test_save_does_not_emit_transient_status_message(
 
 @pytest.mark.gui
 def test_status_bar_shows_error_message_on_corrupt_file(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     corrupt_json = tmp_path / "corrupt.json"

--- a/tests/e2e/unsaved_changes_dialog_test.py
+++ b/tests/e2e/unsaved_changes_dialog_test.py
@@ -76,10 +76,10 @@ def _dir_win_no_autosave(
 
 @pytest.mark.gui
 def test_close_with_unsaved_changes_cancel_keeps_window_open(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_win_no_autosave: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _draw_and_commit_polygon(qtbot=qtbot, win=_raw_win_no_autosave, label="cat")
@@ -101,6 +101,7 @@ def test_close_with_unsaved_changes_cancel_keeps_window_open(
 
 @pytest.mark.gui
 def test_close_choose_save_writes_json_and_closes(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_win_no_autosave: MainWindow,
@@ -130,11 +131,11 @@ def test_close_choose_save_writes_json_and_closes(
 
 @pytest.mark.gui
 def test_close_choose_save_but_cancel_save_dialog_keeps_window_open(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_win_no_autosave: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     _draw_and_commit_polygon(qtbot=qtbot, win=_raw_win_no_autosave, label="cat")
@@ -158,11 +159,11 @@ def test_close_choose_save_but_cancel_save_dialog_keeps_window_open(
 
 @pytest.mark.gui
 def test_close_choose_save_but_write_fails_keeps_window_open(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_win_no_autosave: MainWindow,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     _draw_and_commit_polygon(qtbot=qtbot, win=_raw_win_no_autosave, label="cat")
@@ -191,6 +192,7 @@ def test_close_choose_save_but_write_fails_keeps_window_open(
 
 @pytest.mark.gui
 def test_close_choose_discard_no_json_window_closes(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_win_no_autosave: MainWindow,
@@ -213,10 +215,10 @@ def test_close_choose_discard_no_json_window_closes(
 
 @pytest.mark.gui
 def test_navigate_with_unsaved_changes_shows_prompt(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _dir_win_no_autosave: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _draw_and_commit_polygon(qtbot=qtbot, win=_dir_win_no_autosave, label="cat")
@@ -242,6 +244,7 @@ def test_navigate_with_unsaved_changes_shows_prompt(
 
 @pytest.mark.gui
 def test_close_clean_window_no_prompt(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     _raw_win_no_autosave: MainWindow,

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -150,7 +150,7 @@ def test_multi_select_toggle_propagates(
 
     label_list.clearSelection()
     for i in selected_indices:
-        label_list.select_item(label_list[i])
+        label_list.select_item(item=label_list[i])
     qtbot.wait(50)
     assert {item for item in label_list.selected_items()} == {
         label_list[i] for i in selected_indices
@@ -192,7 +192,7 @@ def test_multi_select_preserves_selection_after_checkbox_click(
 
     label_list.clearSelection()
     for i in selected_indices:
-        label_list.select_item(label_list[i])
+        label_list.select_item(item=label_list[i])
     qtbot.wait(50)
 
     target_index = label_list._model.indexFromItem(label_list[selected_indices[1]])
@@ -225,7 +225,7 @@ def test_multi_select_collapses_on_row_body_click(
 
     label_list.clearSelection()
     for i in selected_indices:
-        label_list.select_item(label_list[i])
+        label_list.select_item(item=label_list[i])
     qtbot.wait(50)
 
     target_index = label_list._model.indexFromItem(label_list[clicked_index])

--- a/tests/e2e/visibility_test.py
+++ b/tests/e2e/visibility_test.py
@@ -12,9 +12,9 @@ from ..conftest import close_or_pause
 
 @pytest.mark.gui
 def test_toggle_all_shapes(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -45,9 +45,9 @@ def test_toggle_all_shapes(
 
 @pytest.mark.gui
 def test_toggle_individual_shape(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -73,9 +73,9 @@ def test_toggle_individual_shape(
 
 @pytest.mark.gui
 def test_visibility_preserved_when_undoing_unrelated_edit(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -108,9 +108,9 @@ def test_visibility_preserved_when_undoing_unrelated_edit(
 
 @pytest.mark.gui
 def test_undo_recovers_accidental_hide(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -137,9 +137,9 @@ def test_undo_recovers_accidental_hide(
 
 @pytest.mark.gui
 def test_multi_select_toggle_propagates(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -179,9 +179,9 @@ def test_multi_select_toggle_propagates(
 
 @pytest.mark.gui
 def test_multi_select_preserves_selection_after_checkbox_click(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     canvas = annotated_win._canvas_widgets.canvas
@@ -213,9 +213,9 @@ def test_multi_select_preserves_selection_after_checkbox_click(
 
 @pytest.mark.gui
 def test_multi_select_collapses_on_row_body_click(
+    *,
     qtbot: QtBot,
     annotated_win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     label_list = annotated_win._docks.label_list

--- a/tests/e2e/window_geometry_persistence_test.py
+++ b/tests/e2e/window_geometry_persistence_test.py
@@ -28,9 +28,9 @@ _TOLERANCE_PX: Final[int] = 10
 
 @pytest.mark.gui
 def test_window_geometry_persists_across_sessions(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
-    *,
     pause: bool,
 ) -> None:
     win1 = main_win(size=None)
@@ -64,12 +64,12 @@ def test_window_geometry_persists_across_sessions(
 
 @pytest.mark.gui
 def test_cancelled_close_keeps_persisted_window_state(
+    *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     PERSISTED_SIZE: Final[QSize] = QSize(900, 700)

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -123,7 +123,7 @@ def test_fit_width_uses_full_width_when_quantized_image_fits_height(
     )
     image.fill(0)
     _win._image = image
-    _win._canvas_widgets.canvas.load_pixmap(QtGui.QPixmap.fromImage(image))
+    _win._canvas_widgets.canvas.load_pixmap(pixmap=QtGui.QPixmap.fromImage(image))
 
     _win.set_fit_width_mode(True)
 

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -40,9 +40,9 @@ def _win(
 
 @pytest.mark.gui
 def test_zoom_fit_window(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _win.set_fit_window_mode(True)
@@ -57,9 +57,9 @@ def test_zoom_fit_window(
 
 @pytest.mark.gui
 def test_zoom_fit_width(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _win.set_fit_window_mode(True)
@@ -74,10 +74,10 @@ def test_zoom_fit_width(
 
 @pytest.mark.gui
 def test_zoom_fit_width_does_not_scroll_horizontally(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     image_path = tmp_path / "portrait.png"
@@ -100,9 +100,9 @@ def test_zoom_fit_width_does_not_scroll_horizontally(
 
 @pytest.mark.gui
 def test_fit_width_uses_full_width_when_quantized_image_fits_height(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     scroll_area = _win.centralWidget()
@@ -137,9 +137,9 @@ def test_fit_width_uses_full_width_when_quantized_image_fits_height(
 
 @pytest.mark.gui
 def test_manual_zoom_only_scrolls_the_overflowing_axis(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _win._set_zoom_to_original()
@@ -157,9 +157,9 @@ def test_manual_zoom_only_scrolls_the_overflowing_axis(
 
 @pytest.mark.gui
 def test_zoom_to_original(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _win.set_fit_window_mode(True)
@@ -175,9 +175,9 @@ def test_zoom_to_original(
 
 @pytest.mark.gui
 def test_zoom_step_keeps_fractional_precision(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
 ) -> None:
     _win._canvas_widgets.zoom_widget.setValue(105)
@@ -251,10 +251,10 @@ def _make_scrolled_win(
 @pytest.mark.gui
 @pytest.mark.parametrize("keep_prev_scale", [True, False])
 def test_navigation_restores_each_image_viewport(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     keep_prev_scale: bool,
 ) -> None:
@@ -324,10 +324,10 @@ def test_navigation_restores_each_image_viewport(
 
 @pytest.mark.gui
 def test_navigation_restores_view_offset_with_retained_brightness(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win = main_win(
@@ -356,10 +356,10 @@ def test_navigation_restores_view_offset_with_retained_brightness(
 
 @pytest.mark.gui
 def test_navigation_restores_viewport_after_layout_settles(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     tmp_path: Path,
-    *,
     pause: bool,
 ) -> None:
     for name, size in [("a.png", (1000, 1500)), ("b.png", (1200, 800))]:
@@ -410,10 +410,10 @@ def test_navigation_restores_viewport_after_layout_settles(
 
 @pytest.mark.gui
 def test_open_file_keeps_previous_viewport(
+    *,
     scrolled_win: tuple[MainWindow, dict[Qt.Orientation, int]],
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win, expected_scroll_values = scrolled_win
@@ -432,10 +432,10 @@ def test_open_file_keeps_previous_viewport(
 
 @pytest.mark.gui
 def test_file_search_keeps_previous_viewport(
+    *,
     scrolled_win: tuple[MainWindow, dict[Qt.Orientation, int]],
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
 ) -> None:
     win, expected_scroll_values = scrolled_win
@@ -456,10 +456,10 @@ def test_file_search_keeps_previous_viewport(
 @pytest.mark.gui
 @pytest.mark.parametrize("next_image_name", ["2011_000003.jpg", "2011_000006.jpg"])
 def test_close_and_open_restores_viewport(
+    *,
     scrolled_win: tuple[MainWindow, dict[Qt.Orientation, int]],
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     next_image_name: str,
 ) -> None:
@@ -527,9 +527,9 @@ def _make_wheel_event(
     ],
 )
 def test_canvas_wheel_event_dispatches_signal(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
     modifiers: Qt.KeyboardModifier,
     angle_delta: QPoint,
@@ -579,9 +579,9 @@ def test_canvas_wheel_event_dispatches_signal(
     ],
 )
 def test_canvas_wheel_event_ignores_non_vertical_zoom(
+    *,
     qtbot: QtBot,
     _win: MainWindow,
-    *,
     pause: bool,
     angle_delta: QPoint,
     phase: Qt.ScrollPhase,
@@ -610,10 +610,10 @@ def test_canvas_wheel_event_ignores_non_vertical_zoom(
     ],
 )
 def test_ctrl_wheel_keeps_image_point_under_cursor(
+    *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     data_path: Path,
-    *,
     pause: bool,
     angle_delta: int,
     repetitions: int,

--- a/tests/unit/__main___test.py
+++ b/tests/unit/__main___test.py
@@ -23,7 +23,7 @@ from labelme.__main__ import main
 
 
 def test_help_uses_console_script_name(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    *, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["launcher-path", "--help"])
 
@@ -36,7 +36,7 @@ def test_help_uses_console_script_name(
 
 @pytest.mark.parametrize("flag", ["--nodata", "--autosave"])
 def test_removed_flag_errors_as_unknown(
-    flag: str, monkeypatch: pytest.MonkeyPatch
+    *, flag: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["labelme", flag])
     with pytest.raises(SystemExit) as exc:
@@ -45,11 +45,11 @@ def test_removed_flag_errors_as_unknown(
 
 
 @pytest.mark.parametrize("level", _LOGGER_LEVELS)
-def test_logger_level_choice_is_a_valid_loguru_level(level: str) -> None:
+def test_logger_level_choice_is_a_valid_loguru_level(*, level: str) -> None:
     assert logger.level(level.upper()).name == level.upper()
 
 
-def test_logger_level_rejects_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_logger_level_rejects_fatal(*, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["labelme", "--logger-level", "fatal"])
     with pytest.raises(SystemExit) as exc:
         main()
@@ -58,7 +58,7 @@ def test_logger_level_rejects_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.parametrize("output", ["notes.json", "notes.JSON"])
 def test_output_rejects_json_file_path_case_insensitively(
-    output: str, monkeypatch: pytest.MonkeyPatch
+    *, output: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["labelme", "--output", output])
     with pytest.raises(SystemExit) as exc:
@@ -76,7 +76,7 @@ def test_output_rejects_json_file_path_case_insensitively(
     ],
 )
 def test_deprecated_alias_warns_pointing_to_canonical(
-    argv: list[str], canonical: str, monkeypatch: pytest.MonkeyPatch
+    *, argv: list[str], canonical: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["labelme", *argv, "--version"])
     with pytest.warns(FutureWarning, match=canonical):
@@ -96,7 +96,7 @@ def test_deprecated_alias_warns_pointing_to_canonical(
     ],
 )
 def test_canonical_flag_does_not_warn(
-    argv: list[str], monkeypatch: pytest.MonkeyPatch
+    *, argv: list[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["labelme", *argv, "--version"])
     with warnings.catch_warnings():
@@ -118,12 +118,12 @@ def test_canonical_flag_does_not_warn(
     ],
 )
 def test_parse_list_arg_splits_comma_separated_value(
-    value: str, expected: list[str]
+    *, value: str, expected: list[str]
 ) -> None:
     assert _parse_list_arg(value) == expected
 
 
-def test_parse_list_arg_reads_and_strips_file_lines(tmp_path: Path) -> None:
+def test_parse_list_arg_reads_and_strips_file_lines(*, tmp_path: Path) -> None:
     labels_file = tmp_path / "labels.txt"
     labels_file.write_text("  cat  \n\ndog\n  \nperson\n", encoding="utf-8")
 
@@ -138,6 +138,7 @@ def test_parse_list_arg_splits_value_too_long_to_be_a_path() -> None:
 
 
 def test_resolve_config_source_falls_back_to_defaults_on_missing_default_file(
+    *,
     tmp_path: Path,
 ) -> None:
     missing_default = tmp_path / "unwritable" / ".labelmerc"
@@ -159,7 +160,9 @@ def test_resolve_config_source_falls_back_to_defaults_on_missing_default_file(
     assert repr(str(missing_default)) in warnings_logged[0]
 
 
-def test_resolve_config_source_reads_an_existing_default_file(tmp_path: Path) -> None:
+def test_resolve_config_source_reads_an_existing_default_file(
+    *, tmp_path: Path
+) -> None:
     default_config_file = tmp_path / ".labelmerc"
     default_config_file.touch()
 
@@ -169,6 +172,7 @@ def test_resolve_config_source_reads_an_existing_default_file(tmp_path: Path) ->
 
 
 def test_resolve_config_source_exits_on_an_explicit_missing_file(
+    *,
     tmp_path: Path,
 ) -> None:
     with pytest.raises(SystemExit) as exc:
@@ -181,6 +185,7 @@ def test_resolve_config_source_exits_on_an_explicit_missing_file(
 
 
 def test_resolve_config_source_exits_on_a_value_too_long_to_be_a_path(
+    *,
     tmp_path: Path,
 ) -> None:
     with pytest.raises(SystemExit) as exc:
@@ -191,7 +196,7 @@ def test_resolve_config_source_exits_on_a_value_too_long_to_be_a_path(
     assert exc.value.code == 1
 
 
-def test_resolve_config_source_reads_an_explicit_file(tmp_path: Path) -> None:
+def test_resolve_config_source_reads_an_explicit_file(*, tmp_path: Path) -> None:
     config_file = tmp_path / "custom.yaml"
     config_file.write_text("auto_save: true\n", encoding="utf-8")
 
@@ -200,7 +205,9 @@ def test_resolve_config_source_reads_an_explicit_file(tmp_path: Path) -> None:
     ) == (config_file, {})
 
 
-def test_resolve_config_source_takes_a_yaml_string_as_overrides(tmp_path: Path) -> None:
+def test_resolve_config_source_takes_a_yaml_string_as_overrides(
+    *, tmp_path: Path
+) -> None:
     assert _resolve_config_source(
         config_arg="{auto_save: true}",
         default_config_file=str(tmp_path / ".labelmerc"),
@@ -242,6 +249,7 @@ def remove_loguru_sinks() -> Iterator[None]:
 
 @pytest.mark.usefixtures("remove_loguru_sinks")
 def test_setup_loguru_degrades_to_stderr_when_the_cache_dir_cannot_be_created(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -259,6 +267,7 @@ def test_setup_loguru_degrades_to_stderr_when_the_cache_dir_cannot_be_created(
 
 @pytest.mark.usefixtures("remove_loguru_sinks")
 def test_setup_loguru_degrades_to_stderr_when_the_home_directory_is_unknown(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -277,6 +286,7 @@ def test_setup_loguru_degrades_to_stderr_when_the_home_directory_is_unknown(
 
 @pytest.mark.usefixtures("remove_loguru_sinks")
 def test_setup_loguru_degrades_to_stderr_when_the_log_file_cannot_be_opened(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -302,6 +312,7 @@ def test_setup_loguru_degrades_to_stderr_when_the_log_file_cannot_be_opened(
 
 @pytest.mark.usefixtures("remove_loguru_sinks")
 def test_setup_loguru_degrades_to_stderr_without_localappdata(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/_app_test.py
+++ b/tests/unit/_app_test.py
@@ -38,6 +38,7 @@ from labelme._shape import Shape
     ],
 )
 def test_resolve_text_annotation_shape_type(
+    *,
     create_mode: str,
     ai_output_format: _automation.AiOutputFormat,
     expected: _automation.AiOutputFormat | None,
@@ -61,7 +62,7 @@ def test_resolve_text_annotation_shape_type(
     ids=["policy-none", "exact-match", "exact-no-match", "unknown-policy"],
 )
 def test_is_valid_label(
-    label: str, existing_labels: list[str], policy: str | None, *, expected: bool
+    *, label: str, existing_labels: list[str], policy: str | None, expected: bool
 ) -> None:
     assert (
         _app._is_valid_label(
@@ -97,10 +98,10 @@ def test_is_valid_label(
     ],
 )
 def test_format_window_title(
+    *,
     image_path: str | None,
     file_index: int | None,
     file_count: int,
-    *,
     dirty: bool,
     expected: str,
 ) -> None:
@@ -130,6 +131,7 @@ def _make_png_bytes(
 
 
 def test_make_image_too_large_message_explains_allocation_limit(
+    *,
     set_allocation_limit: Callable[[int], None],
 ) -> None:
     image_data = _make_png_bytes(
@@ -147,6 +149,7 @@ def test_make_image_too_large_message_explains_allocation_limit(
 
 
 def test_make_image_too_large_message_accounts_for_bit_depth(
+    *,
     set_allocation_limit: Callable[[int], None],
 ) -> None:
     # 800x600 at 16 bits per channel decodes to 8 bytes/pixel (~3.7 MB), so a
@@ -196,6 +199,7 @@ def test_make_image_too_large_message_reports_per_side_limit() -> None:
 
 
 def test_make_image_too_large_message_rounds_the_need_up(
+    *,
     set_allocation_limit: Callable[[int], None],
 ) -> None:
     # 800x680 at 4 bytes/pixel needs ~2.1 MB: over a 2 MB limit, but plain
@@ -300,6 +304,7 @@ def _make_shape_dict(*, label: str, flags: dict[str, bool]) -> ShapeDict:
     ],
 )
 def test_shapes_from_dicts_merges_label_flags(
+    *,
     label: str,
     saved_flags: dict[str, bool],
     label_flags: dict[str, list[str]] | None,
@@ -412,6 +417,7 @@ def test_shape_to_dict_maps_all_fields() -> None:
     ],
 )
 def test_shape_to_dict_coalesces_optional_flags_and_description(
+    *,
     flags: dict[str, bool] | None,
     description: str | None,
     expected_flags: dict[str, bool],
@@ -464,6 +470,7 @@ def test_shape_to_dict_requires_label() -> None:
     ],
 )
 def test_resolve_label_path(
+    *,
     image_or_label_path: str,
     output_dir: Path | None,
     expected: str,
@@ -477,6 +484,7 @@ def test_resolve_label_path(
 
 
 def test_resolve_stored_image_path_falls_back_to_absolute(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*_args: object, **_kwargs: object) -> str:

--- a/tests/unit/_automation/_ai_assist_test.py
+++ b/tests/unit/_automation/_ai_assist_test.py
@@ -18,13 +18,14 @@ from labelme._shape import Shape
 
 @pytest.fixture
 def install_fake_osam_session(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Callable[[osam.types.GenerateResponse], list[str]]:
     def _install(response: osam.types.GenerateResponse) -> list[str]:
         created_model_names: list[str] = []
 
         class _FakeOsamSession:
-            def __init__(self, model_name: str) -> None:
+            def __init__(self, *, model_name: str) -> None:
                 self.model_name = model_name
                 created_model_names.append(model_name)
 
@@ -61,6 +62,7 @@ def _propose(
 
 
 def test_point_prompt_uses_best_answer_and_reuses_session(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> None:
     response = osam.types.GenerateResponse(
@@ -109,6 +111,7 @@ def test_default_model_name_and_output_format() -> None:
 
 
 def test_polygon_detail_controls_ai_polygon_points(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> None:
     mask = np.zeros((100, 100), dtype=bool)
@@ -133,6 +136,7 @@ def test_polygon_detail_controls_ai_polygon_points(
 
 
 def test_polygon_proposal_groups_disconnected_lands(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> None:
     mask = np.zeros((100, 100), dtype=bool)
@@ -153,6 +157,7 @@ def test_polygon_proposal_groups_disconnected_lands(
 
 
 def test_sam3_point_prompt_is_rejected_before_session_creation(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> None:
     response = osam.types.GenerateResponse(model="stub", annotations=[])
@@ -166,6 +171,7 @@ def test_sam3_point_prompt_is_rejected_before_session_creation(
 
 
 def test_sam3_box_prompt_reaches_session(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> None:
     response = osam.types.GenerateResponse(model="stub", annotations=[])
@@ -277,6 +283,7 @@ def test_point_inside_detection_uses_rounded_mask_origin() -> None:
 
 
 def test_point_prompt_reports_best_matching_existing_shape(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> None:
     response = osam.types.GenerateResponse(
@@ -320,6 +327,7 @@ def test_point_prompt_reports_best_matching_existing_shape(
     ],
 )
 def test_point_prompt_reports_matching_existing_shape(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
     existing_bbox: tuple[int, int, int, int],
     proposal_bbox: tuple[int, int, int, int],
@@ -343,6 +351,7 @@ def test_point_prompt_reports_matching_existing_shape(
 
 
 def test_sweep_suppresses_only_proposals_matching_existing_shapes(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
     existing_rectangle: Shape,
 ) -> None:
@@ -372,6 +381,7 @@ def test_sweep_suppresses_only_proposals_matching_existing_shapes(
 
 
 def test_single_result_sweep_reports_matching_existing_shape(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
     existing_rectangle: Shape,
 ) -> None:
@@ -395,6 +405,7 @@ def test_single_result_sweep_reports_matching_existing_shape(
 
 @pytest.fixture(name="duplicate_sweep_session")
 def make_duplicate_sweep_session(
+    *,
     install_fake_osam_session: Callable[[osam.types.GenerateResponse], list[str]],
 ) -> AiAssistSession:
     response = osam.types.GenerateResponse(
@@ -409,6 +420,7 @@ def make_duplicate_sweep_session(
 
 
 def test_sweep_matches_existing_shape_after_greedy_suppression(
+    *,
     duplicate_sweep_session: AiAssistSession,
     existing_rectangle: Shape,
 ) -> None:
@@ -424,6 +436,7 @@ def test_sweep_matches_existing_shape_after_greedy_suppression(
 
 
 def test_sweep_still_applies_greedy_suppression_among_new_detections(
+    *,
     duplicate_sweep_session: AiAssistSession,
 ) -> None:
     proposal = _propose(

--- a/tests/unit/_automation/_geometry_test.py
+++ b/tests/unit/_automation/_geometry_test.py
@@ -85,6 +85,7 @@ def test_compute_oriented_rectangle_from_mask_axis_aligned_taller_than_wide() ->
 
 
 def test_compute_oriented_rectangle_from_mask_recovers_rotation_angle(
+    *,
     rotated_rectangle_mask: NDArray[np.bool_],
     rotated_rectangle_angle: float,
 ) -> None:
@@ -308,6 +309,7 @@ def test_compute_polygons_from_mask_returns_every_disconnected_land() -> None:
 
 
 def test_compute_polygons_from_mask_traces_all_lands_once(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     mask = np.zeros((10, 12), dtype=bool)
@@ -426,7 +428,9 @@ def test_compute_polygons_from_mask_detail_controls_point_count() -> None:
 
 
 @pytest.mark.parametrize("detail", [-1, 101])
-def test_compute_polygons_from_mask_rejects_detail_outside_range(detail: int) -> None:
+def test_compute_polygons_from_mask_rejects_detail_outside_range(
+    *, detail: int
+) -> None:
     with pytest.raises(ValueError, match="detail must be between 0 and 100"):
         compute_polygons_from_mask(mask=np.ones((5, 5), dtype=bool), detail=detail)
 

--- a/tests/unit/_automation/_osam_session_test.py
+++ b/tests/unit/_automation/_osam_session_test.py
@@ -28,13 +28,13 @@ class _FakeModelRegistry:
 class _FakeModel:
     name = "fake-model"
 
-    def __init__(self, registry: _FakeModelRegistry) -> None:
+    def __init__(self, *, registry: _FakeModelRegistry) -> None:
         self._registry = registry
         self.encode_calls = 0
         self.requests: list[osam.types.GenerateRequest] = []
         registry.models.append(self)
 
-    def encode_image(self, image: NDArray[np.uint8]) -> osam.types.ImageEmbedding:
+    def encode_image(self, *, image: NDArray[np.uint8]) -> osam.types.ImageEmbedding:
         if self._registry.encode_raises:
             raise NotImplementedError
         self.encode_calls += 1
@@ -45,7 +45,7 @@ class _FakeModel:
         )
 
     def generate(
-        self, request: osam.types.GenerateRequest
+        self, *, request: osam.types.GenerateRequest
     ) -> osam.types.GenerateResponse:
         self.requests.append(request)
         return osam.types.GenerateResponse(model=self.name, annotations=[])
@@ -53,6 +53,7 @@ class _FakeModel:
 
 @pytest.fixture
 def install_fake_model(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Callable[..., _FakeModelRegistry]:
     def _install(*, encode_raises: bool = False) -> _FakeModelRegistry:
@@ -60,7 +61,7 @@ def install_fake_model(
         monkeypatch.setattr(
             osam.apis,
             "get_model_type_by_name",
-            lambda _name: (lambda: _FakeModel(registry)),
+            lambda _name: (lambda: _FakeModel(registry=registry)),
         )
         return registry
 
@@ -77,6 +78,7 @@ def _run_point(session: OsamSession, /, *, image_id: str) -> None:
 
 
 def test_point_prompt_carries_points_through_to_generate(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -91,6 +93,7 @@ def test_point_prompt_carries_points_through_to_generate(
 
 
 def test_text_prompt_uses_detection_thresholds(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -110,6 +113,7 @@ def test_text_prompt_uses_detection_thresholds(
 
 
 def test_run_without_a_prompt_raises_and_never_generates(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -121,6 +125,7 @@ def test_run_without_a_prompt_raises_and_never_generates(
 
 
 def test_points_without_labels_is_not_treated_as_a_prompt(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -132,6 +137,7 @@ def test_points_without_labels_is_not_treated_as_a_prompt(
 
 
 def test_embedding_is_reused_for_a_repeated_image_id(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -145,6 +151,7 @@ def test_embedding_is_reused_for_a_repeated_image_id(
 
 
 def test_embedding_cache_evicts_by_insertion_order_not_recency(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -161,6 +168,7 @@ def test_embedding_cache_evicts_by_insertion_order_not_recency(
 
 
 def test_model_is_loaded_once_and_reused_across_runs(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model()
@@ -173,6 +181,7 @@ def test_model_is_loaded_once_and_reused_across_runs(
 
 
 def test_unencodable_model_falls_back_to_no_embedding(
+    *,
     install_fake_model: Callable[..., _FakeModelRegistry],
 ) -> None:
     registry = install_fake_model(encode_raises=True)

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -246,8 +246,8 @@ def test_shapes_from_detections_polygon_drops_hole() -> None:
     )
 
     polygon_mask = shape_to_mask(
-        img_shape=mask.shape,
-        points=shape.points.tolist(),
+        mask.shape,
+        shape.points.tolist(),
         shape_type="polygon",
     )
     assert polygon_mask[20, 20]

--- a/tests/unit/_automation/_shape_builders_test.py
+++ b/tests/unit/_automation/_shape_builders_test.py
@@ -105,6 +105,7 @@ def test_shapes_from_detections_oriented_rectangle_without_mask_falls_back() -> 
 
 
 def test_shapes_from_detections_oriented_rectangle_with_rotated_mask(
+    *,
     rotated_rectangle_mask: NDArray[np.bool_],
     rotated_rectangle_angle: float,
 ) -> None:
@@ -333,6 +334,7 @@ def test_shapes_from_detections_mask_drops_empty_mask() -> None:
 
 @pytest.mark.parametrize("shape_type", typing.get_args(AiOutputFormat))
 def test_shapes_from_detections_without_bbox_or_mask_is_dropped(
+    *,
     shape_type: AiOutputFormat,
 ) -> None:
     # Every shape type needs a bbox, a mask, or both; with neither there is

--- a/tests/unit/_automation/_suppression_test.py
+++ b/tests/unit/_automation/_suppression_test.py
@@ -26,6 +26,7 @@ def make_full_detection() -> Callable[..., Detection]:
 
 
 def test_redundant_drops_duplicate_mask_keeps_first(
+    *,
     make_full_detection: Callable[..., Detection],
 ) -> None:
     first = make_full_detection()
@@ -50,6 +51,7 @@ def test_redundant_keeps_first_when_descriptions_differ() -> None:
 
 
 def test_redundant_keeps_only_first_among_three_duplicates(
+    *,
     make_full_detection: Callable[..., Detection],
 ) -> None:
     first = make_full_detection()
@@ -133,6 +135,7 @@ def test_redundant_keeps_triangles_sharing_bbox() -> None:
 
 
 def test_redundant_does_not_suppress_across_labels(
+    *,
     make_full_detection: Callable[..., Detection],
 ) -> None:
     tree = make_full_detection(label="tree")
@@ -376,7 +379,7 @@ def test_overlapping_rasterizes_existing_circle_as_a_disk() -> None:
     ],
 )
 def test_overlapping_skips_existing_shape_without_bbox_interpretation(
-    shape_type: ShapeType, extra_points: list[list[float]]
+    *, shape_type: ShapeType, extra_points: list[list[float]]
 ) -> None:
     # Canvas shapes without a bbox/mask interpretation (e.g. a stray point
     # landmark) must not break the AI suppression call.

--- a/tests/unit/_automation/_text_detection_test.py
+++ b/tests/unit/_automation/_text_detection_test.py
@@ -10,7 +10,7 @@ from labelme._automation._text_detection import nms_bboxes
 
 
 class _FakeOsamSession:
-    def __init__(self, response: osam.types.GenerateResponse) -> None:
+    def __init__(self, *, response: osam.types.GenerateResponse) -> None:
         self.model_name = "stub"
         self._response = response
 
@@ -32,7 +32,7 @@ def _get_bboxes(
     /,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, list[NDArray[np.bool_]] | None]:
     return get_bboxes_from_texts(
-        session=_FakeOsamSession(response),  # ty: ignore[invalid-argument-type]
+        session=_FakeOsamSession(response=response),  # ty: ignore[invalid-argument-type]
         image=np.zeros((4, 4, 3), dtype=np.uint8),
         image_id="img",
         texts=["cat"],
@@ -132,6 +132,7 @@ def test_nms_bboxes_returns_empty_indices_for_no_boxes() -> None:
 
 
 def test_nms_bboxes_scatters_scores_into_one_hot_class_matrix(
+    *,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, np.ndarray] = {}

--- a/tests/unit/_automation/conftest.py
+++ b/tests/unit/_automation/conftest.py
@@ -8,12 +8,12 @@ from numpy.typing import NDArray
 
 
 @pytest.fixture(params=[math.pi / 6, -math.pi / 6], ids=["+30deg", "-30deg"])
-def rotated_rectangle_angle(request: pytest.FixtureRequest) -> float:
+def rotated_rectangle_angle(*, request: pytest.FixtureRequest) -> float:
     return request.param
 
 
 @pytest.fixture
-def rotated_rectangle_mask(rotated_rectangle_angle: float) -> NDArray[np.bool_]:
+def rotated_rectangle_mask(*, rotated_rectangle_angle: float) -> NDArray[np.bool_]:
     cos_a = math.cos(rotated_rectangle_angle)
     sin_a = math.sin(rotated_rectangle_angle)
     half_long, half_short = 10.0, 2.0

--- a/tests/unit/_config/api_test.py
+++ b/tests/unit/_config/api_test.py
@@ -17,7 +17,7 @@ def _steer_home(*, monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
 
 
 def test_get_user_config_file_creates_empty(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _steer_home(monkeypatch=monkeypatch, home=tmp_path)
     config_file = _config.get_user_config_file()
@@ -25,7 +25,7 @@ def test_get_user_config_file_creates_empty(
 
 
 def test_get_user_config_file_does_not_overwrite(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _steer_home(monkeypatch=monkeypatch, home=tmp_path)
     config_path = tmp_path / ".labelmerc"
@@ -36,7 +36,7 @@ def test_get_user_config_file_does_not_overwrite(
 
 
 def test_get_user_config_file_skip_creation(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _steer_home(monkeypatch=monkeypatch, home=tmp_path)
     config_file = _config.get_user_config_file(create_if_missing=False)
@@ -45,7 +45,7 @@ def test_get_user_config_file_skip_creation(
 
 @pytest.mark.parametrize("old_value", [True, False])
 def test_migrate_store_data_to_with_image_data(
-    tmp_path: Path, *, old_value: bool
+    *, tmp_path: Path, old_value: bool
 ) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(f"store_data: {str(old_value).lower()}\n")
@@ -54,7 +54,7 @@ def test_migrate_store_data_to_with_image_data(
     assert "store_data" not in config
 
 
-def test_migrate_removes_logger_level(tmp_path: Path) -> None:
+def test_migrate_removes_logger_level(*, tmp_path: Path) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text("logger_level: info\n")
     config = _config.load_config(config_file=config_file, config_overrides={})
@@ -71,20 +71,21 @@ def test_migrate_removes_logger_level(tmp_path: Path) -> None:
         ("Sam2 (balanced)", "Sam2 (balanced)"),
     ],
 )
-def test_migrate_ai_model_name(input_name: str, expected_name: str) -> None:
+def test_migrate_ai_model_name(*, input_name: str, expected_name: str) -> None:
     config: dict = {"ai": {"default": input_name}}
     _config._migrate_config_from_file(config_from_yaml=config)
     assert config["ai"]["default"] == expected_name
 
 
 @pytest.mark.parametrize("model_name", [True, 42, ["Sam"]])
-def test_migrate_tolerates_non_string_ai_default(model_name: object) -> None:
+def test_migrate_tolerates_non_string_ai_default(*, model_name: object) -> None:
     config: dict = {"ai": {"default": model_name}}
     _config._migrate_config_from_file(config_from_yaml=config)
     assert config["ai"]["default"] == model_name
 
 
 def test_load_config_keeps_other_keys_when_ai_default_is_not_a_string(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -96,7 +97,7 @@ def test_load_config_keeps_other_keys_when_ai_default_is_not_a_string(
 
 @pytest.mark.parametrize("value", [-1, 101, True, "80"])
 def test_load_config_rejects_invalid_polygon_detail(
-    tmp_path: Path, value: object
+    *, tmp_path: Path, value: object
 ) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(f"mask_polygonization:\n  detail: {json.dumps(value)}\n")
@@ -124,7 +125,7 @@ _POLYGON_TO_SHAPE_RENAMES: Final = {
     list(_POLYGON_TO_SHAPE_RENAMES.items()),
     ids=list(_POLYGON_TO_SHAPE_RENAMES.keys()),
 )
-def test_migrate_polygon_shortcut_to_shape(old_key: str, new_key: str) -> None:
+def test_migrate_polygon_shortcut_to_shape(*, old_key: str, new_key: str) -> None:
     config = {"shortcuts": {old_key: "Ctrl+X"}}
     _config._migrate_config_from_file(config_from_yaml=config)
     assert old_key not in config["shortcuts"]
@@ -138,7 +139,7 @@ def test_migrate_polygon_shortcuts_no_shortcuts_key() -> None:
 
 
 @pytest.mark.parametrize("section", ["shortcuts", "ai"])
-def test_migrate_tolerates_empty_section(section: str) -> None:
+def test_migrate_tolerates_empty_section(*, section: str) -> None:
     config = {section: None}
     _config._migrate_config_from_file(config_from_yaml=config)
     assert config[section] is None
@@ -150,7 +151,7 @@ def test_migrate_tolerates_empty_section(section: str) -> None:
     ids=["shortcuts", "ai"],
 )
 def test_load_config_empty_section_keeps_defaults(
-    tmp_path: Path, section: str, probe: tuple[str, str]
+    *, tmp_path: Path, section: str, probe: tuple[str, str]
 ) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(f"{section}:\n")
@@ -160,14 +161,14 @@ def test_load_config_empty_section_keeps_defaults(
 
 
 @pytest.mark.parametrize("section", ["shortcuts", "ai"])
-def test_migrate_leaves_malformed_section_for_merge_to_report(section: str) -> None:
+def test_migrate_leaves_malformed_section_for_merge_to_report(*, section: str) -> None:
     config = {section: "oops"}
     _config._migrate_config_from_file(config_from_yaml=config)
     assert config[section] == "oops"
 
 
 @pytest.mark.parametrize("section", ["shortcuts", "ai"])
-def test_load_config_malformed_section_raises(tmp_path: Path, section: str) -> None:
+def test_load_config_malformed_section_raises(*, tmp_path: Path, section: str) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(f"{section}: oops\n")
     with pytest.raises(
@@ -182,7 +183,7 @@ def test_load_config_malformed_section_raises(tmp_path: Path, section: str) -> N
     ids=list(_POLYGON_TO_SHAPE_RENAMES.keys()),
 )
 def test_migrate_polygon_shortcut_drops_old_key_when_new_key_exists(
-    old_key: str, new_key: str
+    *, old_key: str, new_key: str
 ) -> None:
     config = {"shortcuts": {old_key: "Ctrl+X", new_key: "Ctrl+Y"}}
     _config._migrate_config_from_file(config_from_yaml=config)
@@ -191,6 +192,7 @@ def test_migrate_polygon_shortcut_drops_old_key_when_new_key_exists(
 
 
 def test_load_config_tolerates_both_polygon_and_shape_shortcuts(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -214,6 +216,7 @@ def test_migrate_removes_add_point_to_edge_shortcut() -> None:
 
 
 def test_load_config_tolerates_removed_add_point_to_edge_shortcut(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -253,7 +256,7 @@ def test_migrate_ai_crosshair_keeps_explicit_ai_points_to_shape() -> None:
     assert crosshair["ai_points_to_shape"] is False
 
 
-def test_load_config_tolerates_legacy_ai_crosshair_keys(tmp_path: Path) -> None:
+def test_load_config_tolerates_legacy_ai_crosshair_keys(*, tmp_path: Path) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(
         "canvas:\n  crosshair:\n    ai_polygon: true\n    ai_mask: false\n"
@@ -268,7 +271,7 @@ def test_migrate_leaves_malformed_crosshair_for_merge_to_report() -> None:
     assert config["canvas"]["crosshair"] == "oops"
 
 
-def test_load_config_malformed_crosshair_raises(tmp_path: Path) -> None:
+def test_load_config_malformed_crosshair_raises(*, tmp_path: Path) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text("canvas:\n  crosshair: oops\n")
     with pytest.raises(
@@ -291,7 +294,7 @@ def test_load_config_malformed_crosshair_raises(tmp_path: Path) -> None:
     ids=["brightness", "contrast", "both", "both_disabled"],
 )
 def test_migrate_keep_prev_brightness_contrast(
-    old_config: dict[str, bool], expected: dict[str, bool]
+    *, old_config: dict[str, bool], expected: dict[str, bool]
 ) -> None:
     config = old_config.copy()
     _config._migrate_config_from_file(config_from_yaml=config)
@@ -323,7 +326,7 @@ def test_migrate_keep_prev_brightness_contrast(
         "unknown_key_nested",
     ],
 )
-def test_load_config_rejects_invalid_override(overrides: dict, message: str) -> None:
+def test_load_config_rejects_invalid_override(*, overrides: dict, message: str) -> None:
     with pytest.raises(ValueError, match=message):
         _config.load_config(config_file=None, config_overrides=overrides)
 
@@ -381,7 +384,7 @@ def test_load_config_requires_labels_when_validate_label_enabled() -> None:
     ids=["auto", "uniform", "by-label"],
 )
 def test_load_config_migrates_legacy_shape_color_from_file(
-    tmp_path: Path, legacy: dict, expected: dict
+    *, tmp_path: Path, legacy: dict, expected: dict
 ) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(json.dumps(legacy))
@@ -422,6 +425,7 @@ def test_load_config_migrates_legacy_shape_color_sibling_without_mode() -> None:
 
 
 def test_load_config_rejects_invalid_migrated_legacy_shape_color(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -439,6 +443,7 @@ def test_load_config_rejects_invalid_migrated_legacy_shape_color(
 
 
 def test_load_config_rejects_falsey_invalid_legacy_default_shape_color(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -458,6 +463,7 @@ def test_load_config_native_empty_shape_color_section_keeps_defaults() -> None:
 
 
 def test_load_config_validates_native_shape_color_over_legacy_file(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -471,6 +477,7 @@ def test_load_config_validates_native_shape_color_over_legacy_file(
 
 
 def test_legacy_shape_color_override_preserves_config_file_values(
+    *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
@@ -528,7 +535,7 @@ def test_load_config_rejects_mixed_new_and_legacy_shape_color() -> None:
     ids=["mode", "shift", "uniform-rgb", "label-rgb"],
 )
 def test_load_config_rejects_invalid_shape_color(
-    shape_color: dict, message: str
+    *, shape_color: dict, message: str
 ) -> None:
     with pytest.raises(ValueError, match=message):
         _config.load_config(

--- a/tests/unit/_config/schema_test.py
+++ b/tests/unit/_config/schema_test.py
@@ -38,7 +38,7 @@ _INT_SETTINGS: Final = tuple(s for s in SETTINGS if s.kind == "int")
 
 @pytest.mark.parametrize("setting", SETTINGS, ids=_ids(SETTINGS))
 def test_key_path_resolves_in_default_config(
-    setting: Setting, default_config: dict
+    *, setting: Setting, default_config: dict
 ) -> None:
     # raises if the key_path does not exist in default_config.yaml
     _resolve(config=default_config, key_path=setting.key_path)
@@ -55,7 +55,7 @@ def test_every_group_is_used() -> None:
 
 
 @pytest.mark.parametrize("setting", _ENUM_SETTINGS, ids=_ids(_ENUM_SETTINGS))
-def test_enum_default_is_a_choice(setting: Setting, default_config: dict) -> None:
+def test_enum_default_is_a_choice(*, setting: Setting, default_config: dict) -> None:
     assert setting.choices is not None
     assert len(setting.choices) >= 1
     default = _resolve(config=default_config, key_path=setting.key_path)
@@ -63,7 +63,7 @@ def test_enum_default_is_a_choice(setting: Setting, default_config: dict) -> Non
 
 
 @pytest.mark.parametrize("setting", _ENUM_SETTINGS, ids=_ids(_ENUM_SETTINGS))
-def test_enum_choice_labels_match_choices(setting: Setting) -> None:
+def test_enum_choice_labels_match_choices(*, setting: Setting) -> None:
     assert setting.choices is not None
     if setting.choice_labels is not None:
         assert len(setting.choice_labels) == len(setting.choices)
@@ -79,13 +79,13 @@ def test_ai_choice_labels_match_shared_model_names() -> None:
 
 
 @pytest.mark.parametrize("setting", _BOOL_SETTINGS, ids=_ids(_BOOL_SETTINGS))
-def test_bool_default_is_bool(setting: Setting, default_config: dict) -> None:
+def test_bool_default_is_bool(*, setting: Setting, default_config: dict) -> None:
     default = _resolve(config=default_config, key_path=setting.key_path)
     assert isinstance(default, bool), setting.key_path
 
 
 @pytest.mark.parametrize("setting", _COLOR_SETTINGS, ids=_ids(_COLOR_SETTINGS))
-def test_color_default_is_rgb(setting: Setting, default_config: dict) -> None:
+def test_color_default_is_rgb(*, setting: Setting, default_config: dict) -> None:
     default = _resolve(config=default_config, key_path=setting.key_path)
     assert (
         isinstance(default, list)
@@ -96,7 +96,7 @@ def test_color_default_is_rgb(setting: Setting, default_config: dict) -> None:
 
 @pytest.mark.parametrize("setting", _INT_SETTINGS, ids=_ids(_INT_SETTINGS))
 def test_int_default_matches_editor_range(
-    setting: Setting, default_config: dict
+    *, setting: Setting, default_config: dict
 ) -> None:
     assert (setting.minimum is None) == (setting.maximum is None)
     default = _resolve(config=default_config, key_path=setting.key_path)

--- a/tests/unit/_config/writer_test.py
+++ b/tests/unit/_config/writer_test.py
@@ -16,7 +16,7 @@ def _parse(config_file: Path, /) -> dict | None:
     return _yaml.safe_load(config_file.read_text(encoding="utf-8"))
 
 
-def test_creates_file_when_missing(tmp_path: Path) -> None:
+def test_creates_file_when_missing(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], False)])
@@ -24,7 +24,7 @@ def test_creates_file_when_missing(tmp_path: Path) -> None:
     assert _parse(config_file) == {"auto_save": False}
 
 
-def test_preserves_comment_on_untouched_key(tmp_path: Path) -> None:
+def test_preserves_comment_on_untouched_key(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("# my custom note\nauto_save: false\n", encoding="utf-8")
 
@@ -37,7 +37,7 @@ def test_preserves_comment_on_untouched_key(tmp_path: Path) -> None:
     assert _parse(config_file) == {"auto_save": False, "with_image_data": True}
 
 
-def test_prunes_key_when_value_equals_default(tmp_path: Path) -> None:
+def test_prunes_key_when_value_equals_default(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text(
         "auto_save: false\nwith_image_data: true\n", encoding="utf-8"
@@ -49,7 +49,7 @@ def test_prunes_key_when_value_equals_default(tmp_path: Path) -> None:
     assert _parse(config_file) == {"with_image_data": True}
 
 
-def test_writes_nested_key(tmp_path: Path) -> None:
+def test_writes_nested_key(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(
@@ -61,7 +61,7 @@ def test_writes_nested_key(tmp_path: Path) -> None:
     assert _parse(config_file) == {"shape": {"point_size": 12}}
 
 
-def test_prunes_nested_key_and_empty_parent(tmp_path: Path) -> None:
+def test_prunes_nested_key_and_empty_parent(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("shape:\n  point_size: 12\n", encoding="utf-8")
 
@@ -73,7 +73,7 @@ def test_prunes_nested_key_and_empty_parent(tmp_path: Path) -> None:
     assert _parse(config_file) is None
 
 
-def test_keeps_sibling_when_pruning_nested_key(tmp_path: Path) -> None:
+def test_keeps_sibling_when_pruning_nested_key(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text(
         "shape:\n  point_size: 12\n  line_color: [1, 2, 3, 4]\n", encoding="utf-8"
@@ -86,7 +86,7 @@ def test_keeps_sibling_when_pruning_nested_key(tmp_path: Path) -> None:
     assert _parse(config_file) == {"shape": {"line_color": [1, 2, 3, 4]}}
 
 
-def test_toggle_then_revert_is_idempotent(tmp_path: Path) -> None:
+def test_toggle_then_revert_is_idempotent(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(
@@ -99,7 +99,7 @@ def test_toggle_then_revert_is_idempotent(tmp_path: Path) -> None:
     assert _parse(config_file) is None
 
 
-def test_writes_list_in_flow_style(tmp_path: Path) -> None:
+def test_writes_list_in_flow_style(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(
@@ -110,7 +110,9 @@ def test_writes_list_in_flow_style(tmp_path: Path) -> None:
     assert "color: [255, 0, 0]" in config_file.read_text(encoding="utf-8")
 
 
-def test_nested_shape_color_write_migrates_legacy_scalar_config(tmp_path: Path) -> None:
+def test_nested_shape_color_write_migrates_legacy_scalar_config(
+    *, tmp_path: Path
+) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text(
         "shape_color: manual\nlabel_colors:\n  cat: [1, 2, 3]\n",
@@ -135,7 +137,9 @@ def test_nested_shape_color_write_migrates_legacy_scalar_config(tmp_path: Path) 
     assert config["shape_color"]["by_label"]["fallback"] == [4, 5, 6]
 
 
-def test_nested_shape_color_write_removes_legacy_sibling_keys(tmp_path: Path) -> None:
+def test_nested_shape_color_write_removes_legacy_sibling_keys(
+    *, tmp_path: Path
+) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text(
         "default_shape_color: [1, 2, 3]\n",
@@ -157,7 +161,7 @@ def test_nested_shape_color_write_removes_legacy_sibling_keys(tmp_path: Path) ->
     _config.load_config(config_file=config_file, config_overrides={})
 
 
-def test_shape_color_write_rejects_invalid_legacy_values(tmp_path: Path) -> None:
+def test_shape_color_write_rejects_invalid_legacy_values(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     original = "shape_color: manual\nshift_auto_shape_color: invalid\n"
     config_file.write_text(original, encoding="utf-8")
@@ -171,7 +175,7 @@ def test_shape_color_write_rejects_invalid_legacy_values(tmp_path: Path) -> None
     assert config_file.read_text(encoding="utf-8") == original
 
 
-def test_shape_color_write_rejects_invalid_new_value(tmp_path: Path) -> None:
+def test_shape_color_write_rejects_invalid_new_value(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     original = "shape_color: manual\n"
     config_file.write_text(original, encoding="utf-8")
@@ -185,7 +189,7 @@ def test_shape_color_write_rejects_invalid_new_value(tmp_path: Path) -> None:
     assert config_file.read_text(encoding="utf-8") == original
 
 
-def test_set_overrides_applies_batch_in_one_write(tmp_path: Path) -> None:
+def test_set_overrides_applies_batch_in_one_write(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("auto_save: false\n", encoding="utf-8")
 
@@ -199,7 +203,7 @@ def test_set_overrides_applies_batch_in_one_write(tmp_path: Path) -> None:
     assert _parse(config_file) == {"shape": {"point_size": 12}}
 
 
-def test_set_overrides_bad_key_leaves_file_untouched(tmp_path: Path) -> None:
+def test_set_overrides_bad_key_leaves_file_untouched(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("auto_save: false\n", encoding="utf-8")
 
@@ -213,7 +217,7 @@ def test_set_overrides_bad_key_leaves_file_untouched(tmp_path: Path) -> None:
     assert _parse(config_file) == {"auto_save": False}
 
 
-def test_label_named_like_a_boolean_survives_round_trip(tmp_path: Path) -> None:
+def test_label_named_like_a_boolean_survives_round_trip(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(
@@ -224,21 +228,21 @@ def test_label_named_like_a_boolean_survives_round_trip(tmp_path: Path) -> None:
     assert config["labels"] == ["yes", "no"]
 
 
-def test_empty_key_path_raises(tmp_path: Path) -> None:
+def test_empty_key_path_raises(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     with pytest.raises(ValueError, match="key_path must not be empty"):
         _config.set_overrides(config_file=config_file, overrides=[([], 1)])
 
 
-def test_unknown_key_raises(tmp_path: Path) -> None:
+def test_unknown_key_raises(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     with pytest.raises(ValueError, match="Unknown config key"):
         _config.set_overrides(config_file=config_file, overrides=[(["nope"], 1)])
 
 
-def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
+def test_raises_when_parent_key_is_not_a_mapping(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("shape: 42\n", encoding="utf-8")
 
@@ -248,7 +252,7 @@ def test_raises_when_parent_key_is_not_a_mapping(tmp_path: Path) -> None:
         )
 
 
-def test_overwrites_when_top_level_is_not_a_mapping(tmp_path: Path) -> None:
+def test_overwrites_when_top_level_is_not_a_mapping(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("- one\n- two\n", encoding="utf-8")
 
@@ -257,7 +261,7 @@ def test_overwrites_when_top_level_is_not_a_mapping(tmp_path: Path) -> None:
     assert _parse(config_file) == {"auto_save": False}
 
 
-def test_empties_file_when_last_override_pruned(tmp_path: Path) -> None:
+def test_empties_file_when_last_override_pruned(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
     config_file.write_text("auto_save: false\n", encoding="utf-8")
 
@@ -267,7 +271,7 @@ def test_empties_file_when_last_override_pruned(tmp_path: Path) -> None:
     assert config_file.read_text(encoding="utf-8") == ""
 
 
-def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
+def test_written_file_reloads_via_load_config(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(config_file=config_file, overrides=[(["auto_save"], False)])
@@ -283,7 +287,7 @@ def test_written_file_reloads_via_load_config(tmp_path: Path) -> None:
     assert config["with_image_data"] is False
 
 
-def test_non_ascii_label_round_trips(tmp_path: Path) -> None:
+def test_non_ascii_label_round_trips(*, tmp_path: Path) -> None:
     config_file = tmp_path / ".labelmerc"
 
     _config.set_overrides(
@@ -294,7 +298,7 @@ def test_non_ascii_label_round_trips(tmp_path: Path) -> None:
     assert config["labels"] == ["ラベル", "café"]
 
 
-def test_non_ascii_label_round_trips_under_non_utf8_locale(tmp_path: Path) -> None:
+def test_non_ascii_label_round_trips_under_non_utf8_locale(*, tmp_path: Path) -> None:
     # The default text encoding is fixed at interpreter startup, so the only way
     # to exercise a non-UTF-8 locale is to relaunch Python. The script goes to a
     # file rather than `python -c`: source files are decoded as UTF-8 regardless
@@ -339,7 +343,7 @@ def test_non_ascii_label_round_trips_under_non_utf8_locale(tmp_path: Path) -> No
 
 
 def test_write_failure_leaves_no_temp_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config_file = tmp_path / ".labelmerc"
 

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -27,7 +27,7 @@ from labelme._label_file import write_label_file
 from labelme._utils import img_arr_to_b64
 
 
-def test_read_label_file_load_windows_path(data_path: Path, tmp_path: Path) -> None:
+def test_read_label_file_load_windows_path(*, data_path: Path, tmp_path: Path) -> None:
     """Test that read_label_file loads JSON with Windows-style backslash paths.
 
     Regression test for https://github.com/wkentaro/labelme/issues/1725
@@ -52,14 +52,14 @@ def test_read_label_file_load_windows_path(data_path: Path, tmp_path: Path) -> N
 
 
 @pytest.fixture()
-def annotated_raw(data_path: Path) -> dict[str, Any]:
+def annotated_raw(*, data_path: Path) -> dict[str, Any]:
     src = data_path / "annotated" / "2011_000003.json"
     with open(src) as f:
         return json.load(f)
 
 
 @pytest.fixture()
-def annotated_dst(data_path: Path, tmp_path: Path) -> Path:
+def annotated_dst(*, data_path: Path, tmp_path: Path) -> Path:
     shutil.copy(
         data_path / "annotated" / "2011_000003.jpg",
         tmp_path / "2011_000003.jpg",
@@ -72,7 +72,7 @@ def _dump_json(*, path: Path, raw: dict[str, Any]) -> None:
         json.dump(raw, f)
 
 
-def test_read_label_file_returns_label_data(data_path: Path) -> None:
+def test_read_label_file_returns_label_data(*, data_path: Path) -> None:
     label_data = read_label_file(
         filename=str(data_path / "annotated" / "2011_000003.json")
     )
@@ -83,6 +83,7 @@ def test_read_label_file_returns_label_data(data_path: Path) -> None:
 
 
 def test_read_label_file_extracts_other_data(
+    *,
     annotated_raw: dict[str, Any],
     annotated_dst: Path,
 ) -> None:
@@ -129,6 +130,7 @@ def test_read_label_file_extracts_other_data(
     ],
 )
 def test_read_label_file_raises_read_error_on_malformed(
+    *,
     annotated_raw: dict[str, Any],
     annotated_dst: Path,
     mutator: Callable[[dict[str, Any]], Any],
@@ -185,6 +187,7 @@ def test_read_label_file_raises_read_error_on_malformed(
     ],
 )
 def test_read_label_file_raises_on_malformed_shape_field(
+    *,
     annotated_raw: dict[str, Any],
     annotated_dst: Path,
     break_shape: Callable[[dict[str, Any]], Any],
@@ -234,7 +237,7 @@ def sample_mask() -> NDArray[np.bool_]:
     ],
 )
 def test_load_shape_json_obj_accepts_supported_geometry(
-    shape_type: str, points: list[list[float]]
+    *, shape_type: str, points: list[list[float]]
 ) -> None:
     loaded = _load_shape_json_obj(
         shape_json_obj={
@@ -249,6 +252,7 @@ def test_load_shape_json_obj_accepts_supported_geometry(
 
 
 def test_load_shape_json_obj_accepts_out_of_bounds_mask_shape(
+    *,
     sample_mask: NDArray[np.bool_],
 ) -> None:
     loaded = _load_shape_json_obj(
@@ -279,7 +283,7 @@ def test_load_shape_json_obj_accepts_out_of_bounds_mask_shape(
     ],
 )
 def test_load_shape_json_obj_rejects_wrong_point_count(
-    shape_type: str, points: list[list[float]]
+    *, shape_type: str, points: list[list[float]]
 ) -> None:
     shape_json_obj: dict[str, Any] = {
         "label": "shape",
@@ -327,6 +331,7 @@ def test_load_shape_json_obj_requires_mask_for_mask_shape() -> None:
 
 
 def test_load_shape_json_obj_rejects_mask_for_non_mask_shape(
+    *,
     sample_mask: NDArray[np.bool_],
 ) -> None:
     with pytest.raises(ValueError, match="mask"):
@@ -353,6 +358,7 @@ def test_load_shape_json_obj_rejects_multichannel_mask() -> None:
 
 
 def test_load_shape_json_obj_accepts_mask_extent_mismatch(
+    *,
     sample_mask: NDArray[np.bool_],
 ) -> None:
     # Fractional whole-shape drags shift points without resampling the mask,
@@ -371,6 +377,7 @@ def test_load_shape_json_obj_accepts_mask_extent_mismatch(
 
 
 def test_read_label_file_reports_shape_index_field_and_filename(
+    *,
     annotated_raw: dict[str, Any],
     annotated_dst: Path,
 ) -> None:
@@ -390,6 +397,7 @@ def test_read_label_file_reports_shape_index_field_and_filename(
 
 
 def test_read_label_file_wraps_coordinate_overflow(
+    *,
     annotated_raw: dict[str, Any],
     annotated_dst: Path,
 ) -> None:
@@ -482,6 +490,7 @@ def test_load_shape_json_obj_buckets_unknown_keys_into_other_data() -> None:
 
 
 def test_load_shape_json_obj_decodes_mask_to_bool_array(
+    *,
     sample_mask: NDArray[np.bool_],
 ) -> None:
     loaded = _load_shape_json_obj(
@@ -524,7 +533,7 @@ def test_dump_shape_to_json_obj_without_mask() -> None:
     }
 
 
-def test_shape_codec_round_trips_mask(sample_mask: NDArray[np.bool_]) -> None:
+def test_shape_codec_round_trips_mask(*, sample_mask: NDArray[np.bool_]) -> None:
     shape = ShapeDict(
         label="thing",
         points=[[0.0, 0.0], [4.0, 3.0]],
@@ -542,7 +551,7 @@ def test_shape_codec_round_trips_mask(sample_mask: NDArray[np.bool_]) -> None:
     assert np.array_equal(reloaded["mask"], sample_mask)
 
 
-def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:
+def test_write_label_file_round_trips(*, data_path: Path, tmp_path: Path) -> None:
     src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
     dst = tmp_path / "out.json"
 
@@ -571,7 +580,7 @@ def test_write_label_file_round_trips(data_path: Path, tmp_path: Path) -> None:
 
 
 def test_write_label_file_round_trips_mask_shape(
-    data_path: Path, annotated_dst: Path
+    *, data_path: Path, annotated_dst: Path
 ) -> None:
     src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
     mask = np.zeros((4, 5), dtype=bool)
@@ -624,13 +633,14 @@ def annotation_to_write() -> Annotation:
 
 
 @pytest.fixture()
-def existing_label_file(tmp_path: Path) -> Path:
+def existing_label_file(*, tmp_path: Path) -> Path:
     filename = tmp_path / "annotation.json"
     filename.write_text("last good", encoding="utf-8")
     return filename
 
 
 def test_write_label_file_atomically_replaces_existing_file(
+    *,
     annotation_to_write: Annotation,
     existing_label_file: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -666,6 +676,7 @@ def test_write_label_file_atomically_replaces_existing_file(
 
 @pytest.mark.skipif(os.name == "nt", reason="requires POSIX file modes")
 def test_write_label_file_preserves_existing_file_mode(
+    *,
     annotation_to_write: Annotation,
     existing_label_file: Path,
 ) -> None:
@@ -684,6 +695,7 @@ def test_write_label_file_preserves_existing_file_mode(
 
 @pytest.mark.skipif(os.name == "nt", reason="requires POSIX file modes")
 def test_write_label_file_uses_default_mode_for_new_file(
+    *,
     annotation_to_write: Annotation,
     tmp_path: Path,
 ) -> None:
@@ -706,6 +718,7 @@ def test_write_label_file_uses_default_mode_for_new_file(
 
 @pytest.mark.skipif(os.name == "nt", reason="requires POSIX filename limits")
 def test_write_label_file_supports_long_filename(
+    *,
     annotation_to_write: Annotation,
     tmp_path: Path,
 ) -> None:
@@ -724,6 +737,7 @@ def test_write_label_file_supports_long_filename(
 
 
 def test_write_label_file_serialization_failure_preserves_existing_file(
+    *,
     annotation_to_write: Annotation,
     existing_label_file: Path,
 ) -> None:
@@ -749,6 +763,7 @@ def test_write_label_file_serialization_failure_preserves_existing_file(
 
 
 def test_write_label_file_write_failure_preserves_existing_file(
+    *,
     annotation_to_write: Annotation,
     existing_label_file: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -773,6 +788,7 @@ def test_write_label_file_write_failure_preserves_existing_file(
 
 
 def test_write_label_file_close_failure_preserves_existing_file(
+    *,
     annotation_to_write: Annotation,
     existing_label_file: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -799,6 +815,7 @@ def test_write_label_file_close_failure_preserves_existing_file(
 
 
 def test_write_label_file_replacement_failure_preserves_existing_file(
+    *,
     annotation_to_write: Annotation,
     existing_label_file: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -834,7 +851,7 @@ def test_write_label_file_replacement_failure_preserves_existing_file(
     ],
 )
 def test_write_label_file_rejects_reserved_other_data_key(
-    tmp_path: Path, reserved_key: str
+    *, tmp_path: Path, reserved_key: str
 ) -> None:
     annotation = Annotation(
         image_path="foo.jpg",
@@ -854,7 +871,7 @@ def test_write_label_file_rejects_reserved_other_data_key(
 
 
 def test_write_label_file_raises_on_dimension_mismatch(
-    data_path: Path, tmp_path: Path
+    *, data_path: Path, tmp_path: Path
 ) -> None:
     src = read_label_file(filename=str(data_path / "annotated" / "2011_000003.json"))
     annotation = Annotation(
@@ -875,7 +892,7 @@ def test_write_label_file_raises_on_dimension_mismatch(
         )
 
 
-def test_write_label_file_raises_write_error_on_io_failure(tmp_path: Path) -> None:
+def test_write_label_file_raises_write_error_on_io_failure(*, tmp_path: Path) -> None:
     bad_path = tmp_path / "missing_dir" / "out.json"
     annotation = Annotation(
         image_path="foo.jpg",
@@ -933,18 +950,18 @@ def test_normalize_to_uint8_maps_non_finite_pixels_deterministically() -> None:
         ("dir.json/foo.png", False),
     ],
 )
-def test_is_label_file_path(filename: str, *, expected: bool) -> None:
+def test_is_label_file_path(*, filename: str, expected: bool) -> None:
     assert is_label_file_path(filename=filename) is expected
 
 
 @pytest.fixture()
-def sample_image_data(data_path: Path) -> bytes:
+def sample_image_data(*, data_path: Path) -> bytes:
     return read_label_file(
         filename=str(data_path / "annotated" / "2011_000003.json")
     ).image_data
 
 
-def test_check_image_dimensions_both_none_is_noop(sample_image_data: bytes) -> None:
+def test_check_image_dimensions_both_none_is_noop(*, sample_image_data: bytes) -> None:
     result = _check_image_dimensions(
         image_data=sample_image_data,
         expected_height=None,
@@ -954,6 +971,7 @@ def test_check_image_dimensions_both_none_is_noop(sample_image_data: bytes) -> N
 
 
 def test_check_image_dimensions_accepts_matching_dimensions(
+    *,
     sample_image_data: bytes,
 ) -> None:
     # The image embedded in 2011_000003.json is 500x338.
@@ -973,6 +991,7 @@ def test_check_image_dimensions_accepts_matching_dimensions(
     ids=["height_mismatch", "width_mismatch"],
 )
 def test_check_image_dimensions_raises_on_mismatch(
+    *,
     sample_image_data: bytes,
     expected_height: int | None,
     expected_width: int | None,

--- a/tests/unit/_label_file_test.py
+++ b/tests/unit/_label_file_test.py
@@ -934,7 +934,7 @@ def test_normalize_to_uint8_maps_non_finite_pixels_deterministically() -> None:
     ],
 )
 def test_is_label_file_path(filename: str, *, expected: bool) -> None:
-    assert is_label_file_path(filename) is expected
+    assert is_label_file_path(filename=filename) is expected
 
 
 @pytest.fixture()

--- a/tests/unit/_shape_clipboard_test.py
+++ b/tests/unit/_shape_clipboard_test.py
@@ -78,7 +78,7 @@ def test_store_preserves_all_shapes_in_order() -> None:
     ],
 )
 def test_availability_changed_emits_only_on_emptiness_transitions(
-    prior_count: int, new_count: int, expected_emissions: list[bool]
+    *, prior_count: int, new_count: int, expected_emissions: list[bool]
 ) -> None:
     clipboard = ShapeClipboard()
     clipboard.store(shapes=[_make_polygon() for _ in range(prior_count)])

--- a/tests/unit/_shape_clipboard_test.py
+++ b/tests/unit/_shape_clipboard_test.py
@@ -23,7 +23,7 @@ def test_paste_returns_independent_copies_each_call() -> None:
     # Regression guard: paste() must hand out fresh copies so editing one
     # pasted shape never mutates a later paste of the same buffer.
     clipboard = ShapeClipboard()
-    clipboard.store([_make_polygon()])
+    clipboard.store(shapes=[_make_polygon()])
 
     first = clipboard.paste()
     second = clipboard.paste()
@@ -38,7 +38,7 @@ def test_store_snapshots_shapes_at_store_time() -> None:
     # leak into the buffer.
     clipboard = ShapeClipboard()
     source = _make_polygon()
-    clipboard.store([source])
+    clipboard.store(shapes=[source])
 
     source.move_vertex(i=0, pos=(99.0, 99.0))
 
@@ -52,7 +52,7 @@ def test_store_preserves_all_shapes_in_order() -> None:
     second.label = "second"
     clipboard = ShapeClipboard()
 
-    clipboard.store([first, second])
+    clipboard.store(shapes=[first, second])
     pasted = clipboard.paste()
 
     assert [shape.label for shape in pasted] == ["first", "second"]
@@ -81,10 +81,10 @@ def test_availability_changed_emits_only_on_emptiness_transitions(
     prior_count: int, new_count: int, expected_emissions: list[bool]
 ) -> None:
     clipboard = ShapeClipboard()
-    clipboard.store([_make_polygon() for _ in range(prior_count)])
+    clipboard.store(shapes=[_make_polygon() for _ in range(prior_count)])
     emissions: list[bool] = []
     clipboard.availability_changed.connect(emissions.append)
 
-    clipboard.store([_make_polygon() for _ in range(new_count)])
+    clipboard.store(shapes=[_make_polygon() for _ in range(new_count)])
 
     assert emissions == expected_emissions

--- a/tests/unit/_shape_color_test.py
+++ b/tests/unit/_shape_color_test.py
@@ -53,5 +53,5 @@ from labelme._shape_color import resolve_shape_color
     ],
     ids=["auto", "uniform", "by-label-match", "by-label-fallback"],
 )
-def test_resolve_shape_color(config: dict, expected: tuple[int, int, int]) -> None:
+def test_resolve_shape_color(*, config: dict, expected: tuple[int, int, int]) -> None:
     assert resolve_shape_color(config=config, label="cat", label_index=0) == expected

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -200,7 +200,7 @@ def _make_open_linestrip() -> Shape:
         ("mask", False),
     ],
 )
-def test_can_add_point(shape_type: ShapeType, *, expected: bool) -> None:
+def test_can_add_point(*, shape_type: ShapeType, expected: bool) -> None:
     assert Shape(shape_type=shape_type).can_add_point() is expected
 
 
@@ -398,7 +398,7 @@ def test_translate_shifts_all_points_by_offset() -> None:
     ],
 )
 def test_nearest_edge_index_matches_edge_under_point(
-    point: tuple[float, float], expected_edge: int
+    *, point: tuple[float, float], expected_edge: int
 ) -> None:
     shape = _make_square_polygon()
 
@@ -515,7 +515,7 @@ def test_nearest_vertex_index_returns_none_for_empty_shape() -> None:
     ],
 )
 def test_get_rotation_handle_returns_edge_midpoints(
-    index: int, expected: tuple[float, float]
+    *, index: int, expected: tuple[float, float]
 ) -> None:
     shape = _make_axis_aligned_oriented_rectangle()
 

--- a/tests/unit/_yaml_test.py
+++ b/tests/unit/_yaml_test.py
@@ -29,6 +29,6 @@ def test_safe_load_returns_none_for_empty_string() -> None:
         "!!python/module:os",
     ],
 )
-def test_safe_load_rejects_unsafe_python_tag(payload: str) -> None:
+def test_safe_load_rejects_unsafe_python_tag(*, payload: str) -> None:
     with pytest.raises(YAMLError):
         _yaml.safe_load(payload)

--- a/tests/unit/examples/utils_test.py
+++ b/tests/unit/examples/utils_test.py
@@ -33,7 +33,9 @@ def _mask_shape(
 def test_shapes_to_label_mask_paints_bbox_pixels() -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[2.0, 1.0], [6.0, 3.0]], mask=patch)
-    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = utils.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[1:4, 2:7] = True
     assert np.array_equal(cls > 0, painted)
@@ -42,14 +44,18 @@ def test_shapes_to_label_mask_paints_bbox_pixels() -> None:
 def test_shapes_to_label_mask_clips_bbox_off_left_edge() -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[-6.0, 1.0], [-2.0, 3.0]], mask=patch)
-    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = utils.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     assert not (cls > 0).any()
 
 
 def test_shapes_to_label_mask_clips_bbox_over_right_edge() -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[17.0, 1.0], [21.0, 3.0]], mask=patch)
-    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = utils.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[1:4, 17:20] = True
     assert np.array_equal(cls > 0, painted)
@@ -60,7 +66,9 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     patch[1, 2] = True  # -> canvas (0, 0)
     patch[4, 4] = True  # -> canvas (3, 2)
     shape = _mask_shape(points=[[-2.0, -1.0], [2.0, 3.0]], mask=patch)
-    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = utils.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[0, 0] = True
     painted[3, 2] = True
@@ -80,7 +88,9 @@ def test_shapes_to_label_mask_rounds_origin_without_cropping_mask(
 ) -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=points, mask=patch)
-    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = utils.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     x, y = expected_origin
     painted[y : y + patch.shape[0], x : x + patch.shape[1]] = True
@@ -90,7 +100,9 @@ def test_shapes_to_label_mask_rounds_origin_without_cropping_mask(
 def test_shapes_to_label_mask_keeps_integer_bbox_extent() -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[2.0, 1.0], [4.0, 3.0]], mask=patch)
-    cls, _ = utils.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = utils.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[1:4, 2:5] = True
     assert np.array_equal(cls > 0, painted)

--- a/tests/unit/examples/utils_test.py
+++ b/tests/unit/examples/utils_test.py
@@ -84,7 +84,7 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     ids=["different-fractions", "ties-to-even"],
 )
 def test_shapes_to_label_mask_rounds_origin_without_cropping_mask(
-    points: list[list[float]], expected_origin: tuple[int, int]
+    *, points: list[list[float]], expected_origin: tuple[int, int]
 ) -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=points, mask=patch)
@@ -130,7 +130,7 @@ def _make_source_rgb() -> PIL.Image.Image:
 
 @pytest.mark.parametrize("mode", _SOURCE_MODES)
 def test_decode_img_data_as_rgb_returns_rgb_for_every_source_mode(
-    mode: str, source_rgb: PIL.Image.Image
+    *, mode: str, source_rgb: PIL.Image.Image
 ) -> None:
     arr = utils.decode_img_data_as_rgb(_encode_png(source_rgb.convert(mode)))
     assert arr.dtype == np.uint8
@@ -139,7 +139,7 @@ def test_decode_img_data_as_rgb_returns_rgb_for_every_source_mode(
 
 @pytest.mark.parametrize("mode", _SOURCE_MODES)
 def test_decode_img_data_as_rgb_output_is_jpeg_writable(
-    mode: str, source_rgb: PIL.Image.Image
+    *, mode: str, source_rgb: PIL.Image.Image
 ) -> None:
     # The reported crash: the VOC converters write the decoded array as JPEG,
     # which cannot represent an alpha channel.
@@ -148,6 +148,7 @@ def test_decode_img_data_as_rgb_output_is_jpeg_writable(
 
 
 def test_decode_img_data_as_rgb_resolves_palette_colors(
+    *,
     source_rgb: PIL.Image.Image,
 ) -> None:
     arr = utils.decode_img_data_as_rgb(_encode_png(source_rgb.convert("P")))
@@ -155,6 +156,7 @@ def test_decode_img_data_as_rgb_resolves_palette_colors(
 
 
 def test_decode_img_data_as_rgb_discards_alpha_without_compositing(
+    *,
     source_rgb: PIL.Image.Image,
 ) -> None:
     rgba = source_rgb.convert("RGBA")

--- a/tests/unit/read_image_file_test.py
+++ b/tests/unit/read_image_file_test.py
@@ -19,19 +19,19 @@ def _make_image(tmp_path: Path, /, *, filename: str, mode: str) -> Path:
     return path
 
 
-def test_tiff_without_alpha_encoded_as_jpeg(tmp_path: Path) -> None:
+def test_tiff_without_alpha_encoded_as_jpeg(*, tmp_path: Path) -> None:
     path = _make_image(tmp_path, filename="test.tiff", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data[:2] == b"\xff\xd8"
 
 
-def test_tiff_with_alpha_encoded_as_png(tmp_path: Path) -> None:
+def test_tiff_with_alpha_encoded_as_png(*, tmp_path: Path) -> None:
     path = _make_image(tmp_path, filename="test.tiff", mode="RGBA")
     data = read_image_file(filename=str(path))
     assert data[:4] == b"\x89PNG"
 
 
-def test_corrupt_tiff_raises_os_error(tmp_path: Path) -> None:
+def test_corrupt_tiff_raises_os_error(*, tmp_path: Path) -> None:
     path = tmp_path / "corrupt.tiff"
     path.write_bytes(b"II*\x00")
 
@@ -39,20 +39,22 @@ def test_corrupt_tiff_raises_os_error(tmp_path: Path) -> None:
         read_image_file(filename=str(path))
 
 
-def test_jpeg_returns_raw_bytes(tmp_path: Path) -> None:
+def test_jpeg_returns_raw_bytes(*, tmp_path: Path) -> None:
     path = _make_image(tmp_path, filename="test.jpg", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 
 
-def test_png_returns_raw_bytes(tmp_path: Path) -> None:
+def test_png_returns_raw_bytes(*, tmp_path: Path) -> None:
     path = _make_image(tmp_path, filename="test.png", mode="RGB")
     data = read_image_file(filename=str(path))
     assert data == path.read_bytes()
 
 
 @pytest.mark.parametrize("ext", ["gif", "bmp"])
-def test_palette_image_without_alpha_encoded_as_jpeg(tmp_path: Path, ext: str) -> None:
+def test_palette_image_without_alpha_encoded_as_jpeg(
+    *, tmp_path: Path, ext: str
+) -> None:
     arr = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
     path = tmp_path / f"test.{ext}"
     PIL.Image.fromarray(arr, mode="RGB").convert("P").save(str(path))
@@ -62,7 +64,7 @@ def test_palette_image_without_alpha_encoded_as_jpeg(tmp_path: Path, ext: str) -
     assert data[:2] == b"\xff\xd8"
 
 
-def test_transparent_palette_gif_encoded_as_png(tmp_path: Path) -> None:
+def test_transparent_palette_gif_encoded_as_png(*, tmp_path: Path) -> None:
     arr = np.random.randint(0, 255, (100, 100, 4), dtype=np.uint8)
     arr[:20, :20, 3] = 0
     path = tmp_path / "test.gif"
@@ -76,7 +78,7 @@ def test_transparent_palette_gif_encoded_as_png(tmp_path: Path) -> None:
     assert "transparency" in PIL.Image.open(io.BytesIO(data)).info
 
 
-def test_palette_with_alpha_tiff_encoded_as_png(tmp_path: Path) -> None:
+def test_palette_with_alpha_tiff_encoded_as_png(*, tmp_path: Path) -> None:
     path = tmp_path / "test.tiff"
     PIL.Image.new("PA", (100, 100)).save(str(path))
     assert PIL.Image.open(str(path)).mode == "PA"
@@ -85,7 +87,7 @@ def test_palette_with_alpha_tiff_encoded_as_png(tmp_path: Path) -> None:
     assert data[:4] == b"\x89PNG"
 
 
-def test_bilevel_image_encoded_as_jpeg_without_widening(tmp_path: Path) -> None:
+def test_bilevel_image_encoded_as_jpeg_without_widening(*, tmp_path: Path) -> None:
     path = tmp_path / "test.bmp"
     PIL.Image.new("1", (100, 100)).save(str(path))
     assert PIL.Image.open(str(path)).mode == "1"
@@ -95,7 +97,7 @@ def test_bilevel_image_encoded_as_jpeg_without_widening(tmp_path: Path) -> None:
     assert PIL.Image.open(io.BytesIO(data)).mode == "L"
 
 
-def test_multispectral_tiff_float32(tmp_path: Path) -> None:
+def test_multispectral_tiff_float32(*, tmp_path: Path) -> None:
     arr = np.random.rand(64, 64, 5).astype(np.float32) * 0.5
     path = tmp_path / "multispectral.tif"
     tifffile.imwrite(str(path), arr)
@@ -108,7 +110,7 @@ def test_multispectral_tiff_float32(tmp_path: Path) -> None:
     assert img.size == (64, 64)
 
 
-def test_grayscale_tiff_float32(tmp_path: Path) -> None:
+def test_grayscale_tiff_float32(*, tmp_path: Path) -> None:
     arr = np.random.rand(64, 64).astype(np.float32)
     path = tmp_path / "grayscale.tif"
     tifffile.imwrite(str(path), arr)
@@ -118,7 +120,7 @@ def test_grayscale_tiff_float32(tmp_path: Path) -> None:
     assert img.size == (64, 64)
 
 
-def test_constant_value_tiff_returns_black(tmp_path: Path) -> None:
+def test_constant_value_tiff_returns_black(*, tmp_path: Path) -> None:
     arr = np.full((64, 64), 42.0, dtype=np.float32)
     path = tmp_path / "constant.tif"
     tifffile.imwrite(str(path), arr)
@@ -129,7 +131,7 @@ def test_constant_value_tiff_returns_black(tmp_path: Path) -> None:
     assert np.array(img).max() == 0
 
 
-def test_two_band_tiff_falls_back_to_first_band(tmp_path: Path) -> None:
+def test_two_band_tiff_falls_back_to_first_band(*, tmp_path: Path) -> None:
     arr = np.random.rand(64, 64, 2).astype(np.float32)
     path = tmp_path / "twoband.tif"
     tifffile.imwrite(str(path), arr)

--- a/tests/unit/tools/artifact_install_smoke_test.py
+++ b/tests/unit/tools/artifact_install_smoke_test.py
@@ -9,7 +9,7 @@ from tools.artifact_install_smoke import _check_packaged_resources
 
 
 def test_check_packaged_resources_rejects_corrupt_translation(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A truncated .qm is the failure mode QTranslator.load() swallows silently,
     # so it is the one case a stat-based check would wrongly pass. A real build

--- a/tests/unit/utils/image_test.py
+++ b/tests/unit/utils/image_test.py
@@ -125,6 +125,7 @@ def _find_brightest_red_rowcol(image: PIL.Image.Image, /) -> tuple[int, int]:
     ],
 )
 def test_apply_exif_orientation_transforms_marker(
+    *,
     orientation: int,
     expected_size: tuple[int, int],
     expected_rowcol: tuple[int, int],

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -365,7 +365,7 @@ def test_add_actions_adds_qaction_to_menu(qtbot: QtBot) -> None:
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
     action = QtGui.QAction("Cut", parent)
-    add_actions(menu, [action])
+    add_actions(widget=menu, actions=[action])
     assert action in menu.actions()
 
 
@@ -374,7 +374,7 @@ def test_add_actions_none_adds_separator_to_menu(qtbot: QtBot) -> None:
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
     action = QtGui.QAction("Cut", parent)
-    add_actions(menu, [action, None])
+    add_actions(widget=menu, actions=[action, None])
     separators = [a for a in menu.actions() if a.isSeparator()]
     assert len(separators) == 1
 
@@ -384,7 +384,7 @@ def test_add_actions_submenu_to_menu(qtbot: QtBot) -> None:
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
     submenu = QtWidgets.QMenu("Sub", parent)
-    add_actions(menu, [submenu])
+    add_actions(widget=menu, actions=[submenu])
     # QMenu added as submenu appears in actions list
     titles = [a.text() for a in menu.actions()]
     assert "Sub" in titles
@@ -394,7 +394,7 @@ def test_add_actions_adds_qaction_to_toolbar(qtbot: QtBot) -> None:
     toolbar = QtWidgets.QToolBar()
     qtbot.addWidget(toolbar)
     action = QtGui.QAction("Copy", toolbar)
-    add_actions(toolbar, [action])
+    add_actions(widget=toolbar, actions=[action])
     assert action in toolbar.actions()
 
 
@@ -402,7 +402,7 @@ def test_add_actions_none_adds_separator_to_toolbar(qtbot: QtBot) -> None:
     toolbar = QtWidgets.QToolBar()
     qtbot.addWidget(toolbar)
     action = QtGui.QAction("Copy", toolbar)
-    add_actions(toolbar, [action, None])
+    add_actions(widget=toolbar, actions=[action, None])
     separators = [a for a in toolbar.actions() if a.isSeparator()]
     assert len(separators) == 1
 
@@ -411,5 +411,5 @@ def test_add_actions_empty_sequence(qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
-    add_actions(menu, [])
+    add_actions(widget=menu, actions=[])
     assert menu.actions() == []

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -28,7 +28,7 @@ from labelme._utils.qt import project_point_on_perpendicular_line
         ((0.0, -5.0), -math.pi / 2),
     ],
 )
-def test_direction_angle(end: tuple[float, float], expected: float) -> None:
+def test_direction_angle(*, end: tuple[float, float], expected: float) -> None:
     assert direction_angle(start=(0.0, 0.0), end=end) == pytest.approx(expected)
 
 
@@ -41,7 +41,7 @@ def test_direction_angle(end: tuple[float, float], expected: float) -> None:
     ],
 )
 def test_project_point_on_perpendicular_line(
-    point: QPointF, expected: tuple[float, float]
+    *, point: QPointF, expected: tuple[float, float]
 ) -> None:
     projected = project_point_on_perpendicular_line(
         point=point, line_start=QPointF(0.0, 0.0), line_end=QPointF(10.0, 0.0)
@@ -66,7 +66,9 @@ def test_project_point_on_perpendicular_line_zero_length_returns_point() -> None
         (QPointF(4.0, 7.0), (4.0, 0.0)),
     ],
 )
-def test_project_point_on_line(point: QPointF, expected: tuple[float, float]) -> None:
+def test_project_point_on_line(
+    *, point: QPointF, expected: tuple[float, float]
+) -> None:
     projected = project_point_on_line(
         point=point, line_start=QPointF(0.0, 0.0), line_end=QPointF(10.0, 0.0)
     )
@@ -158,6 +160,7 @@ def _set_window_text(app: QtWidgets.QApplication, /, *, color: QtGui.QColor) -> 
 
 
 def test_tinted_svg_engine_renders_window_text_color(
+    *,
     qapp: QtWidgets.QApplication,
 ) -> None:
     original = qapp.palette()
@@ -177,6 +180,7 @@ def test_tinted_svg_engine_renders_window_text_color(
 
 
 def test_tinted_svg_engine_renders_highlighted_text_color_when_selected(
+    *,
     qapp: QtWidgets.QApplication,
 ) -> None:
     original = qapp.palette()
@@ -202,6 +206,7 @@ def test_tinted_svg_engine_renders_highlighted_text_color_when_selected(
 
 
 def test_new_icon_tints_monochrome_icon_to_palette(
+    *,
     qapp: QtWidgets.QApplication,
 ) -> None:
     original = qapp.palette()
@@ -216,7 +221,7 @@ def test_new_icon_tints_monochrome_icon_to_palette(
         qapp.setPalette(original)
 
 
-def test_new_icon_keeps_accent_icon_fixed(qapp: QtWidgets.QApplication) -> None:
+def test_new_icon_keeps_accent_icon_fixed(*, qapp: QtWidgets.QApplication) -> None:
     original = qapp.palette()
     try:
         icon = new_icon("phosphor/floppy-disk.svg")  # baked accent color, not tinted
@@ -234,70 +239,70 @@ def test_new_icon_keeps_accent_icon_fixed(qapp: QtWidgets.QApplication) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_new_action_returns_qaction(qtbot: QtBot) -> None:
+def test_new_action_returns_qaction(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="Open")
     assert isinstance(action, QtGui.QAction)
 
 
-def test_new_action_text(qtbot: QtBot) -> None:
+def test_new_action_text(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="Save")
     assert action.text() == "Save"
 
 
-def test_new_action_enabled_by_default(qtbot: QtBot) -> None:
+def test_new_action_enabled_by_default(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X")
     assert action.isEnabled()
 
 
-def test_new_action_disabled(qtbot: QtBot) -> None:
+def test_new_action_disabled(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", enabled=False)
     assert not action.isEnabled()
 
 
-def test_new_action_not_checkable_by_default(qtbot: QtBot) -> None:
+def test_new_action_not_checkable_by_default(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X")
     assert not action.isCheckable()
 
 
-def test_new_action_checkable(qtbot: QtBot) -> None:
+def test_new_action_checkable(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", checkable=True)
     assert action.isCheckable()
 
 
-def test_new_action_not_checked_by_default(qtbot: QtBot) -> None:
+def test_new_action_not_checked_by_default(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", checkable=True)
     assert not action.isChecked()
 
 
-def test_new_action_checked(qtbot: QtBot) -> None:
+def test_new_action_checked(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", checkable=True, checked=True)
     assert action.isChecked()
 
 
-def test_new_action_shortcut_string(qtbot: QtBot) -> None:
+def test_new_action_shortcut_string(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", shortcut="Ctrl+S")
     assert action.shortcut().toString() == "Ctrl+S"
 
 
-def test_new_action_shortcut_list(qtbot: QtBot) -> None:
+def test_new_action_shortcut_list(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", shortcut=["Ctrl+S", "Ctrl+W"])
@@ -306,7 +311,7 @@ def test_new_action_shortcut_list(qtbot: QtBot) -> None:
     assert "Ctrl+W" in keys
 
 
-def test_new_action_shortcut_tuple(qtbot: QtBot) -> None:
+def test_new_action_shortcut_tuple(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", shortcut=("Ctrl+S", "Ctrl+W"))
@@ -315,7 +320,7 @@ def test_new_action_shortcut_tuple(qtbot: QtBot) -> None:
     assert "Ctrl+W" in keys
 
 
-def test_new_action_tip(qtbot: QtBot) -> None:
+def test_new_action_tip(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     action = new_action(parent, text="X", tip="My tip")
@@ -323,7 +328,7 @@ def test_new_action_tip(qtbot: QtBot) -> None:
     assert action.statusTip() == "My tip"
 
 
-def test_new_action_no_tip_by_default(qtbot: QtBot) -> None:
+def test_new_action_no_tip_by_default(*, qtbot: QtBot) -> None:
     # Qt 6 behavior: toolTip() falls back to the action text when no tip is set;
     # statusTip() returns empty string.
     parent = QtWidgets.QWidget()
@@ -333,7 +338,7 @@ def test_new_action_no_tip_by_default(qtbot: QtBot) -> None:
     assert action.statusTip() == ""
 
 
-def test_new_action_with_icon_sets_icon_text(qtbot: QtBot) -> None:
+def test_new_action_with_icon_sets_icon_text(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     # Use an icon file that actually exists so Qt loads it as non-null.
@@ -346,7 +351,7 @@ def test_new_action_with_icon_sets_icon_text(qtbot: QtBot) -> None:
     assert not action.icon().isNull()
 
 
-def test_new_action_slot(qtbot: QtBot) -> None:
+def test_new_action_slot(*, qtbot: QtBot) -> None:
     calls: list[bool] = []
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
@@ -360,7 +365,7 @@ def test_new_action_slot(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_add_actions_adds_qaction_to_menu(qtbot: QtBot) -> None:
+def test_add_actions_adds_qaction_to_menu(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
@@ -369,7 +374,7 @@ def test_add_actions_adds_qaction_to_menu(qtbot: QtBot) -> None:
     assert action in menu.actions()
 
 
-def test_add_actions_none_adds_separator_to_menu(qtbot: QtBot) -> None:
+def test_add_actions_none_adds_separator_to_menu(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
@@ -379,7 +384,7 @@ def test_add_actions_none_adds_separator_to_menu(qtbot: QtBot) -> None:
     assert len(separators) == 1
 
 
-def test_add_actions_submenu_to_menu(qtbot: QtBot) -> None:
+def test_add_actions_submenu_to_menu(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
@@ -390,7 +395,7 @@ def test_add_actions_submenu_to_menu(qtbot: QtBot) -> None:
     assert "Sub" in titles
 
 
-def test_add_actions_adds_qaction_to_toolbar(qtbot: QtBot) -> None:
+def test_add_actions_adds_qaction_to_toolbar(*, qtbot: QtBot) -> None:
     toolbar = QtWidgets.QToolBar()
     qtbot.addWidget(toolbar)
     action = QtGui.QAction("Copy", toolbar)
@@ -398,7 +403,7 @@ def test_add_actions_adds_qaction_to_toolbar(qtbot: QtBot) -> None:
     assert action in toolbar.actions()
 
 
-def test_add_actions_none_adds_separator_to_toolbar(qtbot: QtBot) -> None:
+def test_add_actions_none_adds_separator_to_toolbar(*, qtbot: QtBot) -> None:
     toolbar = QtWidgets.QToolBar()
     qtbot.addWidget(toolbar)
     action = QtGui.QAction("Copy", toolbar)
@@ -407,7 +412,7 @@ def test_add_actions_none_adds_separator_to_toolbar(qtbot: QtBot) -> None:
     assert len(separators) == 1
 
 
-def test_add_actions_empty_sequence(qtbot: QtBot) -> None:
+def test_add_actions_empty_sequence(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -18,7 +18,9 @@ def test_shapes_to_label() -> None:
         label_value = len(label_name_to_value)
         label_name_to_value[label_name] = label_value
     cls, _ = shape_module.shapes_to_label(
-        img.shape, data["shapes"], label_name_to_value
+        img_shape=img.shape,
+        shapes=data["shapes"],
+        label_name_to_value=label_name_to_value,
     )
     assert cls.shape == img.shape[:2]
 
@@ -35,7 +37,9 @@ def test_shapes_to_label_raises_clear_error_for_unknown_label() -> None:
         other_data={},
     )
     with pytest.raises(ValueError, match="shape labels not in the provided labels"):
-        shape_module.shapes_to_label((20, 20), [shape], {"road": 1})
+        shape_module.shapes_to_label(
+            img_shape=(20, 20), shapes=[shape], label_name_to_value={"road": 1}
+        )
 
 
 def test_shapes_to_label_places_mask_shape_at_its_bbox() -> None:
@@ -54,7 +58,9 @@ def test_shapes_to_label_places_mask_shape_at_its_bbox() -> None:
         mask=patch,
         other_data={},
     )
-    cls, ins = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, ins = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     assert cls[3, 2] == 0  # patch[0, 0] is False, so the bbox corner stays empty
     assert cls[3, 3] == 1
     assert cls[5, 8] == 1  # bottom-right corner; a row/col swap would miss it
@@ -75,7 +81,9 @@ def test_shapes_to_label_raises_when_mask_shape_has_no_ndarray() -> None:
         other_data={},
     )
     with pytest.raises(ValueError, match=r"shape\['mask'\] must be numpy.ndarray"):
-        shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+        shape_module.shapes_to_label(
+            img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+        )
 
 
 def test_shapes_to_label_groups_instances_by_label_and_group_id() -> None:
@@ -96,7 +104,9 @@ def test_shapes_to_label_groups_instances_by_label_and_group_id() -> None:
         _rectangle([[10.0, 10.0], [14.0, 14.0]], group_id=2),
         _rectangle([[16.0, 16.0], [19.0, 19.0]], group_id=1),
     ]
-    cls, ins = shape_module.shapes_to_label((20, 20), shapes, {"car": 1})
+    cls, ins = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=shapes, label_name_to_value={"car": 1}
+    )
     assert cls[2, 2] == 1
     assert cls[12, 12] == 1
     assert cls[17, 17] == 1
@@ -121,7 +131,9 @@ def _mask_shape(*, points: list[list[float]], mask: NDArray[np.bool_]) -> ShapeD
 def test_shapes_to_label_mask_paints_bbox_pixels() -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[2.0, 1.0], [6.0, 3.0]], mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[1:4, 2:7] = True
     assert np.array_equal(cls > 0, painted)
@@ -132,7 +144,9 @@ def test_shapes_to_label_mask_clips_bbox_off_left_edge() -> None:
     # negative slice would wrap the patch onto the opposite edge instead (ADR 0004).
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[-6.0, 1.0], [-2.0, 3.0]], mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     assert not (cls > 0).any()
 
 
@@ -141,7 +155,9 @@ def test_shapes_to_label_mask_clips_bbox_over_right_edge() -> None:
     # clipped rather than raising a broadcast error (ADR 0004).
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[17.0, 1.0], [21.0, 3.0]], mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[1:4, 17:20] = True
     assert np.array_equal(cls > 0, painted)
@@ -156,7 +172,9 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
     patch[1, 2] = True  # -> canvas (0, 0)
     patch[4, 4] = True  # -> canvas (3, 2)
     shape = _mask_shape(points=[[-2.0, -1.0], [2.0, 3.0]], mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[0, 0] = True
     painted[3, 2] = True
@@ -166,7 +184,9 @@ def test_shapes_to_label_mask_clips_bbox_off_top_left_corner() -> None:
 def test_shapes_to_label_mask_keeps_integer_bbox_extent() -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=[[2.0, 1.0], [4.0, 3.0]], mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[1:4, 2:5] = True
     assert np.array_equal(cls > 0, painted)
@@ -187,7 +207,9 @@ def test_shapes_to_label_mask_rounds_fractional_bounds(
 ) -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=points, mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     x, y = expected_origin
     painted[y : y + patch.shape[0], x : x + patch.shape[1]] = True
@@ -199,7 +221,9 @@ def test_shapes_to_label_mask_rounds_negative_bounds_to_nearest_pixel() -> None:
     patch[2, 3] = True  # -> canvas (0, 0)
     patch[4, 4] = True  # -> canvas (2, 1)
     shape = _mask_shape(points=[[-2.6, -1.6], [1.4, 2.4]], mask=patch)
-    cls, _ = shape_module.shapes_to_label((20, 20), [shape], {"car": 1})
+    cls, _ = shape_module.shapes_to_label(
+        img_shape=(20, 20), shapes=[shape], label_name_to_value={"car": 1}
+    )
     painted = np.zeros((20, 20), dtype=bool)
     painted[0, 0] = True
     painted[2, 1] = True
@@ -217,8 +241,8 @@ def test_shape_to_mask() -> None:
 def test_shape_to_mask_oriented_rectangle_marks_inside_pixels() -> None:
     # Rect spans x in [0, 10], y in [0, 4]; mask is indexed (row=y, col=x).
     mask = shape_module.shape_to_mask(
-        img_shape=(20, 20),
-        points=[[0.0, 0.0], [10.0, 0.0], [10.0, 4.0], [0.0, 4.0]],
+        (20, 20),
+        [[0.0, 0.0], [10.0, 0.0], [10.0, 4.0], [0.0, 4.0]],
         shape_type="oriented_rectangle",
     )
     assert mask.dtype == bool
@@ -235,8 +259,8 @@ def test_shape_to_mask_linestrip_fills_notch_at_turning_point() -> None:
     line_width = 25
     apex_x, apex_y = 50, 50
     mask = shape_module.shape_to_mask(
-        img_shape=img_shape,
-        points=[[40.0, 10.0], [apex_x, apex_y], [60.0, 10.0]],
+        img_shape,
+        [[40.0, 10.0], [apex_x, apex_y], [60.0, 10.0]],
         shape_type="linestrip",
         line_width=line_width,
     )
@@ -286,8 +310,8 @@ def test_shape_to_mask_circle_marks_center_and_clears_outside() -> None:
     # points are (x, y); the 2nd point sets the radius (here dist=5). Center
     # cx != cy so an x/y swap is caught. mask is indexed [row=y, col=x].
     mask = shape_module.shape_to_mask(
-        img_shape=(30, 30),
-        points=[[12.0, 10.0], [12.0, 15.0]],
+        (30, 30),
+        [[12.0, 10.0], [12.0, 15.0]],
         shape_type="circle",
     )
     assert mask.dtype == bool
@@ -300,8 +324,8 @@ def test_shape_to_mask_circle_marks_center_and_clears_outside() -> None:
 def test_shape_to_mask_line_marks_pixels_along_segment() -> None:
     # points are (x, y); mask is indexed [row=y, col=x].
     mask = shape_module.shape_to_mask(
-        img_shape=(100, 100),
-        points=[[10.0, 50.0], [90.0, 50.0]],
+        (100, 100),
+        [[10.0, 50.0], [90.0, 50.0]],
         shape_type="line",
         line_width=10,
     )
@@ -317,8 +341,8 @@ def test_shape_to_mask_point_marks_pixels_around_center() -> None:
     # points are (x, y); cx != cy so an x/y swap is caught. mask is indexed
     # [row=y, col=x].
     mask = shape_module.shape_to_mask(
-        img_shape=(100, 100),
-        points=[[40.0, 60.0]],
+        (100, 100),
+        [[40.0, 60.0]],
         shape_type="point",
         point_size=5,
     )

--- a/tests/unit/utils/shape_test.py
+++ b/tests/unit/utils/shape_test.py
@@ -203,7 +203,7 @@ def test_shapes_to_label_mask_keeps_integer_bbox_extent() -> None:
     ids=["down", "up", "ties-to-even", "different-fractions"],
 )
 def test_shapes_to_label_mask_rounds_fractional_bounds(
-    points: list[list[float]], expected_origin: tuple[int, int]
+    *, points: list[list[float]], expected_origin: tuple[int, int]
 ) -> None:
     patch = np.ones((3, 5), dtype=bool)
     shape = _mask_shape(points=points, mask=patch)

--- a/tests/unit/widgets/_ai_assisted_annotation_widget_test.py
+++ b/tests/unit/widgets/_ai_assisted_annotation_widget_test.py
@@ -37,7 +37,7 @@ def _make_widget(
 
 
 def test_construction_exposes_default_without_firing_callbacks(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     widget = _make_widget(
         qtbot=qtbot,
@@ -53,7 +53,7 @@ def test_construction_exposes_default_without_firing_callbacks(
 
 
 def test_first_listed_default_resolves(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     widget = _make_widget(
         qtbot=qtbot,
@@ -66,7 +66,7 @@ def test_first_listed_default_resolves(
 
 
 def test_unknown_default_falls_back_to_first_model(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     widget = _make_widget(
         qtbot=qtbot,
@@ -79,7 +79,7 @@ def test_unknown_default_falls_back_to_first_model(
 
 
 def test_selecting_another_model_fires_callback(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     widget = _make_widget(
         qtbot=qtbot,
@@ -93,7 +93,7 @@ def test_selecting_another_model_fires_callback(
 
 
 def test_selecting_another_output_format_fires_callback(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     widget = _make_widget(
         qtbot=qtbot,
@@ -115,7 +115,7 @@ def test_selecting_another_output_format_fires_callback(
 
 
 def test_polygon_detail_control_fires_callback_and_exposes_value(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     details: list[int] = []
     widget = _make_widget(
@@ -134,7 +134,7 @@ def test_polygon_detail_control_fires_callback_and_exposes_value(
 
 
 def test_setting_polygon_detail_from_config_does_not_fire_callback(
-    qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
+    *, qtbot: QtBot, models: list[str], formats: list[AiOutputFormat]
 ) -> None:
     details: list[int] = []
     widget = _make_widget(

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -37,7 +37,7 @@ def _isolated_override_cursor_stack() -> Generator[None, None, None]:
 
 
 @pytest.fixture()
-def canvas(qtbot: QtBot) -> Canvas:
+def canvas(*, qtbot: QtBot) -> Canvas:
     c = Canvas()
     c.pixmap = QtGui.QPixmap(_W, _H)
     # Resize to exactly the pixmap dimensions so the image-origin offset is
@@ -97,7 +97,7 @@ def _clear_cursor_override(*, canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_cursor_is_cross_when_hovering_in_create_mode(canvas: Canvas) -> None:
+def test_cursor_is_cross_when_hovering_in_create_mode(*, canvas: Canvas) -> None:
     # Any mouse move in CREATE mode should engage CrossCursor.
     canvas.set_editing(value=False)
     canvas.create_mode = "rectangle"
@@ -112,7 +112,7 @@ def test_cursor_is_cross_when_hovering_in_create_mode(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_cursor_reverts_to_no_override_after_cursor_cleared(canvas: Canvas) -> None:
+def test_cursor_reverts_to_no_override_after_cursor_cleared(*, canvas: Canvas) -> None:
     # After _release_cursor the override stack is empty; callers treat that
     # as ArrowCursor.
     canvas.set_editing(value=False)
@@ -133,6 +133,7 @@ def test_cursor_reverts_to_no_override_after_cursor_cleared(canvas: Canvas) -> N
 
 @pytest.mark.gui
 def test_cursor_is_arrow_when_hovering_empty_canvas_in_edit_mode(
+    *,
     canvas: Canvas,
 ) -> None:
     # Moving over blank canvas area (no shapes) leaves no override cursor.
@@ -152,6 +153,7 @@ def test_cursor_is_arrow_when_hovering_empty_canvas_in_edit_mode(
 
 @pytest.mark.gui
 def test_cursor_is_open_hand_when_hovering_shape_body_in_edit_mode(
+    *,
     canvas: Canvas,
 ) -> None:
     # Hovering the interior of a shape (not near a vertex or edge) uses
@@ -182,6 +184,7 @@ def test_cursor_is_open_hand_when_hovering_shape_body_in_edit_mode(
 
 @pytest.mark.gui
 def test_shape_hidden_while_hovered_stops_being_hover_interactive(
+    *,
     canvas: Canvas,
 ) -> None:
     # Regression for #2250: hiding the hovered shape must make it inert to the
@@ -220,6 +223,7 @@ def test_shape_hidden_while_hovered_stops_being_hover_interactive(
 
 @pytest.mark.gui
 def test_cursor_is_pointing_hand_when_hovering_vertex_in_edit_mode(
+    *,
     canvas: Canvas,
 ) -> None:
     # Hovering a vertex in EDIT mode engages PointingHandCursor.
@@ -248,6 +252,7 @@ def test_cursor_is_pointing_hand_when_hovering_vertex_in_edit_mode(
 
 @pytest.mark.gui
 def test_cursor_is_pointing_hand_when_hovering_edge_in_edit_mode(
+    *,
     canvas: Canvas,
 ) -> None:
     # Hovering an edge midpoint of a polygon (but not near a vertex) also
@@ -278,6 +283,7 @@ def test_cursor_is_pointing_hand_when_hovering_edge_in_edit_mode(
 
 @pytest.mark.gui
 def test_cursor_is_pointing_hand_when_snapping_to_polygon_origin(
+    *,
     canvas: Canvas,
 ) -> None:
     # While drawing a polygon with 3+ points, approaching the first point
@@ -302,7 +308,7 @@ def test_cursor_is_pointing_hand_when_snapping_to_polygon_origin(
 
 
 @pytest.mark.gui
-def test_cursor_is_cross_when_far_from_polygon_origin(canvas: Canvas) -> None:
+def test_cursor_is_cross_when_far_from_polygon_origin(*, canvas: Canvas) -> None:
     # When the cursor is more than epsilon/scale away from the polygon origin,
     # CrossCursor is kept (no snap engagement).
     canvas.set_editing(value=False)
@@ -330,7 +336,7 @@ def test_cursor_is_cross_when_far_from_polygon_origin(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_context_menus_pair_holds_two_menus(canvas: Canvas) -> None:
+def test_context_menus_pair_holds_two_menus(*, canvas: Canvas) -> None:
     # The public context_menus pair exposes a no-selection menu and a
     # selection menu as named QMenu attributes.
     assert isinstance(canvas.context_menus.without_selection, QtWidgets.QMenu)
@@ -339,6 +345,7 @@ def test_context_menus_pair_holds_two_menus(canvas: Canvas) -> None:
 
 @pytest.mark.gui
 def test_right_release_without_selection_copy_executes_menus_0(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -365,6 +372,7 @@ def test_right_release_without_selection_copy_executes_menus_0(
 
 @pytest.mark.gui
 def test_right_release_with_selection_copy_executes_menus_1(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -431,6 +439,7 @@ def _make_center_polygon() -> Shape:
     ids=["scale_0.5", "scale_1.0", "scale_2.0"],
 )
 def test_vertex_hover_within_epsilon_screen_pixels_gives_pointing_hand(
+    *,
     qtbot: QtBot,
     scale: float,
 ) -> None:
@@ -470,6 +479,7 @@ def test_vertex_hover_within_epsilon_screen_pixels_gives_pointing_hand(
     ids=["scale_0.5", "scale_1.0", "scale_2.0"],
 )
 def test_vertex_hover_beyond_epsilon_screen_pixels_does_not_select_vertex(
+    *,
     qtbot: QtBot,
     scale: float,
 ) -> None:
@@ -501,6 +511,7 @@ def test_vertex_hover_beyond_epsilon_screen_pixels_does_not_select_vertex(
 
 @pytest.mark.gui
 def test_screen_pixel_hit_radius_is_constant_across_scale_levels(
+    *,
     qtbot: QtBot,
 ) -> None:
     # Confirm parity: a fixed 7-screen-pixel offset from the vertex always

--- a/tests/unit/widgets/_canvas_interaction/primitives_test.py
+++ b/tests/unit/widgets/_canvas_interaction/primitives_test.py
@@ -351,7 +351,9 @@ def test_is_within_pick_threshold_larger_scale_smaller_image_radius() -> None:
         (CursorRole.MOVE, Qt.CursorShape.ClosedHandCursor),
     ],
 )
-def test_cursor_shape_for_all_roles(role: CursorRole, expected: Qt.CursorShape) -> None:
+def test_cursor_shape_for_all_roles(
+    *, role: CursorRole, expected: Qt.CursorShape
+) -> None:
     assert cursor_shape_for(role) == expected
 
 

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -92,6 +92,7 @@ def _shape(*, shape_type: ShapeType, points: list[list[float]]) -> Shape:
     ],
 )
 def test_bounds_spans_the_shape(
+    *,
     shape_type: ShapeType,
     points: list[list[float]],
     expected: tuple[float, float, float, float],
@@ -113,7 +114,7 @@ def test_bounds_spans_the_shape(
     ],
 )
 def test_bounds_is_empty_for_incomplete_shape(
-    shape_type: ShapeType, points: list[list[float]]
+    *, shape_type: ShapeType, points: list[list[float]]
 ) -> None:
     shape = _shape(shape_type=shape_type, points=points)
     assert bounds(shape=shape).getRect() == (0.0, 0.0, 0.0, 0.0)

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -40,7 +40,7 @@ def _render(*, shape: Shape, show_label: bool, scale: float) -> QtGui.QImage:
     painter = QtGui.QPainter(image)
     context = ShapeRenderContext(
         scale=scale,
-        palette=Palette.from_rgb(rgb=(255, 0, 0)),
+        palette=Palette.from_rgb((255, 0, 0)),
         point_size=8,
         point_type="round",
         selected=False,

--- a/tests/unit/widgets/brightness_contrast_dialog/alpha_test.py
+++ b/tests/unit/widgets/brightness_contrast_dialog/alpha_test.py
@@ -32,7 +32,7 @@ def _make_dialog(
 
 
 def test_apply_preserves_rgba_at_identity(
-    qtbot: QtBot, rgba_img: PIL.Image.Image
+    *, qtbot: QtBot, rgba_img: PIL.Image.Image
 ) -> None:
     dialog, captured = _make_dialog(qtbot=qtbot, img=rgba_img)
 
@@ -43,7 +43,7 @@ def test_apply_preserves_rgba_at_identity(
 
 
 def test_slider_change_preserves_alpha_while_brightening(
-    qtbot: QtBot, rgba_img: PIL.Image.Image
+    *, qtbot: QtBot, rgba_img: PIL.Image.Image
 ) -> None:
     dialog, captured = _make_dialog(qtbot=qtbot, img=rgba_img)
 
@@ -56,7 +56,7 @@ def test_slider_change_preserves_alpha_while_brightening(
     assert not np.array_equal(emitted[..., :3], src[..., :3])
 
 
-def test_apply_outputs_rgb_without_alpha_channel(qtbot: QtBot) -> None:
+def test_apply_outputs_rgb_without_alpha_channel(*, qtbot: QtBot) -> None:
     rgb_img = PIL.Image.new("RGB", (4, 3), color=(100, 150, 200))
     dialog, captured = _make_dialog(qtbot=qtbot, img=rgb_img)
 

--- a/tests/unit/widgets/brightness_contrast_dialog/i18n_test.py
+++ b/tests/unit/widgets/brightness_contrast_dialog/i18n_test.py
@@ -25,7 +25,7 @@ _SLIDER_LABELS: Final = ("Brightness:", "Contrast:")
 
 
 @pytest.fixture()
-def japanese_translator(qapp: QApplication) -> Iterator[None]:
+def japanese_translator(*, qapp: QApplication) -> Iterator[None]:
     translator = QTranslator()
     assert translator.load(str(_locale.TRANSLATE_DIR / f"{_LOCALE}.qm"))
     qapp.installTranslator(translator)
@@ -33,7 +33,7 @@ def japanese_translator(qapp: QApplication) -> Iterator[None]:
     qapp.removeTranslator(translator)
 
 
-def test_slider_labels_are_extractable_by_lupdate(tmp_path: Path) -> None:
+def test_slider_labels_are_extractable_by_lupdate(*, tmp_path: Path) -> None:
     lupdate = shutil.which(
         "pyside6-lupdate", path=str(Path(sys.executable).parent)
     ) or shutil.which("pyside6-lupdate")
@@ -52,7 +52,7 @@ def test_slider_labels_are_extractable_by_lupdate(tmp_path: Path) -> None:
 
 
 @pytest.mark.usefixtures("japanese_translator")
-def test_slider_labels_render_the_installed_translation(qtbot: QtBot) -> None:
+def test_slider_labels_render_the_installed_translation(*, qtbot: QtBot) -> None:
     translated = {
         source: QCoreApplication.translate("BrightnessContrastDialog", source)
         for source in _SLIDER_LABELS

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -291,9 +291,9 @@ def test_move_by_keyboard_ignores_stale_mouse_position(canvas: Canvas) -> None:
         points=np.array([(40, 20), (60, 30)], dtype=np.float64),
         closed=True,
     )
-    canvas.load_pixmap(QtGui.QPixmap(200, 100))
+    canvas.load_pixmap(pixmap=QtGui.QPixmap(200, 100))
     canvas._prev_point = QPointF(150, 80)
-    canvas.load_pixmap(QtGui.QPixmap(_WIDTH, _HEIGHT))
+    canvas.load_pixmap(pixmap=QtGui.QPixmap(_WIDTH, _HEIGHT))
     canvas.shapes = [shape]
     canvas.selected_shapes = [shape]
 
@@ -475,14 +475,14 @@ def test_set_shape_visible_toggles_visibility(canvas: Canvas) -> None:
         points=np.array([(0, 0), (10, 10)], dtype=np.float64),
         closed=True,
     )
-    canvas.load_shapes([shape])
+    canvas.load_shapes(shapes=[shape])
 
     assert canvas.shapes[0].visible is True
 
-    canvas.set_shape_visible(canvas.shapes[0], value=False)
+    canvas.set_shape_visible(shape=canvas.shapes[0], value=False)
     assert canvas.shapes[0].visible is False
 
-    canvas.set_shape_visible(canvas.shapes[0], value=True)
+    canvas.set_shape_visible(shape=canvas.shapes[0], value=True)
     assert canvas.shapes[0].visible is True
 
 
@@ -496,11 +496,11 @@ def test_shape_visibility_survives_backup_and_restore(canvas: Canvas) -> None:
         points=np.array([(0, 0), (10, 10)], dtype=np.float64),
         closed=True,
     )
-    canvas.load_shapes([shape])
+    canvas.load_shapes(shapes=[shape])
 
-    canvas.set_shape_visible(canvas.shapes[0], value=False)
+    canvas.set_shape_visible(shape=canvas.shapes[0], value=False)
     canvas.backup_shapes()
-    canvas.load_shapes([shape.copy()])
+    canvas.load_shapes(shapes=[shape.copy()])
     assert canvas.shapes[0].visible is False
 
     canvas.restore_last_shape()
@@ -528,9 +528,9 @@ def test_set_last_label_applies_only_to_trailing_unlabeled_run(
     labeled = _make_rectangle(label="old")
     fresh_a = _make_rectangle(label=None)
     fresh_b = _make_rectangle(label=None)
-    canvas.load_shapes([stale, labeled, fresh_a, fresh_b])
+    canvas.load_shapes(shapes=[stale, labeled, fresh_a, fresh_b])
 
-    updated = canvas.set_last_label("new", {"occluded": True})
+    updated = canvas.set_last_label(text="new", flags={"occluded": True})
 
     assert updated == [fresh_a, fresh_b]
     assert stale.label is None
@@ -544,7 +544,7 @@ def test_set_last_label_applies_only_to_trailing_unlabeled_run(
 @pytest.mark.gui
 def test_set_last_label_rejects_empty_text(canvas: Canvas) -> None:
     with pytest.raises(ValueError, match="text must not be empty"):
-        canvas.set_last_label("", {})
+        canvas.set_last_label(text="", flags={})
 
 
 @pytest.mark.gui
@@ -596,7 +596,7 @@ def test_existing_shape_suppression_is_disabled_by_default(
         points=np.array([(20, 20), (30, 30)], dtype=np.float64),
         closed=True,
     )
-    canvas.load_shapes([existing])
+    canvas.load_shapes(shapes=[existing])
 
     def propose_shapes(
         *, existing_shapes: list[Shape], **_: object
@@ -656,7 +656,7 @@ def test_ai_proposal_uses_out_of_bounds_setting(
     "change_setting",
     [
         pytest.param(
-            lambda canvas: canvas.set_ai_model_name("efficientsam:10m"),
+            lambda canvas: canvas.set_ai_model_name(model_name="efficientsam:10m"),
             id="model",
         ),
         pytest.param(
@@ -689,7 +689,7 @@ def test_changing_polygon_detail_requests_preview_repaint(
     update = Mock()
     monkeypatch.setattr(canvas, "update", update)
 
-    canvas.set_ai_polygon_detail(60)
+    canvas.set_ai_polygon_detail(detail=60)
 
     update.assert_called_once_with()
 
@@ -697,10 +697,10 @@ def test_changing_polygon_detail_requests_preview_repaint(
 @pytest.mark.gui
 def test_delete_shape_clears_highlights(canvas: Canvas) -> None:
     existing = _make_rectangle(label="existing")
-    canvas.load_shapes([existing])
+    canvas.load_shapes(shapes=[existing])
     canvas._set_ai_existing_shape_highlights(shapes=[existing])
 
-    canvas.delete_shape(existing)
+    canvas.delete_shape(shape=existing)
 
     assert canvas._ai_existing_shape_highlights == []
 
@@ -708,7 +708,7 @@ def test_delete_shape_clears_highlights(canvas: Canvas) -> None:
 @pytest.mark.gui
 def test_delete_selected_clears_highlights(canvas: Canvas) -> None:
     existing = _make_rectangle(label="existing")
-    canvas.load_shapes([existing])
+    canvas.load_shapes(shapes=[existing])
     canvas.selected_shapes.append(existing)
     canvas._set_ai_existing_shape_highlights(shapes=[existing])
 
@@ -737,7 +737,7 @@ def ai_existing_shape_highlight_harness(
         points=np.array([[20, 10], [60, 40]], dtype=np.float64),
         visible=False,
     )
-    canvas.load_shapes([existing])
+    canvas.load_shapes(shapes=[existing])
     canvas.set_ai_existing_shape_suppression(enabled=True)
     canvas.create_mode = "ai_box_to_shape"
     canvas.set_editing(value=False)
@@ -954,7 +954,7 @@ def test_ai_points_rejects_incompatible_model_before_download(
     qtbot: QtBot,
 ) -> None:
     canvas = ai_points_harness.canvas
-    canvas.set_ai_model_name("sam3:latest")
+    canvas.set_ai_model_name(model_name="sam3:latest")
 
     qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(10, 10))
 
@@ -978,12 +978,12 @@ def test_ai_points_rejects_incompatible_model_after_draft_started(
 
     monkeypatch.setattr(canvas, "_propose_ai_shapes", _propose_ai_shapes)
     canvas.point_prompt_rejected.connect(lambda _: canvas.repaint())
-    canvas.set_ai_model_name("sam2:latest")
+    canvas.set_ai_model_name(model_name="sam2:latest")
 
     qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(10, 10))
     draft_before_rejection = canvas._current
     assert draft_before_rejection is not None
-    canvas.set_ai_model_name("sam3:latest")
+    canvas.set_ai_model_name(model_name="sam3:latest")
 
     qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(20, 20))
 
@@ -1010,12 +1010,12 @@ def test_ai_points_rejects_incompatible_model_on_finalize(
     monkeypatch.setattr(canvas, "_propose_ai_shapes", _propose_ai_shapes)
     canvas.point_prompt_rejected.connect(lambda _: canvas.repaint())
     canvas.inference_failed.connect(inference_failures.append)
-    canvas.set_ai_model_name("sam2:latest")
+    canvas.set_ai_model_name(model_name="sam2:latest")
 
     qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(10, 10))
     draft_before_rejection = canvas._current
     assert draft_before_rejection is not None
-    canvas.set_ai_model_name("sam3:latest")
+    canvas.set_ai_model_name(model_name="sam3:latest")
 
     qtbot.keyClick(canvas, Qt.Key.Key_Return)
 
@@ -1033,7 +1033,7 @@ def test_ai_points_ignores_incompatible_first_click_outside_image(
 ) -> None:
     canvas = ai_points_harness.canvas
     canvas.resize(_WIDTH * 2, _HEIGHT * 2)
-    canvas.set_ai_model_name("sam3:latest")
+    canvas.set_ai_model_name(model_name="sam3:latest")
 
     qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(1, 1))
 
@@ -1169,7 +1169,7 @@ def test_load_pixmap_rearms_inference_failure_report(canvas: Canvas) -> None:
     # A new image is a fresh inference context: a previous image's latched
     # failure must not mute the first failure report on the new image.
     canvas._ai_inference_failed = True
-    canvas.load_pixmap(QtGui.QPixmap(_WIDTH, _HEIGHT))
+    canvas.load_pixmap(pixmap=QtGui.QPixmap(_WIDTH, _HEIGHT))
     assert canvas._ai_inference_failed is False
 
 

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -38,7 +38,7 @@ _HEIGHT: Final[int] = 50
 
 
 @pytest.fixture()
-def canvas(qtbot: QtBot) -> Canvas:
+def canvas(*, qtbot: QtBot) -> Canvas:
     canvas = Canvas()
     canvas.pixmap = QtGui.QPixmap(_WIDTH, _HEIGHT)
     qtbot.addWidget(canvas)
@@ -47,6 +47,7 @@ def canvas(qtbot: QtBot) -> Canvas:
 
 @pytest.mark.gui
 def test_propose_ai_shapes_passes_rgb_image_to_model(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -74,6 +75,7 @@ def _make_oriented_rectangle(*, corners: list[tuple[float, float]]) -> Shape:
 
 @pytest.mark.gui
 def test_drag_hovered_rotation_point_does_not_drift_on_repeated_drags(
+    *,
     canvas: Canvas,
 ) -> None:
     # Rotate a shape through many small steps, then back to the start. Without
@@ -110,6 +112,7 @@ def test_drag_hovered_rotation_point_does_not_drift_on_repeated_drags(
 
 @pytest.mark.gui
 def test_bounded_move_oriented_rectangle_vertex_clips_when_perpendicular_corner_outside(
+    *,
     canvas: Canvas,
 ) -> None:
     # Tilted parallelogram chosen so dragging vertex 2 to (95, 5) keeps the
@@ -128,6 +131,7 @@ def test_bounded_move_oriented_rectangle_vertex_clips_when_perpendicular_corner_
 
 @pytest.mark.gui
 def test_bounded_move_oriented_rectangle_vertex_clips_when_parallel_corner_outside(
+    *,
     canvas: Canvas,
 ) -> None:
     # Same tilted shape; dragging vertex 2 to (95, 45) keeps the moving and
@@ -145,7 +149,7 @@ def test_bounded_move_oriented_rectangle_vertex_clips_when_parallel_corner_outsi
 
 
 @pytest.mark.gui
-def test_bounded_move_vertex_clamps_to_image_by_default(canvas: Canvas) -> None:
+def test_bounded_move_vertex_clamps_to_image_by_default(*, canvas: Canvas) -> None:
     shape = Shape(
         shape_type="rectangle",
         points=np.array([(10, 10), (50, 40)], dtype=np.float64),
@@ -161,7 +165,9 @@ def test_bounded_move_vertex_clamps_to_image_by_default(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_bounded_move_vertex_keeps_out_of_bounds_when_enabled(canvas: Canvas) -> None:
+def test_bounded_move_vertex_keeps_out_of_bounds_when_enabled(
+    *, canvas: Canvas
+) -> None:
     canvas.set_allow_out_of_bounds_points(value=True)
     shape = Shape(
         shape_type="rectangle",
@@ -206,7 +212,7 @@ def test_reproject_oriented_rectangle_skips_clip_when_out_of_bounds_allowed() ->
 
 
 @pytest.mark.gui
-def test_drag_shapes_blocked_off_image_by_default(canvas: Canvas) -> None:
+def test_drag_shapes_blocked_off_image_by_default(*, canvas: Canvas) -> None:
     shape = Shape(
         shape_type="rectangle",
         points=np.array([(40, 20), (60, 30)], dtype=np.float64),
@@ -225,7 +231,7 @@ def test_drag_shapes_blocked_off_image_by_default(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_drag_shapes_keeps_out_of_bounds_when_enabled(canvas: Canvas) -> None:
+def test_drag_shapes_keeps_out_of_bounds_when_enabled(*, canvas: Canvas) -> None:
     canvas.set_allow_out_of_bounds_points(value=True)
     shape = Shape(
         shape_type="rectangle",
@@ -253,7 +259,7 @@ def test_drag_shapes_keeps_out_of_bounds_when_enabled(canvas: Canvas) -> None:
     ],
 )
 def test_move_by_keyboard_moves_clickless_selection(
-    canvas: Canvas, offset: QPointF, expected: list[tuple[float, float]]
+    *, canvas: Canvas, offset: QPointF, expected: list[tuple[float, float]]
 ) -> None:
     shape = Shape(
         shape_type="rectangle",
@@ -269,7 +275,9 @@ def test_move_by_keyboard_moves_clickless_selection(
 
 
 @pytest.mark.gui
-def test_move_by_keyboard_clamps_clickless_selection_to_image(canvas: Canvas) -> None:
+def test_move_by_keyboard_clamps_clickless_selection_to_image(
+    *, canvas: Canvas
+) -> None:
     shape = Shape(
         shape_type="rectangle",
         points=np.array([(85, 20), (95, 30)], dtype=np.float64),
@@ -285,7 +293,7 @@ def test_move_by_keyboard_clamps_clickless_selection_to_image(canvas: Canvas) ->
 
 
 @pytest.mark.gui
-def test_move_by_keyboard_ignores_stale_mouse_position(canvas: Canvas) -> None:
+def test_move_by_keyboard_ignores_stale_mouse_position(*, canvas: Canvas) -> None:
     shape = Shape(
         shape_type="rectangle",
         points=np.array([(40, 20), (60, 30)], dtype=np.float64),
@@ -303,7 +311,7 @@ def test_move_by_keyboard_ignores_stale_mouse_position(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_move_by_keyboard_rebuilds_mismatched_drag_anchor(canvas: Canvas) -> None:
+def test_move_by_keyboard_rebuilds_mismatched_drag_anchor(*, canvas: Canvas) -> None:
     old_shape = Shape(
         shape_type="rectangle",
         points=np.array([(40, 20), (60, 30)], dtype=np.float64),
@@ -374,6 +382,7 @@ def test_move_by_keyboard_rebuilds_mismatched_drag_anchor(canvas: Canvas) -> Non
     ],
 )
 def test_drag_shapes_moves_oversized_shape_in_requested_direction(
+    *,
     canvas: Canvas,
     points: list[tuple[float, float]],
     click: QPointF,
@@ -410,7 +419,7 @@ def test_drag_shapes_moves_oversized_shape_in_requested_direction(
     ],
 )
 def test_drag_shapes_stops_oversized_shape_at_symmetric_bound(
-    canvas: Canvas, points: list[tuple[float, float]], offset: QPointF
+    *, canvas: Canvas, points: list[tuple[float, float]], offset: QPointF
 ) -> None:
     shape = Shape(
         shape_type="rectangle",
@@ -434,6 +443,7 @@ def test_drag_shapes_stops_oversized_shape_at_symmetric_bound(
 
 @pytest.mark.gui
 def test_drag_shapes_preserves_orthogonal_out_of_bounds_position(
+    *,
     canvas: Canvas,
 ) -> None:
     shape = Shape(
@@ -457,6 +467,7 @@ def test_drag_shapes_preserves_orthogonal_out_of_bounds_position(
 
 @pytest.mark.gui
 def test_should_draw_crosshair_off_image_when_out_of_bounds_allowed(
+    *,
     canvas: Canvas,
 ) -> None:
     canvas.set_allow_out_of_bounds_points(value=True)
@@ -467,7 +478,7 @@ def test_should_draw_crosshair_off_image_when_out_of_bounds_allowed(
 
 
 @pytest.mark.gui
-def test_set_shape_visible_toggles_visibility(canvas: Canvas) -> None:
+def test_set_shape_visible_toggles_visibility(*, canvas: Canvas) -> None:
     # Visibility is canvas state keyed by object identity.
     shape = Shape(
         label="a",
@@ -487,7 +498,7 @@ def test_set_shape_visible_toggles_visibility(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_shape_visibility_survives_backup_and_restore(canvas: Canvas) -> None:
+def test_shape_visibility_survives_backup_and_restore(*, canvas: Canvas) -> None:
     # `visible` is the one ephemeral view flag kept on the Qt-free Shape so it
     # rides along the deepcopy-based undo/backup stack.
     shape = Shape(
@@ -518,6 +529,7 @@ def _make_rectangle(*, label: str | None) -> Shape:
 
 @pytest.mark.gui
 def test_set_last_label_applies_only_to_trailing_unlabeled_run(
+    *,
     canvas: Canvas,
 ) -> None:
     # After the label dialog is accepted, _app labels the batch of just-drawn
@@ -542,7 +554,7 @@ def test_set_last_label_applies_only_to_trailing_unlabeled_run(
 
 
 @pytest.mark.gui
-def test_set_last_label_rejects_empty_text(canvas: Canvas) -> None:
+def test_set_last_label_rejects_empty_text(*, canvas: Canvas) -> None:
     with pytest.raises(ValueError, match="text must not be empty"):
         canvas.set_last_label(text="", flags={})
 
@@ -550,6 +562,7 @@ def test_set_last_label_rejects_empty_text(canvas: Canvas) -> None:
 @pytest.mark.gui
 @pytest.mark.parametrize("create_mode", ["ai_box_to_shape", "ai_points_to_shape"])
 def test_finalize_with_empty_inference_resets_state_and_notifies(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
     create_mode: str,
@@ -587,6 +600,7 @@ def test_finalize_with_empty_inference_resets_state_and_notifies(
 
 @pytest.mark.gui
 def test_existing_shape_suppression_is_disabled_by_default(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -630,9 +644,9 @@ def test_existing_shape_suppression_is_disabled_by_default(
     [(False, (_WIDTH, _HEIGHT)), (True, None)],
 )
 def test_ai_proposal_uses_out_of_bounds_setting(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
-    *,
     allow_out_of_bounds: bool,
     expected_image_size: tuple[int, int] | None,
 ) -> None:
@@ -670,6 +684,7 @@ def test_ai_proposal_uses_out_of_bounds_setting(
     ],
 )
 def test_changing_ai_assist_setting_clears_highlights(
+    *,
     canvas: Canvas,
     change_setting: Callable[[Canvas], None],
 ) -> None:
@@ -683,6 +698,7 @@ def test_changing_ai_assist_setting_clears_highlights(
 
 @pytest.mark.gui
 def test_changing_polygon_detail_requests_preview_repaint(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -695,7 +711,7 @@ def test_changing_polygon_detail_requests_preview_repaint(
 
 
 @pytest.mark.gui
-def test_delete_shape_clears_highlights(canvas: Canvas) -> None:
+def test_delete_shape_clears_highlights(*, canvas: Canvas) -> None:
     existing = _make_rectangle(label="existing")
     canvas.load_shapes(shapes=[existing])
     canvas._set_ai_existing_shape_highlights(shapes=[existing])
@@ -706,7 +722,7 @@ def test_delete_shape_clears_highlights(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_delete_selected_clears_highlights(canvas: Canvas) -> None:
+def test_delete_selected_clears_highlights(*, canvas: Canvas) -> None:
     existing = _make_rectangle(label="existing")
     canvas.load_shapes(shapes=[existing])
     canvas.selected_shapes.append(existing)
@@ -727,6 +743,7 @@ class _AiExistingShapeHighlightHarness:
 
 @pytest.fixture()
 def ai_existing_shape_highlight_harness(
+    *,
     canvas: Canvas,
     qtbot: QtBot,
 ) -> _AiExistingShapeHighlightHarness:
@@ -766,6 +783,7 @@ def ai_existing_shape_highlight_harness(
 @pytest.mark.gui
 @pytest.mark.parametrize("clear_action", ["edit", "pointer", "wheel", "key"])
 def test_finalize_existing_only_inference_highlights_hidden_shape(
+    *,
     ai_existing_shape_highlight_harness: _AiExistingShapeHighlightHarness,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
@@ -828,6 +846,7 @@ def test_finalize_existing_only_inference_highlights_hidden_shape(
 
 @pytest.mark.gui
 def test_finalize_mixed_inference_adds_new_and_highlights_existing(
+    *,
     ai_existing_shape_highlight_harness: _AiExistingShapeHighlightHarness,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -860,6 +879,7 @@ def test_finalize_mixed_inference_adds_new_and_highlights_existing(
     "create_mode", ["point", "ai_box_to_shape", "ai_points_to_shape"]
 )
 def test_finalize_paints_new_shape_before_notifying(
+    *,
     canvas: Canvas,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
@@ -922,6 +942,7 @@ class _AiPointsTestHarness:
 
 @pytest.fixture()
 def ai_points_harness(
+    *,
     canvas: Canvas,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
@@ -950,6 +971,7 @@ def ai_points_harness(
 
 @pytest.mark.gui
 def test_ai_points_rejects_incompatible_model_before_download(
+    *,
     ai_points_harness: _AiPointsTestHarness,
     qtbot: QtBot,
 ) -> None:
@@ -965,6 +987,7 @@ def test_ai_points_rejects_incompatible_model_before_download(
 
 @pytest.mark.gui
 def test_ai_points_rejects_incompatible_model_after_draft_started(
+    *,
     ai_points_harness: _AiPointsTestHarness,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
@@ -995,6 +1018,7 @@ def test_ai_points_rejects_incompatible_model_after_draft_started(
 
 @pytest.mark.gui
 def test_ai_points_rejects_incompatible_model_on_finalize(
+    *,
     ai_points_harness: _AiPointsTestHarness,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
@@ -1028,6 +1052,7 @@ def test_ai_points_rejects_incompatible_model_on_finalize(
 
 @pytest.mark.gui
 def test_ai_points_ignores_incompatible_first_click_outside_image(
+    *,
     ai_points_harness: _AiPointsTestHarness,
     qtbot: QtBot,
 ) -> None:
@@ -1045,6 +1070,7 @@ def test_ai_points_ignores_incompatible_first_click_outside_image(
 @pytest.mark.gui
 @pytest.mark.parametrize("create_mode", ["ai_box_to_shape", "ai_points_to_shape"])
 def test_finalize_reports_inference_error_and_cancels(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
     create_mode: str,
@@ -1077,6 +1103,7 @@ def test_finalize_reports_inference_error_and_cancels(
 
 @pytest.mark.gui
 def test_points_preview_hides_failed_and_empty_predictions(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1118,6 +1145,7 @@ def test_points_preview_hides_failed_and_empty_predictions(
 
 @pytest.mark.gui
 def test_ai_points_preview_renders_every_proposed_shape(
+    *,
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1165,7 +1193,7 @@ def test_ai_points_preview_renders_every_proposed_shape(
 
 
 @pytest.mark.gui
-def test_load_pixmap_rearms_inference_failure_report(canvas: Canvas) -> None:
+def test_load_pixmap_rearms_inference_failure_report(*, canvas: Canvas) -> None:
     # A new image is a fresh inference context: a previous image's latched
     # failure must not mute the first failure report on the new image.
     canvas._ai_inference_failed = True
@@ -1174,7 +1202,7 @@ def test_load_pixmap_rearms_inference_failure_report(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_create_mode_switch_retypes_one_point_partial(canvas: Canvas) -> None:
+def test_create_mode_switch_retypes_one_point_partial(*, canvas: Canvas) -> None:
     # Retype must update _current.shape_type and _line.shape_type, but must
     # NOT re-seed _line.points (which would alias both slots and break the
     # next extend click).
@@ -1201,6 +1229,7 @@ def test_create_mode_switch_retypes_one_point_partial(canvas: Canvas) -> None:
 
 @pytest.mark.gui
 def test_create_mode_switch_cancels_multi_point_partial_with_new_mode_observable(
+    *,
     canvas: Canvas,
 ) -> None:
     # Multi-point partial cancels, and listeners on drawing_polygon must
@@ -1229,6 +1258,7 @@ def test_create_mode_switch_cancels_multi_point_partial_with_new_mode_observable
 
 @pytest.mark.gui
 def test_create_mode_switch_to_ai_target_cancels_one_point_partial(
+    *,
     canvas: Canvas,
 ) -> None:
     # AI modes carry per-point labels, so a non-AI seed can't be
@@ -1247,7 +1277,7 @@ def test_create_mode_switch_to_ai_target_cancels_one_point_partial(
 
 
 @pytest.mark.gui
-def test_create_mode_switch_preserves_seed_point_label(canvas: Canvas) -> None:
+def test_create_mode_switch_preserves_seed_point_label(*, canvas: Canvas) -> None:
     # Retype must preserve _current.point_labels (a shift-click sets label=0).
     canvas.create_mode = "polygon"
     canvas._current = _DraftShape(
@@ -1263,7 +1293,7 @@ def test_create_mode_switch_preserves_seed_point_label(canvas: Canvas) -> None:
 @pytest.mark.gui
 @pytest.mark.parametrize("to_mode", ["rectangle", "circle", "line"])
 def test_extend_after_mode_switch_finalizes_at_last_cursor(
-    canvas: Canvas, to_mode: str
+    *, canvas: Canvas, to_mode: str
 ) -> None:
     # After mode switch, the preserved [seed, last_cursor] _line drives
     # extend so finalize commits a non-degenerate shape.
@@ -1301,7 +1331,7 @@ def test_extend_after_mode_switch_finalizes_at_last_cursor(
 @pytest.mark.gui
 @pytest.mark.parametrize("to_mode", ["polygon", "linestrip", "oriented_rectangle"])
 def test_extend_after_mode_switch_grows_partial_at_last_cursor(
-    canvas: Canvas, to_mode: str
+    *, canvas: Canvas, to_mode: str
 ) -> None:
     # Non-finalizing modes grow at last_cursor; for oriented_rectangle the
     # locked first edge has non-zero length.
@@ -1375,7 +1405,7 @@ def test_extend_after_mode_switch_grows_partial_at_last_cursor(
     ],
 )
 def test_is_degenerate_draft(
-    shape_type: ShapeType, points: list[tuple[float, float]], *, expected: bool
+    *, shape_type: ShapeType, points: list[tuple[float, float]], expected: bool
 ) -> None:
     draft = _DraftShape(
         shape_type=shape_type,
@@ -1397,7 +1427,7 @@ def test_is_degenerate_draft(
         pytest.param((_WIDTH / 2, _HEIGHT + 0.1), True, id="below_image"),
     ],
 )
-def test_is_out_of_image(point: tuple[float, float], *, expected: bool) -> None:
+def test_is_out_of_image(*, point: tuple[float, float], expected: bool) -> None:
     # The image rect is inclusive at both edges: a point exactly on the far
     # width/height boundary counts as inside, since the clamping callers treat
     # the pixmap size as a reachable coordinate rather than an exclusive extent.
@@ -1407,7 +1437,7 @@ def test_is_out_of_image(point: tuple[float, float], *, expected: bool) -> None:
 @pytest.mark.gui
 @pytest.mark.parametrize("shape_type", ["rectangle", "circle", "line"])
 def test_finalize_rejects_degenerate_shape(
-    canvas: Canvas, shape_type: ShapeType
+    *, canvas: Canvas, shape_type: ShapeType
 ) -> None:
     # Zero-area / zero-length shapes never enter canvas.shapes; the user gets
     # a clean cancel instead of a silent malformed annotation, and the rejection
@@ -1430,6 +1460,7 @@ def test_finalize_rejects_degenerate_shape(
 
 @pytest.mark.gui
 def test_finalize_rejects_polygon_with_fewer_than_three_distinct_points(
+    *,
     canvas: Canvas,
 ) -> None:
     canvas.create_mode = "polygon"
@@ -1749,7 +1780,7 @@ _IMAGE_SIZE: Final[QSize] = QSize(100, 50)
     ],
 )
 def test_compute_intersection_edges_image(
-    p1: QPointF, p2: QPointF, expected: QPointF
+    *, p1: QPointF, p2: QPointF, expected: QPointF
 ) -> None:
     assert (
         _compute_intersection_edges_image(p1=p1, p2=p2, image_size=_IMAGE_SIZE)
@@ -1767,7 +1798,7 @@ def test_compute_intersection_edges_image(
     ],
 )
 def test_normalize_bbox_points_returns_top_left_and_bottom_right(
-    p1: QPointF, p2: QPointF
+    *, p1: QPointF, p2: QPointF
 ) -> None:
     assert _normalize_bbox_points(bbox_points=[p1, p2]) == [
         QPointF(10, 20),
@@ -1917,6 +1948,7 @@ def test_pick_pending_moved_shape_returns_hovered_when_present() -> None:
     ],
 )
 def test_snap_cursor_pos_for_square(
+    *,
     pos: tuple[float, float],
     opposite_vertex: tuple[float, float],
     expected: tuple[float, float],
@@ -1937,7 +1969,7 @@ def _make_polygon() -> Shape:
 
 @pytest.mark.gui
 def test_add_point_to_edge_repaints(
-    canvas: Canvas, monkeypatch: pytest.MonkeyPatch
+    *, canvas: Canvas, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     shape = _make_polygon()
     canvas.load_shapes(shapes=[shape])
@@ -1956,7 +1988,7 @@ def test_add_point_to_edge_repaints(
 
 @pytest.mark.gui
 def test_remove_selected_point_repaints(
-    canvas: Canvas, monkeypatch: pytest.MonkeyPatch
+    *, canvas: Canvas, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     shape = _make_polygon()
     canvas.load_shapes(shapes=[shape])
@@ -1974,7 +2006,7 @@ def test_remove_selected_point_repaints(
 
 @pytest.mark.gui
 def test_reset_view_offset_repaints(
-    canvas: Canvas, monkeypatch: pytest.MonkeyPatch
+    *, canvas: Canvas, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     canvas._view_offset = QPointF(17, 23)
     update = Mock()
@@ -1987,7 +2019,7 @@ def test_reset_view_offset_repaints(
 
 
 @pytest.mark.gui
-def test_reset_state_clears_view_offset(canvas: Canvas) -> None:
+def test_reset_state_clears_view_offset(*, canvas: Canvas) -> None:
     canvas._view_offset = QPointF(17, 23)
 
     canvas.reset_state()
@@ -1996,7 +2028,7 @@ def test_reset_state_clears_view_offset(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_remove_selected_point_deselects_vertex(canvas: Canvas) -> None:
+def test_remove_selected_point_deselects_vertex(*, canvas: Canvas) -> None:
     shape = _make_polygon()
     canvas.load_shapes(shapes=[shape])
     canvas._last_hovered_shape = shape
@@ -2011,7 +2043,7 @@ def test_remove_selected_point_deselects_vertex(canvas: Canvas) -> None:
 
 
 @pytest.mark.gui
-def test_end_move_in_place_copies_points(canvas: Canvas) -> None:
+def test_end_move_in_place_copies_points(*, canvas: Canvas) -> None:
     shape = _make_polygon()
     canvas.load_shapes(shapes=[shape])
     canvas.selected_shapes = [shape]

--- a/tests/unit/widgets/download_test.py
+++ b/tests/unit/widgets/download_test.py
@@ -21,6 +21,7 @@ _MODEL_NAME: Final = "efficientsam:10m"
 
 @pytest.fixture()
 def isolated_model_type(
+    *,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> type[osam.types.Model]:
@@ -41,6 +42,7 @@ def isolated_model_type(
 @pytest.mark.gui
 @pytest.mark.usefixtures("close_failed_download_dialog")
 def test_download_ai_model_returns_true_when_pull_succeeds(
+    *,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
     isolated_model_type: type[osam.types.Model],
@@ -81,6 +83,7 @@ def test_download_ai_model_returns_true_when_pull_succeeds(
 @pytest.mark.gui
 @pytest.mark.usefixtures("close_failed_download_dialog")
 def test_download_ai_model_returns_false_when_pull_fails(
+    *,
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -102,6 +105,7 @@ def test_download_ai_model_returns_false_when_pull_fails(
 @pytest.mark.network
 @pytest.mark.usefixtures("close_failed_download_dialog")
 def test_download_ai_model_from_network(
+    *,
     qtbot: QtBot,
     isolated_model_type: type[osam.types.Model],
 ) -> None:
@@ -132,5 +136,5 @@ def test_download_ai_model_from_network(
         (1099511627776, "1.0 TB"),
     ],
 )
-def test_format_bytes(n: int, expected: str) -> None:
+def test_format_bytes(*, n: int, expected: str) -> None:
     assert _format_bytes(n) == expected

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -80,7 +80,7 @@ def _ok_button(dialog: LabelDialog, /) -> QtWidgets.QPushButton:
 # ---------------------------------------------------------------------------
 
 
-def test_set_list_widget_stores_reference(qtbot: QtBot) -> None:
+def test_set_list_widget_stores_reference(*, qtbot: QtBot) -> None:
     edit = LabelQLineEdit()
     qtbot.addWidget(edit)
     list_widget = QtWidgets.QListWidget()
@@ -89,7 +89,7 @@ def test_set_list_widget_stores_reference(qtbot: QtBot) -> None:
     assert edit.list_widget is list_widget
 
 
-def test_key_down_forwarded_to_list_widget(qtbot: QtBot) -> None:
+def test_key_down_forwarded_to_list_widget(*, qtbot: QtBot) -> None:
     edit = LabelQLineEdit()
     qtbot.addWidget(edit)
     list_widget = QtWidgets.QListWidget()
@@ -102,7 +102,7 @@ def test_key_down_forwarded_to_list_widget(qtbot: QtBot) -> None:
     assert list_widget.currentRow() == 1
 
 
-def test_key_up_forwarded_to_list_widget(qtbot: QtBot) -> None:
+def test_key_up_forwarded_to_list_widget(*, qtbot: QtBot) -> None:
     edit = LabelQLineEdit()
     qtbot.addWidget(edit)
     list_widget = QtWidgets.QListWidget()
@@ -115,7 +115,7 @@ def test_key_up_forwarded_to_list_widget(qtbot: QtBot) -> None:
     assert list_widget.currentRow() == 1
 
 
-def test_other_keys_edit_text_not_forwarded(qtbot: QtBot) -> None:
+def test_other_keys_edit_text_not_forwarded(*, qtbot: QtBot) -> None:
     edit = LabelQLineEdit()
     qtbot.addWidget(edit)
     list_widget = QtWidgets.QListWidget()
@@ -134,7 +134,7 @@ def test_other_keys_edit_text_not_forwarded(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_default_widgets_exist(qtbot: QtBot) -> None:
+def test_default_widgets_exist(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     assert isinstance(dialog.edit, LabelQLineEdit)
     assert isinstance(dialog.edit_group_id, QtWidgets.QLineEdit)
@@ -142,33 +142,33 @@ def test_default_widgets_exist(qtbot: QtBot) -> None:
     assert isinstance(dialog.label_list, QtWidgets.QListWidget)
 
 
-def test_default_placeholder_is_non_empty(qtbot: QtBot) -> None:
+def test_default_placeholder_is_non_empty(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     assert dialog.edit.placeholderText() != ""
 
 
-def test_custom_placeholder_text(qtbot: QtBot) -> None:
+def test_custom_placeholder_text(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(text="Type here"))
     assert dialog.edit.placeholderText() == "Type here"
 
 
-def test_group_id_and_description_placeholders_non_empty(qtbot: QtBot) -> None:
+def test_group_id_and_description_placeholders_non_empty(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     assert dialog.edit_group_id.placeholderText() != ""
     assert dialog.edit_description.placeholderText() != ""
 
 
-def test_show_text_field_true_parents_edit_to_dialog(qtbot: QtBot) -> None:
+def test_show_text_field_true_parents_edit_to_dialog(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(show_text_field=True))
     assert dialog.edit.parent() is dialog
 
 
-def test_show_text_field_false_leaves_edit_parentless(qtbot: QtBot) -> None:
+def test_show_text_field_false_leaves_edit_parentless(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(show_text_field=False))
     assert dialog.edit.parent() is None
 
 
-def test_initial_labels_listed(qtbot: QtBot) -> None:
+def test_initial_labels_listed(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(labels=["banana", "apple", "cherry"])
     )
@@ -176,7 +176,7 @@ def test_initial_labels_listed(qtbot: QtBot) -> None:
     assert set(items) == {"apple", "banana", "cherry"}
 
 
-def test_sort_labels_true_sorts(qtbot: QtBot) -> None:
+def test_sort_labels_true_sorts(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot,
         dialog=LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=True),
@@ -185,7 +185,7 @@ def test_sort_labels_true_sorts(qtbot: QtBot) -> None:
     assert items == ["apple", "banana", "cherry"]
 
 
-def test_sort_labels_false_preserves_order_and_enables_drag(qtbot: QtBot) -> None:
+def test_sort_labels_false_preserves_order_and_enables_drag(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot,
         dialog=LabelDialog(labels=["banana", "apple", "cherry"], sort_labels=False),
@@ -201,7 +201,7 @@ def test_sort_labels_false_preserves_order_and_enables_drag(qtbot: QtBot) -> Non
 @pytest.mark.parametrize("row_off", [True, False])
 @pytest.mark.parametrize("col_off", [True, False])
 def test_fit_to_content_scrollbar_policies(
-    qtbot: QtBot, *, row_off: bool, col_off: bool
+    *, qtbot: QtBot, row_off: bool, col_off: bool
 ) -> None:
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(fit_to_content={"row": row_off, "column": col_off})
@@ -218,7 +218,7 @@ def test_fit_to_content_scrollbar_policies(
 # ---------------------------------------------------------------------------
 
 
-def test_completion_startswith_inline(qtbot: QtBot) -> None:
+def test_completion_startswith_inline(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(completion="startswith"))
     assert (
         dialog.edit.completer().completionMode()
@@ -226,7 +226,7 @@ def test_completion_startswith_inline(qtbot: QtBot) -> None:
     )
 
 
-def test_completion_contains_popup_and_matchcontains(qtbot: QtBot) -> None:
+def test_completion_contains_popup_and_matchcontains(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(completion="contains"))
     completer = dialog.edit.completer()
     assert (
@@ -242,7 +242,7 @@ def test_completion_invalid_raises() -> None:
         LabelDialog(completion="fuzzy")
 
 
-def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
+def test_completer_bound_to_label_list_model(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a", "b"]))
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
@@ -252,21 +252,21 @@ def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_add_label_history_appends_new(qtbot: QtBot) -> None:
+def test_add_label_history_appends_new(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=[]))
     dialog.add_label_history(label="dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert "dog" in items
 
 
-def test_add_label_history_no_duplicate(qtbot: QtBot) -> None:
+def test_add_label_history_no_duplicate(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["dog"]))
     dialog.add_label_history(label="dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items.count("dog") == 1
 
 
-def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
+def test_add_label_history_sorts_when_sort_enabled(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(labels=["banana", "apple"], sort_labels=True)
     )
@@ -275,7 +275,7 @@ def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
     assert items == ["apple", "banana", "cherry"]
 
 
-def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
+def test_set_predefined_labels_merges_and_dedups(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a"], sort_labels=False))
     dialog.add_label_history(label="b")
     dialog.set_predefined_labels(labels=["a", "c"])
@@ -284,7 +284,7 @@ def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
     assert len(items) == 3
 
 
-def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
+def test_set_predefined_labels_keeps_completer_bound(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a"]))
     dialog.set_predefined_labels(labels=["a", "b", "c"])
     assert dialog.edit.completer().model() is dialog.label_list.model()
@@ -295,21 +295,21 @@ def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_editing_finished_strips_whitespace(qtbot: QtBot) -> None:
+def test_editing_finished_strips_whitespace(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("  hello  ")
     dialog.edit.editingFinished.emit()
     assert dialog.edit.text() == "hello"
 
 
-def test_selecting_label_sets_edit_text(qtbot: QtBot) -> None:
+def test_selecting_label_sets_edit_text(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog"]))
     item = dialog.label_list.findItems("dog", QtCore.Qt.MatchFlag.MatchExactly)[0]
     dialog.label_list.setCurrentItem(item)
     assert dialog.edit.text() == "dog"
 
 
-def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
+def test_clearing_selection_with_none_does_not_crash(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
     dialog.label_list.setCurrentItem(
         dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
@@ -323,28 +323,28 @@ def test_clearing_selection_with_none_does_not_crash(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_ok_with_text_accepts(qtbot: QtBot) -> None:
+def test_ok_with_text_accepts(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("car")
     _ok_button(dialog).click()
     assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
 
 
-def test_ok_with_empty_text_does_not_accept(qtbot: QtBot) -> None:
+def test_ok_with_empty_text_does_not_accept(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("")
     _ok_button(dialog).click()
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
-def test_ok_with_whitespace_text_does_not_accept(qtbot: QtBot) -> None:
+def test_ok_with_whitespace_text_does_not_accept(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("   ")
     _ok_button(dialog).click()
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
-def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
+def test_ok_accepts_when_edit_disabled_even_if_empty(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("")
     dialog.edit.setEnabled(False)
@@ -352,7 +352,7 @@ def test_ok_accepts_when_edit_disabled_even_if_empty(qtbot: QtBot) -> None:
     assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
 
 
-def test_double_click_label_accepts(qtbot: QtBot) -> None:
+def test_double_click_label_accepts(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
     item = dialog.label_list.findItems("cat", QtCore.Qt.MatchFlag.MatchExactly)[0]
     dialog.label_list.setCurrentItem(item)  # selection sets the edit text
@@ -365,7 +365,7 @@ def test_double_click_label_accepts(qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_flags_shown_for_matching_label(qtbot: QtBot) -> None:
+def test_flags_shown_for_matching_label(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor", "outdoor"]})
     )
@@ -374,20 +374,20 @@ def test_flags_shown_for_matching_label(qtbot: QtBot) -> None:
     assert names == {"indoor", "outdoor"}
 
 
-def test_flags_absent_for_non_matching_label(qtbot: QtBot) -> None:
+def test_flags_absent_for_non_matching_label(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"]}))
     dialog.edit.setText("dog")
     assert _checkboxes(dialog) == []
 
 
-def test_flags_shown_for_prefix_match(qtbot: QtBot) -> None:
+def test_flags_shown_for_prefix_match(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"car": ["fast"]}))
     dialog.edit.setText("car_red")
     names = {cb.text() for cb in _checkboxes(dialog)}
     assert names == {"fast"}
 
 
-def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
+def test_flag_checked_state_preserved_across_text_change(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     dialog.edit.setText("cat")
     box = next(cb for cb in _checkboxes(dialog) if cb.text() == "indoor")
@@ -397,7 +397,7 @@ def test_flag_checked_state_preserved_across_text_change(qtbot: QtBot) -> None:
     assert box2.isChecked()
 
 
-def test_flag_checked_state_preserved_across_non_matching_text(qtbot: QtBot) -> None:
+def test_flag_checked_state_preserved_across_non_matching_text(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     dialog.edit.setText("cat")
     _checkbox(dialog=dialog, name="indoor").setChecked(True)
@@ -407,7 +407,7 @@ def test_flag_checked_state_preserved_across_non_matching_text(qtbot: QtBot) -> 
     assert _checkbox(dialog=dialog, name="indoor").isChecked()
 
 
-def test_flag_checked_state_shared_across_labels(qtbot: QtBot) -> None:
+def test_flag_checked_state_shared_across_labels(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"], "^dog$": ["indoor"]})
     )
@@ -417,7 +417,7 @@ def test_flag_checked_state_shared_across_labels(qtbot: QtBot) -> None:
     assert _checkbox(dialog=dialog, name="indoor").isChecked()
 
 
-def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(qtbot: QtBot) -> None:
+def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={".*": ["occluded"]}))
     dialog.edit.setText("cat")
     with qtbot.waitExposed(dialog):
@@ -429,7 +429,7 @@ def test_flag_checkboxes_stay_visible_when_rebuilt_while_shown(qtbot: QtBot) -> 
     )
 
 
-def test_flag_named_by_two_matching_patterns_shown_once(qtbot: QtBot) -> None:
+def test_flag_named_by_two_matching_patterns_shown_once(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot,
         dialog=LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]}),
@@ -439,6 +439,7 @@ def test_flag_named_by_two_matching_patterns_shown_once(qtbot: QtBot) -> None:
 
 
 def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
+    *,
     qtbot: QtBot,
 ) -> None:
     dialog = _add_dialog(
@@ -464,7 +465,7 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
 # ---------------------------------------------------------------------------
 
 
-def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
+def test_popup_returns_typed_values_on_accept(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
     text, flags, group_id, description = _run_popup(
         dialog=dialog,
@@ -482,7 +483,7 @@ def test_popup_returns_typed_values_on_accept(qtbot: QtBot) -> None:
     assert flags == {}
 
 
-def test_popup_preserves_html_like_description(qtbot: QtBot) -> None:
+def test_popup_preserves_html_like_description(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _, _, _, description = _run_popup(
         dialog=dialog,
@@ -497,7 +498,7 @@ def test_popup_preserves_html_like_description(qtbot: QtBot) -> None:
     assert description == "<b>bold</b>"
 
 
-def test_popup_returns_all_none_on_reject(qtbot: QtBot) -> None:
+def test_popup_returns_all_none_on_reject(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     result = _run_popup(
         dialog=dialog,
@@ -512,7 +513,7 @@ def test_popup_returns_all_none_on_reject(qtbot: QtBot) -> None:
     assert result == (None, None, None, None)
 
 
-def test_popup_group_id_none_yields_empty_then_none(qtbot: QtBot) -> None:
+def test_popup_group_id_none_yields_empty_then_none(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _, _, group_id, _ = _run_popup(
@@ -529,7 +530,7 @@ def test_popup_group_id_none_yields_empty_then_none(qtbot: QtBot) -> None:
     assert group_id is None
 
 
-def test_popup_group_id_zero_is_preserved(qtbot: QtBot) -> None:
+def test_popup_group_id_zero_is_preserved(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _, _, group_id, _ = _run_popup(
         dialog=dialog,
@@ -544,7 +545,7 @@ def test_popup_group_id_zero_is_preserved(qtbot: QtBot) -> None:
     assert group_id == 0
 
 
-def test_popup_sets_group_id_text_at_show(qtbot: QtBot) -> None:
+def test_popup_sets_group_id_text_at_show(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _run_popup(
@@ -560,7 +561,7 @@ def test_popup_sets_group_id_text_at_show(qtbot: QtBot) -> None:
     assert seen["gid"] == "7"
 
 
-def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
+def test_popup_text_none_preserves_existing_edit_text(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("preexisting")
@@ -577,7 +578,7 @@ def test_popup_text_none_preserves_existing_edit_text(qtbot: QtBot) -> None:
     assert seen["t"] == "preexisting"
 
 
-def test_popup_text_none_selects_existing_edit_text(qtbot: QtBot) -> None:
+def test_popup_text_none_selects_existing_edit_text(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("preexisting")
@@ -594,7 +595,7 @@ def test_popup_text_none_selects_existing_edit_text(qtbot: QtBot) -> None:
     assert seen["sel"] == "preexisting"
 
 
-def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
+def test_popup_highlights_matching_label_at_show(*, qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog"]))
     _run_popup(
@@ -614,7 +615,7 @@ def test_popup_highlights_matching_label_at_show(qtbot: QtBot) -> None:
     assert seen["cur"] == "dog"
 
 
-def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> None:
+def test_popup_highlights_matching_label_case_insensitively(*, qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["Cat", "Dog"]))
     _run_popup(
@@ -634,7 +635,7 @@ def test_popup_highlights_matching_label_case_insensitively(qtbot: QtBot) -> Non
     assert seen["cur"] == "Cat"
 
 
-def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
+def test_popup_sets_description_at_show(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     _run_popup(
@@ -650,7 +651,7 @@ def test_popup_sets_description_at_show(qtbot: QtBot) -> None:
     assert seen["desc"] == "hello world"
 
 
-def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
+def test_popup_flags_disabled_disables_checkboxes(*, qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
@@ -671,7 +672,7 @@ def test_popup_flags_disabled_disables_checkboxes(qtbot: QtBot) -> None:
     assert not any(seen["enabled"])
 
 
-def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
+def test_popup_flags_enabled_by_default(*, qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
@@ -692,7 +693,7 @@ def test_popup_flags_enabled_by_default(qtbot: QtBot) -> None:
     assert all(seen["enabled"])
 
 
-def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
+def test_flags_disabled_resets_between_popups(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     _run_popup(
         dialog=dialog,
@@ -723,6 +724,7 @@ def test_flags_disabled_resets_between_popups(qtbot: QtBot) -> None:
 
 
 def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
+    *,
     qtbot: QtBot,
 ) -> None:
     seen: dict[str, bool] = {}
@@ -753,6 +755,7 @@ def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
 
 
 def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
+    *,
     qtbot: QtBot,
 ) -> None:
     seen: dict[str, bool] = {}
@@ -782,7 +785,7 @@ def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
     assert seen["checked"] is False
 
 
-def test_flags_disabled_survives_text_edit_rebuild(qtbot: QtBot) -> None:
+def test_flags_disabled_survives_text_edit_rebuild(*, qtbot: QtBot) -> None:
     seen: dict[str, list[bool]] = {}
 
     def edit_then_inspect(d: LabelDialog) -> None:

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -85,7 +85,7 @@ def test_set_list_widget_stores_reference(qtbot: QtBot) -> None:
     qtbot.addWidget(edit)
     list_widget = QtWidgets.QListWidget()
     qtbot.addWidget(list_widget)
-    edit.set_list_widget(list_widget)
+    edit.set_list_widget(list_widget=list_widget)
     assert edit.list_widget is list_widget
 
 
@@ -96,7 +96,7 @@ def test_key_down_forwarded_to_list_widget(qtbot: QtBot) -> None:
     qtbot.addWidget(list_widget)
     list_widget.addItems(["a", "b", "c"])
     list_widget.setCurrentRow(0)
-    edit.set_list_widget(list_widget)
+    edit.set_list_widget(list_widget=list_widget)
     edit.show()
     qtbot.keyClick(edit, QtCore.Qt.Key.Key_Down)
     assert list_widget.currentRow() == 1
@@ -109,7 +109,7 @@ def test_key_up_forwarded_to_list_widget(qtbot: QtBot) -> None:
     qtbot.addWidget(list_widget)
     list_widget.addItems(["a", "b", "c"])
     list_widget.setCurrentRow(2)
-    edit.set_list_widget(list_widget)
+    edit.set_list_widget(list_widget=list_widget)
     edit.show()
     qtbot.keyClick(edit, QtCore.Qt.Key.Key_Up)
     assert list_widget.currentRow() == 1
@@ -122,7 +122,7 @@ def test_other_keys_edit_text_not_forwarded(qtbot: QtBot) -> None:
     qtbot.addWidget(list_widget)
     list_widget.addItems(["a", "b", "c"])
     list_widget.setCurrentRow(0)
-    edit.set_list_widget(list_widget)
+    edit.set_list_widget(list_widget=list_widget)
     edit.show()
     qtbot.keyClicks(edit, "x")
     assert edit.text() == "x"
@@ -254,14 +254,14 @@ def test_completer_bound_to_label_list_model(qtbot: QtBot) -> None:
 
 def test_add_label_history_appends_new(qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=[]))
-    dialog.add_label_history("dog")
+    dialog.add_label_history(label="dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert "dog" in items
 
 
 def test_add_label_history_no_duplicate(qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["dog"]))
-    dialog.add_label_history("dog")
+    dialog.add_label_history(label="dog")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items.count("dog") == 1
 
@@ -270,15 +270,15 @@ def test_add_label_history_sorts_when_sort_enabled(qtbot: QtBot) -> None:
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(labels=["banana", "apple"], sort_labels=True)
     )
-    dialog.add_label_history("cherry")
+    dialog.add_label_history(label="cherry")
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert items == ["apple", "banana", "cherry"]
 
 
 def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a"], sort_labels=False))
-    dialog.add_label_history("b")
-    dialog.set_predefined_labels(["a", "c"])
+    dialog.add_label_history(label="b")
+    dialog.set_predefined_labels(labels=["a", "c"])
     items = [dialog.label_list.item(i).text() for i in range(dialog.label_list.count())]
     assert set(items) == {"a", "b", "c"}
     assert len(items) == 3
@@ -286,7 +286,7 @@ def test_set_predefined_labels_merges_and_dedups(qtbot: QtBot) -> None:
 
 def test_set_predefined_labels_keeps_completer_bound(qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["a"]))
-    dialog.set_predefined_labels(["a", "b", "c"])
+    dialog.set_predefined_labels(labels=["a", "b", "c"])
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
 

--- a/tests/unit/widgets/label_dialog/screen_fit_test.py
+++ b/tests/unit/widgets/label_dialog/screen_fit_test.py
@@ -20,7 +20,7 @@ def _checkbox_gaps(dialog: LabelDialog, /) -> list[int]:
     return [bottom - top for top, bottom in zip(tops, tops[1:])]
 
 
-def test_flag_spacing_is_identical_with_and_without_scrollbar(qtbot: QtBot) -> None:
+def test_flag_spacing_is_identical_with_and_without_scrollbar(*, qtbot: QtBot) -> None:
     few = _make_dialog(qtbot, flag_count=3)
     many = _make_dialog(qtbot, flag_count=12)
     for dialog in (few, many):
@@ -36,7 +36,7 @@ def test_flag_spacing_is_identical_with_and_without_scrollbar(qtbot: QtBot) -> N
     assert few_gaps == many_gaps
 
 
-def test_many_flags_are_capped_and_scrollable(qtbot: QtBot) -> None:
+def test_many_flags_are_capped_and_scrollable(*, qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=60)
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -45,7 +45,7 @@ def test_many_flags_are_capped_and_scrollable(qtbot: QtBot) -> None:
     assert dialog._flags_scroll.verticalScrollBar().maximum() > 0
 
 
-def test_few_flags_shrink_below_cap(qtbot: QtBot) -> None:
+def test_few_flags_shrink_below_cap(*, qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=2)
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -55,7 +55,7 @@ def test_few_flags_shrink_below_cap(qtbot: QtBot) -> None:
 
 
 @pytest.mark.parametrize("corner", ["topLeft", "topRight", "bottomLeft", "bottomRight"])
-def test_move_keeps_dialog_within_screen(qtbot: QtBot, corner: str) -> None:
+def test_move_keeps_dialog_within_screen(*, qtbot: QtBot, corner: str) -> None:
     dialog = _make_dialog(qtbot, flag_count=3)
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -66,7 +66,7 @@ def test_move_keeps_dialog_within_screen(qtbot: QtBot, corner: str) -> None:
     assert available.contains(dialog.frameGeometry())
 
 
-def test_move_anchors_content_corner_at_target(qtbot: QtBot) -> None:
+def test_move_anchors_content_corner_at_target(*, qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=3)
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -84,7 +84,7 @@ def test_move_anchors_content_corner_at_target(qtbot: QtBot) -> None:
     assert dialog.geometry().topLeft() == target
 
 
-def test_clamp_does_not_move_dialog_already_on_screen(qtbot: QtBot) -> None:
+def test_clamp_does_not_move_dialog_already_on_screen(*, qtbot: QtBot) -> None:
     dialog = _make_dialog(qtbot, flag_count=3)
     with qtbot.waitExposed(dialog):
         dialog.show()

--- a/tests/unit/widgets/label_dialog/updates_test.py
+++ b/tests/unit/widgets/label_dialog/updates_test.py
@@ -12,29 +12,32 @@ def _labels(dialog: LabelDialog, /) -> set[str]:
 
 
 @pytest.fixture
-def dialog(qtbot: QtBot) -> LabelDialog:
+def dialog(*, qtbot: QtBot) -> LabelDialog:
     label_dialog = LabelDialog(labels=["cat", "dog"])
     qtbot.addWidget(label_dialog)
     return label_dialog
 
 
-def test_set_predefined_labels_adds_new_label(dialog: LabelDialog) -> None:
+def test_set_predefined_labels_adds_new_label(*, dialog: LabelDialog) -> None:
     dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert _labels(dialog) == {"cat", "dog", "bird"}
 
 
-def test_set_predefined_labels_removes_unused_label(dialog: LabelDialog) -> None:
+def test_set_predefined_labels_removes_unused_label(*, dialog: LabelDialog) -> None:
     dialog.set_predefined_labels(labels=["cat"])
     assert _labels(dialog) == {"cat"}
 
 
-def test_set_predefined_labels_preserves_session_history(dialog: LabelDialog) -> None:
+def test_set_predefined_labels_preserves_session_history(
+    *, dialog: LabelDialog
+) -> None:
     dialog.add_label_history(label="ad-hoc")
     dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert _labels(dialog) == {"cat", "dog", "bird", "ad-hoc"}
 
 
 def test_removed_predefined_label_kept_when_used_this_session(
+    *,
     dialog: LabelDialog,
 ) -> None:
     dialog.add_label_history(label="dog")
@@ -42,12 +45,13 @@ def test_removed_predefined_label_kept_when_used_this_session(
     assert _labels(dialog) == {"cat", "dog"}
 
 
-def test_completer_model_stays_bound_after_update(dialog: LabelDialog) -> None:
+def test_completer_model_stays_bound_after_update(*, dialog: LabelDialog) -> None:
     dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
 
 def test_set_predefined_labels_with_selected_item_does_not_raise(
+    *,
     dialog: LabelDialog,
 ) -> None:
     dialog.label_list.setCurrentRow(0)
@@ -56,6 +60,7 @@ def test_set_predefined_labels_with_selected_item_does_not_raise(
 
 
 def test_set_predefined_labels_empty_keeps_only_session_history(
+    *,
     dialog: LabelDialog,
 ) -> None:
     dialog.add_label_history(label="ad-hoc")
@@ -63,7 +68,7 @@ def test_set_predefined_labels_empty_keeps_only_session_history(
     assert _labels(dialog) == {"ad-hoc"}
 
 
-def test_update_flags_skips_an_invalid_pattern(qtbot: QtBot) -> None:
+def test_update_flags_skips_an_invalid_pattern(*, qtbot: QtBot) -> None:
     dialog = LabelDialog(labels=["cat"], flags={"cat(": ["occluded"]})
     qtbot.addWidget(dialog)
     dialog._update_flags("cat")
@@ -71,6 +76,7 @@ def test_update_flags_skips_an_invalid_pattern(qtbot: QtBot) -> None:
 
 
 def test_update_flags_applies_a_valid_pattern_despite_an_invalid_one(
+    *,
     qtbot: QtBot,
 ) -> None:
     dialog = LabelDialog(

--- a/tests/unit/widgets/label_dialog/updates_test.py
+++ b/tests/unit/widgets/label_dialog/updates_test.py
@@ -19,31 +19,31 @@ def dialog(qtbot: QtBot) -> LabelDialog:
 
 
 def test_set_predefined_labels_adds_new_label(dialog: LabelDialog) -> None:
-    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert _labels(dialog) == {"cat", "dog", "bird"}
 
 
 def test_set_predefined_labels_removes_unused_label(dialog: LabelDialog) -> None:
-    dialog.set_predefined_labels(["cat"])
+    dialog.set_predefined_labels(labels=["cat"])
     assert _labels(dialog) == {"cat"}
 
 
 def test_set_predefined_labels_preserves_session_history(dialog: LabelDialog) -> None:
-    dialog.add_label_history("ad-hoc")
-    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    dialog.add_label_history(label="ad-hoc")
+    dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert _labels(dialog) == {"cat", "dog", "bird", "ad-hoc"}
 
 
 def test_removed_predefined_label_kept_when_used_this_session(
     dialog: LabelDialog,
 ) -> None:
-    dialog.add_label_history("dog")
-    dialog.set_predefined_labels(["cat"])
+    dialog.add_label_history(label="dog")
+    dialog.set_predefined_labels(labels=["cat"])
     assert _labels(dialog) == {"cat", "dog"}
 
 
 def test_completer_model_stays_bound_after_update(dialog: LabelDialog) -> None:
-    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert dialog.edit.completer().model() is dialog.label_list.model()
 
 
@@ -51,15 +51,15 @@ def test_set_predefined_labels_with_selected_item_does_not_raise(
     dialog: LabelDialog,
 ) -> None:
     dialog.label_list.setCurrentRow(0)
-    dialog.set_predefined_labels(["cat", "dog", "bird"])
+    dialog.set_predefined_labels(labels=["cat", "dog", "bird"])
     assert _labels(dialog) == {"cat", "dog", "bird"}
 
 
 def test_set_predefined_labels_empty_keeps_only_session_history(
     dialog: LabelDialog,
 ) -> None:
-    dialog.add_label_history("ad-hoc")
-    dialog.set_predefined_labels([])
+    dialog.add_label_history(label="ad-hoc")
+    dialog.set_predefined_labels(labels=[])
     assert _labels(dialog) == {"ad-hoc"}
 
 

--- a/tests/unit/widgets/label_list_widget_test.py
+++ b/tests/unit/widgets/label_list_widget_test.py
@@ -44,7 +44,7 @@ def _pixels_with_color(
 
 
 @pytest.fixture()
-def widget(qtbot: QtBot) -> LabelListWidget:
+def widget(*, qtbot: QtBot) -> LabelListWidget:
     widget = LabelListWidget()
     qtbot.addWidget(widget)
     widget.resize(200, 200)
@@ -53,6 +53,7 @@ def widget(qtbot: QtBot) -> LabelListWidget:
 
 
 def test_label_list_text_matches_stock_delegate_when_selected_unfocused(
+    *,
     widget: LabelListWidget,
 ) -> None:
     option = QtWidgets.QStyleOptionViewItem()
@@ -89,6 +90,7 @@ def test_label_list_text_matches_stock_delegate_when_selected_unfocused(
 
 
 def test_color_dot_is_painted_without_a_text_colored_fringe(
+    *,
     widget: LabelListWidget,
 ) -> None:
     option = QtWidgets.QStyleOptionViewItem()
@@ -121,7 +123,7 @@ def test_color_dot_is_painted_without_a_text_colored_fringe(
     ]
 
 
-def test_label_list_item_clone_preserves_color_dot(widget: LabelListWidget) -> None:
+def test_label_list_item_clone_preserves_color_dot(*, widget: LabelListWidget) -> None:
     item = LabelListWidgetItem(shape=Shape(label="cat"))
     item.set_label(text="cat", color=(0, 255, 0))
     option = QtWidgets.QStyleOptionViewItem()
@@ -138,6 +140,7 @@ def test_label_list_item_clone_preserves_color_dot(widget: LabelListWidget) -> N
 
 @pytest.fixture()
 def selected_pair(
+    *,
     widget: LabelListWidget,
 ) -> tuple[LabelListWidgetItem, LabelListWidgetItem]:
     item_a = LabelListWidgetItem(text="cat")
@@ -168,7 +171,7 @@ def _press_on_item(
 
 
 def test_selection_at_press_drops_items_removed_before_release(
-    qtbot: QtBot, widget: LabelListWidget
+    *, qtbot: QtBot, widget: LabelListWidget
 ) -> None:
     # A context menu or drag can consume the mouse release, so the press
     # snapshot legally outlives the items it references (e.g. right-click
@@ -188,6 +191,7 @@ def test_selection_at_press_drops_items_removed_before_release(
 
 
 def test_mouse_release_after_item_removal_does_not_crash(
+    *,
     qtbot: QtBot,
     widget: LabelListWidget,
     selected_pair: tuple[LabelListWidgetItem, LabelListWidgetItem],
@@ -203,6 +207,7 @@ def test_mouse_release_after_item_removal_does_not_crash(
 
 
 def test_selection_at_press_returns_live_multi_selection(
+    *,
     qtbot: QtBot,
     widget: LabelListWidget,
     selected_pair: tuple[LabelListWidgetItem, LabelListWidgetItem],
@@ -214,6 +219,7 @@ def test_selection_at_press_returns_live_multi_selection(
 
 
 def test_release_keeps_multi_selection_when_press_toggled_checkbox(
+    *,
     qtbot: QtBot,
     widget: LabelListWidget,
     selected_pair: tuple[LabelListWidgetItem, LabelListWidgetItem],
@@ -263,7 +269,7 @@ def test_release_keeps_multi_selection_when_press_toggled_checkbox(
         "keeps_markup_literal",
     ],
 )
-def test_format_shape_label(shape: Shape, expected: str) -> None:
+def test_format_shape_label(*, shape: Shape, expected: str) -> None:
     assert format_shape_label(shape=shape) == expected
 
 
@@ -273,6 +279,7 @@ def _model_texts(model: _ItemModel, /) -> list[str]:
 
 @pytest.fixture()
 def item_model(
+    *,
     qapp: QtWidgets.QApplication,  # noqa: ARG001 -- a fixture cannot use usefixtures
 ) -> _ItemModel:
     model = _ItemModel()
@@ -283,6 +290,7 @@ def item_model(
 
 
 def test_drop_on_item_inserts_after_it_without_overwriting(
+    *,
     item_model: _ItemModel,
 ) -> None:
     # Drop the dragged "c" (row 2) onto "a" (row 0) with row == -1, the way a
@@ -300,7 +308,7 @@ def test_drop_on_item_inserts_after_it_without_overwriting(
     assert _model_texts(item_model) == ["a", "c", "b", "c"]
 
 
-def test_drop_in_empty_space_appends_to_end(item_model: _ItemModel) -> None:
+def test_drop_in_empty_space_appends_to_end(*, item_model: _ItemModel) -> None:
     # A drop below the last row reports row == -1 with an invalid parent.
     mime = item_model.mimeData([item_model.index(0, 0)])
     dropped = item_model.dropMimeData(
@@ -313,7 +321,7 @@ def test_drop_in_empty_space_appends_to_end(item_model: _ItemModel) -> None:
     assert _model_texts(item_model) == ["a", "b", "c", "a"]
 
 
-def test_remove_rows_emits_item_dropped(item_model: _ItemModel) -> None:
+def test_remove_rows_emits_item_dropped(*, item_model: _ItemModel) -> None:
     fired: list[None] = []
     item_model.item_dropped.connect(lambda: fired.append(None))
 

--- a/tests/unit/widgets/label_list_widget_test.py
+++ b/tests/unit/widgets/label_list_widget_test.py
@@ -142,10 +142,10 @@ def selected_pair(
 ) -> tuple[LabelListWidgetItem, LabelListWidgetItem]:
     item_a = LabelListWidgetItem(text="cat")
     item_b = LabelListWidgetItem(text="dog")
-    widget.add_item(item_a)
-    widget.add_item(item_b)
-    widget.select_item(item_a)
-    widget.select_item(item_b)
+    widget.add_item(item=item_a)
+    widget.add_item(item=item_b)
+    widget.select_item(item=item_a)
+    widget.select_item(item=item_b)
     return item_a, item_b
 
 
@@ -174,13 +174,13 @@ def test_selection_at_press_drops_items_removed_before_release(
     # snapshot legally outlives the items it references (e.g. right-click
     # -> Delete on macOS, where the menu opens on press).
     item = LabelListWidgetItem(text="cat")
-    widget.add_item(item)
-    widget.select_item(item)
+    widget.add_item(item=item)
+    widget.select_item(item=item)
     _press_on_item(qtbot=qtbot, widget=widget, item=item)
 
-    widget.remove_item(item)
+    widget.remove_item(item=item)
     replacement = LabelListWidgetItem(text="cat")
-    widget.add_item(replacement)
+    widget.add_item(item=replacement)
 
     selection_at_press = widget.selection_at_press()
     assert replacement not in selection_at_press
@@ -195,7 +195,7 @@ def test_mouse_release_after_item_removal_does_not_crash(
     item_a, _ = selected_pair
     _press_on_item(qtbot=qtbot, widget=widget, item=item_a)
 
-    widget.remove_item(item_a)
+    widget.remove_item(item=item_a)
     release_pos = widget.viewport().rect().center()
     qtbot.mouseRelease(widget.viewport(), Qt.MouseButton.LeftButton, pos=release_pos)
 

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -66,18 +66,19 @@ def _make_dialog(
 
 
 @pytest.fixture
-def dialog(qtbot: QtBot, applied: Applied) -> SettingsDialog:
+def dialog(*, qtbot: QtBot, applied: Applied) -> SettingsDialog:
     return _make_dialog(
         qtbot=qtbot, applied=applied, overrides={}, succeed=True, previewed=None
     )
 
 
 @pytest.mark.usefixtures("dialog")
-def test_no_apply_on_construction(applied: Applied) -> None:
+def test_no_apply_on_construction(*, applied: Applied) -> None:
     assert applied == []
 
 
 def test_existing_shape_suppression_is_disabled_by_default(
+    *,
     dialog: SettingsDialog,
 ) -> None:
     checkbox = dialog._editors[("ai", "suppress_existing_shape_matches")]
@@ -86,7 +87,7 @@ def test_existing_shape_suppression_is_disabled_by_default(
 
 
 def test_polygon_detail_slider_applies_integer_value(
-    dialog: SettingsDialog, applied: Applied
+    *, dialog: SettingsDialog, applied: Applied
 ) -> None:
     slider = dialog._editors[("mask_polygonization", "detail")]
     assert isinstance(slider, IntegerSlider)
@@ -98,7 +99,7 @@ def test_polygon_detail_slider_applies_integer_value(
 
 
 def test_unbounded_integer_edit_accepts_python_ints(
-    qtbot: QtBot, applied: Applied
+    *, qtbot: QtBot, applied: Applied
 ) -> None:
     initial = 2**31
     dialog = _make_dialog(
@@ -122,7 +123,7 @@ def test_unbounded_integer_edit_accepts_python_ints(
     assert (("shape_color", "auto", "shift"), initial + 1) in applied
 
 
-def test_editors_have_accessible_names(dialog: SettingsDialog) -> None:
+def test_editors_have_accessible_names(*, dialog: SettingsDialog) -> None:
     for setting in schema.SETTINGS:
         editor = dialog._editors[setting.key_path]
         assert editor.accessibleName() == dialog.tr(setting.label)
@@ -136,7 +137,7 @@ def test_editors_have_accessible_names(dialog: SettingsDialog) -> None:
 
 
 def test_shape_color_mode_enables_only_its_control(
-    dialog: SettingsDialog, applied: Applied
+    *, dialog: SettingsDialog, applied: Applied
 ) -> None:
     mode = dialog._editors[("shape_color", "mode")]
     shift = dialog._editors[("shape_color", "auto", "shift")]
@@ -177,6 +178,7 @@ def test_shape_color_mode_enables_only_its_control(
 
 @pytest.mark.usefixtures("use_widget_color_dialog")
 def test_shape_color_picker_applies_rgb(
+    *,
     qtbot: QtBot,
     applied: Applied,
 ) -> None:
@@ -213,7 +215,7 @@ def test_shape_color_picker_applies_rgb(
     ]
 
 
-def test_setting_note_is_accessible_description(dialog: SettingsDialog) -> None:
+def test_setting_note_is_accessible_description(*, dialog: SettingsDialog) -> None:
     setting = next(
         setting
         for setting in schema.SETTINGS
@@ -227,7 +229,7 @@ def test_setting_note_is_accessible_description(dialog: SettingsDialog) -> None:
     )
 
 
-def test_beta_settings_render_a_badge(dialog: SettingsDialog) -> None:
+def test_beta_settings_render_a_badge(*, dialog: SettingsDialog) -> None:
     expected = {dialog.tr(setting.label) for setting in schema.SETTINGS if setting.beta}
     assert expected, "no beta settings to verify"
 
@@ -247,31 +249,33 @@ def test_beta_settings_render_a_badge(dialog: SettingsDialog) -> None:
 
 
 def test_accept_does_not_reapply_unchanged_str_list(
-    dialog: SettingsDialog, applied: Applied
+    *, dialog: SettingsDialog, applied: Applied
 ) -> None:
     dialog.accept()
     assert applied == []
 
 
-def test_str_list_none_initial_is_blank(dialog: SettingsDialog) -> None:
+def test_str_list_none_initial_is_blank(*, dialog: SettingsDialog) -> None:
     edit = dialog._editors[("labels",)]
     assert isinstance(edit, QtWidgets.QPlainTextEdit)
     assert edit.toPlainText() == ""
 
 
-def test_language_default_selects_system(dialog: SettingsDialog) -> None:
+def test_language_default_selects_system(*, dialog: SettingsDialog) -> None:
     combo = dialog._editors[("language",)]
     assert isinstance(combo, QtWidgets.QComboBox)
     assert combo.currentData() is None
 
 
-def test_language_lists_bundled_locales(dialog: SettingsDialog) -> None:
+def test_language_lists_bundled_locales(*, dialog: SettingsDialog) -> None:
     combo = dialog._editors[("language",)]
     assert isinstance(combo, QtWidgets.QComboBox)
     assert combo.findData("ja_JP") >= 0
 
 
-def test_language_applies_locale_code(dialog: SettingsDialog, applied: Applied) -> None:
+def test_language_applies_locale_code(
+    *, dialog: SettingsDialog, applied: Applied
+) -> None:
     combo = dialog._editors[("language",)]
     assert isinstance(combo, QtWidgets.QComboBox)
     combo.setCurrentIndex(combo.findData("en_US"))
@@ -279,7 +283,7 @@ def test_language_applies_locale_code(dialog: SettingsDialog, applied: Applied) 
 
 
 def test_language_applies_discovered_locale(
-    dialog: SettingsDialog, applied: Applied
+    *, dialog: SettingsDialog, applied: Applied
 ) -> None:
     combo = dialog._editors[("language",)]
     assert isinstance(combo, QtWidgets.QComboBox)
@@ -290,7 +294,7 @@ def test_language_applies_discovered_locale(
 
 
 def test_language_unknown_code_falls_back_to_system(
-    qtbot: QtBot, applied: Applied
+    *, qtbot: QtBot, applied: Applied
 ) -> None:
     dialog = _make_dialog(
         qtbot=qtbot,
@@ -306,7 +310,7 @@ def test_language_unknown_code_falls_back_to_system(
 
 
 def test_clearing_labels_is_rejected_when_validate_label_is_exact(
-    qtbot: QtBot, applied: Applied, monkeypatch: pytest.MonkeyPatch
+    *, qtbot: QtBot, applied: Applied, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     dialog = _make_dialog(
         qtbot=qtbot,
@@ -347,7 +351,7 @@ def test_clearing_labels_is_rejected_when_validate_label_is_exact(
     assert labels_editor.toPlainText() == "cat"
 
 
-def test_failed_apply_reverts_checkbox(qtbot: QtBot, applied: Applied) -> None:
+def test_failed_apply_reverts_checkbox(*, qtbot: QtBot, applied: Applied) -> None:
     dialog = _make_dialog(
         qtbot=qtbot,
         applied=applied,
@@ -364,7 +368,7 @@ def test_failed_apply_reverts_checkbox(qtbot: QtBot, applied: Applied) -> None:
     assert checkbox.isChecked()  # reverted to the last-saved value
 
 
-def test_failed_apply_reverts_labels_editor(qtbot: QtBot, applied: Applied) -> None:
+def test_failed_apply_reverts_labels_editor(*, qtbot: QtBot, applied: Applied) -> None:
     dialog = _make_dialog(
         qtbot=qtbot,
         applied=applied,
@@ -385,7 +389,7 @@ def test_failed_apply_reverts_labels_editor(qtbot: QtBot, applied: Applied) -> N
     assert applied == []
 
 
-def test_groups_and_navigation_follow_schema_order(dialog: SettingsDialog) -> None:
+def test_groups_and_navigation_follow_schema_order(*, dialog: SettingsDialog) -> None:
     expected = list(typing.get_args(schema.Group))
     assert [group.title() for group in dialog._page._groups] == expected
     assert [
@@ -400,6 +404,7 @@ def test_groups_and_navigation_follow_schema_order(dialog: SettingsDialog) -> No
 
 
 def test_navigation_uses_readable_typography_and_spacing(
+    *,
     dialog: SettingsDialog,
 ) -> None:
     navigation = dialog._page._navigation
@@ -413,7 +418,7 @@ def test_navigation_uses_readable_typography_and_spacing(
 
 
 def test_navigation_elides_long_localized_names_without_squeezing_content(
-    qapp: QtWidgets.QApplication, qtbot: QtBot, applied: Applied
+    *, qapp: QtWidgets.QApplication, qtbot: QtBot, applied: Applied
 ) -> None:
     translator = QtCore.QTranslator()
     translation_path = Path(__file__).parents[3] / "labelme" / "translate" / "ru_RU.qm"
@@ -443,7 +448,7 @@ def test_navigation_elides_long_localized_names_without_squeezing_content(
 
 
 def test_default_size_scrolls_vertically_only(
-    qtbot: QtBot, dialog: SettingsDialog
+    *, qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -457,7 +462,7 @@ def test_default_size_scrolls_vertically_only(
     assert scroll_area.verticalScrollBar().maximum() > 0
 
 
-def test_dialog_is_resizable(dialog: SettingsDialog) -> None:
+def test_dialog_is_resizable(*, dialog: SettingsDialog) -> None:
     target_width = dialog.width() + 40
     target_height = dialog.height() + 40
     dialog.resize(target_width, target_height)
@@ -466,7 +471,7 @@ def test_dialog_is_resizable(dialog: SettingsDialog) -> None:
 
 
 def test_dialog_prevents_narrow_content_overflow(
-    qtbot: QtBot, dialog: SettingsDialog
+    *, qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -482,7 +487,7 @@ def test_dialog_prevents_narrow_content_overflow(
 
 @pytest.mark.parametrize("target", range(len(typing.get_args(schema.Group))))
 def test_navigation_jumps_to_group(
-    qtbot: QtBot, dialog: SettingsDialog, target: int
+    *, qtbot: QtBot, dialog: SettingsDialog, target: int
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -511,7 +516,7 @@ def test_navigation_jumps_to_group(
     assert navigation.currentRow() == target
 
 
-def test_scrolling_updates_navigation(qtbot: QtBot, dialog: SettingsDialog) -> None:
+def test_scrolling_updates_navigation(*, qtbot: QtBot, dialog: SettingsDialog) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
 
@@ -524,7 +529,7 @@ def test_scrolling_updates_navigation(qtbot: QtBot, dialog: SettingsDialog) -> N
 
 
 def test_scrolling_updates_navigation_after_a_jump(
-    qtbot: QtBot, dialog: SettingsDialog
+    *, qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -544,7 +549,7 @@ def test_scrolling_updates_navigation_after_a_jump(
 
 
 def test_navigation_returns_to_first_group_when_resize_removes_scrollbar(
-    qtbot: QtBot, dialog: SettingsDialog
+    *, qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -561,7 +566,7 @@ def test_navigation_returns_to_first_group_when_resize_removes_scrollbar(
 
 
 def test_reopening_preserves_scroll_position(
-    qtbot: QtBot, dialog: SettingsDialog
+    *, qtbot: QtBot, dialog: SettingsDialog
 ) -> None:
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -575,7 +580,7 @@ def test_reopening_preserves_scroll_position(
     assert scroll_bar.value() == expected
 
 
-def test_short_dialog_scrolls_page(qtbot: QtBot, dialog: SettingsDialog) -> None:
+def test_short_dialog_scrolls_page(*, qtbot: QtBot, dialog: SettingsDialog) -> None:
     dialog.resize(dialog.width(), 160)
     with qtbot.waitExposed(dialog):
         dialog.show()
@@ -584,7 +589,7 @@ def test_short_dialog_scrolls_page(qtbot: QtBot, dialog: SettingsDialog) -> None
 
 
 def test_large_font_uses_default_size_with_scrolling(
-    qtbot: QtBot, applied: Applied
+    *, qtbot: QtBot, applied: Applied
 ) -> None:
     original_font = QtWidgets.QApplication.font()
     large_font = QtGui.QFont(original_font)

--- a/tests/unit/widgets/tool_bar_test.py
+++ b/tests/unit/widgets/tool_bar_test.py
@@ -39,7 +39,7 @@ def actions() -> list[QtGui.QAction | None]:
 
 
 @pytest.fixture()
-def toolbar_h(qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
+def toolbar_h(*, qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
     tb = ToolBar(
         title="Test",
         actions=actions,
@@ -50,7 +50,7 @@ def toolbar_h(qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
 
 
 @pytest.fixture()
-def toolbar_v(qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
+def toolbar_v(*, qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
     tb = ToolBar(
         title="Test",
         actions=actions,
@@ -63,7 +63,7 @@ def toolbar_v(qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
 # --- object name ---
 
 
-def test_toolbar_object_name_uses_title(qtbot: QtBot) -> None:
+def test_toolbar_object_name_uses_title(*, qtbot: QtBot) -> None:
     tb = ToolBar(title="MyBar", actions=[])
     qtbot.addWidget(tb)
     assert tb.objectName() == "MyBarToolBar"
@@ -72,31 +72,31 @@ def test_toolbar_object_name_uses_title(qtbot: QtBot) -> None:
 # --- movable / floatable ---
 
 
-def test_toolbar_is_not_movable(toolbar_h: ToolBar) -> None:
+def test_toolbar_is_not_movable(*, toolbar_h: ToolBar) -> None:
     assert not toolbar_h.isMovable()
 
 
-def test_toolbar_is_not_floatable(toolbar_h: ToolBar) -> None:
+def test_toolbar_is_not_floatable(*, toolbar_h: ToolBar) -> None:
     assert not toolbar_h.isFloatable()
 
 
 # --- frameless window flag ---
 
 
-def test_toolbar_has_frameless_window_flag(toolbar_h: ToolBar) -> None:
+def test_toolbar_has_frameless_window_flag(*, toolbar_h: ToolBar) -> None:
     assert toolbar_h.windowFlags() & Qt.WindowType.FramelessWindowHint
 
 
 # --- layout spacing / margins ---
 
 
-def test_toolbar_layout_spacing_is_zero(toolbar_h: ToolBar) -> None:
+def test_toolbar_layout_spacing_is_zero(*, toolbar_h: ToolBar) -> None:
     layout = toolbar_h.layout()
     assert layout is not None
     assert layout.spacing() == 0
 
 
-def test_toolbar_layout_contents_margins_all_zero(toolbar_h: ToolBar) -> None:
+def test_toolbar_layout_contents_margins_all_zero(*, toolbar_h: ToolBar) -> None:
     layout = toolbar_h.layout()
     assert layout is not None
     m = layout.contentsMargins()
@@ -109,22 +109,22 @@ def test_toolbar_layout_contents_margins_all_zero(toolbar_h: ToolBar) -> None:
 # --- orientation ---
 
 
-def test_toolbar_default_orientation_is_horizontal(toolbar_h: ToolBar) -> None:
+def test_toolbar_default_orientation_is_horizontal(*, toolbar_h: ToolBar) -> None:
     assert toolbar_h.orientation() == Qt.Orientation.Horizontal
 
 
-def test_toolbar_vertical_orientation(toolbar_v: ToolBar) -> None:
+def test_toolbar_vertical_orientation(*, toolbar_v: ToolBar) -> None:
     assert toolbar_v.orientation() == Qt.Orientation.Vertical
 
 
 # --- tool button style ---
 
 
-def test_toolbar_default_button_style_is_text_under_icon(toolbar_h: ToolBar) -> None:
+def test_toolbar_default_button_style_is_text_under_icon(*, toolbar_h: ToolBar) -> None:
     assert toolbar_h.toolButtonStyle() == Qt.ToolButtonStyle.ToolButtonTextUnderIcon
 
 
-def test_toolbar_custom_button_style(qtbot: QtBot) -> None:
+def test_toolbar_custom_button_style(*, qtbot: QtBot) -> None:
     tb = ToolBar(
         title="T",
         actions=[],
@@ -137,18 +137,18 @@ def test_toolbar_custom_button_style(qtbot: QtBot) -> None:
 # --- actions produce QToolButton children ---
 
 
-def test_toolbar_actions_create_tool_buttons(toolbar_h: ToolBar) -> None:
+def test_toolbar_actions_create_tool_buttons(*, toolbar_h: ToolBar) -> None:
     # 3 real actions + None separator = 3 user buttons (separator is not a button)
     buttons = _user_buttons(toolbar_h)
     assert len(buttons) == 3
 
 
-def test_toolbar_tool_buttons_inherit_button_style(toolbar_h: ToolBar) -> None:
+def test_toolbar_tool_buttons_inherit_button_style(*, toolbar_h: ToolBar) -> None:
     for btn in _user_buttons(toolbar_h):
         assert btn.toolButtonStyle() == toolbar_h.toolButtonStyle()
 
 
-def test_toolbar_tool_buttons_have_default_action(toolbar_h: ToolBar) -> None:
+def test_toolbar_tool_buttons_have_default_action(*, toolbar_h: ToolBar) -> None:
     for btn in _user_buttons(toolbar_h):
         assert btn.defaultAction() is not None
 
@@ -156,7 +156,7 @@ def test_toolbar_tool_buttons_have_default_action(toolbar_h: ToolBar) -> None:
 # --- separator ---
 
 
-def test_toolbar_none_action_inserts_separator(toolbar_h: ToolBar) -> None:
+def test_toolbar_none_action_inserts_separator(*, toolbar_h: ToolBar) -> None:
     separators = [a for a in toolbar_h.actions() if a.isSeparator()]
     assert len(separators) == 1
 
@@ -164,7 +164,7 @@ def test_toolbar_none_action_inserts_separator(toolbar_h: ToolBar) -> None:
 # --- QWidgetAction bypasses QToolButton wrapping ---
 
 
-def test_toolbar_widget_action_not_wrapped_in_tool_button(qtbot: QtBot) -> None:
+def test_toolbar_widget_action_not_wrapped_in_tool_button(*, qtbot: QtBot) -> None:
     inner = QtWidgets.QLabel("label")
     wa = QtWidgets.QWidgetAction(None)  # ty: ignore[invalid-argument-type]
     wa.setDefaultWidget(inner)
@@ -180,7 +180,7 @@ def test_toolbar_widget_action_not_wrapped_in_tool_button(qtbot: QtBot) -> None:
 # --- button style change propagates to existing buttons ---
 
 
-def test_toolbar_button_style_change_propagates(toolbar_h: ToolBar) -> None:
+def test_toolbar_button_style_change_propagates(*, toolbar_h: ToolBar) -> None:
     toolbar_h.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
     for btn in _user_buttons(toolbar_h):
         assert btn.toolButtonStyle() == Qt.ToolButtonStyle.ToolButtonIconOnly
@@ -189,7 +189,7 @@ def test_toolbar_button_style_change_propagates(toolbar_h: ToolBar) -> None:
 # --- vertical toolbar: buttons equalized ---
 
 
-def test_toolbar_vertical_buttons_equal_min_width(toolbar_v: ToolBar) -> None:
+def test_toolbar_vertical_buttons_equal_min_width(*, toolbar_v: ToolBar) -> None:
     buttons = _user_buttons(toolbar_v)
     assert len(buttons) >= 2
     widths = [btn.minimumWidth() for btn in buttons]
@@ -197,7 +197,7 @@ def test_toolbar_vertical_buttons_equal_min_width(toolbar_v: ToolBar) -> None:
     assert widths[0] > 0
 
 
-def test_toolbar_horizontal_buttons_not_equalized(toolbar_h: ToolBar) -> None:
+def test_toolbar_horizontal_buttons_not_equalized(*, toolbar_h: ToolBar) -> None:
     # Horizontal toolbar does NOT call _equalize_button_widths; minimumWidth stays 0.
     for btn in _user_buttons(toolbar_h):
         assert btn.minimumWidth() == 0
@@ -206,7 +206,7 @@ def test_toolbar_horizontal_buttons_not_equalized(toolbar_h: ToolBar) -> None:
 # --- font scaling when font_base is provided ---
 
 
-def test_toolbar_font_scaled_when_font_base_given(qtbot: QtBot) -> None:
+def test_toolbar_font_scaled_when_font_base_given(*, qtbot: QtBot) -> None:
     base_font = QtGui.QFont()
     base_font.setPointSizeF(16.0)
 
@@ -216,7 +216,7 @@ def test_toolbar_font_scaled_when_font_base_given(qtbot: QtBot) -> None:
     assert tb.font().pointSizeF() < base_font.pointSizeF()
 
 
-def test_toolbar_no_font_scaling_without_font_base(qtbot: QtBot) -> None:
+def test_toolbar_no_font_scaling_without_font_base(*, qtbot: QtBot) -> None:
     tb = ToolBar(title="F2", actions=[], font_base=None)
     qtbot.addWidget(tb)
 
@@ -230,7 +230,7 @@ def test_toolbar_no_font_scaling_without_font_base(qtbot: QtBot) -> None:
 # --- empty action list is valid ---
 
 
-def test_toolbar_empty_actions(qtbot: QtBot) -> None:
+def test_toolbar_empty_actions(*, qtbot: QtBot) -> None:
     tb = ToolBar(title="Empty", actions=[])
     qtbot.addWidget(tb)
     assert len(_user_buttons(tb)) == 0

--- a/tests/unit/widgets/unique_label_qlist_widget_test.py
+++ b/tests/unit/widgets/unique_label_qlist_widget_test.py
@@ -9,7 +9,7 @@ from labelme._widgets.unique_label_qlist_widget import UniqueLabelQListWidget
 
 
 @pytest.fixture()
-def widget(qtbot: QtBot) -> UniqueLabelQListWidget:
+def widget(*, qtbot: QtBot) -> UniqueLabelQListWidget:
     widget = UniqueLabelQListWidget()
     qtbot.addWidget(widget)
     widget.resize(200, 200)
@@ -18,7 +18,7 @@ def widget(qtbot: QtBot) -> UniqueLabelQListWidget:
 
 
 @pytest.fixture()
-def selected_widget(widget: UniqueLabelQListWidget) -> UniqueLabelQListWidget:
+def selected_widget(*, widget: UniqueLabelQListWidget) -> UniqueLabelQListWidget:
     widget.add_label_item(label="cat", color=(255, 0, 0))
     widget.setCurrentRow(0)
     assert widget.selectedItems()
@@ -26,6 +26,7 @@ def selected_widget(widget: UniqueLabelQListWidget) -> UniqueLabelQListWidget:
 
 
 def test_add_label_item_is_findable_and_rendered(
+    *,
     widget: UniqueLabelQListWidget,
 ) -> None:
     widget.add_label_item(label="cat", color=(255, 0, 0))
@@ -42,6 +43,7 @@ def test_add_label_item_is_findable_and_rendered(
 
 
 def test_add_label_item_rejects_duplicate_label(
+    *,
     widget: UniqueLabelQListWidget,
 ) -> None:
     widget.add_label_item(label="cat", color=(255, 0, 0))
@@ -53,6 +55,7 @@ def test_add_label_item_rejects_duplicate_label(
 
 
 def test_find_label_item_returns_none_for_unknown_label(
+    *,
     widget: UniqueLabelQListWidget,
 ) -> None:
     widget.add_label_item(label="cat", color=(255, 0, 0))
@@ -61,7 +64,7 @@ def test_find_label_item_returns_none_for_unknown_label(
 
 
 def test_escape_key_clears_selection(
-    qtbot: QtBot, selected_widget: UniqueLabelQListWidget
+    *, qtbot: QtBot, selected_widget: UniqueLabelQListWidget
 ) -> None:
     qtbot.keyClick(selected_widget, Qt.Key.Key_Escape)
 
@@ -69,7 +72,7 @@ def test_escape_key_clears_selection(
 
 
 def test_press_on_empty_area_clears_selection(
-    qtbot: QtBot, selected_widget: UniqueLabelQListWidget
+    *, qtbot: QtBot, selected_widget: UniqueLabelQListWidget
 ) -> None:
     empty_pos = selected_widget.viewport().rect().bottomRight()
     assert not selected_widget.indexAt(empty_pos).isValid()

--- a/tests/unit/widgets/zoom_widget/presentation_test.py
+++ b/tests/unit/widgets/zoom_widget/presentation_test.py
@@ -16,7 +16,7 @@ from labelme._widgets.zoom_widget import ZoomWidget
 
 
 @pytest.fixture()
-def widget(qtbot: QtBot) -> ZoomWidget:
+def widget(*, qtbot: QtBot) -> ZoomWidget:
     w = ZoomWidget()
     qtbot.addWidget(w)
     return w
@@ -40,57 +40,59 @@ def test_zoom_widget_percent_suffix_constant() -> None:
 # --- suffix ---
 
 
-def test_zoom_widget_suffix_matches_constant(widget: ZoomWidget) -> None:
+def test_zoom_widget_suffix_matches_constant(*, widget: ZoomWidget) -> None:
     assert widget.suffix() == ZoomWidget.PERCENT_SUFFIX
 
 
 # --- range ---
 
 
-def test_zoom_widget_minimum_is_one(widget: ZoomWidget) -> None:
+def test_zoom_widget_minimum_is_one(*, widget: ZoomWidget) -> None:
     assert widget.minimum() == pytest.approx(1.0)
 
 
-def test_zoom_widget_maximum_equals_percent_max(widget: ZoomWidget) -> None:
+def test_zoom_widget_maximum_equals_percent_max(*, widget: ZoomWidget) -> None:
     assert widget.maximum() == pytest.approx(ZoomWidget.PERCENT_MAX)
 
 
 # --- decimals ---
 
 
-def test_zoom_widget_decimals_matches_constant(widget: ZoomWidget) -> None:
+def test_zoom_widget_decimals_matches_constant(*, widget: ZoomWidget) -> None:
     assert widget.decimals() == ZoomWidget.PERCENT_DECIMALS
 
 
 # --- alignment ---
 
 
-def test_zoom_widget_alignment_is_center(widget: ZoomWidget) -> None:
+def test_zoom_widget_alignment_is_center(*, widget: ZoomWidget) -> None:
     assert widget.alignment() == QtCore.Qt.AlignmentFlag.AlignCenter
 
 
 # --- button symbols ---
 
 
-def test_zoom_widget_no_spin_buttons(widget: ZoomWidget) -> None:
+def test_zoom_widget_no_spin_buttons(*, widget: ZoomWidget) -> None:
     assert widget.buttonSymbols() == QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons
 
 
 # --- tooltip and status tip ---
 
 
-def test_zoom_widget_tooltip_is_zoom_level(widget: ZoomWidget) -> None:
+def test_zoom_widget_tooltip_is_zoom_level(*, widget: ZoomWidget) -> None:
     assert widget.toolTip() == "Zoom Level"
 
 
-def test_zoom_widget_status_tip_is_zoom_level(widget: ZoomWidget) -> None:
+def test_zoom_widget_status_tip_is_zoom_level(*, widget: ZoomWidget) -> None:
     assert widget.statusTip() == "Zoom Level"
 
 
 # --- minimum width ---
 
 
-def test_zoom_widget_minimum_width_accommodates_max_value(widget: ZoomWidget) -> None:
+def test_zoom_widget_minimum_width_accommodates_max_value(
+    *, widget: ZoomWidget
+) -> None:
     # The minimum width must be wide enough to display the maximum zoom string.
     sample = (
         f"{ZoomWidget.PERCENT_MAX:.{ZoomWidget.PERCENT_DECIMALS}f}"
@@ -104,5 +106,5 @@ def test_zoom_widget_minimum_width_accommodates_max_value(widget: ZoomWidget) ->
 # --- is a QDoubleSpinBox ---
 
 
-def test_zoom_widget_is_double_spin_box(widget: ZoomWidget) -> None:
+def test_zoom_widget_is_double_spin_box(*, widget: ZoomWidget) -> None:
     assert isinstance(widget, QtWidgets.QDoubleSpinBox)

--- a/tests/unit/widgets/zoom_widget/value_test.py
+++ b/tests/unit/widgets/zoom_widget/value_test.py
@@ -7,27 +7,27 @@ from labelme._widgets.zoom_widget import ZoomWidget
 
 
 @pytest.fixture
-def widget(qtbot: QtBot) -> ZoomWidget:
+def widget(*, qtbot: QtBot) -> ZoomWidget:
     zoom_widget = ZoomWidget()
     qtbot.addWidget(zoom_widget)
     return zoom_widget
 
 
-def test_zoom_widget_defaults_to_100(widget: ZoomWidget) -> None:
+def test_zoom_widget_defaults_to_100(*, widget: ZoomWidget) -> None:
     assert widget.value() == 100.0
 
 
-def test_zoom_widget_accepts_one_decimal(widget: ZoomWidget) -> None:
+def test_zoom_widget_accepts_one_decimal(*, widget: ZoomWidget) -> None:
     widget.setValue(150.5)
     assert widget.value() == pytest.approx(150.5)
 
 
-def test_zoom_widget_rounds_to_one_decimal(widget: ZoomWidget) -> None:
+def test_zoom_widget_rounds_to_one_decimal(*, widget: ZoomWidget) -> None:
     widget.setValue(150.56)
     assert widget.value() == pytest.approx(150.6)
 
 
-def test_zoom_widget_clamps_to_range(widget: ZoomWidget) -> None:
+def test_zoom_widget_clamps_to_range(*, widget: ZoomWidget) -> None:
     widget.setValue(10000)
     assert widget.value() == ZoomWidget.PERCENT_MAX
     widget.setValue(0)


### PR DESCRIPTION
Completes gruff adoption — all six rules now enabled. GR005 lands in two commits for review: package code (153 signatures), then tests (694 signatures, dropping the temporary carve-out). A third commit registers the `GR` prefix as external noqa codes so ruff stops warning about them.

Four non-obvious bits:

1. pluggy calls pytest hook implementations positionally, so `pytest_addoption` and friends must stay positional — the only 3 test suppressions, discovered by the suite aborting at collection.

2. `ty` cannot see through `functools.partial`: the `partial(new_action, self)` wrapper hid 22 call sites passing positionally into a now-keyword-only signature, breaking the entire e2e suite (one test hung behind a modal error dialog). Only running the tests caught it; both suites pass at each commit.

3. `_ItemModel.removeRows` keeps one GR005 noqa: PySide6's stub declares `parent` positional-or-keyword, and narrowing either way is an invalid override.

4. Test signatures were rewritten programmatically (ast-driven `*` insertion off gruff's own finding offsets, then `ruff format`), safe because pytest injects fixtures and parametrize arguments by keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1u8KFsjSHJF2ejJ6LdSs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>