### PR TITLE
refactor(label-dialog): return LabelDialogEntry and lock fields

### DIFF
--- a/changelog.d/2587.changed.md
+++ b/changelog.d/2587.changed.md
@@ -1,0 +1,1 @@
+Improved the Label dialog so blank labels cannot be submitted and shared fields can be edited across Shapes with different Labels when validate_label is exact

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -53,6 +53,8 @@ from ._widgets import AiTextToAnnotationWidget
 from ._widgets import BrightnessContrastDialog
 from ._widgets import Canvas
 from ._widgets import LabelDialog
+from ._widgets import LabelDialogEntry
+from ._widgets import LabelDialogField
 from ._widgets import LabelListWidget
 from ._widgets import LabelListWidgetItem
 from ._widgets import Palette
@@ -1577,29 +1579,16 @@ class MainWindow(QtWidgets.QMainWindow):
 
         shapes = [cast(Shape, item.shape()) for item in items]
         first_shape = shapes[0]
-
-        if len(items) == 1:
-            edit_text = True
-            edit_flags = True
-            edit_group_id = True
-            edit_description = True
-        else:
-            edit_text = all(shape.label == first_shape.label for shape in shapes[1:])
-            edit_flags = all(shape.flags == first_shape.flags for shape in shapes[1:])
-            edit_group_id = all(
-                shape.group_id == first_shape.group_id for shape in shapes[1:]
+        # A field whose value differs across the selection has no single value
+        # to show, so it is locked in the dialog and left untouched on accept.
+        locked = {
+            field
+            for field in typing.get_args(LabelDialogField)
+            if any(
+                getattr(shape, field) != getattr(first_shape, field)
+                for shape in shapes[1:]
             )
-            edit_description = all(
-                shape.description == first_shape.description for shape in shapes[1:]
-            )
-
-        if not edit_text:
-            self._label_dialog.edit.setDisabled(True)
-            self._label_dialog.label_list.setDisabled(True)
-        if not edit_group_id:
-            self._label_dialog.edit_group_id.setDisabled(True)
-        if not edit_description:
-            self._label_dialog.edit_description.setDisabled(True)
+        }
 
         canvas_menu_origin = self._canvas_widgets.canvas.context_menu_origin
         menu_origin = (
@@ -1607,35 +1596,26 @@ class MainWindow(QtWidgets.QMainWindow):
             if canvas_menu_origin is not None
             else self._label_list_menu_origin
         )
-
-        text, flags, group_id, description = self._label_dialog.popup(
-            text=first_shape.label if edit_text else "",
+        entry = self._label_dialog.popup(
+            text=first_shape.label,
+            flags=first_shape.flags,
+            group_id=first_shape.group_id,
+            description=first_shape.description,
+            locked=locked,
             position=menu_origin,
-            flags=first_shape.flags if edit_flags else None,
-            group_id=first_shape.group_id if edit_group_id else None,
-            description=first_shape.description if edit_description else None,
-            flags_disabled=not edit_flags,
         )
-
-        if not edit_text:
-            self._label_dialog.edit.setDisabled(False)
-            self._label_dialog.label_list.setDisabled(False)
-        if not edit_group_id:
-            self._label_dialog.edit_group_id.setDisabled(False)
-        if not edit_description:
-            self._label_dialog.edit_description.setDisabled(False)
-
-        if text is None:
-            assert flags is None
-            assert group_id is None
-            assert description is None
+        if entry is None:
+            # The next new-shape dialog starts from the label that was on show.
+            self._label_dialog.remember_label(
+                label="" if "label" in locked else first_shape.label or ""
+            )
             return
 
-        if not self.validate_label(label=text):
+        if "label" not in locked and not self.validate_label(label=entry.label):
             self.show_error_message(
                 title=self.tr("Invalid label"),
                 message=self.tr("Invalid label '{}' with validation type '{}'").format(
-                    text, self._config["validate_label"]
+                    entry.label, self._config["validate_label"]
                 ),
             )
             return
@@ -1644,15 +1624,9 @@ class MainWindow(QtWidgets.QMainWindow):
         for item in items:
             shape = item.shape()
             assert shape is not None
-
-            if edit_text:
-                shape.label = text
-            if edit_flags:
-                shape.flags = flags
-            if edit_group_id:
-                shape.group_id = group_id
-            if edit_description:
-                shape.description = description
+            for field in typing.get_args(LabelDialogField):
+                if field not in locked:
+                    setattr(shape, field, getattr(entry, field))
 
             assert shape.label is not None
             fill_rgb = self._get_rgb_by_label(
@@ -1905,42 +1879,40 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_new_shape(self) -> None:
         items = self._docks.unique_label_list.selectedItems()
-        text = None
-        if items:
-            text = items[0].data(Qt.ItemDataRole.UserRole)
-        flags = {}
-        group_id = None
-        description = ""
+        text = items[0].data(Qt.ItemDataRole.UserRole) if items else None
         if self._config["display_label_popup"] or not text:
-            previous_text = self._label_dialog.edit.text()
-            text, flags, group_id, description = self._label_dialog.popup(text=text)
-            if not text:
-                self._label_dialog.edit.setText(previous_text)
+            entry = self._label_dialog.popup(text=text)
+        else:
+            entry = LabelDialogEntry(
+                label=text, flags={}, group_id=None, description=""
+            )
 
-        if text and not self.validate_label(label=text):
+        if entry is not None and not self.validate_label(label=entry.label):
             self.show_error_message(
                 title=self.tr("Invalid label"),
                 message=self.tr("Invalid label '{}' with validation type '{}'").format(
-                    text, self._config["validate_label"]
+                    entry.label, self._config["validate_label"]
                 ),
             )
-            text = ""
-        if text:
-            self._docks.label_list.clearSelection()
-            assert isinstance(flags, dict)
-            shapes = self._canvas_widgets.canvas.set_last_label(text=text, flags=flags)
-            for shape in shapes:
-                if group_id is not None or shape.group_id is None:
-                    shape.group_id = group_id
-                shape.description = description
-                self.add_label(shape=shape)
-            self._actions.edit_mode.setEnabled(True)
-            self._actions.undo_last_point.setEnabled(False)
-            self._actions.undo.setEnabled(True)
-            self.mark_dirty()
-        else:
+            entry = None
+        if entry is None:
             self._canvas_widgets.canvas.undo_last_line()
             self._canvas_widgets.canvas.shape_backups.pop()
+            return
+
+        self._docks.label_list.clearSelection()
+        shapes = self._canvas_widgets.canvas.set_last_label(
+            text=entry.label, flags=entry.flags
+        )
+        for shape in shapes:
+            if entry.group_id is not None or shape.group_id is None:
+                shape.group_id = entry.group_id
+            shape.description = entry.description
+            self.add_label(shape=shape)
+        self._actions.edit_mode.setEnabled(True)
+        self._actions.undo_last_point.setEnabled(False)
+        self._actions.undo.setEnabled(True)
+        self.mark_dirty()
 
     def _on_inference_produced_no_shapes(self) -> None:
         self.show_status_message(

--- a/labelme/_utils/__init__.py
+++ b/labelme/_utils/__init__.py
@@ -7,7 +7,6 @@ from .image import img_qt_to_arr
 from .image import img_qt_to_rgb_arr
 from .qt import apply_color_theme
 from .qt import direction_angle
-from .qt import label_validator
 from .qt import new_action
 from .qt import new_icon
 from .qt import new_separator
@@ -26,7 +25,6 @@ __all__ = [
     "img_data_to_pil",
     "img_qt_to_arr",
     "img_qt_to_rgb_arr",
-    "label_validator",
     "new_action",
     "new_icon",
     "new_separator",

--- a/labelme/_utils/qt.py
+++ b/labelme/_utils/qt.py
@@ -158,12 +158,6 @@ def new_separator(parent: QtWidgets.QWidget, /) -> QtGui.QAction:
     return separator
 
 
-def label_validator() -> QtGui.QRegularExpressionValidator:
-    # Accepts strings of 2+ chars not starting with space or tab.
-    # Single non-whitespace char is Intermediate (handled by regex partial match).
-    return QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"[^ \t].+"))
-
-
 def direction_angle(*, start: npt.ArrayLike, end: npt.ArrayLike) -> float:
     s = np.asarray(start, dtype=float)
     e = np.asarray(end, dtype=float)

--- a/labelme/_widgets/__init__.py
+++ b/labelme/_widgets/__init__.py
@@ -6,6 +6,8 @@ from .brightness_contrast_dialog import BrightnessContrastDialog
 from .canvas import Canvas
 from .download import download_ai_model
 from .label_dialog import LabelDialog
+from .label_dialog import LabelDialogEntry
+from .label_dialog import LabelDialogField
 from .label_list_widget import LabelListWidget
 from .label_list_widget import LabelListWidgetItem
 from .label_list_widget import format_shape_label
@@ -20,6 +22,8 @@ __all__ = [
     "BrightnessContrastDialog",
     "Canvas",
     "LabelDialog",
+    "LabelDialogEntry",
+    "LabelDialogField",
     "LabelListWidget",
     "LabelListWidgetItem",
     "Palette",

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
+import dataclasses
+from collections.abc import Collection
 from typing import Final
+from typing import Literal
 
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 from .._label_flags import compile_label_flags
-from .._utils import label_validator
+
+LabelDialogField = Literal["label", "flags", "group_id", "description"]
+
+
+@dataclasses.dataclass(frozen=True)
+class LabelDialogEntry:
+    label: str
+    flags: dict[str, bool]
+    group_id: int | None
+    description: str
+
 
 _PLACEHOLDER_TEXT: Final[str] = "Enter object label"
 
@@ -56,7 +69,11 @@ class LabelDialog(QtWidgets.QDialog):
         self._sort_labels = sort_labels
         self._flags_spec = compile_label_flags(label_flags=flags)
         self._label_history = label_history[:] if label_history is not None else []
-        self._flags_disabled = False
+        # Fields the current popup shows read-only because the caller has no
+        # single value for them (a mixed multi-selection).
+        self._locked: frozenset[LabelDialogField] = frozenset()
+        # A popup opened without a label starts from the last one accepted.
+        self._last_label = ""
         # The flags currently on show, keyed by flag name, so a flag named by
         # two matching label_flags patterns gets exactly one checkbox.
         self._flag_checkboxes: dict[str, QtWidgets.QCheckBox] = {}
@@ -73,7 +90,6 @@ class LabelDialog(QtWidgets.QDialog):
         # Build widgets
         self.edit = LabelQLineEdit()
         self.edit.setPlaceholderText(text)
-        self.edit.setValidator(label_validator())
 
         self.edit_group_id = QtWidgets.QLineEdit()
         self.edit_group_id.setPlaceholderText(GROUP_ID_PLACEHOLDER)
@@ -116,10 +132,11 @@ class LabelDialog(QtWidgets.QDialog):
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
         )
-        button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).clicked.connect(
-            self._on_ok_clicked
-        )
+        button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
+        self._ok_button = button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
 
         # Build layout
         main_layout = QtWidgets.QVBoxLayout()
@@ -154,16 +171,17 @@ class LabelDialog(QtWidgets.QDialog):
         main_layout.addWidget(self.edit_description)
 
         # Connect signals
-        self.edit.editingFinished.connect(self._strip_edit_text)
-        self.edit.textChanged.connect(self._update_flags)
+        self.edit.textChanged.connect(self._on_text_changed)
         self.label_list.currentItemChanged.connect(self._on_label_selected)
-        self.label_list.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self.label_list.itemDoubleClicked.connect(self._submit_item)
 
         # Populate initial labels
         for label in dict.fromkeys([*(labels or []), *self._label_history]):
             self.label_list.addItem(label)
         if sort_labels:
             self.label_list.sortItems()
+
+        self._refresh_ok_button()
 
     @property
     def label_history(self) -> list[str]:
@@ -186,8 +204,22 @@ class LabelDialog(QtWidgets.QDialog):
         else:
             raise ValueError(f"Unknown completion mode: {completion!r}")
 
-    def _strip_edit_text(self) -> None:
-        self.edit.setText(self.edit.text().strip())
+    def _on_text_changed(self, text: str, /) -> None:
+        # Leading whitespace never belongs to a label, so undo it as it is typed;
+        # the re-entrant signal then handles the corrected text.
+        if text != text.lstrip():
+            self.edit.setText(text.lstrip())
+            return
+        self._refresh_ok_button()
+        if "flags" not in self._locked:
+            self._update_flags(text)
+
+    def _refresh_ok_button(self) -> None:
+        # Return only ever reaches an enabled default button, so disabling OK is
+        # what keeps a blank label from being submitted.
+        self._ok_button.setEnabled(
+            "label" in self._locked or bool(self.edit.text().strip())
+        )
 
     def _on_label_selected(
         self,
@@ -199,13 +231,9 @@ class LabelDialog(QtWidgets.QDialog):
             return
         self.edit.setText(current.text())
 
-    def _on_item_double_clicked(self, item: QtWidgets.QListWidgetItem, /) -> None:
+    def _submit_item(self, item: QtWidgets.QListWidgetItem, /) -> None:
         self.label_list.setCurrentItem(item)
-        self._on_ok_clicked()
-
-    def _on_ok_clicked(self) -> None:
-        if not self.edit.isEnabled() or self.edit.text().strip():
-            self.accept()
+        self._ok_button.click()
 
     def _clear_flag_checkboxes(self) -> None:
         self._flag_checkboxes.clear()
@@ -249,48 +277,63 @@ class LabelDialog(QtWidgets.QDialog):
         if self._sort_labels:
             self.label_list.sortItems()
 
+    def remember_label(self, *, label: str) -> None:
+        self._last_label = label
+
     def popup(
         self,
         *,
         text: str | None = None,
-        move: bool = True,
-        position: QtCore.QPoint | None = None,
         flags: dict[str, bool] | None = None,
         group_id: int | None = None,
         description: str | None = None,
-        flags_disabled: bool = False,
-    ) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
+        locked: Collection[LabelDialogField] = (),
+        move: bool = True,
+        position: QtCore.QPoint | None = None,
+    ) -> LabelDialogEntry | None:
+        self._locked = frozenset(locked)
         # Drop the previous popup's checkboxes and their remembered states so a
         # fresh popup starts unchecked. This has to precede setText() below,
         # whose textChanged signal would otherwise re-seed the states from the
         # previous popup's checkboxes; the flags block below rebuilds them.
         self._flag_states.clear()
         self._clear_flag_checkboxes()
-        self._flags_disabled = flags_disabled
 
-        if text is not None:
-            self.edit.setText(text)
+        # A locked field shows nothing: the caller's value is not shared by the
+        # whole selection, and the field is skipped when the entry is applied.
+        for name, widgets in self._get_field_widgets().items():
+            for widget in widgets:
+                widget.setEnabled(name not in self._locked)
+        if "label" in self._locked:
+            text = ""
+            self.label_list.setCurrentRow(-1)
+        elif text is None:
+            text = self._last_label
+        if "group_id" in self._locked:
+            group_id = None
+        if "description" in self._locked:
+            description = None
+        if "flags" in self._locked:
+            flags = {}
+
+        self.edit.setText(text)
+        # Read the text back: a stored label with leading whitespace is shown
+        # normalized, and the flags and list match must follow what is shown.
+        text = self.edit.text()
         self.edit.selectAll()
-
+        self.edit_group_id.setText("" if group_id is None else str(group_id))
         self.edit_description.setPlainText(description or "")
-
-        if group_id is None:
-            self.edit_group_id.setText("")
-        else:
-            self.edit_group_id.setText(str(group_id))
-
         if flags is None:
-            self._update_flags(self.edit.text())
+            self._update_flags(text)
         else:
             self._set_flag_checkboxes(flags=flags)
 
-        matches = self.label_list.findItems(
-            self.edit.text(), QtCore.Qt.MatchFlag.MatchFixedString
-        )
+        matches = self.label_list.findItems(text, QtCore.Qt.MatchFlag.MatchFixedString)
         if matches:
             self.label_list.setCurrentItem(matches[0])
 
         self._fit_label_list_to_content()
+        self._refresh_ok_button()
         self.edit.setFocus(QtCore.Qt.FocusReason.PopupFocusReason)
 
         if move:
@@ -302,17 +345,33 @@ class LabelDialog(QtWidgets.QDialog):
             # visible dialog, while the clamp is a no-op unless it overflows.
             QtCore.QTimer.singleShot(0, lambda: self._clamp_within_screen(target))
 
-        result = self.exec()
+        if self.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
 
-        if result == QtWidgets.QDialog.DialogCode.Accepted:
-            label = self.edit.text()
-            returned_flags = self._collect_flags()
-            gid_text = self.edit_group_id.text()
-            returned_group_id: int | None = int(gid_text) if gid_text else None
-            returned_description = self.edit_description.toPlainText()
-            return label, returned_flags, returned_group_id, returned_description
+        # The flag checkboxes follow the text, so normalize it before they are
+        # collected: "cat " must yield the flags of "cat", not none.
+        self.edit.setText(self.edit.text().strip())
+        group_id_text = self.edit_group_id.text()
+        entry = LabelDialogEntry(
+            label=self.edit.text(),
+            flags=self._collect_flags(),
+            group_id=int(group_id_text) if group_id_text else None,
+            description=self.edit_description.toPlainText(),
+        )
+        # A locked label is accepted as blank, and the next new-shape popup
+        # starts blank too, exactly as a cancelled locked edit leaves it.
+        self.remember_label(label=entry.label)
+        return entry
 
-        return None, None, None, None
+    def _get_field_widgets(
+        self,
+    ) -> dict[LabelDialogField, tuple[QtWidgets.QWidget, ...]]:
+        return {
+            "label": (self.edit, self.label_list),
+            "flags": (self._flags_container,),
+            "group_id": (self.edit_group_id,),
+            "description": (self.edit_description,),
+        }
 
     def _set_flag_checkboxes(self, *, flags: dict[str, bool]) -> None:
         FLAGS_SCROLL_MAX_HEIGHT: Final[int] = 150
@@ -321,7 +380,6 @@ class LabelDialog(QtWidgets.QDialog):
         for key, checked in flags.items():
             checkbox = QtWidgets.QCheckBox(key)
             checkbox.setChecked(checked)
-            checkbox.setEnabled(not self._flags_disabled)
             self._flag_checkboxes[key] = checkbox
             self._flags_layout.addWidget(checkbox)
             # A widget added to a visible layout stays hidden until the event

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -14,6 +14,7 @@ from pytestqt.qtbot import QtBot
 from labelme._app import MainWindow
 from labelme._automation._types import AiOutputFormat
 from labelme._shape import Shape
+from labelme._widgets import LabelDialogEntry
 
 from ..conftest import assert_labelfile_sanity
 from ..conftest import close_or_pause
@@ -37,7 +38,9 @@ def test_labeling_ai_lands_preserves_generated_group(
     monkeypatch.setattr(
         win._label_dialog,
         "popup",
-        lambda *_args, **_kwargs: ("land", {}, None, ""),
+        lambda *_args, **_kwargs: LabelDialogEntry(
+            label="land", flags={}, group_id=None, description=""
+        ),
     )
 
     win._on_new_shape()

--- a/tests/e2e/label_list_canvas_selection_test.py
+++ b/tests/e2e/label_list_canvas_selection_test.py
@@ -14,6 +14,7 @@ from labelme._widgets.canvas import Canvas
 from ..conftest import close_or_pause
 from .conftest import MainWinFactory
 from .conftest import click_canvas_fraction
+from .conftest import draw_triangle
 from .conftest import schedule_on_dialog
 from .conftest import select_shape
 from .conftest import show_window_and_wait_for_imagedata
@@ -269,7 +270,7 @@ def test_edit_label_invalid_label_keeps_labels_and_shows_error(
 
 
 @pytest.mark.gui
-def test_edit_label_multi_shape_mismatch_disables_text_field(
+def test_cancel_mixed_label_edit_keeps_next_shape_prefill_blank(
     *,
     qtbot: QtBot,
     annotated_with_labels: MainWindow,
@@ -301,8 +302,74 @@ def test_edit_label_multi_shape_mismatch_disables_text_field(
     label_list.item_double_clicked.emit(label_list[0])
     qtbot.waitUntil(lambda: not label_dialog.isVisible(), timeout=3000)
 
+    next_prefill: list[str] = []
+
+    def capture_prefill_then_cancel() -> None:
+        next_prefill.append(label_dialog.edit.text())
+        qtbot.keyClick(label_dialog, Qt.Key.Key_Escape)
+
+    schedule_on_dialog(label_dialog=label_dialog, action=capture_prefill_then_cancel)
+    draw_triangle(
+        qtbot=qtbot,
+        win=win,
+        vertices=((0.2, 0.2), (0.5, 0.2), (0.5, 0.5)),
+    )
+    qtbot.keyPress(canvas, Qt.Key.Key_Return)
+    qtbot.waitUntil(lambda: bool(next_prefill), timeout=3000)
+
     assert [s.label for s in canvas.shapes] == original_labels
     assert edit_disabled_during_popup == [True]
+    assert next_prefill == [""]
+
+    close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    "annotated_with_labels",
+    [{"validate_label": "exact", "labels": ["dog"]}],
+    indirect=True,
+)
+def test_edit_label_multi_shape_mismatch_skips_label_validation(
+    *,
+    qtbot: QtBot,
+    annotated_with_labels: MainWindow,
+    monkeypatch: pytest.MonkeyPatch,
+    pause: bool,
+) -> None:
+    # With the label locked there is nothing to validate; accepting the dialog
+    # must apply the shared fields instead of rejecting the blank label.
+    win = annotated_with_labels
+    canvas = win._canvas_widgets.canvas
+    label_list = win._docks.label_list
+    label_dialog = win._label_dialog
+    original_labels = [s.label for s in canvas.shapes]
+    assert original_labels[0] != original_labels[3]
+
+    error_shown: list[bool] = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "critical",
+        lambda *_args, **_kwargs: error_shown.append(True)
+        or QMessageBox.StandardButton.Ok,
+    )
+
+    label_list.clearSelection()
+    label_list.select_item(item=label_list[0])
+    label_list.select_item(item=label_list[3])
+
+    def set_group_id_then_accept() -> None:
+        qtbot.keyClicks(label_dialog.edit_group_id, "7")
+        qtbot.keyClick(label_dialog.edit_group_id, Qt.Key.Key_Enter)
+
+    schedule_on_dialog(label_dialog=label_dialog, action=set_group_id_then_accept)
+    label_list.item_double_clicked.emit(label_list[0])
+    qtbot.waitUntil(lambda: not label_dialog.isVisible(), timeout=3000)
+
+    assert not error_shown
+    assert [s.label for s in canvas.shapes] == original_labels
+    assert canvas.shapes[0].group_id == 7
+    assert canvas.shapes[3].group_id == 7
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 

--- a/tests/unit/utils/qt_test.py
+++ b/tests/unit/utils/qt_test.py
@@ -11,7 +11,6 @@ from pytestqt.qtbot import QtBot
 
 from labelme._utils.qt import _TintedSvgIconEngine
 from labelme._utils.qt import direction_angle
-from labelme._utils.qt import label_validator
 from labelme._utils.qt import new_action
 from labelme._utils.qt import new_icon
 from labelme._utils.qt import new_separator
@@ -83,41 +82,6 @@ def test_project_point_on_line_zero_length_returns_point() -> None:
         point=point, line_start=QPointF(2.0, 2.0), line_end=QPointF(2.0, 2.0)
     )
     assert (projected.x(), projected.y()) == pytest.approx((4.0, 7.0))
-
-
-# ---------------------------------------------------------------------------
-# label_validator
-# ---------------------------------------------------------------------------
-
-
-def test_label_validator_returns_validator() -> None:
-    v = label_validator()
-    assert isinstance(v, QtGui.QRegularExpressionValidator)
-
-
-def test_label_validator_rejects_leading_space() -> None:
-    v = label_validator()
-    state, _, _ = v.validate(" label", 0)  # ty: ignore[not-iterable]
-    assert state == QtGui.QValidator.State.Invalid
-
-
-def test_label_validator_rejects_leading_tab() -> None:
-    v = label_validator()
-    state, _, _ = v.validate("\tlabel", 0)  # ty: ignore[not-iterable]
-    assert state == QtGui.QValidator.State.Invalid
-
-
-def test_label_validator_accepts_normal_label() -> None:
-    v = label_validator()
-    state, _, _ = v.validate("cat", 3)  # ty: ignore[not-iterable]
-    assert state == QtGui.QValidator.State.Acceptable
-
-
-def test_label_validator_rejects_single_char() -> None:
-    # A single non-whitespace character is not yet an acceptable label.
-    v = label_validator()
-    state, _, _ = v.validate("c", 1)  # ty: ignore[not-iterable]
-    assert state != QtGui.QValidator.State.Acceptable
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from collections.abc import Collection
 
 import pytest
 from PySide6 import QtCore
@@ -8,6 +9,8 @@ from PySide6 import QtWidgets
 from pytestqt.qtbot import QtBot
 
 from labelme._widgets.label_dialog import LabelDialog
+from labelme._widgets.label_dialog import LabelDialogEntry
+from labelme._widgets.label_dialog import LabelDialogField
 from labelme._widgets.label_dialog import LabelQLineEdit
 
 # Black-box characterization of LabelDialog: behavior is exercised only through
@@ -31,8 +34,8 @@ def _run_popup(
     flags: dict[str, bool] | None,
     group_id: int | None,
     description: str | None,
-    flags_disabled: bool,
-) -> tuple[str, dict[str, bool], int | None, str] | tuple[None, None, None, None]:
+    locked: Collection[LabelDialogField],
+) -> LabelDialogEntry | None:
     code = (
         QtWidgets.QDialog.DialogCode.Accepted
         if accept
@@ -53,7 +56,7 @@ def _run_popup(
         flags=flags,
         group_id=group_id,
         description=description,
-        flags_disabled=flags_disabled,
+        locked=locked,
     )
 
 
@@ -295,11 +298,28 @@ def test_set_predefined_labels_keeps_completer_bound(*, qtbot: QtBot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_editing_finished_strips_whitespace(*, qtbot: QtBot) -> None:
+def test_leading_whitespace_is_undone_while_typing(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    dialog.edit.setText("  hello  ")
-    dialog.edit.editingFinished.emit()
+    dialog.edit.setText("  hello")
     assert dialog.edit.text() == "hello"
+    dialog.edit.setText("\thello")
+    assert dialog.edit.text() == "hello"
+
+
+def test_accepted_label_is_stripped(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
+    entry = _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="hello  ",
+        at_show=None,
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=(),
+    )
+    assert entry is not None
+    assert entry.label == "hello"
 
 
 def test_selecting_label_sets_edit_text(*, qtbot: QtBot) -> None:
@@ -330,6 +350,15 @@ def test_ok_with_text_accepts(*, qtbot: QtBot) -> None:
     assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
 
 
+def test_ok_is_disabled_until_a_label_is_typed(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
+    assert not _ok_button(dialog).isEnabled()
+    dialog.edit.setText("car")
+    assert _ok_button(dialog).isEnabled()
+    dialog.edit.setText("   ")
+    assert not _ok_button(dialog).isEnabled()
+
+
 def test_ok_with_empty_text_does_not_accept(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
     dialog.edit.setText("")
@@ -344,12 +373,86 @@ def test_ok_with_whitespace_text_does_not_accept(*, qtbot: QtBot) -> None:
     assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
 
 
-def test_ok_accepts_when_edit_disabled_even_if_empty(*, qtbot: QtBot) -> None:
+def test_ok_accepts_empty_label_when_label_is_locked(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
+    dialog.label_list.setCurrentRow(0)
+    seen: dict[str, object] = {}
+
+    def inspect(d: LabelDialog) -> None:
+        seen.update(
+            text=d.edit.text(),
+            edit_enabled=d.edit.isEnabled(),
+            list_enabled=d.label_list.isEnabled(),
+            list_current=d.label_list.currentItem(),
+            ok_enabled=_ok_button(d).isEnabled(),
+        )
+
+    entry = _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="cat",
+        at_show=inspect,
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=("label",),
+    )
+    assert seen == {
+        "text": "",
+        "edit_enabled": False,
+        "list_enabled": False,
+        "list_current": None,
+        "ok_enabled": True,
+    }
+    assert entry is not None
+    assert entry.label == ""
+
+
+def test_locked_fields_are_blank_and_disabled_for_one_popup(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    dialog.edit.setText("")
-    dialog.edit.setEnabled(False)
-    _ok_button(dialog).click()
-    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+    seen: dict[str, object] = {}
+
+    def inspect(d: LabelDialog) -> None:
+        seen.update(
+            gid=d.edit_group_id.text(),
+            gid_enabled=d.edit_group_id.isEnabled(),
+            desc=d.edit_description.toPlainText(),
+            desc_enabled=d.edit_description.isEnabled(),
+        )
+
+    _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="cat",
+        at_show=inspect,
+        flags=None,
+        group_id=4,
+        description="mixed",
+        locked=("group_id", "description"),
+    )
+    assert seen == {
+        "gid": "",
+        "gid_enabled": False,
+        "desc": "",
+        "desc_enabled": False,
+    }
+
+    _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="cat",
+        at_show=inspect,
+        flags=None,
+        group_id=4,
+        description="shared",
+        locked=(),
+    )
+    assert seen == {
+        "gid": "4",
+        "gid_enabled": True,
+        "desc": "shared",
+        "desc_enabled": True,
+    }
 
 
 def test_double_click_label_accepts(*, qtbot: QtBot) -> None:
@@ -447,7 +550,7 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
         dialog=LabelDialog(flags={".*": ["occluded"], "^cat$": ["occluded", "urgent"]}),
     )
 
-    _, flags, _, _ = _run_popup(
+    entry = _run_popup(
         dialog=dialog,
         accept=True,
         text="cat",
@@ -455,9 +558,10 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
-    assert flags == {"occluded": True, "urgent": False}
+    assert entry is not None
+    assert entry.flags == {"occluded": True, "urgent": False}
 
 
 # ---------------------------------------------------------------------------
@@ -465,9 +569,61 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
 # ---------------------------------------------------------------------------
 
 
+def test_accepted_label_with_trailing_whitespace_keeps_its_flags(
+    *, qtbot: QtBot
+) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat$": ["indoor"]}))
+
+    def check_then_add_trailing_space(d: LabelDialog) -> None:
+        _checkbox(dialog=d, name="indoor").setChecked(True)
+        d.edit.setText("cat ")
+
+    entry = _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="cat",
+        at_show=check_then_add_trailing_space,
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=(),
+    )
+    assert entry == LabelDialogEntry(
+        label="cat", flags={"indoor": True}, group_id=None, description=""
+    )
+
+
+def test_popup_with_leading_whitespace_label_matches_flags_and_list(
+    *, qtbot: QtBot
+) -> None:
+    seen: dict[str, object] = {}
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(labels=["cat"], flags={"^cat$": ["indoor"]})
+    )
+    entry = _run_popup(
+        dialog=dialog,
+        accept=True,
+        text=" cat",
+        at_show=lambda d: seen.update(
+            text=d.edit.text(),
+            current=d.label_list.currentItem().text()
+            if d.label_list.currentItem()
+            else None,
+        ),
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=(),
+    )
+    assert seen == {"text": "cat", "current": "cat"}
+    assert entry == LabelDialogEntry(
+        label="cat", flags={"indoor": False}, group_id=None, description=""
+    )
+
+
 def test_popup_returns_typed_values_on_accept(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
-    text, flags, group_id, description = _run_popup(
+    entry = _run_popup(
         dialog=dialog,
         accept=True,
         text="cat",
@@ -475,17 +631,16 @@ def test_popup_returns_typed_values_on_accept(*, qtbot: QtBot) -> None:
         description="a pet",
         at_show=None,
         flags=None,
-        flags_disabled=False,
+        locked=(),
     )
-    assert text == "cat"
-    assert group_id == 3
-    assert description == "a pet"
-    assert flags == {}
+    assert entry == LabelDialogEntry(
+        label="cat", flags={}, group_id=3, description="a pet"
+    )
 
 
 def test_popup_preserves_html_like_description(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    _, _, _, description = _run_popup(
+    entry = _run_popup(
         dialog=dialog,
         accept=True,
         text="cat",
@@ -493,14 +648,15 @@ def test_popup_preserves_html_like_description(*, qtbot: QtBot) -> None:
         at_show=None,
         flags=None,
         group_id=None,
-        flags_disabled=False,
+        locked=(),
     )
-    assert description == "<b>bold</b>"
+    assert entry is not None
+    assert entry.description == "<b>bold</b>"
 
 
-def test_popup_returns_all_none_on_reject(*, qtbot: QtBot) -> None:
+def test_popup_returns_none_on_reject(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    result = _run_popup(
+    entry = _run_popup(
         dialog=dialog,
         accept=False,
         text="cat",
@@ -508,15 +664,15 @@ def test_popup_returns_all_none_on_reject(*, qtbot: QtBot) -> None:
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
-    assert result == (None, None, None, None)
+    assert entry is None
 
 
 def test_popup_group_id_none_yields_empty_then_none(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    _, _, group_id, _ = _run_popup(
+    entry = _run_popup(
         dialog=dialog,
         accept=True,
         text="x",
@@ -524,15 +680,16 @@ def test_popup_group_id_none_yields_empty_then_none(*, qtbot: QtBot) -> None:
         at_show=lambda d: seen.update(gid=d.edit_group_id.text()),
         flags=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["gid"] == ""
-    assert group_id is None
+    assert entry is not None
+    assert entry.group_id is None
 
 
 def test_popup_group_id_zero_is_preserved(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    _, _, group_id, _ = _run_popup(
+    entry = _run_popup(
         dialog=dialog,
         accept=True,
         text="x",
@@ -540,9 +697,10 @@ def test_popup_group_id_zero_is_preserved(*, qtbot: QtBot) -> None:
         at_show=None,
         flags=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
-    assert group_id == 0
+    assert entry is not None
+    assert entry.group_id == 0
 
 
 def test_popup_sets_group_id_text_at_show(*, qtbot: QtBot) -> None:
@@ -556,32 +714,80 @@ def test_popup_sets_group_id_text_at_show(*, qtbot: QtBot) -> None:
         at_show=lambda d: seen.update(gid=d.edit_group_id.text()),
         flags=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["gid"] == "7"
 
 
-def test_popup_text_none_preserves_existing_edit_text(*, qtbot: QtBot) -> None:
-    seen: dict[str, str] = {}
-    dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    dialog.edit.setText("preexisting")
+def _accept_label(*, dialog: LabelDialog, label: str) -> None:
     _run_popup(
         dialog=dialog,
         accept=True,
-        text=None,
+        text=label,
+        at_show=None,
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=(),
+    )
+
+
+def _get_shown_text(*, dialog: LabelDialog, accept: bool, text: str | None) -> str:
+    seen: dict[str, str] = {}
+    _run_popup(
+        dialog=dialog,
+        accept=accept,
+        text=text,
         at_show=lambda d: seen.update(t=d.edit.text()),
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
-    assert seen["t"] == "preexisting"
+    return seen["t"]
 
 
-def test_popup_text_none_selects_existing_edit_text(*, qtbot: QtBot) -> None:
+def test_popup_text_none_starts_from_last_accepted_label(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
+    assert _get_shown_text(dialog=dialog, accept=True, text=None) == ""
+    _accept_label(dialog=dialog, label="first")
+    assert _get_shown_text(dialog=dialog, accept=True, text=None) == "first"
+
+
+def test_cancel_leaves_last_accepted_label_untouched(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
+    _accept_label(dialog=dialog, label="first")
+    assert _get_shown_text(dialog=dialog, accept=False, text="typed") == "typed"
+    assert _get_shown_text(dialog=dialog, accept=True, text=None) == "first"
+
+
+def test_accepted_locked_label_leaves_next_prefill_blank(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
+    _accept_label(dialog=dialog, label="first")
+    _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="mixed",
+        at_show=None,
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=("label",),
+    )
+    assert _get_shown_text(dialog=dialog, accept=True, text=None) == ""
+
+
+def test_remember_label_sets_next_prefill(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog())
+    _accept_label(dialog=dialog, label="first")
+    dialog.remember_label(label="edited")
+    assert _get_shown_text(dialog=dialog, accept=True, text=None) == "edited"
+
+
+def test_popup_text_none_selects_prefilled_text(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    dialog.edit.setText("preexisting")
+    _accept_label(dialog=dialog, label="preexisting")
     _run_popup(
         dialog=dialog,
         accept=True,
@@ -590,7 +796,7 @@ def test_popup_text_none_selects_existing_edit_text(*, qtbot: QtBot) -> None:
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["sel"] == "preexisting"
 
@@ -610,7 +816,7 @@ def test_popup_highlights_matching_label_at_show(*, qtbot: QtBot) -> None:
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["cur"] == "dog"
 
@@ -630,7 +836,7 @@ def test_popup_highlights_matching_label_case_insensitively(*, qtbot: QtBot) -> 
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["cur"] == "Cat"
 
@@ -646,13 +852,13 @@ def test_popup_sets_description_at_show(*, qtbot: QtBot) -> None:
         at_show=lambda d: seen.update(desc=d.edit_description.toPlainText()),
         flags=None,
         group_id=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["desc"] == "hello world"
 
 
-def test_popup_flags_disabled_disables_checkboxes(*, qtbot: QtBot) -> None:
-    seen: dict[str, list[bool]] = {}
+def test_popup_locked_flags_hides_checkboxes(*, qtbot: QtBot) -> None:
+    seen: dict[str, int] = {}
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
     )
@@ -661,15 +867,12 @@ def test_popup_flags_disabled_disables_checkboxes(*, qtbot: QtBot) -> None:
         accept=True,
         text="cat",
         flags={"indoor": True},
-        flags_disabled=True,
-        at_show=lambda d: seen.update(
-            enabled=[cb.isEnabled() for cb in _checkboxes(d)]
-        ),
+        locked=("flags",),
+        at_show=lambda d: seen.update(count=len(_checkboxes(d))),
         group_id=None,
         description=None,
     )
-    assert seen["enabled"]
-    assert not any(seen["enabled"])
+    assert seen["count"] == 0
 
 
 def test_popup_flags_enabled_by_default(*, qtbot: QtBot) -> None:
@@ -687,19 +890,19 @@ def test_popup_flags_enabled_by_default(*, qtbot: QtBot) -> None:
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["enabled"]
     assert all(seen["enabled"])
 
 
-def test_flags_disabled_resets_between_popups(*, qtbot: QtBot) -> None:
+def test_locked_flags_reset_between_popups(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog(flags={"^cat": ["indoor"]}))
     _run_popup(
         dialog=dialog,
         accept=True,
         text="cat",
-        flags_disabled=True,
+        locked=("flags",),
         at_show=None,
         flags=None,
         group_id=None,
@@ -717,7 +920,7 @@ def test_flags_disabled_resets_between_popups(*, qtbot: QtBot) -> None:
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["enabled"]
     assert all(seen["enabled"])
@@ -737,7 +940,7 @@ def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     _run_popup(
         dialog=dialog,
@@ -749,7 +952,7 @@ def test_flag_checked_state_does_not_leak_into_next_new_shape_popup(
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["checked"] is False
 
@@ -768,7 +971,7 @@ def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
         at_show=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     _run_popup(
         dialog=dialog,
@@ -780,17 +983,17 @@ def test_edited_shape_flags_do_not_leak_into_next_new_shape_popup(
         flags=None,
         group_id=None,
         description=None,
-        flags_disabled=False,
+        locked=(),
     )
     assert seen["checked"] is False
 
 
-def test_flags_disabled_survives_text_edit_rebuild(*, qtbot: QtBot) -> None:
-    seen: dict[str, list[bool]] = {}
+def test_locked_flags_stay_hidden_after_label_edit(*, qtbot: QtBot) -> None:
+    seen: dict[str, int] = {}
 
     def edit_then_inspect(d: LabelDialog) -> None:
         d.edit.setText("cattle")
-        seen.update(enabled=[cb.isEnabled() for cb in _checkboxes(d)])
+        seen.update(count=len(_checkboxes(d)))
 
     dialog = _add_dialog(
         qtbot, dialog=LabelDialog(flags={"^cat": ["indoor", "outdoor"]})
@@ -799,11 +1002,10 @@ def test_flags_disabled_survives_text_edit_rebuild(*, qtbot: QtBot) -> None:
         dialog=dialog,
         accept=True,
         text="cat",
-        flags_disabled=True,
+        locked=("flags",),
         at_show=edit_then_inspect,
         flags=None,
         group_id=None,
         description=None,
     )
-    assert seen["enabled"]
-    assert not any(seen["enabled"])
+    assert seen["count"] == 0


### PR DESCRIPTION
## What

`LabelDialog.popup()` now returns a frozen `LabelDialogEntry` (or `None` on cancel) and accepts locked `LabelDialogField` values that the caller cannot fill. The dialog owns its widget state, blanks and disables mixed fields, remembers the last accepted label for the next popup, and gates submission through the OK button.

The app no longer reaches into dialog widgets, and mixed multi-selection editing no longer validates a blank locked Label under `validate_label: exact`.

## Behavior

- OK is disabled while the Label is blank, so Return stays in the dialog. Leading whitespace is removed as it is typed, and submitted Labels are stripped.
- Shared fields can be edited across Shapes with different Labels under exact validation.
- Locked Label and Flags controls remain blank, including after Label changes.
- Cancelling a single-Label edit preserves that Label as the next new-Shape prefill; cancelling a mixed-Label edit preserves the blank prefill.

The unused `label_validator()` helper is removed in a follow-up commit.

## Tests

`make lint` passes. `uv run --no-sync pytest -q tests` passes (1,339 passed, 6 skipped, 11 deselected). Unit and end-to-end regressions cover submission gating, locked fields, remembered Labels, mixed-label editing, and cancel prefill behavior.

