### PR TITLE
chore: drop stale declarative-settings comment

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1031,7 +1031,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._default_state = self.saveState()
         #
-        # XXX: Could be completely declarative.
         # Restore the window geometry and dock layout (separate from the user
         # Config; this Qt store holds only window state).
         self._window_state = QtCore.QSettings("labelme", "labelme")


### PR DESCRIPTION
Deletes the `# XXX: Could be completely declarative.` comment in `labelme/_app.py`. It dates from the original 2011 settings code and describes no current or planned work.

No user-facing change, so no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvGZowth1Zr2iiHj6eubGH