### PR TITLE
refactor(canvas): drop redundant precondition in undo_last_line

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1961,7 +1961,6 @@ class Canvas(QtWidgets.QWidget):
         return shapes
 
     def undo_last_line(self) -> None:
-        assert self.shapes
         if self.create_mode in _AI_CREATE_MODES:
             # Remove all unlabeled shapes at the tail (added by AI in one shot)
             while self.shapes and self.shapes[-1].label is None:


### PR DESCRIPTION
The only caller runs right after a shape was finalized, so the shape list is never empty at that point. The AI-mode branch already tolerates an empty list, and the non-AI branch pops immediately, so the assertion added nothing beyond what the pop itself raises.

No behavior change. Canvas unit tests and the cancel-label e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EYbWQwkc4wZoYGqF8mGcd
