### PR TITLE
refactor(canvas): share one click handler across open-path modes

### DIFF
--- a/changelog.d/2596.changed.md
+++ b/changelog.d/2596.changed.md
@@ -1,0 +1,1 @@
+Polygon, linestrip, and AI-Points clicks share one canvas handler; Ctrl+Shift+click now also places the last linestrip point, matching AI-Points

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1073,45 +1073,45 @@ class Canvas(QtWidgets.QWidget):
         self, *, current: _DraftShape, event: QtGui.QMouseEvent
     ) -> None:
         mode = self.create_mode
-        modifiers = event.modifiers()
-        if mode == "polygon":
-            current = current.add_point(self._line.points[1], autoclose=True)
-            self._current = current
-            self._line = dataclasses.replace(
-                self._line, points=(current.points[-1],) + self._line.points[1:]
-            )
-            if current.closed:
-                self._finalize()
+        if mode in ("polygon", "linestrip", "ai_points_to_shape"):
+            self._commit_preview_vertex(current=current, event=event)
         elif mode == "oriented_rectangle":
             if len(current.points) == ORIENTED_RECTANGLE_POINT_COUNT:
                 self._finalize()
             else:
                 assert len(current.points) == 1
                 self._lock_oriented_rectangle_first_edge(current=current)
-        elif mode in ("rectangle", "circle", "line", "ai_box_to_shape"):
+        else:
+            assert mode in ("rectangle", "circle", "line", "ai_box_to_shape")
             assert len(current.points) == 1
             self._current = dataclasses.replace(current, points=self._line.points)
             self._finalize()
-        elif mode == "linestrip":
-            current = current.add_point(self._line.points[1])
-            self._current = current
-            self._line = dataclasses.replace(
-                self._line, points=(current.points[-1],) + self._line.points[1:]
-            )
-            if modifiers == Qt.KeyboardModifier.ControlModifier:
-                self._finalize()
-        elif mode == "ai_points_to_shape":
-            current = current.add_point(
-                self._line.points[1], label=self._line.point_labels[1]
-            )
-            self._current = current
-            self._line = dataclasses.replace(
-                self._line,
-                points=(current.points[-1],) + self._line.points[1:],
-                point_labels=(current.point_labels[-1],) + self._line.point_labels[1:],
-            )
-            if modifiers & Qt.KeyboardModifier.ControlModifier:
-                self._finalize()
+
+    def _commit_preview_vertex(
+        self, *, current: _DraftShape, event: QtGui.QMouseEvent
+    ) -> None:
+        # The preview segment runs from the last committed vertex to the cursor.
+        # A click promotes its cursor end into the draft, and the next preview
+        # segment collapses onto that vertex until the cursor moves again.
+        vertex = self._line.points[1]
+        label = self._line.point_labels[1]
+        current = current.add_point(
+            vertex, label=label, autoclose=self.create_mode == "polygon"
+        )
+        self._current = current
+        if current.closed or self._is_final_open_path_click(event=event):
+            self._finalize()
+            return
+        self._line = dataclasses.replace(
+            self._line, points=(vertex, vertex), point_labels=(label, label)
+        )
+
+    def _is_final_open_path_click(self, *, event: QtGui.QMouseEvent) -> bool:
+        # A polygon ends by returning to its first vertex; the modes with no
+        # natural end let Ctrl mark the last click instead.
+        if self.create_mode == "polygon":
+            return False
+        return bool(event.modifiers() & Qt.KeyboardModifier.ControlModifier)
 
     def _lock_oriented_rectangle_first_edge(self, *, current: _DraftShape) -> None:
         first_corner = self._line.points[0]
@@ -1968,6 +1968,10 @@ class Canvas(QtWidgets.QWidget):
             self._line = dataclasses.replace(
                 self._line,
                 points=(self._current.points[-1], self._current.points[0]),
+                point_labels=(
+                    self._current.point_labels[-1],
+                    self._current.point_labels[0],
+                ),
             )
         elif self.create_mode in (
             "rectangle",

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -18,6 +18,7 @@ from pytestqt.qtbot import QtBot
 from labelme._automation._ai_assist import AiAssistProposal
 from labelme._shape import Shape
 from labelme._shape import ShapeType
+from labelme._widgets.canvas import _CREATE_MODE_TO_SHAPE_TYPE
 from labelme._widgets.canvas import Canvas
 from labelme._widgets.canvas import _compute_intersection_edges_image
 from labelme._widgets.canvas import _draft_to_shape
@@ -1365,6 +1366,162 @@ def test_extend_after_mode_switch_grows_partial_at_last_cursor(
         assert canvas._current.points[0] != canvas._current.points[1]
     else:
         assert canvas._current.points == (QPointF(10, 10), QPointF(50, 30))
+
+
+def _left_press(*, pos: QPointF, modifiers: Qt.KeyboardModifier) -> QtGui.QMouseEvent:
+    return QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseButtonPress,
+        pos,
+        pos,
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        modifiers,
+    )
+
+
+def _start_open_path(*, canvas: Canvas, mode: str, cursor: QPointF) -> _DraftShape:
+    canvas.create_mode = mode
+    shape_type = _CREATE_MODE_TO_SHAPE_TYPE[canvas.create_mode]
+    canvas._current = _DraftShape(
+        shape_type=shape_type, points=(QPointF(10, 10),), point_labels=(1,)
+    )
+    canvas._line = _DraftShape(
+        shape_type=shape_type, points=(QPointF(10, 10), cursor), point_labels=(1, 1)
+    )
+    return canvas._current
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("mode", ["polygon", "linestrip"])
+def test_extend_open_path_commits_cursor_and_previews_from_it(
+    *, canvas: Canvas, mode: str
+) -> None:
+    current = _start_open_path(canvas=canvas, mode=mode, cursor=QPointF(50, 30))
+
+    canvas._extend_current_shape(
+        current=current,
+        event=_left_press(
+            pos=QPointF(50, 30), modifiers=Qt.KeyboardModifier.NoModifier
+        ),
+    )
+
+    assert canvas.shapes == []
+    assert canvas._current is not None
+    assert canvas._current.points == (QPointF(10, 10), QPointF(50, 30))
+    assert canvas._line.points[0] == QPointF(50, 30)
+
+
+@pytest.mark.gui
+def test_extend_linestrip_with_control_click_finishes_at_cursor(
+    *, canvas: Canvas
+) -> None:
+    current = _start_open_path(canvas=canvas, mode="linestrip", cursor=QPointF(50, 30))
+
+    canvas._extend_current_shape(
+        current=current,
+        event=_left_press(
+            pos=QPointF(50, 30), modifiers=Qt.KeyboardModifier.ControlModifier
+        ),
+    )
+
+    assert canvas._current is None
+    assert len(canvas.shapes) == 1
+    assert canvas.shapes[0].shape_type == "linestrip"
+    np.testing.assert_array_equal(canvas.shapes[0].points, [[10, 10], [50, 30]])
+
+
+@pytest.mark.gui
+def test_extend_ai_points_carries_negative_preview_label_into_draft(
+    *, canvas: Canvas
+) -> None:
+    current = _start_open_path(
+        canvas=canvas, mode="ai_points_to_shape", cursor=QPointF(50, 30)
+    )
+    # Shift during the move marks the cursor end as a background point.
+    canvas._line = dataclasses.replace(canvas._line, point_labels=(1, 0))
+
+    canvas._extend_current_shape(
+        current=current,
+        event=_left_press(
+            pos=QPointF(50, 30), modifiers=Qt.KeyboardModifier.NoModifier
+        ),
+    )
+
+    assert canvas.shapes == []
+    assert canvas._current is not None
+    assert canvas._current.point_labels == (1, 0)
+    assert canvas._line.point_labels == (0, 0)
+
+
+@pytest.mark.gui
+def test_extend_polygon_on_first_vertex_closes_it(*, canvas: Canvas) -> None:
+    canvas.create_mode = "polygon"
+    points = (QPointF(10, 10), QPointF(50, 30), QPointF(30, 60))
+    canvas._current = _DraftShape(
+        shape_type="polygon", points=points, point_labels=(1, 1, 1)
+    )
+    canvas._line = _DraftShape(
+        shape_type="polygon", points=(points[-1], points[0]), point_labels=(1, 1)
+    )
+
+    canvas._extend_current_shape(
+        current=canvas._current,
+        event=_left_press(pos=points[0], modifiers=Qt.KeyboardModifier.NoModifier),
+    )
+
+    assert canvas._current is None
+    assert len(canvas.shapes) == 1
+    assert canvas.shapes[0].closed
+    np.testing.assert_array_equal(
+        canvas.shapes[0].points, [[10, 10], [50, 30], [30, 60]]
+    )
+
+
+@pytest.mark.gui
+def test_undo_last_line_then_click_without_moving_recloses_polygon(
+    *, canvas: Canvas
+) -> None:
+    canvas.create_mode = "polygon"
+    canvas.shapes.append(
+        Shape(
+            shape_type="polygon",
+            points=np.array([[10, 10], [50, 30], [30, 60]], dtype=np.float64),
+            closed=True,
+        )
+    )
+
+    canvas.undo_last_line()
+    assert canvas._current is not None
+    # The reopened preview runs back to the first vertex, so a click there
+    # closes the polygon again.
+    canvas._extend_current_shape(
+        current=canvas._current,
+        event=_left_press(
+            pos=QPointF(10, 10), modifiers=Qt.KeyboardModifier.NoModifier
+        ),
+    )
+
+    assert canvas._current is None
+    assert len(canvas.shapes) == 1
+    np.testing.assert_array_equal(
+        canvas.shapes[0].points, [[10, 10], [50, 30], [30, 60]]
+    )
+
+
+@pytest.mark.gui
+def test_extend_polygon_with_control_click_keeps_drawing(*, canvas: Canvas) -> None:
+    current = _start_open_path(canvas=canvas, mode="polygon", cursor=QPointF(50, 30))
+
+    canvas._extend_current_shape(
+        current=current,
+        event=_left_press(
+            pos=QPointF(50, 30), modifiers=Qt.KeyboardModifier.ControlModifier
+        ),
+    )
+
+    assert canvas.shapes == []
+    assert canvas._current is not None
+    assert canvas._current.points == (QPointF(10, 10), QPointF(50, 30))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -1412,16 +1412,21 @@ def test_extend_open_path_commits_cursor_and_previews_from_it(
 
 
 @pytest.mark.gui
+@pytest.mark.parametrize(
+    "modifiers",
+    [
+        Qt.KeyboardModifier.ControlModifier,
+        Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier,
+    ],
+    ids=["control", "control-shift"],
+)
 def test_extend_linestrip_with_control_click_finishes_at_cursor(
-    *, canvas: Canvas
+    *, canvas: Canvas, modifiers: Qt.KeyboardModifier
 ) -> None:
     current = _start_open_path(canvas=canvas, mode="linestrip", cursor=QPointF(50, 30))
 
     canvas._extend_current_shape(
-        current=current,
-        event=_left_press(
-            pos=QPointF(50, 30), modifiers=Qt.KeyboardModifier.ControlModifier
-        ),
+        current=current, event=_left_press(pos=QPointF(50, 30), modifiers=modifiers)
     )
 
     assert canvas._current is None


### PR DESCRIPTION
## What

Polygon, linestrip, and AI-Points each had their own branch in the canvas click handler for growing the draft. The three bodies differed only in how the draft ends: a polygon closes when the click lands on its first vertex, and the other two end on Ctrl. One handler now promotes the preview's cursor end into the draft and asks a small predicate whether that click was the last, so the per-mode branches are gone.

## Behavior

- Click, Ctrl+click, and polygon self-closing behave as before for all three modes; the annotation and canvas-interaction e2e tests pass unchanged.
- Linestrip now treats Ctrl as a modifier bit, so Ctrl+Shift+click also places the last point, matching AI-Points.
- After undoing a committed polygon or linestrip, the preview segment carries point labels for both ends, matching the invariant the paint path already asserts.

## Tests

The first commit adds canvas unit tests that pin the behavior the shared handler has to keep: a click grows a polygon or linestrip and restarts the preview from the new vertex, Ctrl finishes a linestrip but not a polygon, a click on the first vertex closes a polygon, an AI-Points click carries the preview's Shift label into the draft and the next preview, and a click right after undoing a committed polygon closes it again. All of them pass against the pre-refactor handler. The refactor commit extends the linestrip Ctrl test to Ctrl+Shift, since that is the one behavior this PR changes.

Each of the five one-line mutations of the new handler (drop the vertex label, drop the preview labels, exact-Ctrl compare, no autoclose, revert the undo label fix) now fails at least one unit test; before, all five passed the full suite.

`make lint` passes. `uv run --no-sync pytest tests/unit` passes (1127 passed), and the non-network annotation and canvas-interaction e2e tests pass (37 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

