### PR TITLE
refactor(brightness-contrast): drop the redundant modal flag

### DIFF
--- a/labelme/_widgets/brightness_contrast_dialog.py
+++ b/labelme/_widgets/brightness_contrast_dialog.py
@@ -23,7 +23,6 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle(self.tr("Brightness/Contrast"))
-        self.setModal(True)
         self._publish = callback
 
         # Alpha rides along as an untouched band; every other mode collapses


### PR DESCRIPTION
## Summary

Removes the explicit modal setter from the Brightness/Contrast dialog. The app only shows the dialog through `exec()`, which already runs it application-modal, so the line never changed anything observable.

## Test plan

- [x] `ruff check` and `ruff format --check` on the dialog module
- [x] `pytest tests/unit/widgets/brightness_contrast_dialog tests/e2e/brightness_contrast_test.py` (7 passed)