### PR TITLE
fix(release): format generated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shape labels shown on the canvas now include their group ID, matching the Shape List ([#2589](https://github.com/wkentaro/labelme/pull/2589))
 - The dock listing the current Image's Shapes is now titled Shape List. ([#2593](https://github.com/wkentaro/labelme/pull/2593))
 
-
 ## 7.2.0 - 2026-08-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ release:  # Prepare a release: make release VERSION=X.Y.Z
 		exit 1; \
 	}
 	$(call exec,uv run towncrier build --yes --version $(VERSION))
+	$(call exec,uv run mdformat CHANGELOG.md)
 	@printf "\n\033[1;32mNext steps\033[0m\n"
 	@echo "  git commit -am \"chore: prep $(VERSION) release\""
 	@echo "  git tag v$(VERSION)"


### PR DESCRIPTION
Prevents `make release` from producing a changelog that immediately fails Markdown lint, as happened during the v7.3.0 release.

Towncrier leaves an extra blank line between release sections, so the release target now normalizes its output with the formatter already enforced by `make lint`.
