### PR TITLE
refactor(brightness-contrast): drive the sliders through lookup tables and show percent readouts

### DIFF
--- a/changelog.d/2585.changed.md
+++ b/changelog.d/2585.changed.md
@@ -1,0 +1,1 @@
+The Brightness/Contrast dialog applies adjustments with lookup tables while preserving prior rendering and transparency, and shows each slider value as a percentage

--- a/labelme/_widgets/brightness_contrast_dialog.py
+++ b/labelme/_widgets/brightness_contrast_dialog.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Final
 
 import PIL.Image
 import PIL.ImageEnhance
+import PIL.ImageStat
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QImage
 
+_NEUTRAL: Final = 50
+
 
 class BrightnessContrastDialog(QtWidgets.QDialog):
-    _base_value = 50
-
-    img: PIL.Image.Image
-
     def __init__(
         self,
         *,
@@ -24,75 +24,71 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setWindowTitle(self.tr("Brightness/Contrast"))
         self.setModal(True)
+        self._publish = callback
 
-        self._on_image_changed = callback
+        # Alpha rides along as an untouched band; every other mode collapses
+        # to RGB so one lookup table covers all color channels.
+        self._img = img.convert("RGBA" if "A" in img.getbands() else "RGB")
+        self.slider_brightness = QtWidgets.QSlider(Qt.Orientation.Horizontal)
+        self.slider_contrast = QtWidgets.QSlider(Qt.Orientation.Horizontal)
 
-        grid = QtWidgets.QGridLayout()
+        grid = QtWidgets.QGridLayout(self)
         grid.setColumnStretch(1, 1)
-        self.slider_brightness = self._add_slider_row(
-            grid=grid, row=0, title=self.tr("Brightness:")
+        captioned = (
+            (self.tr("Brightness:"), self.slider_brightness),
+            (self.tr("Contrast:"), self.slider_contrast),
         )
-        self.slider_contrast = self._add_slider_row(
-            grid=grid, row=1, title=self.tr("Contrast:")
-        )
-        self.setLayout(grid)
-
-        self._alpha = None
-        if "A" in img.getbands():
-            self._alpha = img.getchannel("A")
-        if img.mode != "RGB":
-            img = img.convert("RGB")
-        self.img = img
-
-    def _add_slider_row(
-        self, *, grid: QtWidgets.QGridLayout, row: int, title: str
-    ) -> QtWidgets.QSlider:
-        slider = QtWidgets.QSlider(Qt.Orientation.Horizontal)
-        slider.setRange(0, 3 * self._base_value)
-        slider.setValue(self._base_value)
-
-        value_label = QtWidgets.QLabel(self._format_factor(slider.value()))
-        value_label.setAlignment(Qt.AlignmentFlag.AlignRight)
-
-        slider.valueChanged.connect(lambda _: self.apply())
-        slider.valueChanged.connect(
-            lambda value: value_label.setText(self._format_factor(value))
-        )
-
-        grid.addWidget(QtWidgets.QLabel(title), row, 0)
-        grid.addWidget(slider, row, 1)
-        grid.addWidget(value_label, row, 2)
-        return slider
-
-    def _format_factor(self, value: int, /) -> str:
-        return f"{value / self._base_value:.2f}"
+        for row, (caption, slider) in enumerate(captioned):
+            slider.setRange(0, 3 * _NEUTRAL)
+            slider.setValue(_NEUTRAL)
+            readout = QtWidgets.QLabel(_as_percent(slider.value()))
+            readout.setAlignment(Qt.AlignmentFlag.AlignRight)
+            slider.valueChanged.connect(
+                lambda value, readout=readout: readout.setText(_as_percent(value))
+            )
+            slider.valueChanged.connect(lambda _value: self.apply())
+            grid.addWidget(QtWidgets.QLabel(caption), row, 0)
+            grid.addWidget(slider, row, 1)
+            grid.addWidget(readout, row, 2)
 
     def apply(self) -> None:
-        img: PIL.Image.Image = self.img
-        enhancers = [
-            (
-                self.slider_brightness.value() / self._base_value,
-                PIL.ImageEnhance.Brightness,
-            ),
-            (
-                self.slider_contrast.value() / self._base_value,
-                PIL.ImageEnhance.Contrast,
-            ),
-        ]
-        for factor, enhancer_cls in enhancers:
-            if factor == 1.0:
-                continue
-            img = enhancer_cls(img).enhance(factor)
-
-        fmt: QImage.Format
-        if self._alpha is None:
-            fmt = QImage.Format.Format_RGB888
-        else:
-            img = img.convert("RGBA")
-            img.putalpha(self._alpha)
-            fmt = QImage.Format.Format_RGBA8888
-
-        qimage = QImage(
-            img.tobytes(), img.width, img.height, img.width * len(img.getbands()), fmt
+        gain = self.slider_brightness.value() / _NEUTRAL
+        spread = self.slider_contrast.value() / _NEUTRAL
+        identity = list(range(256))
+        alpha_lut = identity if self._img.mode == "RGBA" else []
+        ramp = PIL.Image.frombytes("L", (256, 1), bytes(identity))
+        bright_ramp = PIL.ImageEnhance.Brightness(ramp).enhance(gain)
+        bright_lut = list(bright_ramp.tobytes())
+        bright_img = (
+            self._img if gain == 1.0 else self._img.point(bright_lut * 3 + alpha_lut)
         )
-        self._on_image_changed(qimage)
+
+        if spread == 1.0:
+            img = bright_img
+        else:
+            # Pillow derives the contrast pivot after brightness has clipped
+            # and rounded, so the combined table must use that intermediate.
+            pivot = int(PIL.ImageStat.Stat(bright_img.convert("L")).mean[0] + 0.5)
+            contrast_ramp = PIL.Image.blend(
+                PIL.Image.new("L", ramp.size, pivot), bright_ramp, spread
+            )
+            contrast_lut = list(contrast_ramp.tobytes())
+            img = self._img.point(contrast_lut * 3 + alpha_lut)
+
+        image_format = (
+            QImage.Format.Format_RGBA8888
+            if img.mode == "RGBA"
+            else QImage.Format.Format_RGB888
+        )
+        qimage = QImage(
+            img.tobytes(),
+            img.width,
+            img.height,
+            img.width * len(img.getbands()),
+            image_format,
+        )
+        self._publish(qimage)
+
+
+def _as_percent(value: int, /) -> str:
+    return f"{value * 100 // _NEUTRAL}%"

--- a/tests/unit/widgets/brightness_contrast_dialog/output_test.py
+++ b/tests/unit/widgets/brightness_contrast_dialog/output_test.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import numpy as np
+import PIL.Image
+from pytestqt.qtbot import QtBot
+
+from labelme._utils.image import img_qt_to_arr
+from labelme._widgets.brightness_contrast_dialog import BrightnessContrastDialog
+
+
+def test_combined_adjustment_preserves_clipped_brightness_pivot(
+    *, qtbot: QtBot
+) -> None:
+    source = PIL.Image.fromarray(
+        np.array([[[0, 0, 0], [255, 255, 255]]], dtype=np.uint8), mode="RGB"
+    )
+    captured: list[np.ndarray] = []
+    dialog = BrightnessContrastDialog(
+        img=source, callback=lambda image: captured.append(img_qt_to_arr(image))
+    )
+    qtbot.addWidget(dialog)
+
+    dialog.slider_brightness.setValue(100)
+    dialog.slider_contrast.setValue(0)
+
+    expected = np.full((1, 2, 3), 128, dtype=np.uint8)
+    np.testing.assert_array_equal(captured[-1], expected)


### PR DESCRIPTION
## Summary

Each slider tick used to run two Pillow enhancers over the full image and split the alpha band off and paste it back afterwards. The dialog now derives a 256-entry lookup table from Pillow's own brightness and contrast mappings by enhancing a one-row ramp image, and applies it to the picture with `Image.point`. Alpha rides along as an identity band in the same table, so the split/paste step is gone.

The non-obvious constraint is the contrast pivot. Pillow computes it from the brightness-adjusted image after clipping and rounding, so when both sliders are off neutral the dialog still materializes the brightened image once to take that mean before building the combined table. That keeps every slider combination pixel-identical to the previous rendering, which `tests/unit/widgets/brightness_contrast_dialog/output_test.py` pins on a black/white pair at 200% brightness and 0% contrast.

The two rows are built from a caption/slider list, and the readouts show percentages (`150%`) instead of a bare factor (`1.50`). Slider range, the neutral position, dialog modality, the `slider_brightness` / `slider_contrast` / `apply()` surface used by the main window, and the translatable strings are unchanged, so no catalog or `_app.py` edits were needed.

## Test plan

- `make lint`
- `make check_translate`
- `uv run pytest tests/unit`
- `uv run pytest tests/e2e/brightness_contrast_test.py tests/e2e/zoom_test.py -k brightness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R99Deii5mzeqNHXSLkGdmy
