### PR TITLE
chore: bump gruff to 0.0.5 and select the whole GR prefix

### DIFF
--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -198,26 +198,28 @@ def main() -> None:
                 )
             )
 
-        if not args.noviz:
-            viz = img
-            if masks:
-                labels, captions, masks = zip(
-                    *[
-                        (class_name_to_id[cnm], cnm, msk)
-                        for (cnm, gid), msk in masks.items()
-                        if cnm in class_name_to_id
-                    ]
-                )
-                viz = imgviz.instances2rgb(
-                    image=img,
-                    labels=labels,
-                    masks=masks,
-                    captions=captions,
-                    font_size=15,
-                    line_width=2,
-                )
-            out_viz_file = output_dir / "Visualization" / f"{base}.jpg"
-            imgviz.io.imsave(out_viz_file, viz)
+        if args.noviz:
+            continue
+
+        viz = img
+        if masks:
+            labels, captions, masks = zip(
+                *[
+                    (class_name_to_id[cnm], cnm, msk)
+                    for (cnm, gid), msk in masks.items()
+                    if cnm in class_name_to_id
+                ]
+            )
+            viz = imgviz.instances2rgb(
+                image=img,
+                labels=labels,
+                masks=masks,
+                captions=captions,
+                font_size=15,
+                line_width=2,
+            )
+        out_viz_file = output_dir / "Visualization" / f"{base}.jpg"
+        imgviz.io.imsave(out_viz_file, viz)
 
     with open(out_ann_file, "w") as f:
         json.dump(data, f)

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -122,22 +122,26 @@ def main() -> None:
             )
             imgviz.io.imsave(out_clsv_file, clsv)
 
-        if not args.noobject:
-            # instance label
-            imgviz.io.lblsave(out_insp_file, ins.astype(np.uint8))
-            if not args.nonpy:
-                np.save(out_ins_file, ins)
-            if not args.noviz:
-                instance_ids = np.unique(ins)
-                instance_names = [str(i) for i in range(max(instance_ids) + 1)]
-                insv = imgviz.label2rgb(
-                    ins,
-                    imgviz.rgb2gray(img),
-                    label_names=instance_names,
-                    font_size=15,
-                    loc="rb",
-                )
-                imgviz.io.imsave(out_insv_file, insv)
+        if args.noobject:
+            continue
+
+        # instance label
+        imgviz.io.lblsave(out_insp_file, ins.astype(np.uint8))
+        if not args.nonpy:
+            np.save(out_ins_file, ins)
+        if args.noviz:
+            continue
+
+        instance_ids = np.unique(ins)
+        instance_names = [str(i) for i in range(max(instance_ids) + 1)]
+        insv = imgviz.label2rgb(
+            ins,
+            imgviz.rgb2gray(img),
+            label_names=instance_names,
+            font_size=15,
+            loc="rb",
+        )
+        imgviz.io.imsave(out_insv_file, insv)
 
 
 if __name__ == "__main__":

--- a/examples/tutorial/draw_label_png.py
+++ b/examples/tutorial/draw_label_png.py
@@ -26,19 +26,18 @@ def main() -> None:
     parser.add_argument("--image", help="image file", default=None)
     args = parser.parse_args()
 
-    if args.labels is not None:
-        if Path(args.labels).exists():
-            with open(args.labels) as f:
-                label_names = [label.strip() for label in f]
-        else:
-            label_names = args.labels.split(",")
-    else:
+    if args.labels is None:
         label_names = None
-
-    if args.image is not None:
-        image = imgviz.io.imread(args.image)
+    elif Path(args.labels).exists():
+        with open(args.labels) as f:
+            label_names = [label.strip() for label in f]
     else:
+        label_names = args.labels.split(",")
+
+    if args.image is None:
         image = None
+    else:
+        image = imgviz.io.imread(args.image)
 
     label = imgviz.io.imread(args.label_png)
     label = label.astype(np.int32)

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -49,11 +49,11 @@ def load_label_file(filename: str, /) -> LabeledImage:
     with open(filename, encoding="utf-8") as f:
         data = json.load(f)
 
-    if data.get("imageData") is not None:
-        image_data = base64.b64decode(data["imageData"])
-    else:
+    if data.get("imageData") is None:
         image_path = PureWindowsPath(data["imagePath"]).as_posix()
         image_data = (Path(filename).parent / image_path).read_bytes()
+    else:
+        image_data = base64.b64decode(data["imageData"])
 
     shapes = [
         {

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1557,10 +1557,11 @@ class MainWindow(QtWidgets.QMainWindow):
             " }"
         )
         for mode, action in self._actions.draw:
-            if mode in _AI_CREATE_MODES:
-                for widget in action.associatedObjects():
-                    if isinstance(widget, QtWidgets.QToolButton):
-                        widget.setStyleSheet(style)
+            if mode not in _AI_CREATE_MODES:
+                continue
+            for widget in action.associatedObjects():
+                if isinstance(widget, QtWidgets.QToolButton):
+                    widget.setStyleSheet(style)
 
     def show_label_list_menu(self, point: QtCore.QPoint, /) -> None:
         self._label_list_menu_origin = self._docks.label_list.mapToGlobal(point)
@@ -3141,13 +3142,13 @@ def _shapes_from_dicts(
         )
 
         default_flags: dict[str, bool] = {}
-        if not isinstance(shape.label, str):
-            logger.warning("shape.label is not str: {}", shape.label)
-        else:
+        if isinstance(shape.label, str):
             for pattern, keys in compiled_label_flags.items():
                 if pattern.match(shape.label):
                     for key in keys:
                         default_flags[key] = False
+        else:
+            logger.warning("shape.label is not str: {}", shape.label)
         shape.flags = default_flags
         shape.flags.update(shape_dict["flags"])
         shape.other_data = shape_dict["other_data"]

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -68,16 +68,15 @@ def _validate_config_item(*, key_path: tuple[str, ...], value: object) -> None:
         )
     if key == "validate_label" and value not in [None, "exact"]:
         raise ValueError(f"Unexpected value for config key 'validate_label': {value}")
-    if key == "labels" and value is not None:
-        if not isinstance(value, list):
-            raise ValueError(
-                f"Config key 'labels' must be a list, "
-                f"but got {type(value).__name__}: {value!r}"
-            )
-        if len(value) != len(set(value)):
-            raise ValueError(
-                f"Duplicates are detected for config key 'labels': {value}"
-            )
+    if key != "labels" or value is None:
+        return
+    if not isinstance(value, list):
+        raise ValueError(
+            f"Config key 'labels' must be a list, "
+            f"but got {type(value).__name__}: {value!r}"
+        )
+    if len(value) != len(set(value)):
+        raise ValueError(f"Duplicates are detected for config key 'labels': {value}")
 
 
 def _migrate_config_from_file(*, config_from_yaml: dict) -> None:
@@ -163,15 +162,16 @@ def _migrate_config_from_file(*, config_from_yaml: dict) -> None:
         crosshair = {}
     ai_polygon = crosshair.pop("ai_polygon", None)
     ai_mask = crosshair.pop("ai_mask", None)
-    if ai_polygon is not None or ai_mask is not None:
-        logger.info(
-            "Migrating old config: canvas.crosshair.ai_polygon={} or "
-            "canvas.crosshair.ai_mask={} -> canvas.crosshair.ai_points_to_shape",
-            ai_polygon,
-            ai_mask,
-        )
-        if "ai_points_to_shape" not in crosshair:
-            crosshair["ai_points_to_shape"] = bool(ai_polygon) or bool(ai_mask)
+    if ai_polygon is None and ai_mask is None:
+        return
+    logger.info(
+        "Migrating old config: canvas.crosshair.ai_polygon={} or "
+        "canvas.crosshair.ai_mask={} -> canvas.crosshair.ai_points_to_shape",
+        ai_polygon,
+        ai_mask,
+    )
+    if "ai_points_to_shape" not in crosshair:
+        crosshair["ai_points_to_shape"] = bool(ai_polygon) or bool(ai_mask)
 
 
 def get_user_config_file(*, create_if_missing: bool = True) -> str:

--- a/labelme/_config/_shape_color.py
+++ b/labelme/_config/_shape_color.py
@@ -55,27 +55,27 @@ def validate_shape_color(*, config: object) -> None:
         uniform = cast(dict[str, object], uniform)
         if "color" in uniform:
             _validate_rgb(path="shape_color.uniform.color", value=uniform["color"])
-    if "by_label" in config:
-        by_label = config["by_label"]
-        if by_label is None:
-            by_label = {}
-        if not isinstance(by_label, dict):
-            raise ValueError("shape_color.by_label must be a mapping")
-        by_label = cast(dict[str, object], by_label)
-        if "fallback" in by_label:
-            _validate_rgb(
-                path="shape_color.by_label.fallback", value=by_label["fallback"]
+    if "by_label" not in config:
+        return
+    by_label = config["by_label"]
+    if by_label is None:
+        by_label = {}
+    if not isinstance(by_label, dict):
+        raise ValueError("shape_color.by_label must be a mapping")
+    by_label = cast(dict[str, object], by_label)
+    if "fallback" in by_label:
+        _validate_rgb(path="shape_color.by_label.fallback", value=by_label["fallback"])
+    if "colors" not in by_label or by_label["colors"] is None:
+        return
+    colors = by_label["colors"]
+    if not isinstance(colors, dict):
+        raise ValueError("shape_color.by_label.colors must be a mapping")
+    for label, color in colors.items():
+        if not isinstance(label, str) or not label:
+            raise ValueError(
+                "shape_color.by_label.colors keys must be non-empty strings"
             )
-        if "colors" in by_label and by_label["colors"] is not None:
-            colors = by_label["colors"]
-            if not isinstance(colors, dict):
-                raise ValueError("shape_color.by_label.colors must be a mapping")
-            for label, color in colors.items():
-                if not isinstance(label, str) or not label:
-                    raise ValueError(
-                        "shape_color.by_label.colors keys must be non-empty strings"
-                    )
-                _validate_rgb(path=f"shape_color.by_label.colors.{label}", value=color)
+        _validate_rgb(path=f"shape_color.by_label.colors.{label}", value=color)
 
 
 def migrate_shape_color(*, config: dict) -> None:

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -307,12 +307,12 @@ def read_label_file(*, filename: str) -> Annotation:
         with open(filename, encoding="utf-8") as f:
             raw: dict[str, Any] = json.load(f)
         image_path = PureWindowsPath(raw["imagePath"]).as_posix()
-        if raw["imageData"] is not None:
-            image_data = base64.b64decode(raw["imageData"])
-        else:
+        if raw["imageData"] is None:
             image_data = read_image_file(
                 filename=str(Path(filename).parent / image_path)
             )
+        else:
+            image_data = base64.b64decode(raw["imageData"])
         _check_image_dimensions(
             image_data=image_data,
             expected_height=raw.get("imageHeight"),

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -2152,11 +2152,12 @@ def _compute_intersection_edges_image(
     t_exit = 1.0
     exit_axis = "x"
     for axis, numerator, denominator in boundary_pairs:
-        if denominator > 0.0:
-            t = numerator / denominator
-            if t < t_exit:
-                t_exit = t
-                exit_axis = axis
+        if denominator <= 0.0:
+            continue
+        t = numerator / denominator
+        if t < t_exit:
+            t_exit = t
+            exit_axis = axis
 
     if t_exit > 0.0:
         return QPointF(start_x + t_exit * delta_x, start_y + t_exit * delta_y)

--- a/labelme/_widgets/download.py
+++ b/labelme/_widgets/download.py
@@ -113,14 +113,14 @@ def download_ai_model(*, model_name: str, parent: QWidget) -> bool:
         label = (
             f"Downloading {model_name} ({file_index + 1}/{file_count})\n\n{filename}\n"
         )
-        if bytes_total != _DownloadThread.UNKNOWN_SIZE:
-            dialog.setRange(0, bytes_total)
-            dialog.setValue(bytes_so_far)
-            label += f"{_format_bytes(bytes_so_far)} / {_format_bytes(bytes_total)}"
-        else:
+        if bytes_total == _DownloadThread.UNKNOWN_SIZE:
             dialog.setRange(0, 0)
             if bytes_so_far > 0:
                 label += _format_bytes(bytes_so_far)
+        else:
+            dialog.setRange(0, bytes_total)
+            dialog.setValue(bytes_so_far)
+            label += f"{_format_bytes(bytes_so_far)} / {_format_bytes(bytes_total)}"
         dialog.setLabelText(label)
 
     def _on_succeeded() -> None:

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -113,7 +113,6 @@ class LabelDialog(QtWidgets.QDialog):
         self.edit.setCompleter(completer)
         self.edit.set_list_widget(list_widget=self.label_list)
 
-        # Button box
         button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
@@ -234,10 +233,11 @@ class LabelDialog(QtWidgets.QDialog):
         if label not in self._label_history:
             self._label_history.append(label)
 
-        if not self.label_list.findItems(label, QtCore.Qt.MatchFlag.MatchExactly):
-            self.label_list.addItem(label)
-            if self._sort_labels:
-                self.label_list.sortItems()
+        if self.label_list.findItems(label, QtCore.Qt.MatchFlag.MatchExactly):
+            return
+        self.label_list.addItem(label)
+        if self._sort_labels:
+            self.label_list.sortItems()
 
     def set_predefined_labels(self, *, labels: list[str]) -> None:
         history_extras = [h for h in self._label_history if h not in labels]
@@ -280,10 +280,10 @@ class LabelDialog(QtWidgets.QDialog):
         else:
             self.edit_group_id.setText(str(group_id))
 
-        if flags is not None:
-            self._set_flag_checkboxes(flags=flags)
-        else:
+        if flags is None:
             self._update_flags(self.edit.text())
+        else:
+            self._set_flag_checkboxes(flags=flags)
 
         matches = self.label_list.findItems(
             self.edit.text(), QtCore.Qt.MatchFlag.MatchFixedString

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
   "typos>=1.45.0",
   "yamlfix>=1.19.1",
   "towncrier>=24.8",
-  "gruff>=0.0.4",
+  "gruff>=0.0.5",
 ]
 
 [project.scripts]
@@ -96,7 +96,7 @@ markers = [
 ]
 
 [tool.gruff.lint]
-select = ["GR001", "GR002", "GR003", "GR004", "GR005", "GR006"]
+select = ["GR"]
 
 [tool.ruff.lint]
 select = [

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -147,12 +147,13 @@ def main_win(
         assert exc_info.value.code == 0
 
         for widget in app.topLevelWidgets():
-            if isinstance(widget, MainWindow) and widget not in existing:
-                created.append(widget)
-                qtbot.addWidget(widget)
-                if size is not None:
-                    widget.resize(size)
-                return widget
+            if not isinstance(widget, MainWindow) or widget in existing:
+                continue
+            created.append(widget)
+            qtbot.addWidget(widget)
+            if size is not None:
+                widget.resize(size)
+            return widget
 
         raise RuntimeError("main() did not create a MainWindow")
 

--- a/uv.lock
+++ b/uv.lock
@@ -503,14 +503,14 @@ wheels = [
 
 [[package]]
 name = "gruff"
-version = "0.0.4"
+version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/0e/24c140fee9989e7d7e6f5384717867842037ad6289ed82a6f2a59262d41c/gruff-0.0.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f53421c9a91e5ebe845f0ccbb02e5b449f4a72d63d7273116f04b1482eb47a4b", size = 1937646, upload-time = "2026-08-29T07:41:11.86Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/9e/1b9d45affcbe2b9cfccfc90e90bce2b2c5e17e9d4b6051e2511077ffb8c9/gruff-0.0.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:225e57823c9df70b428be74118bedce5f64194969184ed69faf8f6027f90cb02", size = 1870836, upload-time = "2026-08-29T07:41:13.578Z" },
-    { url = "https://files.pythonhosted.org/packages/69/34/658ed6c931969e731ec6c6a3ba3fd5e881d72ab12756f880fb793550f6ba/gruff-0.0.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dfd760bc120e83ee902a8ba40dafcdcd654a8dc679089c1cf1583f7aec2c6ce", size = 1894000, upload-time = "2026-08-29T07:41:15.17Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/d2/ca51b537863bbbe44d1582a7d30434210ec8b2222a0f929aec2f5951baac/gruff-0.0.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33c6c718d8385b600900ef5da6647d01cdfc9e67c5f58451f45568f6a0fd94ad", size = 2008931, upload-time = "2026-08-29T07:41:16.861Z" },
-    { url = "https://files.pythonhosted.org/packages/34/01/8cc8290e77fa1af663ae00283916c04c1195a7d1ae660f7666abdd294517/gruff-0.0.4-py3-none-win_amd64.whl", hash = "sha256:cbb2f381626136a81938b859ad4424e18c09599759ab50a42f86d9d35598c34d", size = 1915240, upload-time = "2026-08-29T07:41:18.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4c/7f19aad3e7b621e73a13822e854c13195ca29366bd4952d0fd03df51981a/gruff-0.0.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:662c389fc1c090bade52c8ab991a9a63b41f3cec7108007e81479ade0b8a8043", size = 1977054, upload-time = "2026-09-01T03:37:46.342Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/3a/56990ab23561e9464e9dae2e87f2e438758c90e66e29cbe8e6f609b9b76d/gruff-0.0.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f078a6737c5a36a5a9497586875410e01a3d77002688ac5a00f9f33f577db6c3", size = 1909040, upload-time = "2026-09-01T03:37:48.432Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f7/f78caabea24456e5af4b272d99c349cf8ed9d7893f9a94d2daa3ec5b7ed1/gruff-0.0.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e240efbea06923d2880e7028f46240f481b9cbbfa9587b00872a6e4a60cb0e71", size = 1933481, upload-time = "2026-09-01T03:37:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/b5b48628f6305709aaa9d4bf4ef5ad19cc08a4f309f0995fe7c2ae2b481e/gruff-0.0.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:728ae005c8505f3ff3a5d71de2c4013ae64fd1a6ee1f057ebaf309600b3d7b61", size = 2053551, upload-time = "2026-09-01T03:37:52.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/91/fc069b049a6cc958597b277c148232e15096e033d8cc24c1095950cb24de/gruff-0.0.5-py3-none-win_amd64.whl", hash = "sha256:df0f012ea4090c2c44ccb4261241dcf608112dfae1c40471e57edfe8cf09be68", size = 1958544, upload-time = "2026-09-01T03:37:53.703Z" },
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "gruff", specifier = ">=0.0.4" },
+    { name = "gruff", specifier = ">=0.0.5" },
     { name = "ipython" },
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },


### PR DESCRIPTION
Gruff 0.0.5 adds GR007 (no-subsumed-comments), GR008 (no-exception-swallowing-tests), GR009 (no-guarded-tails), and GR010 (positive-branch-conditions). Selecting the bare `GR` prefix replaces the per-code list so future rules turn on with the version bump instead of a config edit.

The first commit is the mechanical adoption sweep: 17 findings (1 GR007, 9 GR009, 7 GR010; GR008 was already clean), each an early-return/continue inversion, an if/else branch swap to the positive condition, or a deleted redundant comment. No behavior change; no `noqa` suppressions were needed.

One non-obvious bit: in the Liang–Barsky loop in `canvas.py`, the inverted guard evaluates a NaN denominator differently at the branch, but a NaN entering the old body produced `t = nan`, which never updated `t_exit`; the outcome is identical either way.

Verified: `gruff check`, `ruff check`, `ruff format --check`, and the non-GUI pytest suite (1009 passed) are green.
