### PR TITLE
fix(changelog): correct zoom action names

### DIFF
--- a/changelog.d/2580.changed.md
+++ b/changelog.d/2580.changed.md
@@ -1,1 +1,1 @@
-Renamed the View-menu zoom actions to Enlarge, Reduce, Actual Size, Scale to Window, and Scale to Width, and reworded their tooltips to describe the effect on the displayed image; shortcuts and behavior are unchanged
+Renamed the View-menu actions Original Size, Fit Window, and Fit Width to Actual Size, Fit to Window, and Fit to Width, and reworded the zoom tooltips to describe the effect on the displayed image; shortcuts and behavior are unchanged


### PR DESCRIPTION
Prevents v7.3.0 release notes from announcing zoom action names that never shipped.

The corrected fragment now matches #2580's implementation and the labels verified in the real GUI.
