### PR TITLE
feat(canvas): show group ID in shape labels

### DIFF
--- a/changelog.d/2589.changed.md
+++ b/changelog.d/2589.changed.md
@@ -1,0 +1,1 @@
+Shape labels shown on the canvas now include their group ID, matching the annotation list

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -116,10 +116,13 @@ def _paint_shape_label(
     # Anchor at the points' top-left so the text stays close to the shape and
     # tracks zoom/pan; lift it by the pen width to clear the outline stroke.
     top_left = shape.points.min(axis=0) * context.scale
+    text = shape.label
+    if shape.group_id is not None:
+        text += f" ({shape.group_id})"
     painter.setPen(QtGui.QPen(context.palette.line))
     painter.drawText(
         QtCore.QPointF(float(top_left[0]), float(top_left[1]) - PEN_WIDTH),
-        shape.label,
+        text,
     )
 
 

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -137,6 +137,19 @@ def test_show_labels_draws_text_above_shape() -> None:
 
 @pytest.mark.gui
 @pytest.mark.usefixtures("qapp")
+@pytest.mark.parametrize("group_id", [0, 3])
+def test_show_labels_draws_group_id(*, group_id: int) -> None:
+    grouped = _polygon(label="person")
+    grouped.group_id = group_id
+    expected = _polygon(label=f"person ({group_id})")
+
+    assert _render(shape=grouped, show_label=True, scale=1.0) == _render(
+        shape=expected, show_label=True, scale=1.0
+    )
+
+
+@pytest.mark.gui
+@pytest.mark.usefixtures("qapp")
 def test_empty_label_draws_no_text() -> None:
     for label in (None, ""):
         shape = _polygon(label=label)


### PR DESCRIPTION
Canvas labels omitted instance identity even though the annotation list exposed it, making grouped shapes difficult to distinguish.

<img width="1773" height="1068" alt="Screenshot 2026-09-02 at 17-07-20" src="https://github.com/user-attachments/assets/6940a524-3d50-4ae0-a20f-aeb52b75656b" />

Enabled flags remain sidebar-only; #2183 scopes this to the label plus group ID.

Verified with `make lint`, `make test` (1339 passed, 6 skipped), and isolated GUI QA.

Closes #2183
