### PR TITLE
refactor: build menus and toolbars from plain QAction lists

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -165,8 +165,8 @@ class _Actions(NamedTuple):
     zoom: tuple[ZoomWidget | QtGui.QAction, ...]
     on_load_active: tuple[QtGui.QAction, ...]
     on_shapes_present: tuple[QtGui.QAction, ...]
-    context_menu: tuple[QtGui.QAction | None, ...]
-    edit_menu: tuple[QtGui.QAction | None, ...]
+    context_menu: tuple[QtGui.QAction, ...]
+    edit_menu: tuple[QtGui.QAction, ...]
 
 
 class _Menus(NamedTuple):
@@ -323,6 +323,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _setup_actions(self) -> _Actions:
         action = functools.partial(_utils.new_action, self)
+        separator = functools.partial(_utils.new_separator, self)
         shortcuts = self._config["shortcuts"]
 
         about = action(
@@ -758,26 +759,26 @@ class MainWindow(QtWidgets.QMainWindow):
         context_menu = (
             *[draw_action for _, draw_action in draw],
             edit_mode,
-            None,
+            separator(),
             *history,
-            None,
+            separator(),
             *clipboard,
-            None,
+            separator(),
             edit,
             delete,
             add_point_to_edge,
             remove_point,
         )
         edit_menu = (
-            None,
+            separator(),
             *history,
-            None,
+            separator(),
             *clipboard,
-            None,
+            separator(),
             edit,
             delete,
             remove_point,
-            None,
+            separator(),
             keep_prev_action,
         )
         return _Actions(
@@ -837,6 +838,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _setup_menus(self) -> _Menus:
         action = functools.partial(_utils.new_action, self)
+        separator = functools.partial(_utils.new_separator, self)
         shortcuts = self._config["shortcuts"]
 
         quit_ = action(
@@ -867,14 +869,12 @@ class MainWindow(QtWidgets.QMainWindow):
             tip=self.tr("Show tutorial page"),
         )
 
-        file_menu = self.menu(self.tr("&File"))
-        edit_menu = self.menu(self.tr("&Edit"))
-        view_menu = self.menu(self.tr("&View"))
-        help_menu = self.menu(self.tr("&Help"))
+        file_menu = self.menuBar().addMenu(self.tr("&File"))
+        edit_menu = self.menuBar().addMenu(self.tr("&Edit"))
+        view_menu = self.menuBar().addMenu(self.tr("&View"))
+        help_menu = self.menuBar().addMenu(self.tr("&Help"))
         label_menu = QtWidgets.QMenu()
-        _utils.add_actions(
-            widget=label_menu, actions=(self._actions.edit, self._actions.delete)
-        )
+        label_menu.addActions((self._actions.edit, self._actions.delete))
         self._docks.label_list.setContextMenuPolicy(
             Qt.ContextMenuPolicy.CustomContextMenu
         )
@@ -882,9 +882,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.show_label_list_menu
         )
 
-        _utils.add_actions(
-            widget=file_menu,
-            actions=(
+        file_menu.addActions(
+            (
                 self._actions.open,
                 self._actions.open_next_img,
                 self._actions.open_prev_img,
@@ -896,52 +895,49 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._actions.save_with_image_data,
                 self._actions.close,
                 self._actions.delete_file,
-                None,
+                separator(),
                 open_config,
-                None,
+                separator(),
                 quit_,
-            ),
+            )
         )
-        _utils.add_actions(widget=help_menu, actions=(help_, self._actions.about))
-        _utils.add_actions(
-            widget=view_menu,
-            actions=(
+        help_menu.addActions((help_, self._actions.about))
+        view_menu.addActions(
+            (
                 self._docks.flag_dock.toggleViewAction(),
                 self._docks.label_dock.toggleViewAction(),
                 self._docks.shape_dock.toggleViewAction(),
                 self._docks.file_dock.toggleViewAction(),
-                None,
+                separator(),
                 self._actions.reset_layout,
-                None,
+                separator(),
                 self._actions.fill_drawing,
-                None,
+                separator(),
                 self._actions.hide_all,
                 self._actions.show_all,
                 self._actions.toggle_all,
-                None,
+                separator(),
                 self._actions.zoom_in,
                 self._actions.zoom_out,
                 self._actions.zoom_org,
                 self._actions.keep_prev_zoom,
-                None,
+                separator(),
                 self._actions.fit_window,
                 self._actions.fit_width,
-                None,
+                separator(),
                 self._actions.brightness_contrast,
                 self._actions.toggle_keep_prev_brightness_contrast,
-            ),
+            )
         )
 
-        _utils.add_actions(
-            widget=self._canvas_widgets.canvas.context_menus.without_selection,
-            actions=self._actions.context_menu,
+        self._canvas_widgets.canvas.context_menus.without_selection.addActions(
+            self._actions.context_menu
         )
-        _utils.add_actions(
-            widget=self._canvas_widgets.canvas.context_menus.with_selection,
-            actions=(
+        self._canvas_widgets.canvas.context_menus.with_selection.addActions(
+            (
                 action(text="&Copy here", slot=self.copy_shape),
                 action(text="&Move here", slot=self.move_shape),
-            ),
+            )
         )
 
         return _Menus(
@@ -953,6 +949,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def _setup_toolbars(self) -> None:
+        separator = functools.partial(_utils.new_separator, self)
         select_ai_model = QtWidgets.QWidgetAction(self)
         select_ai_model.setDefaultWidget(self._ai_annotation)
 
@@ -970,18 +967,18 @@ class MainWindow(QtWidgets.QMainWindow):
                     self._actions.open_next_img,
                     self._actions.save,
                     self._actions.delete_file,
-                    None,
+                    separator(),
                     self._actions.edit_mode,
                     self._actions.duplicate,
                     self._actions.delete,
                     self._actions.undo,
                     self._actions.brightness_contrast,
-                    None,
+                    separator(),
                     self._actions.fit_window,
                     self._actions.zoom_widget_action,
-                    None,
+                    separator(),
                     select_ai_model,
-                    None,
+                    separator(),
                     ai_prompt_action,
                 ],
                 font_base=self.font(),
@@ -997,7 +994,7 @@ class MainWindow(QtWidgets.QMainWindow):
                         for mode, a in self._actions.draw
                         if not mode.startswith("ai_")
                     ],
-                    None,
+                    separator(),
                     *[a for mode, a in self._actions.draw if mode.startswith("ai_")],
                 ],
                 orientation=Qt.Orientation.Vertical,
@@ -1279,18 +1276,6 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         return config_file, config
 
-    def menu(
-        self,
-        title: str,
-        /,
-        *,
-        actions: tuple[QtGui.QAction | QtWidgets.QMenu | None, ...] | None = None,
-    ) -> QtWidgets.QMenu:
-        menu = self.menuBar().addMenu(title)
-        if actions:
-            _utils.add_actions(widget=menu, actions=actions)
-        return menu
-
     # Support Functions
 
     def has_no_shapes(self) -> bool:
@@ -1298,9 +1283,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def populate_mode_actions(self) -> None:
         self._canvas_widgets.canvas.context_menus.without_selection.clear()
-        _utils.add_actions(
-            widget=self._canvas_widgets.canvas.context_menus.without_selection,
-            actions=self._actions.context_menu,
+        self._canvas_widgets.canvas.context_menus.without_selection.addActions(
+            self._actions.context_menu
         )
         self._menus.edit.clear()
         actions = (
@@ -1308,7 +1292,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._actions.edit_mode,
             *self._actions.edit_menu,
         )
-        _utils.add_actions(widget=self._menus.edit, actions=actions)
+        self._menus.edit.addActions(actions)
 
     def _get_window_title(self, *, dirty: bool) -> str:
         file_list = self._docks.file_list

--- a/labelme/_utils/__init__.py
+++ b/labelme/_utils/__init__.py
@@ -5,19 +5,18 @@ from .image import img_b64_to_arr
 from .image import img_data_to_pil
 from .image import img_qt_to_arr
 from .image import img_qt_to_rgb_arr
-from .qt import add_actions
 from .qt import apply_color_theme
 from .qt import direction_angle
 from .qt import label_validator
 from .qt import new_action
 from .qt import new_icon
+from .qt import new_separator
 from .qt import project_point_on_line
 from .qt import project_point_on_perpendicular_line
 from .shape import shape_to_mask
 from .shape import shapes_to_label
 
 __all__ = [
-    "add_actions",
     "apply_color_theme",
     "apply_exif_orientation",
     "direction_angle",
@@ -30,6 +29,7 @@ __all__ = [
     "label_validator",
     "new_action",
     "new_icon",
+    "new_separator",
     "project_point_on_line",
     "project_point_on_perpendicular_line",
     "shape_to_mask",

--- a/labelme/_utils/qt.py
+++ b/labelme/_utils/qt.py
@@ -128,45 +128,33 @@ def new_action(
     *,
     text: str = "",
     slot: Callable[..., object] | None = None,
-    shortcut: str | list[str] | tuple[str, ...] | None = None,
+    shortcut: str | Sequence[str] | None = None,
     icon: str | None = None,
     tip: str | None = None,
     checkable: bool = False,
     enabled: bool = True,
     checked: bool = False,
 ) -> QtGui.QAction:
-    action = QtGui.QAction(text, parent)
-    if icon is not None:
-        action.setIcon(new_icon(icon))
-        action.setIconText(text.replace(" ", "\n"))
-    if shortcut is not None:
-        if isinstance(shortcut, list | tuple):
-            action.setShortcuts([QtGui.QKeySequence(s) for s in shortcut])
-        else:
-            action.setShortcut(QtGui.QKeySequence(shortcut))
-    if tip is not None:
-        action.setToolTip(tip)
-        action.setStatusTip(tip)
+    action = QtGui.QAction(new_icon(icon) if icon else QtGui.QIcon(), text, parent)
+    keys = [shortcut] if isinstance(shortcut, str) else shortcut or ()
+    action.setShortcuts([QtGui.QKeySequence(key) for key in keys])
+    action.setToolTip(tip or "")
+    action.setStatusTip(tip or "")
     action.setCheckable(checkable)
-    action.setEnabled(enabled)
     action.setChecked(checked)
-    if slot is not None:
+    action.setEnabled(enabled)
+    if icon:
+        # Tool buttons show the icon text; stacking words keeps them narrow.
+        action.setIconText(text.replace(" ", "\n"))
+    if slot:
         action.triggered.connect(slot)
     return action
 
 
-def add_actions(
-    *,
-    widget: QtWidgets.QMenu | QtWidgets.QToolBar,
-    actions: Sequence[QtGui.QAction | QtWidgets.QMenu | None],
-) -> None:
-    for action in actions:
-        if action is None:
-            widget.addSeparator()
-        elif isinstance(action, QtWidgets.QMenu):
-            widget.addMenu(action)  # ty: ignore[unresolved-attribute]
-        else:
-            widget.addAction(action)
+def new_separator(parent: QtWidgets.QWidget, /) -> QtGui.QAction:
+    separator = QtGui.QAction(parent)
+    separator.setSeparator(True)
+    return separator
 
 
 def label_validator() -> QtGui.QRegularExpressionValidator:

--- a/labelme/_widgets/tool_bar.py
+++ b/labelme/_widgets/tool_bar.py
@@ -6,8 +6,6 @@ from PySide6 import QtGui
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 
-from .._utils import add_actions
-
 _OBJECT_NAME_SUFFIX: Final = "ToolBar"
 _FONT_SCALE_FACTOR: Final = 0.8
 _VERTICAL_SEPARATOR_STYLE: Final = (
@@ -20,7 +18,7 @@ class ToolBar(QtWidgets.QToolBar):
         self,
         *,
         title: str,
-        actions: list[QtGui.QAction | None],
+        actions: list[QtGui.QAction],
         orientation: Qt.Orientation = Qt.Orientation.Horizontal,
         button_style: Qt.ToolButtonStyle = Qt.ToolButtonStyle.ToolButtonTextUnderIcon,
         font_base: QtGui.QFont | None = None,
@@ -46,13 +44,14 @@ class ToolBar(QtWidgets.QToolBar):
         if orientation == Qt.Orientation.Vertical:
             self.setStyleSheet(_VERTICAL_SEPARATOR_STYLE)
 
-        add_actions(widget=self, actions=actions)
+        for action in actions:
+            self.addAction(action)
 
         if orientation == Qt.Orientation.Vertical:
             self._equalize_button_widths()
 
     def addAction(self, action: QtGui.QAction, /) -> None:  # ty: ignore[invalid-method-override]
-        if isinstance(action, QtWidgets.QWidgetAction):
+        if isinstance(action, QtWidgets.QWidgetAction) or action.isSeparator():
             super().addAction(action)
             return
 

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -10,11 +10,11 @@ from PySide6.QtCore import QPointF
 from pytestqt.qtbot import QtBot
 
 from labelme._utils.qt import _TintedSvgIconEngine
-from labelme._utils.qt import add_actions
 from labelme._utils.qt import direction_angle
 from labelme._utils.qt import label_validator
 from labelme._utils.qt import new_action
 from labelme._utils.qt import new_icon
+from labelme._utils.qt import new_separator
 from labelme._utils.qt import project_point_on_line
 from labelme._utils.qt import project_point_on_perpendicular_line
 
@@ -361,60 +361,26 @@ def test_new_action_slot(*, qtbot: QtBot) -> None:
 
 
 # ---------------------------------------------------------------------------
-# add_actions
+# new_separator
 # ---------------------------------------------------------------------------
 
 
-def test_add_actions_adds_qaction_to_menu(*, qtbot: QtBot) -> None:
+def test_new_separator_renders_as_menu_separator(*, qtbot: QtBot) -> None:
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
     menu = QtWidgets.QMenu(parent)
-    action = QtGui.QAction("Cut", parent)
-    add_actions(widget=menu, actions=[action])
-    assert action in menu.actions()
+    menu.addActions([QtGui.QAction("Cut", parent), new_separator(parent)])
+    assert [a.isSeparator() for a in menu.actions()] == [False, True]
 
 
-def test_add_actions_none_adds_separator_to_menu(*, qtbot: QtBot) -> None:
+def test_new_separator_survives_menu_clear(*, qtbot: QtBot) -> None:
+    # Menus rebuilt at runtime keep their separator objects, so a separator must
+    # belong to the caller rather than to the menu that clear() empties.
     parent = QtWidgets.QWidget()
     qtbot.addWidget(parent)
+    separator = new_separator(parent)
     menu = QtWidgets.QMenu(parent)
-    action = QtGui.QAction("Cut", parent)
-    add_actions(widget=menu, actions=[action, None])
-    separators = [a for a in menu.actions() if a.isSeparator()]
-    assert len(separators) == 1
-
-
-def test_add_actions_submenu_to_menu(*, qtbot: QtBot) -> None:
-    parent = QtWidgets.QWidget()
-    qtbot.addWidget(parent)
-    menu = QtWidgets.QMenu(parent)
-    submenu = QtWidgets.QMenu("Sub", parent)
-    add_actions(widget=menu, actions=[submenu])
-    # QMenu added as submenu appears in actions list
-    titles = [a.text() for a in menu.actions()]
-    assert "Sub" in titles
-
-
-def test_add_actions_adds_qaction_to_toolbar(*, qtbot: QtBot) -> None:
-    toolbar = QtWidgets.QToolBar()
-    qtbot.addWidget(toolbar)
-    action = QtGui.QAction("Copy", toolbar)
-    add_actions(widget=toolbar, actions=[action])
-    assert action in toolbar.actions()
-
-
-def test_add_actions_none_adds_separator_to_toolbar(*, qtbot: QtBot) -> None:
-    toolbar = QtWidgets.QToolBar()
-    qtbot.addWidget(toolbar)
-    action = QtGui.QAction("Copy", toolbar)
-    add_actions(widget=toolbar, actions=[action, None])
-    separators = [a for a in toolbar.actions() if a.isSeparator()]
-    assert len(separators) == 1
-
-
-def test_add_actions_empty_sequence(*, qtbot: QtBot) -> None:
-    parent = QtWidgets.QWidget()
-    qtbot.addWidget(parent)
-    menu = QtWidgets.QMenu(parent)
-    add_actions(widget=menu, actions=[])
-    assert menu.actions() == []
+    menu.addAction(separator)
+    menu.clear()
+    menu.addAction(separator)
+    assert [a.isSeparator() for a in menu.actions()] == [True]

--- a/tests/unit/widgets/tool_bar_test.py
+++ b/tests/unit/widgets/tool_bar_test.py
@@ -28,18 +28,24 @@ def _make_action(text: str, /) -> QtGui.QAction:
     return QtGui.QAction(text)
 
 
+def _make_separator() -> QtGui.QAction:
+    separator = QtGui.QAction()
+    separator.setSeparator(True)
+    return separator
+
+
 @pytest.fixture()
-def actions() -> list[QtGui.QAction | None]:
+def actions() -> list[QtGui.QAction]:
     return [
         _make_action("Alpha"),
         _make_action("Beta"),
-        None,
+        _make_separator(),
         _make_action("Gamma"),
     ]
 
 
 @pytest.fixture()
-def toolbar_h(*, qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
+def toolbar_h(*, qtbot: QtBot, actions: list[QtGui.QAction]) -> ToolBar:
     tb = ToolBar(
         title="Test",
         actions=actions,
@@ -50,7 +56,7 @@ def toolbar_h(*, qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
 
 
 @pytest.fixture()
-def toolbar_v(*, qtbot: QtBot, actions: list[QtGui.QAction | None]) -> ToolBar:
+def toolbar_v(*, qtbot: QtBot, actions: list[QtGui.QAction]) -> ToolBar:
     tb = ToolBar(
         title="Test",
         actions=actions,
@@ -156,7 +162,7 @@ def test_toolbar_tool_buttons_have_default_action(*, toolbar_h: ToolBar) -> None
 # --- separator ---
 
 
-def test_toolbar_none_action_inserts_separator(*, toolbar_h: ToolBar) -> None:
+def test_toolbar_separator_action_inserts_separator(*, toolbar_h: ToolBar) -> None:
     separators = [a for a in toolbar_h.actions() if a.isSeparator()]
     assert len(separators) == 1
 


### PR DESCRIPTION
Drops the private menu/toolbar filler that walked a mixed list where `None` meant a separator and a `QMenu` meant a submenu. Qt covers both natively: a `QAction` flagged as a separator renders as one, and `addActions` takes the whole list.

Two non-obvious bits:

1. Separator actions are owned by the main window, not the menu. The edit menu is cleared and rebuilt on every mode change, and `QMenu.clear()` deletes menu-owned actions, so window-owned separators survive the rebuild; verified by a unit test and an offscreen smoke run (file 2, view 6, edit 3 before and after rebuild, toolbars 4 and 1, all matching `main`).

2. `ToolBar.addAction` now routes separator actions to the base class the same way it already did for widget actions, so they are not wrapped in a `QToolButton`.

Submenu support is dropped from the helper because no caller passed a `QMenu`; `menu.addMenu` covers it if one ever does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sPH8v4aEj6KXCsaHCZeKy
