### PR TITLE
fix: ignore a label dialog answer from a replaced session

### DIFF
--- a/changelog.d/2574.fixed.md
+++ b/changelog.d/2574.fixed.md
@@ -1,0 +1,1 @@
+Fix a crash and a silent mislabel when the file was switched or closed while a label dialog was open.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1647,6 +1647,21 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             return
 
+        rows = list(self._docks.label_list)
+        if any(item not in rows for item in items):
+            # The dialog spins a nested event loop. Application modality keeps
+            # user input out of it, so this is defence in depth rather than a
+            # path anyone has reproduced -- but writing through rows something
+            # else replaced would rename the shape without ever updating what
+            # the user sees, so it is worth the two lines.
+            logger.warning(
+                "Label list rebuilt under a modal dialog: {} rows, {} selected, {!r}",
+                len(rows),
+                len(items),
+                self._image_path,
+            )
+            return
+
         self._canvas_widgets.canvas.backup_shapes()
         for item in items:
             shape = item.shape()
@@ -1928,6 +1943,33 @@ class MainWindow(QtWidgets.QMainWindow):
                 ),
             )
             text = ""
+
+        canvas = self._canvas_widgets.canvas
+        if not canvas.shapes or canvas.shapes[-1].label is not None:
+            # The label dialog and the invalid-label box each spin a nested
+            # event loop. An empty canvas is the state behind the crash this
+            # guard exists for, and returning here covers it whatever emptied
+            # it. The labeled-tail half is defence in depth: application
+            # modality keeps user input out of those loops, so nothing has
+            # reproduced it, but a replacement never ends in an unlabeled
+            # shape, and going on would dirty the file now on screen -- with
+            # auto-save, write it -- or, on the way out, take one of its
+            # shapes, since outside the AI modes the last shape is popped
+            # whatever it is. That is why this is stricter than the check
+            # guarding an edited label.
+            logger.warning(
+                "Canvas changed under a modal dialog: {} shapes, mode={!r}, {!r}",
+                len(canvas.shapes),
+                canvas.create_mode,
+                self._image_path,
+            )
+            # The success path below lifts the same mid-draw toolbar freeze;
+            # this one has to as well, or the replacement session is stuck in
+            # it until a draw mode is picked again.
+            self._actions.edit_mode.setEnabled(True)
+            self._actions.undo_last_point.setEnabled(False)
+            return
+
         if text:
             self._docks.label_list.clearSelection()
             assert isinstance(flags, dict)

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2183,8 +2183,14 @@ class MainWindow(QtWidgets.QMainWindow):
             else image_or_label_path
         )
 
+        # A shape still waiting to be named cannot be carried forward: the
+        # label list rejects a shape with no label.
         prev_shapes: list[Shape] = (
-            self._canvas_widgets.canvas.shapes
+            [
+                shape
+                for shape in self._canvas_widgets.canvas.shapes
+                if shape.label is not None
+            ]
             if self._config["keep_prev"]
             or QtWidgets.QApplication.keyboardModifiers()
             == (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier)

--- a/tests/e2e/label_dialog_session_test.py
+++ b/tests/e2e/label_dialog_session_test.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+import pytest
+from pytestqt.qtbot import QtBot
+
+from labelme._app import MainWindow
+from labelme._shape import Shape
+
+from ..conftest import close_or_pause
+from .conftest import MainWinFactory
+from .conftest import schedule_on_dialog
+from .conftest import show_window_and_wait_for_imagedata
+
+# A modal dialog holds a nested event loop. These tests replace the session
+# from inside that loop programmatically -- application modality keeps real
+# user input out, so they pin the guards rather than reproduce a user gesture.
+# Switching to an annotated file and to an unannotated one land differently:
+# one leaves the canvas holding another file's shapes, the other leaves it
+# empty, which is the state behind the reported crash.
+_UNANNOTATED: Final[str] = "raw/2011_000006.jpg"
+
+
+@pytest.fixture()
+def make_win(main_win: MainWinFactory, qtbot: QtBot, data_path: Path) -> MainWinFactory:
+    def build(**config: object) -> MainWindow:
+        window = main_win(
+            file_or_dir=str(data_path / "annotated"),
+            config_overrides={"auto_save": False, **config},
+        )
+        show_window_and_wait_for_imagedata(qtbot=qtbot, win=window)
+        return window
+
+    return build
+
+
+def _stage_unnamed_shape(window: MainWindow) -> None:
+    # Mirrors what finalizing a drawn shape leaves behind: appended, backed up,
+    # and the toolbar still in mid-draw state.
+    canvas = window._canvas_widgets.canvas
+    canvas.shapes.append(Shape())
+    canvas.backup_shapes()
+    window._on_drawing_polygon_changed(True)
+
+
+def _assert_session_untouched(window: MainWindow, switched: dict[str, object]) -> None:
+    # Read the dirty flag before clearing it: a failing assertion would
+    # otherwise leave teardown blocked on the unsaved-changes prompt.
+    changed = window._is_changed
+    window.mark_clean()
+
+    canvas = window._canvas_widgets.canvas
+    assert canvas.shapes == switched["shapes"]
+    assert [shape.label for shape in canvas.shapes] == switched["labels"]
+    assert len(canvas.shape_backups) == switched["backups"]
+    assert not changed
+    # However the dialog closed, the guard has to lift the mid-draw toolbar
+    # freeze, or the replacement session is stuck in it.
+    assert window._actions.edit_mode.isEnabled()
+    assert not window._actions.undo_last_point.isEnabled()
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    "target",
+    ["annotated/2011_000006.jpg", _UNANNOTATED],
+    ids=["annotated", "unannotated"],
+)
+@pytest.mark.parametrize(
+    "dialog_result",
+    [("cat", {}, None, ""), (None, None, None, None)],
+    ids=["confirmed", "cancelled"],
+)
+def test_new_shape_ignores_dialog_answer_from_a_replaced_session(
+    make_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+    dialog_result: tuple[str | None, dict | None, int | None, str | None],
+    target: str,
+) -> None:
+    window = make_win()
+    _stage_unnamed_shape(window=window)
+    canvas = window._canvas_widgets.canvas
+    switched: dict[str, object] = {}
+
+    def switch_files_then_answer(*_args: object, **_kwargs: object) -> tuple:
+        window._load_file(image_or_label_path=str(data_path / target))
+        switched["shapes"] = canvas.shapes[:]
+        switched["labels"] = [shape.label for shape in canvas.shapes]
+        switched["backups"] = len(canvas.shape_backups)
+        return dialog_result
+
+    monkeypatch.setattr(window._label_dialog, "popup", switch_files_then_answer)
+
+    window._on_new_shape()
+
+    _assert_session_untouched(window=window, switched=switched)
+    close_or_pause(qtbot=qtbot, widget=window, pause=pause)
+
+
+@pytest.mark.gui
+def test_new_shape_ignores_session_replaced_during_invalid_label_warning(
+    make_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    # The warning box is a second nested loop, entered after the label dialog
+    # has already returned, so the check has to sit downstream of both.
+    window = make_win(validate_label="exact", labels=["person"])
+    _stage_unnamed_shape(window=window)
+    canvas = window._canvas_widgets.canvas
+    monkeypatch.setattr(
+        window._label_dialog, "popup", lambda *_a, **_k: ("never-seen", {}, None, "")
+    )
+    switched: dict[str, object] = {}
+
+    def switch_files(*_args: object, **_kwargs: object) -> int:
+        window._load_file(image_or_label_path=str(data_path / _UNANNOTATED))
+        switched["shapes"] = canvas.shapes[:]
+        switched["labels"] = [shape.label for shape in canvas.shapes]
+        switched["backups"] = len(canvas.shape_backups)
+        return 0
+
+    monkeypatch.setattr(window, "show_error_message", switch_files)
+
+    window._on_new_shape()
+
+    _assert_session_untouched(window=window, switched=switched)
+    close_or_pause(qtbot=qtbot, widget=window, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("keep_prev", [False, True], ids=["fresh", "keep_prev"])
+def test_edit_label_ignores_dialog_answer_from_a_replaced_session(
+    make_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+    keep_prev: bool,
+) -> None:
+    window = make_win(keep_prev=keep_prev)
+    canvas = window._canvas_widgets.canvas
+    window._docks.label_list.select_item(window._docks.label_list[0])
+    edited = window._docks.label_list[0].shape()
+    assert edited is not None
+    label_before = edited.label
+    switched: dict[str, object] = {}
+
+    def switch_files_then_answer(*_args: object, **_kwargs: object) -> tuple:
+        window._load_file(image_or_label_path=str(data_path / _UNANNOTATED))
+        switched["shapes"] = canvas.shapes[:]
+        switched["labels"] = [shape.label for shape in canvas.shapes]
+        switched["backups"] = len(canvas.shape_backups)
+        return "cat", {}, None, ""
+
+    monkeypatch.setattr(window._label_dialog, "popup", switch_files_then_answer)
+
+    window._edit_label()
+
+    # Read the dirty flag before clearing it, or a failing assertion leaves
+    # teardown blocked on the unsaved-changes prompt.
+    changed = window._is_changed
+    window.mark_clean()
+
+    # The shape itself is the direct observation; carrying shapes forward keeps
+    # them reachable, so a leaked rename lands on this object.
+    assert edited.label == label_before
+    assert len(canvas.shape_backups) == switched["backups"]
+    # Carrying shapes forward dirties the new file by design.
+    assert keep_prev or not changed
+    assert window._docks.unique_label_list.find_label_item("cat") is None
+    assert "cat" not in [shape.label for shape in canvas.shapes]
+    close_or_pause(qtbot=qtbot, widget=window, pause=pause)
+
+
+@pytest.mark.gui
+def test_edit_label_applies_when_shapes_are_only_appended(
+    make_win: MainWinFactory,
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    # Pasting, duplicating and AI text-to-annotation add rows without
+    # destroying anything, so the edited row survives and the rename must still
+    # land. Naming a new shape is deliberately stricter -- see the guard there.
+    window = make_win()
+    window._docks.label_list.select_item(window._docks.label_list[0])
+    edited = window._docks.label_list[0].shape()
+    assert edited is not None
+
+    rows_before = len(window._docks.label_list)
+
+    def append_shape_then_answer(*_args: object, **_kwargs: object) -> tuple:
+        window._load_shapes(shapes=[Shape(label="pasted")], replace=False)
+        return "renamed", {}, None, ""
+
+    monkeypatch.setattr(window._label_dialog, "popup", append_shape_then_answer)
+
+    window._edit_label()
+
+    assert len(window._docks.label_list) == rows_before + 1
+    assert edited.label == "renamed"
+    window.mark_clean()
+    close_or_pause(qtbot=qtbot, widget=window, pause=pause)
+
+
+@pytest.mark.gui
+def test_keep_prev_does_not_carry_a_shape_that_is_still_being_named(
+    make_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    # Carrying shapes forward reads the canvas directly, so it runs inside the
+    # dialog's event loop and cannot be covered by a check made after it.
+    window = make_win(keep_prev=True)
+    _stage_unnamed_shape(window=window)
+    canvas = window._canvas_widgets.canvas
+
+    def switch_files_then_answer(*_args: object, **_kwargs: object) -> tuple:
+        window._load_file(image_or_label_path=str(data_path / _UNANNOTATED))
+        return None, None, None, None
+
+    monkeypatch.setattr(window._label_dialog, "popup", switch_files_then_answer)
+
+    window._on_new_shape()
+
+    # Clear before asserting: carrying shapes forward dirties the new file by
+    # design, and a failing assertion would block teardown on the prompt.
+    window.mark_clean()
+
+    assert canvas.shapes
+    assert all(shape.label is not None for shape in canvas.shapes)
+    close_or_pause(qtbot=qtbot, widget=window, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("accept", [True, False], ids=["confirmed", "cancelled"])
+def test_new_shape_survives_a_switch_made_inside_the_live_dialog(
+    make_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    pause: bool,
+    accept: bool,
+) -> None:
+    # The other cases replace the dialog with a stub, which never enters the
+    # nested loop the guard exists for. Here the real dialog is on screen and
+    # the file is switched from inside its own event loop.
+    window = make_win()
+    _stage_unnamed_shape(window=window)
+    canvas = window._canvas_widgets.canvas
+    switched: dict[str, object] = {}
+
+    def switch_files_then_close() -> None:
+        window._load_file(image_or_label_path=str(data_path / _UNANNOTATED))
+        switched["shapes"] = canvas.shapes[:]
+        switched["labels"] = [shape.label for shape in canvas.shapes]
+        switched["backups"] = len(canvas.shape_backups)
+        if accept:
+            window._label_dialog.edit.setText("cat")
+            window._label_dialog.accept()
+        else:
+            window._label_dialog.reject()
+
+    schedule_on_dialog(
+        label_dialog=window._label_dialog, action=switch_files_then_close
+    )
+
+    window._on_new_shape()
+
+    _assert_session_untouched(window=window, switched=switched)
+    close_or_pause(qtbot=qtbot, widget=window, pause=pause)


### PR DESCRIPTION
Fixes an `AssertionError` a user hit on quit:

```
File "labelme/_app.py", line 1945, in _on_new_shape
  self._canvas_widgets.canvas.undo_last_line()
File "labelme/_widgets/canvas.py", line 1938, in undo_last_line
  assert self.shapes
AssertionError
```

`_on_new_shape` and `_edit_label` each block on a modal dialog that spins a nested event loop, then act on state they captured before it. If the session was replaced meanwhile, the assumption is stale.

**I could not reproduce the trigger, and that is the main thing to weigh before merging.** `LabelDialog.popup` ends in `exec()`, which is application-modal; a window-level click on the file list and the next-image shortcut both fail to switch files while it is open, and there is no timer, watcher, or worker thread that reaches `_load_file`. The user's traceback proves the state happens, so the empty-canvas check is unconditional protection for it whatever emptied the canvas — but the rest is defence in depth, and the tests induce the replacement programmatically rather than through a gesture a user can perform. If the real trigger turns out to be something else, `assert self.shapes` is still reachable by that route.

Three non-obvious bits:

1. The two guards use deliberately different predicates because they write different things. Naming a shape checks the trailing run of unlabeled shapes, because its cancel path pops the last shape whatever it is; editing a label checks the selected rows, because that is what it writes through. A shared predicate was tried and is wrong in both directions: row identity misses `keep_prev` (which carries the same `Shape` objects forward while rebuilding every row, so a rename lands in the saved JSON under a row the user still sees unchanged), and shape membership false-positives on paste, duplicate and AI-append, silently dropping a valid rename. Both directions have a test.

2. Filtering the still-unnamed shape out of `prev_shapes` is a prerequisite, not scope creep. Without it the same file switch dies one frame earlier inside the nested loop, on `add_label`'s `assert shape.label is not None`, before any guard can run. Separate commit.

3. Giving up restores `edit_mode` and `undo_last_point`, which the success path already did. It deliberately does not call `_on_drawing_polygon_changed`, which would also enable Delete with nothing selected — that turns "Permanently delete 0 shapes?" into a `mark_dirty()`, and with auto-save on, writes a `.json` next to an untouched image.

Both guards log and return silently rather than showing a status message: `self.tr()` strings are gated by `make check_translate` across 20 languages in CI, which is disproportionate for a path with no reproduced trigger. The log lines carry shape count, create mode, row count, selection size and the image path, so a recurrence is diagnosable.

Not fixed here, all pre-existing and reachable on `main` without any dialog: `_load_file` never restores `edit_mode`/`undo_last_point`, so starting a polygon and switching files strands the toolbar; `delete_file`, `delete_selected_shapes` and `save_file` all re-read state after their own modal without revalidating. Qt documents `exec()` as the thing to avoid here — moving `popup()` to `open()` + `finished` would remove the hazard class rather than guard two of its sites.

Every guard is mutation-checked: reverting `_app.py` to `main` segfaults the new tests, and removing any single guard, either clause of the shape predicate, the toolbar restore, or the `keep_prev` filter fails a distinct subset.
