### PR TITLE
chore: adopt Gruff 0.0.6

### DIFF
--- a/examples/tutorial/draw_label_png.py
+++ b/examples/tutorial/draw_label_png.py
@@ -9,11 +9,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 from loguru import logger
 
-# json_to_dataset stores the ignore label as 255 in the 8-bit label PNG.
-_UNLABELED_PNG_VALUE: Final = 255
-
 
 def main() -> None:
+    # json_to_dataset stores the ignore label as 255 in the 8-bit label PNG.
+    UNLABELED_PNG_VALUE: Final = 255
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
@@ -41,7 +41,7 @@ def main() -> None:
 
     label = imgviz.io.imread(args.label_png)
     label = label.astype(np.int32)
-    label[label == _UNLABELED_PNG_VALUE] = -1
+    label[label == UNLABELED_PNG_VALUE] = -1
 
     unique_label_values = np.unique(label)
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -31,13 +31,6 @@ import PIL.Image
 import PIL.ImageDraw
 from numpy.typing import NDArray
 
-# Point counts each shape type's geometry is defined by.
-_CIRCLE_POINT_COUNT: Final = 2
-_LINE_POINT_COUNT: Final = 2
-_RECTANGLE_POINT_COUNT: Final = 2
-_ORIENTED_RECTANGLE_POINT_COUNT: Final = 4
-_MIN_POLYGON_POINT_COUNT: Final = 3
-
 
 @dataclasses.dataclass(frozen=True)
 class LabeledImage:
@@ -95,18 +88,25 @@ def shape_to_mask(
     line_width: int = 10,
     point_size: int = 5,
 ) -> NDArray[np.bool_]:
+    # Point counts each shape type's geometry is defined by.
+    CIRCLE_POINT_COUNT: Final = 2
+    LINE_POINT_COUNT: Final = 2
+    RECTANGLE_POINT_COUNT: Final = 2
+    ORIENTED_RECTANGLE_POINT_COUNT: Final = 4
+    MIN_POLYGON_POINT_COUNT: Final = 3
+
     mask = PIL.Image.fromarray(np.zeros(img_shape[:2], dtype=np.uint8))
     draw = PIL.ImageDraw.Draw(mask)
     xy = [tuple(point) for point in points]
     if shape_type == "circle":
-        assert len(xy) == _CIRCLE_POINT_COUNT, (
+        assert len(xy) == CIRCLE_POINT_COUNT, (
             "Shape of shape_type=circle must have 2 points"
         )
         (cx, cy), (px, py) = xy
         d = math.sqrt((cx - px) ** 2 + (cy - py) ** 2)
         draw.ellipse(((cx - d, cy - d), (cx + d, cy + d)), outline=1, fill=1)
     elif shape_type == "rectangle":
-        assert len(xy) == _RECTANGLE_POINT_COUNT, (
+        assert len(xy) == RECTANGLE_POINT_COUNT, (
             "Shape of shape_type=rectangle must have 2 points"
         )
         (x0, y0), (x1, y1) = xy
@@ -116,7 +116,7 @@ def shape_to_mask(
             fill=1,
         )
     elif shape_type == "line":
-        assert len(xy) == _LINE_POINT_COUNT, (
+        assert len(xy) == LINE_POINT_COUNT, (
             "Shape of shape_type=line must have 2 points"
         )
         draw.line(xy=xy, fill=1, width=line_width)  # ty: ignore[invalid-argument-type]
@@ -129,12 +129,12 @@ def shape_to_mask(
         r = point_size
         draw.ellipse(((cx - r, cy - r), (cx + r, cy + r)), outline=1, fill=1)
     elif shape_type == "oriented_rectangle":
-        assert len(xy) == _ORIENTED_RECTANGLE_POINT_COUNT, (
+        assert len(xy) == ORIENTED_RECTANGLE_POINT_COUNT, (
             "Shape of shape_type=oriented_rectangle must have 4 points"
         )
         draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]
     elif shape_type in [None, "polygon"]:
-        assert len(xy) >= _MIN_POLYGON_POINT_COUNT, (
+        assert len(xy) >= MIN_POLYGON_POINT_COUNT, (
             "Polygon must have points more than 2"
         )
         draw.polygon(xy=xy, outline=1, fill=1)  # ty: ignore[invalid-argument-type]

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -27,7 +27,13 @@ from ._label_file import is_label_file_path
 from ._utils import apply_color_theme
 from ._utils import new_icon
 
-_LOGGER_LEVELS: Final = ("debug", "info", "warning", "error", "critical")
+_LOGGER_LEVELS: Final = (  # noqa: GR011 -- parametrized by tests
+    "debug",
+    "info",
+    "warning",
+    "error",
+    "critical",
+)
 
 
 class _LoggerIO(io.StringIO):

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -17,8 +17,6 @@ __all__ = ["get_user_config_file", "load_config", "set_overrides"]
 
 here = Path(__file__).resolve().parent
 
-_MASK_POLYGONIZATION_DETAIL_MAX: Final = 100
-
 
 def _update_dict(
     *,
@@ -56,11 +54,13 @@ def _update_dict(
 
 
 def _validate_config_item(*, key_path: tuple[str, ...], value: object) -> None:
+    MASK_POLYGONIZATION_DETAIL_MAX: Final = 100
+
     key = key_path[-1]
     if key_path == ("mask_polygonization", "detail") and (
         isinstance(value, bool)
         or not isinstance(value, int)
-        or not 0 <= value <= _MASK_POLYGONIZATION_DETAIL_MAX
+        or not 0 <= value <= MASK_POLYGONIZATION_DETAIL_MAX
     ):
         raise ValueError(
             "mask_polygonization.detail must be an integer between 0 and 100, "

--- a/labelme/_config/_shape_color.py
+++ b/labelme/_config/_shape_color.py
@@ -6,17 +6,18 @@ from typing import cast
 from loguru import logger
 
 RGB_CHANNEL_COUNT: Final = 3
-_CHANNEL_VALUE_MAX: Final = 255
 
 
 def _is_rgb(value: object, /) -> bool:
+    CHANNEL_VALUE_MAX: Final = 255
+
     return (
         isinstance(value, list)
         and len(value) == RGB_CHANNEL_COUNT
         and all(
             isinstance(channel, int)
             and not isinstance(channel, bool)
-            and 0 <= channel <= _CHANNEL_VALUE_MAX
+            and 0 <= channel <= CHANNEL_VALUE_MAX
             for channel in value
         )
     )

--- a/labelme/_label_file.py
+++ b/labelme/_label_file.py
@@ -29,10 +29,7 @@ from ._utils.shape import ShapeDict
 
 PIL.Image.MAX_IMAGE_PIXELS = None
 
-_POINT_COORDINATE_COUNT: Final = 2
 _SINGLE_CHANNEL_NDIM: Final = 2
-_MULTI_CHANNEL_NDIM: Final = 3
-_RGB_CHANNEL_COUNT: Final = 3
 
 
 def _validate_flags(*, flags: object) -> dict[str, bool]:
@@ -96,6 +93,7 @@ def _validate_shape_semantics(
 
 
 def _load_shape_json_obj(*, shape_json_obj: dict) -> ShapeDict:
+    POINT_COORDINATE_COUNT: Final = 2
     SHAPE_KEYS: Final[set[str]] = {
         "label",
         "points",
@@ -120,7 +118,7 @@ def _load_shape_json_obj(*, shape_json_obj: dict) -> ShapeDict:
         raise ValueError(f"points must be non-empty: {shape_json_obj}")
     if not all(
         isinstance(point, list)
-        and len(point) == _POINT_COORDINATE_COUNT
+        and len(point) == POINT_COORDINATE_COUNT
         and all(
             isinstance(xy, int | float) and not isinstance(xy, bool) for xy in point
         )
@@ -403,14 +401,13 @@ def write_label_file(
         raise LabelFileWriteError(f"failed to write {filename!r}: {e}") from e
 
 
-_DISPLAYABLE_MODES: Final = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
-
-
 def _imread(filename: str, /) -> PIL.Image.Image:
+    DISPLAYABLE_MODES: Final = {"1", "L", "P", "RGB", "RGBA", "LA", "PA"}
+
     ext: str = Path(filename).suffix.lower()
     try:
         image_pil = PIL.Image.open(filename)
-        if image_pil.mode not in _DISPLAYABLE_MODES:
+        if image_pil.mode not in DISPLAYABLE_MODES:
             raise PIL.UnidentifiedImageError
         return image_pil
     except PIL.UnidentifiedImageError:
@@ -420,16 +417,19 @@ def _imread(filename: str, /) -> PIL.Image.Image:
 
 
 def _imread_tiff(filename: str, /) -> PIL.Image.Image:
+    MULTI_CHANNEL_NDIM: Final = 3
+    RGB_CHANNEL_COUNT: Final = 3
+
     img_arr: NDArray = tifffile.imread(filename)
 
     if img_arr.ndim == _SINGLE_CHANNEL_NDIM:
         img_arr_normalized = _normalize_to_uint8(img_arr)
-    elif img_arr.ndim == _MULTI_CHANNEL_NDIM:
-        if img_arr.shape[2] >= _RGB_CHANNEL_COUNT:
+    elif img_arr.ndim == MULTI_CHANNEL_NDIM:
+        if img_arr.shape[2] >= RGB_CHANNEL_COUNT:
             img_arr_normalized = np.stack(
                 [
                     _normalize_to_uint8(img_arr[:, :, i])
-                    for i in range(_RGB_CHANNEL_COUNT)
+                    for i in range(RGB_CHANNEL_COUNT)
                 ],
                 axis=2,
             )

--- a/labelme/_utils/image.py
+++ b/labelme/_utils/image.py
@@ -14,17 +14,6 @@ import PIL.ImageOps
 from numpy.typing import NDArray
 from PySide6 import QtGui
 
-# Values of the EXIF Orientation tag, which encodes the transform needed to
-# display the stored pixels the right way up.
-_EXIF_ORIENTATION_NORMAL: Final = 1
-_EXIF_ORIENTATION_MIRROR_LEFT_TO_RIGHT: Final = 2
-_EXIF_ORIENTATION_ROTATE_180: Final = 3
-_EXIF_ORIENTATION_MIRROR_TOP_TO_BOTTOM: Final = 4
-_EXIF_ORIENTATION_MIRROR_TOP_TO_LEFT: Final = 5
-_EXIF_ORIENTATION_ROTATE_270: Final = 6
-_EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT: Final = 7
-_EXIF_ORIENTATION_ROTATE_90: Final = 8
-
 
 def img_data_to_pil(img_data: bytes, /) -> PIL.Image.Image:
     return PIL.Image.open(io.BytesIO(img_data))
@@ -81,6 +70,17 @@ def img_qt_to_rgb_arr(img_qt: QtGui.QImage, /) -> NDArray[np.uint8]:
 
 
 def apply_exif_orientation(image: PIL.Image.Image, /) -> PIL.Image.Image:
+    # Values of the EXIF Orientation tag, which encodes the transform needed to
+    # display the stored pixels the right way up.
+    EXIF_ORIENTATION_NORMAL: Final = 1
+    EXIF_ORIENTATION_MIRROR_LEFT_TO_RIGHT: Final = 2
+    EXIF_ORIENTATION_ROTATE_180: Final = 3
+    EXIF_ORIENTATION_MIRROR_TOP_TO_BOTTOM: Final = 4
+    EXIF_ORIENTATION_MIRROR_TOP_TO_LEFT: Final = 5
+    EXIF_ORIENTATION_ROTATE_270: Final = 6
+    EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT: Final = 7
+    EXIF_ORIENTATION_ROTATE_90: Final = 8
+
     try:
         exif = image._getexif()  # ty: ignore[unresolved-attribute]
     except AttributeError:
@@ -93,21 +93,21 @@ def apply_exif_orientation(image: PIL.Image.Image, /) -> PIL.Image.Image:
 
     orientation = exif.get("Orientation", None)
 
-    if orientation == _EXIF_ORIENTATION_NORMAL:
+    if orientation == EXIF_ORIENTATION_NORMAL:
         return image
-    elif orientation == _EXIF_ORIENTATION_MIRROR_LEFT_TO_RIGHT:
+    elif orientation == EXIF_ORIENTATION_MIRROR_LEFT_TO_RIGHT:
         return PIL.ImageOps.mirror(image)
-    elif orientation == _EXIF_ORIENTATION_ROTATE_180:
+    elif orientation == EXIF_ORIENTATION_ROTATE_180:
         return image.transpose(PIL.Image.ROTATE_180)
-    elif orientation == _EXIF_ORIENTATION_MIRROR_TOP_TO_BOTTOM:
+    elif orientation == EXIF_ORIENTATION_MIRROR_TOP_TO_BOTTOM:
         return PIL.ImageOps.flip(image)
-    elif orientation == _EXIF_ORIENTATION_MIRROR_TOP_TO_LEFT:
+    elif orientation == EXIF_ORIENTATION_MIRROR_TOP_TO_LEFT:
         return PIL.ImageOps.mirror(image.transpose(PIL.Image.ROTATE_270))
-    elif orientation == _EXIF_ORIENTATION_ROTATE_270:
+    elif orientation == EXIF_ORIENTATION_ROTATE_270:
         return image.transpose(PIL.Image.ROTATE_270)
-    elif orientation == _EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT:
+    elif orientation == EXIF_ORIENTATION_MIRROR_TOP_TO_RIGHT:
         return PIL.ImageOps.mirror(image.transpose(PIL.Image.ROTATE_90))
-    elif orientation == _EXIF_ORIENTATION_ROTATE_90:
+    elif orientation == EXIF_ORIENTATION_ROTATE_90:
         return image.transpose(PIL.Image.ROTATE_90)
     else:
         return image

--- a/labelme/_utils/qt.py
+++ b/labelme/_utils/qt.py
@@ -14,16 +14,15 @@ from PySide6 import QtSvg
 from PySide6 import QtWidgets
 
 _ICONS_DIR: Final = os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons")
-_DEFAULT_ICON_SUFFIX: Final = ".png"
-_SCHEME_BY_THEME: Final = {
-    "system": QtCore.Qt.ColorScheme.Unknown,
-    "light": QtCore.Qt.ColorScheme.Light,
-    "dark": QtCore.Qt.ColorScheme.Dark,
-}
 
 
 def apply_color_theme(*, theme: str) -> None:
-    scheme = _SCHEME_BY_THEME.get(theme, QtCore.Qt.ColorScheme.Unknown)
+    SCHEME_BY_THEME: Final = {
+        "system": QtCore.Qt.ColorScheme.Unknown,
+        "light": QtCore.Qt.ColorScheme.Light,
+        "dark": QtCore.Qt.ColorScheme.Dark,
+    }
+    scheme = SCHEME_BY_THEME.get(theme, QtCore.Qt.ColorScheme.Unknown)
     QtGui.QGuiApplication.styleHints().setColorScheme(scheme)
 
 
@@ -111,8 +110,10 @@ class _TintedSvgIconEngine(QtGui.QIconEngine):
 
 
 def new_icon(name: str, /) -> QtGui.QIcon:
+    DEFAULT_ICON_SUFFIX: Final = ".png"
+
     if not os.path.splitext(name)[1]:
-        name = name + _DEFAULT_ICON_SUFFIX
+        name = name + DEFAULT_ICON_SUFFIX
     path = os.path.join(_ICONS_DIR, name)
     if path.endswith(".svg"):
         with open(path, "rb") as f:

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -44,12 +44,6 @@ from ._shape_render import is_hit_by_point
 from ._shape_render import render_shape
 from .download import download_ai_model
 
-# The latest backup mirrors the current state, so an undo needs a prior one too.
-_MIN_SHAPE_BACKUPS_FOR_UNDO: Final = 2
-# The cursor supplies the closing point, so a fill preview needs one point
-# fewer than the polygon it previews.
-_MIN_POINTS_FOR_FILL_PREVIEW: Final = 2
-
 _DEFAULT_SHAPE_RGB: Final[tuple[int, int, int]] = (0, 255, 0)
 _DEFAULT_PALETTE: Final[Palette] = Palette.from_rgb(_DEFAULT_SHAPE_RGB)
 
@@ -141,18 +135,6 @@ _CREATE_MODE_TO_SHAPE_TYPE: Final[dict[_CreateMode, ShapeType]] = {
     "ai_points_to_shape": "points",
     "ai_box_to_shape": "rectangle",
 }
-
-
-# Modes whose seed point cannot be reinterpreted as the start of another mode.
-# `point` finalizes on click so never has a partial shape; AI modes carry
-# per-point positive/negative labels. Every other mode in _CreateMode shares a
-# 1-click anchor and is seed-compatible by default — new modes participate
-# unless explicitly listed here.
-_SEED_INCOMPATIBLE_CREATE_MODES: Final[tuple[_CreateMode, ...]] = (
-    "point",
-    "ai_points_to_shape",
-    "ai_box_to_shape",
-)
 
 
 class _CanvasMode(enum.Enum):
@@ -424,12 +406,20 @@ class Canvas(QtWidgets.QWidget):
     def _reconcile_partial_shape_on_mode_switch(
         self, *, old_mode: _CreateMode, new_mode: _CreateMode
     ) -> None:
+        # Point mode finalizes on click, while AI modes carry per-point labels;
+        # their seed points cannot start another shape type.
+        SEED_INCOMPATIBLE_CREATE_MODES: Final[tuple[_CreateMode, ...]] = (
+            "point",
+            "ai_points_to_shape",
+            "ai_box_to_shape",
+        )
+
         if self._current is None:
             return
         if not (
             len(self._current.points) == 1
-            and old_mode not in _SEED_INCOMPATIBLE_CREATE_MODES
-            and new_mode not in _SEED_INCOMPATIBLE_CREATE_MODES
+            and old_mode not in SEED_INCOMPATIBLE_CREATE_MODES
+            and new_mode not in SEED_INCOMPATIBLE_CREATE_MODES
         ):
             self._cancel_current_shape()
             return
@@ -513,7 +503,10 @@ class Canvas(QtWidgets.QWidget):
 
     @property
     def can_restore_shape(self) -> bool:
-        return len(self.shape_backups) >= _MIN_SHAPE_BACKUPS_FOR_UNDO
+        # The latest backup mirrors the current state, so undo needs a prior one too.
+        MIN_SHAPE_BACKUPS_FOR_UNDO: Final = 2
+
+        return len(self.shape_backups) >= MIN_SHAPE_BACKUPS_FOR_UNDO
 
     def restore_last_shape(self) -> None:
         # Undo coordinates with app.py::undo_shape_edit, app.py::load_shapes,
@@ -1702,8 +1695,11 @@ class Canvas(QtWidgets.QWidget):
         return []
 
     def _build_polygon_preview(self, *, current: _DraftShape) -> Shape:
+        # The cursor closes the shape, so previewing a fill needs one fewer point.
+        MIN_POINTS_FOR_FILL_PREVIEW: Final = 2
+
         preview = current
-        if self._fill_drawing and len(preview.points) >= _MIN_POINTS_FOR_FILL_PREVIEW:
+        if self._fill_drawing and len(preview.points) >= MIN_POINTS_FOR_FILL_PREVIEW:
             preview = preview.add_point(self._line.points[1], autoclose=True)
         return _draft_to_shape(preview)
 

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -10,11 +10,6 @@ from .._label_flags import compile_label_flags
 from .._utils import label_validator
 
 _PLACEHOLDER_TEXT: Final[str] = "Enter object label"
-_GROUP_ID_PLACEHOLDER: Final[str] = "Group ID"
-_DESCRIPTION_PLACEHOLDER: Final[str] = "Description"
-
-_LABEL_LIST_HEIGHT: Final[int] = 150
-_FLAGS_SCROLL_MAX_HEIGHT: Final[int] = 150
 
 
 class LabelQLineEdit(QtWidgets.QLineEdit):
@@ -52,6 +47,10 @@ class LabelDialog(QtWidgets.QDialog):
         flags: dict[str, list[str]] | None = None,
         label_history: list[str] | None = None,
     ) -> None:
+        GROUP_ID_PLACEHOLDER: Final[str] = "Group ID"
+        DESCRIPTION_PLACEHOLDER: Final[str] = "Description"
+        LABEL_LIST_HEIGHT: Final[int] = 150
+
         super().__init__(parent)
 
         self._sort_labels = sort_labels
@@ -77,17 +76,17 @@ class LabelDialog(QtWidgets.QDialog):
         self.edit.setValidator(label_validator())
 
         self.edit_group_id = QtWidgets.QLineEdit()
-        self.edit_group_id.setPlaceholderText(_GROUP_ID_PLACEHOLDER)
+        self.edit_group_id.setPlaceholderText(GROUP_ID_PLACEHOLDER)
         self.edit_group_id.setValidator(
             QtGui.QRegularExpressionValidator(QtCore.QRegularExpression(r"[0-9]*"))
         )
 
         self.edit_description = QtWidgets.QTextEdit()
-        self.edit_description.setPlaceholderText(_DESCRIPTION_PLACEHOLDER)
+        self.edit_description.setPlaceholderText(DESCRIPTION_PLACEHOLDER)
         self.edit_description.setFixedHeight(50)
 
         self.label_list = QtWidgets.QListWidget()
-        self.label_list.setFixedHeight(_LABEL_LIST_HEIGHT)
+        self.label_list.setFixedHeight(LABEL_LIST_HEIGHT)
 
         # Configure label list
         if sort_labels:
@@ -316,6 +315,8 @@ class LabelDialog(QtWidgets.QDialog):
         return None, None, None, None
 
     def _set_flag_checkboxes(self, *, flags: dict[str, bool]) -> None:
+        FLAGS_SCROLL_MAX_HEIGHT: Final[int] = 150
+
         self._clear_flag_checkboxes()
         for key, checked in flags.items():
             checkbox = QtWidgets.QCheckBox(key)
@@ -330,7 +331,7 @@ class LabelDialog(QtWidgets.QDialog):
             checkbox.show()
 
         content_height = self._flags_container.sizeHint().height()
-        self._flags_scroll.setFixedHeight(min(content_height, _FLAGS_SCROLL_MAX_HEIGHT))
+        self._flags_scroll.setFixedHeight(min(content_height, FLAGS_SCROLL_MAX_HEIGHT))
 
     def _collect_flags(self) -> dict[str, bool]:
         return {key: cb.isChecked() for key, cb in self._flag_checkboxes.items()}

--- a/labelme/_widgets/tool_bar.py
+++ b/labelme/_widgets/tool_bar.py
@@ -6,12 +6,6 @@ from PySide6 import QtGui
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 
-_OBJECT_NAME_SUFFIX: Final = "ToolBar"
-_FONT_SCALE_FACTOR: Final = 0.8
-_VERTICAL_SEPARATOR_STYLE: Final = (
-    "QToolBar::separator { height: 1px; background: palette(mid); margin: 2px 4px; }"
-)
-
 
 class ToolBar(QtWidgets.QToolBar):
     def __init__(
@@ -23,8 +17,15 @@ class ToolBar(QtWidgets.QToolBar):
         button_style: Qt.ToolButtonStyle = Qt.ToolButtonStyle.ToolButtonTextUnderIcon,
         font_base: QtGui.QFont | None = None,
     ) -> None:
+        OBJECT_NAME_SUFFIX: Final = "ToolBar"
+        FONT_SCALE_FACTOR: Final = 0.8
+        VERTICAL_SEPARATOR_STYLE: Final = (
+            "QToolBar::separator { height: 1px; background: palette(mid); "
+            "margin: 2px 4px; }"
+        )
+
         super().__init__(title)
-        self.setObjectName(title + _OBJECT_NAME_SUFFIX)
+        self.setObjectName(title + OBJECT_NAME_SUFFIX)
         self.setWindowFlags(self.windowFlags() | Qt.WindowType.FramelessWindowHint)
         self.setMovable(False)
         self.setFloatable(False)
@@ -38,11 +39,11 @@ class ToolBar(QtWidgets.QToolBar):
 
         if font_base is not None:
             scaled_font = QtGui.QFont(font_base)
-            scaled_font.setPointSizeF(font_base.pointSizeF() * _FONT_SCALE_FACTOR)
+            scaled_font.setPointSizeF(font_base.pointSizeF() * FONT_SCALE_FACTOR)
             self.setFont(scaled_font)
 
         if orientation == Qt.Orientation.Vertical:
-            self.setStyleSheet(_VERTICAL_SEPARATOR_STYLE)
+            self.setStyleSheet(VERTICAL_SEPARATOR_STYLE)
 
         for action in actions:
             self.addAction(action)

--- a/labelme/_widgets/zoom_widget.py
+++ b/labelme/_widgets/zoom_widget.py
@@ -5,8 +5,6 @@ from typing import Final
 from PySide6 import QtCore
 from PySide6 import QtWidgets
 
-_ZOOM_LEVEL_LABEL: Final = "Zoom Level"
-
 
 class ZoomWidget(QtWidgets.QDoubleSpinBox):
     PERCENT_MAX: Final[int] = 1000
@@ -14,6 +12,8 @@ class ZoomWidget(QtWidgets.QDoubleSpinBox):
     PERCENT_SUFFIX: Final[str] = " %"
 
     def __init__(self) -> None:
+        ZOOM_LEVEL_LABEL: Final = "Zoom Level"
+
         super().__init__()
         self.setDecimals(self.PERCENT_DECIMALS)
         self.setRange(1, self.PERCENT_MAX)
@@ -21,8 +21,8 @@ class ZoomWidget(QtWidgets.QDoubleSpinBox):
         self.setSuffix(self.PERCENT_SUFFIX)
         self.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.setToolTip(_ZOOM_LEVEL_LABEL)
-        self.setStatusTip(_ZOOM_LEVEL_LABEL)
+        self.setToolTip(ZOOM_LEVEL_LABEL)
+        self.setStatusTip(ZOOM_LEVEL_LABEL)
 
         sample = f"{self.PERCENT_MAX:.{self.PERCENT_DECIMALS}f}{self.PERCENT_SUFFIX}"
         min_width = self.fontMetrics().horizontalAdvance(sample)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
   "typos>=1.45.0",
   "yamlfix>=1.19.1",
   "towncrier>=24.8",
-  "gruff>=0.0.5",
+  "gruff>=0.0.6",
 ]
 
 [project.scripts]

--- a/tests/e2e/annotation_test.py
+++ b/tests/e2e/annotation_test.py
@@ -20,9 +20,6 @@ from ..conftest import close_or_pause
 from .conftest import MainWinFactory
 from .conftest import show_window_and_wait_for_imagedata
 
-# Smallest available model (~40MB) to keep download and inference fast
-_AI_MODEL: Final = "efficientsam:10m"
-
 
 @pytest.mark.gui
 def test_labeling_ai_lands_preserves_generated_group(
@@ -312,6 +309,9 @@ def test_annotate_shape_types(
     expected_num_points: int | None,
     ai_output_format: AiOutputFormat | None,
 ) -> None:
+    # Smallest available model (~40MB) to keep download and inference fast.
+    AI_MODEL: Final = "efficientsam:10m"
+
     expected_shape_type = ai_output_format if ai_output_format else create_mode
 
     input_file = str(data_path / "raw/2011_000003.jpg")
@@ -326,7 +326,7 @@ def test_annotate_shape_types(
 
     label = "test_shape"
     canvas = win._canvas_widgets.canvas
-    canvas.set_ai_model_name(model_name=_AI_MODEL)
+    canvas.set_ai_model_name(model_name=AI_MODEL)
     if ai_output_format is not None:
         canvas.set_ai_output_format(ai_output_format)
 

--- a/tests/e2e/canvas_interaction_test.py
+++ b/tests/e2e/canvas_interaction_test.py
@@ -33,7 +33,6 @@ from .conftest import select_shape
 from .conftest import show_window_and_wait_for_imagedata
 from .conftest import submit_label_dialog
 
-_TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
 _SHAPE_INDEX: Final[int] = 0
 
 
@@ -133,7 +132,9 @@ def _save_and_check(
     win: MainWindow,
     tmp_path: Path,
 ) -> None:
-    label_path = str(tmp_path / Path(_TEST_FILE_NAME).name)
+    TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
+
+    label_path = str(tmp_path / Path(TEST_FILE_NAME).name)
     win.save_labels(label_path=label_path)
     assert_labelfile_sanity(label_path)
 

--- a/tests/e2e/canvas_paint_snapshot_test.py
+++ b/tests/e2e/canvas_paint_snapshot_test.py
@@ -33,10 +33,8 @@ pytestmark = pytest.mark.pixel_snapshot
 # which the main_win fixture invokes for every test.
 _RENDER_WIDTH: Final[int] = 600
 _RENDER_HEIGHT: Final[int] = 450
-_RENDER_SCALE: Final[float] = 1.0
 _BACKGROUND_COLOR: Final[QColor] = QColor(232, 232, 232)
 _PAINT_SETTLE_MS: Final[int] = 100
-_MODE_SWITCH_SETTLE_MS: Final[int] = 50
 
 _TRIANGLE_FRACTIONS: Final[tuple[tuple[float, float], ...]] = (
     (0.2, 0.2),
@@ -46,8 +44,10 @@ _TRIANGLE_FRACTIONS: Final[tuple[tuple[float, float], ...]] = (
 
 
 def _pin_canvas_for_snapshot(*, qtbot: QtBot, canvas: Canvas) -> None:
+    RENDER_SCALE: Final[float] = 1.0
+
     canvas.setFixedSize(_RENDER_WIDTH, _RENDER_HEIGHT)
-    canvas.scale = _RENDER_SCALE
+    canvas.scale = RENDER_SCALE
     canvas.update()
     qtbot.wait(_PAINT_SETTLE_MS)
 
@@ -206,13 +206,15 @@ def test_snapshot_polygon_mid_draw(
     update_snapshots: bool,
     pause: bool,
 ) -> None:
+    MODE_SWITCH_SETTLE_MS: Final[int] = 50
+
     canvas = raw_win._canvas_widgets.canvas
     pixmap = canvas.pixmap
     assert pixmap is not None
     _pin_canvas_for_snapshot(qtbot=qtbot, canvas=canvas)
 
     raw_win._switch_canvas_mode(edit=False, create_mode="polygon")
-    qtbot.wait(_MODE_SWITCH_SETTLE_MS)
+    qtbot.wait(MODE_SWITCH_SETTLE_MS)
 
     for xy in _TRIANGLE_FRACTIONS[:2]:
         click_canvas_fraction(qtbot=qtbot, canvas=canvas, xy=xy)
@@ -234,7 +236,7 @@ def test_snapshot_polygon_mid_draw(
 
     # Cancel the in-progress shape; without this close_or_pause triggers a dialog.
     qtbot.keyPress(canvas, Qt.Key.Key_Escape)
-    qtbot.wait(_MODE_SWITCH_SETTLE_MS)
+    qtbot.wait(MODE_SWITCH_SETTLE_MS)
     assert canvas._current is None
 
     close_or_pause(qtbot=qtbot, widget=raw_win, pause=pause)

--- a/tests/e2e/save_error_handling_test.py
+++ b/tests/e2e/save_error_handling_test.py
@@ -11,8 +11,6 @@ from ..conftest import close_or_pause
 from .conftest import MainWinFactory
 from .conftest import show_window_and_wait_for_imagedata
 
-_RAW_FILE_NAME: Final[str] = "raw/2011_000003.jpg"
-
 
 @pytest.mark.gui
 def test_save_labels_reports_filesystem_failure_without_crashing(
@@ -24,8 +22,10 @@ def test_save_labels_reports_filesystem_failure_without_crashing(
     monkeypatch: pytest.MonkeyPatch,
     pause: bool,
 ) -> None:
+    RAW_FILE_NAME: Final[str] = "raw/2011_000003.jpg"
+
     win = main_win(
-        file_or_dir=str(data_path / _RAW_FILE_NAME),
+        file_or_dir=str(data_path / RAW_FILE_NAME),
         output_dir=str(tmp_path),
     )
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)

--- a/tests/e2e/status_bar_messages_test.py
+++ b/tests/e2e/status_bar_messages_test.py
@@ -14,8 +14,6 @@ from .conftest import MainWinFactory
 from .conftest import dismiss_active_modal
 from .conftest import show_window_and_wait_for_imagedata
 
-_STATUS_MESSAGE_TIMEOUT_MS: Final[int] = 5000
-
 
 def _wait_for_status_message_containing(
     *,
@@ -23,6 +21,8 @@ def _wait_for_status_message_containing(
     win: MainWindow,
     substring: str,
 ) -> list[str]:
+    STATUS_MESSAGE_TIMEOUT_MS: Final[int] = 5000
+
     captured: list[str] = []
     status_bar = win.statusBar()
     assert status_bar is not None
@@ -33,7 +33,7 @@ def _wait_for_status_message_containing(
             captured.append(msg)
         assert any(substring in m for m in captured)
 
-    qtbot.waitUntil(_check, timeout=_STATUS_MESSAGE_TIMEOUT_MS)
+    qtbot.waitUntil(_check, timeout=STATUS_MESSAGE_TIMEOUT_MS)
     return captured
 
 

--- a/tests/e2e/window_geometry_persistence_test.py
+++ b/tests/e2e/window_geometry_persistence_test.py
@@ -23,7 +23,6 @@ _RESIZE_W: Final[int] = 1100
 _RESIZE_H: Final[int] = 800
 _MOVE_X: Final[int] = 50
 _MOVE_Y: Final[int] = 50
-_TOLERANCE_PX: Final[int] = 10
 
 
 @pytest.mark.gui
@@ -33,6 +32,8 @@ def test_window_geometry_persists_across_sessions(
     qtbot: QtBot,
     pause: bool,
 ) -> None:
+    TOLERANCE_PX: Final[int] = 10
+
     win1 = main_win(size=None)
     win1.show()
     qtbot.wait(100)
@@ -54,10 +55,10 @@ def test_window_geometry_persists_across_sessions(
     restored_size = win2.size()
     restored_pos = win2.pos()
 
-    assert abs(restored_size.width() - saved_size.width()) <= _TOLERANCE_PX
-    assert abs(restored_size.height() - saved_size.height()) <= _TOLERANCE_PX
-    assert abs(restored_pos.x() - saved_pos.x()) <= _TOLERANCE_PX
-    assert abs(restored_pos.y() - saved_pos.y()) <= _TOLERANCE_PX
+    assert abs(restored_size.width() - saved_size.width()) <= TOLERANCE_PX
+    assert abs(restored_size.height() - saved_size.height()) <= TOLERANCE_PX
+    assert abs(restored_pos.x() - saved_pos.x()) <= TOLERANCE_PX
+    assert abs(restored_pos.y() - saved_pos.y()) <= TOLERANCE_PX
 
     close_or_pause(qtbot=qtbot, widget=win2, pause=pause)
 

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -20,7 +20,6 @@ from .conftest import MainWinFactory
 from .conftest import image_to_widget_pos
 from .conftest import show_window_and_wait_for_imagedata
 
-_TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
 _VIEWPORT_ZOOM: Final[int] = 300
 
 
@@ -31,8 +30,10 @@ def _win(
     qtbot: QtBot,
     data_path: Path,
 ) -> MainWindow:
+    TEST_FILE_NAME: Final[str] = "annotated/2011_000003.json"
+
     win = main_win(
-        file_or_dir=str(data_path / _TEST_FILE_NAME),
+        file_or_dir=str(data_path / TEST_FILE_NAME),
     )
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
     return win

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -16,9 +16,6 @@ from labelme._shape import Shape
 from labelme._widgets.canvas import Canvas
 from labelme._widgets.canvas import _DraftShape
 
-# Default epsilon in Canvas (screen-pixel hit radius).
-_EPSILON: Final[float] = 10.0
-
 # Pixmap dimensions used across all tests.
 _W: Final[int] = 200
 _H: Final[int] = 100
@@ -483,6 +480,9 @@ def test_vertex_hover_beyond_epsilon_screen_pixels_does_not_select_vertex(
     qtbot: QtBot,
     scale: float,
 ) -> None:
+    # Default screen-pixel hit radius.
+    EPSILON: Final[float] = 10.0
+
     # A hover that is 12 SCREEN pixels from the vertex is outside epsilon=10
     # and must NOT register as a vertex hit (_hovered_vertex stays None).
     canvas = Canvas()
@@ -504,7 +504,7 @@ def test_vertex_hover_beyond_epsilon_screen_pixels_does_not_select_vertex(
 
     assert canvas._hovered_vertex is None, (
         f"scale={scale}: expected no vertex hit at 12 screen px from vertex "
-        f"(image_offset={image_offset_px:.2f}px, epsilon={_EPSILON})"
+        f"(image_offset={image_offset_px:.2f}px, epsilon={EPSILON})"
     )
     _clear_cursor_override(canvas=canvas)
 

--- a/tests/unit/widgets/tool_bar_test.py
+++ b/tests/unit/widgets/tool_bar_test.py
@@ -10,16 +10,15 @@ from pytestqt.qtbot import QtBot
 
 from labelme._widgets.tool_bar import ToolBar
 
-# Qt automatically adds an internal extension/overflow button to every QToolBar.
-# Filter it out when counting user-added buttons.
-_EXT_BUTTON_NAME: Final = "qt_toolbar_ext_button"
-
 
 def _user_buttons(toolbar: ToolBar, /) -> list[QtWidgets.QToolButton]:
+    # Qt adds an internal overflow button; exclude it from user button counts.
+    EXT_BUTTON_NAME: Final = "qt_toolbar_ext_button"
+
     return [
         b
         for b in toolbar.findChildren(QtWidgets.QToolButton)
-        if b.objectName() != _EXT_BUTTON_NAME
+        if b.objectName() != EXT_BUTTON_NAME
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -503,14 +503,14 @@ wheels = [
 
 [[package]]
 name = "gruff"
-version = "0.0.5"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/4c/7f19aad3e7b621e73a13822e854c13195ca29366bd4952d0fd03df51981a/gruff-0.0.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:662c389fc1c090bade52c8ab991a9a63b41f3cec7108007e81479ade0b8a8043", size = 1977054, upload-time = "2026-09-01T03:37:46.342Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/3a/56990ab23561e9464e9dae2e87f2e438758c90e66e29cbe8e6f609b9b76d/gruff-0.0.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f078a6737c5a36a5a9497586875410e01a3d77002688ac5a00f9f33f577db6c3", size = 1909040, upload-time = "2026-09-01T03:37:48.432Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/f7/f78caabea24456e5af4b272d99c349cf8ed9d7893f9a94d2daa3ec5b7ed1/gruff-0.0.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e240efbea06923d2880e7028f46240f481b9cbbfa9587b00872a6e4a60cb0e71", size = 1933481, upload-time = "2026-09-01T03:37:50.309Z" },
-    { url = "https://files.pythonhosted.org/packages/61/72/b5b48628f6305709aaa9d4bf4ef5ad19cc08a4f309f0995fe7c2ae2b481e/gruff-0.0.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:728ae005c8505f3ff3a5d71de2c4013ae64fd1a6ee1f057ebaf309600b3d7b61", size = 2053551, upload-time = "2026-09-01T03:37:52.162Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/91/fc069b049a6cc958597b277c148232e15096e033d8cc24c1095950cb24de/gruff-0.0.5-py3-none-win_amd64.whl", hash = "sha256:df0f012ea4090c2c44ccb4261241dcf608112dfae1c40471e57edfe8cf09be68", size = 1958544, upload-time = "2026-09-01T03:37:53.703Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/0d517a09090571daa8bf19928a8a9481e1b0c5a1a79366febc23162f7d07/gruff-0.0.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ba23fe2c1ca1bf4b0033325c3c9c12d778757b5ccc3f991f6942b716d9b45557", size = 1999075, upload-time = "2026-09-02T06:26:00.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/97/3a550fe81f2ab03836e1a8fd986904b170d8173aee858dd2bbfb018f29fd/gruff-0.0.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d884fb3b934c577d246de24d9c978be78d90f67dfed02c17e43eb1d1745aee36", size = 1931385, upload-time = "2026-09-02T06:26:02.348Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/a6/d15878075937223819b41627164de9b39588497cda8e5d7a354aca084c7a/gruff-0.0.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28b1ecf709668088af42d3098be5786b608835ccbae17f9e4ac0c4aa434f0e44", size = 1951056, upload-time = "2026-09-02T06:26:03.793Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/38/d2eb584c4d905f3ad08ec0881b0af0ec358cd7dcbedc01f3cfef644835cb/gruff-0.0.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51e9ac387ddac9fb3b6c487a62afce556c05b4012f4e04863c664dec602ab1de", size = 2072288, upload-time = "2026-09-02T06:26:05.228Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/c3/fbf10396f2043a097e65a5fa723371dc5b2e1613f6284185aba1043cd78e/gruff-0.0.6-py3-none-win_amd64.whl", hash = "sha256:1cee0319fc3ce22e23cadb9483fe93515551b4856d4a1ae94d8745329e88d33d", size = 1977267, upload-time = "2026-09-02T06:26:06.579Z" },
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "gruff", specifier = ">=0.0.5" },
+    { name = "gruff", specifier = ">=0.0.6" },
     { name = "ipython" },
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },


### PR DESCRIPTION
Gruff 0.0.6 adds GR011, which the existing `select = ["GR"]` configuration enables automatically; the resulting moves tighten single-consumer constants to their usage sites.

`_LOGGER_LEVELS` intentionally remains module-scoped because the unit tests import it for parametrization. The suppression records that cross-module consumer, which Gruff cannot see while linting one module at a time.
