### PR TITLE
chore: add release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq ($(OS),Windows_NT)
 	SHELL := bash
 endif
 
-.PHONY: help setup format lint test coverage update_translate check_translate
+.PHONY: help setup format lint test coverage update_translate check_translate release
 .DEFAULT_GOAL := help
 
 PYTEST_ARGS ?= --numprocesses=auto
@@ -46,3 +46,16 @@ check_translate:  # Fail if the translation catalogs are stale or incomplete (CI
 
 coverage:  # Run tests with coverage
 	$(MAKE) test PYTEST_ARGS="--cov=labelme --cov-report=term-missing"
+
+release:  # Prepare a release: make release VERSION=X.Y.Z
+	@test -n "$(VERSION)" || { \
+		echo "usage: make release VERSION=X.Y.Z" >&2; \
+		echo "recent releases:" >&2; \
+		git tag --sort=-v:refname | head -5 | sed "s/^/  /" >&2; \
+		exit 1; \
+	}
+	$(call exec,uv run towncrier build --yes --version $(VERSION))
+	@printf "\n\033[1;32mNext steps\033[0m\n"
+	@echo "  git commit -am \"chore: prep $(VERSION) release\""
+	@echo "  git tag v$(VERSION)"
+	@echo "  git push origin main v$(VERSION)"


### PR DESCRIPTION
Mirrors Gruff's release entry point so Labelme's documented towncrier and tagging flow is discoverable from `make help`.

Labelme derives its package version from Git tags, so this intentionally omits Gruff's version-file rewrite.

Checked with `make help`, the missing-`VERSION` guard, `make --dry-run release VERSION=99.99.99`, and `git diff --check`.
