### PR TITLE
refactor: drop undo-path comments that name other functions

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1309,7 +1309,6 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def mark_dirty(self) -> None:
-        # Autosave does not clear the undo stack; keep the undo action available.
         self._actions.undo.setEnabled(self._canvas_widgets.canvas.can_restore_shape)
 
         if self._actions.save_auto.isChecked():
@@ -2566,7 +2565,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # but keep the image on the canvas.
         self._docks.label_list.clear()
         # Drop the pre-delete backups first so undo cannot resurrect the
-        # annotations of the file we just removed; load_shapes then re-seeds the
+        # annotations of the file we just removed; the reload below re-seeds the
         # stack with the empty state, keeping "top mirrors current" intact.
         self._canvas_widgets.canvas.shape_backups.clear()
         self._canvas_widgets.canvas.load_shapes(shapes=[], replace=True)

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -509,14 +509,12 @@ class Canvas(QtWidgets.QWidget):
         return len(self.shape_backups) >= MIN_SHAPE_BACKUPS_FOR_UNDO
 
     def restore_last_shape(self) -> None:
-        # Undo coordinates with app.py::undo_shape_edit, app.py::load_shapes,
-        # and Canvas::load_shapes; this method only adjusts the backup stack.
         if not self.can_restore_shape:
             return
         self.shape_backups.pop()  # discard current state
 
-        # load_shapes (called downstream by the application) will re-push
-        # this entry as the new current state.
+        # Peeking would leave this entry on the stack, and the reload that
+        # follows would record it a second time, making the next undo a no-op.
         self.shapes = self.shape_backups.pop()
         self.selected_shapes.clear()
         self.update()


### PR DESCRIPTION
Comment-only. The removed comments listed which functions the shape backup stack coordinates with; those names go stale silently on rename, and one of them already pointed at a method that no longer exists. The call sites are a grep away.

The one comment kept explains why the restored entry is popped rather than peeked: the reload that follows would otherwise record it twice and make the next undo a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQd2DgsmvKny4v95op2z2Y
