### PR TITLE
refactor: compute zoom scale in one place and simplify resize guard

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -290,7 +290,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._setup_app_state(file_or_dir=file_or_dir, output_dir=output_dir)
 
-        self._canvas_widgets.zoom_widget.valueChanged.connect(self._paint_canvas)
+        self._canvas_widgets.zoom_widget.valueChanged.connect(
+            self._apply_zoom_to_canvas
+        )
 
         self.populate_mode_actions()
 
@@ -2011,7 +2013,8 @@ class MainWindow(QtWidgets.QMainWindow):
         viewport_pos = canvas.mapTo(viewport, pos)
 
         self._sync_zoom_mode_actions()
-        self._canvas_widgets.zoom_widget.setValue(value)  # triggers self._paint_canvas
+        # Setting the value fires valueChanged, which rescales the canvas.
+        self._canvas_widgets.zoom_widget.setValue(value)
 
         target = canvas.transform_image_point_to_widget(
             image_pos, area=canvas.sizeHint()
@@ -2278,7 +2281,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._adjust_scale()
         # The zoom value can be unchanged across images, so update geometry
         # explicitly before restoring positions against the new scroll range.
-        self._paint_canvas()
+        self._apply_zoom_to_canvas()
         if target_viewport is not None:
             for orientation, value in target_viewport.scroll_values.items():
                 self.set_scroll_value(orientation=orientation, value=value)
@@ -2304,23 +2307,16 @@ class MainWindow(QtWidgets.QMainWindow):
         return True
 
     def resizeEvent(self, a0: QtGui.QResizeEvent, /) -> None:
-        if (
-            self._canvas_widgets.canvas
-            and not self._image.isNull()
-            and self._zoom_mode != _ZoomMode.MANUAL_ZOOM
-        ):
-            self._adjust_scale()
         super().resizeEvent(a0)
-
-    def _paint_canvas(self) -> None:
-        if self._image.isNull():
-            logger.warning("image is null, cannot paint canvas")
+        if self._image.isNull() or self._zoom_mode == _ZoomMode.MANUAL_ZOOM:
             return
-        self._canvas_widgets.canvas.scale = (
-            0.01 * self._canvas_widgets.zoom_widget.value()
-        )
-        self._canvas_widgets.canvas.adjustSize()
-        self._canvas_widgets.canvas.update()
+        self._adjust_scale()
+
+    def _apply_zoom_to_canvas(self) -> None:
+        if self._image.isNull():
+            logger.warning("image is null, cannot apply zoom")
+            return
+        self._canvas_widgets.canvas.scale = self._canvas_widgets.zoom_widget.scale
 
     def _adjust_scale(self) -> None:
         if self._zoom_mode == _ZoomMode.FIT_WINDOW:

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -247,7 +247,7 @@ class Canvas(QtWidgets.QWidget):
         self._rotation_center = np.zeros(2)
         self._rotation_initial_angle = 0.0
         self._rotation_original_points = np.empty((0, 2))
-        self.scale: float = 1.0
+        self._scale: float = 1.0
         self._ai_assist_session = _automation.AiAssistSession()
         self._ai_inference_failed = False
         self._ai_suppress_existing_shape_matches = False
@@ -378,6 +378,18 @@ class Canvas(QtWidgets.QWidget):
             highlight=highlight,
             rotation_highlight=rotation_highlight,
         )
+
+    @property
+    def scale(self) -> float:
+        return self._scale
+
+    @scale.setter
+    def scale(self, value: float, /) -> None:
+        self._scale = value
+        # Callers read the scroll range right after assigning, so resize
+        # synchronously instead of waiting for a layout pass.
+        self.adjustSize()
+        self.update()
 
     @property
     def is_drawing(self) -> bool:

--- a/labelme/_widgets/zoom_widget.py
+++ b/labelme/_widgets/zoom_widget.py
@@ -27,3 +27,8 @@ class ZoomWidget(QtWidgets.QDoubleSpinBox):
         sample = f"{self.PERCENT_MAX:.{self.PERCENT_DECIMALS}f}{self.PERCENT_SUFFIX}"
         min_width = self.fontMetrics().horizontalAdvance(sample)
         self.setMinimumWidth(min_width)
+
+    @property
+    def scale(self) -> float:
+        # The spin box shows a percentage; the canvas draws with a factor.
+        return 0.01 * self.value()

--- a/tests/e2e/middle_drag_scroll_test.py
+++ b/tests/e2e/middle_drag_scroll_test.py
@@ -26,8 +26,8 @@ def _diagonal_drag_endpoints(*, canvas: Canvas) -> tuple[QPoint, QPoint]:
 
 def _zoom_until_overflow(*, canvas: Canvas) -> None:
     # Mutates canvas.scale directly to bypass the public zoom path because
-    # this fixture only needs to force overflow; if the zoom pipeline gains
-    # additional side effects relevant to a test, route through that instead.
+    # this fixture only needs to force overflow; if the main window's zoom
+    # pipeline gains side effects relevant to a test, route through that instead.
     viewport = canvas._scroll_viewport()
     assert viewport is not None
     while not (
@@ -35,8 +35,6 @@ def _zoom_until_overflow(*, canvas: Canvas) -> None:
         or canvas.pixmap.height() * canvas.scale > viewport.height()
     ):
         canvas.scale *= 1.5
-        canvas.adjustSize()
-        canvas.update()
 
 
 @pytest.mark.gui
@@ -87,8 +85,6 @@ def test_middle_drag_no_pan_when_image_fits_viewport(
         )
         * 0.5
     )
-    canvas.adjustSize()
-    canvas.update()
 
     start, end = _diagonal_drag_endpoints(canvas=canvas)
 

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -47,6 +47,22 @@ def canvas(*, qtbot: QtBot) -> Canvas:
 
 
 @pytest.mark.gui
+def test_setting_scale_resizes_canvas(*, canvas: Canvas) -> None:
+    canvas.scale = 2.0
+    assert canvas.size() == QSize(2 * _WIDTH, 2 * _HEIGHT)
+
+
+@pytest.mark.gui
+def test_setting_unchanged_scale_still_resizes_canvas(*, canvas: Canvas) -> None:
+    # A new image changes the size hint while the zoom stays put; assigning
+    # the same scale is how the canvas is told to take the new size.
+    canvas.scale = 1.0
+    canvas.pixmap = QtGui.QPixmap(2 * _WIDTH, 2 * _HEIGHT)
+    canvas.scale = 1.0
+    assert canvas.size() == QSize(2 * _WIDTH, 2 * _HEIGHT)
+
+
+@pytest.mark.gui
 def test_propose_ai_shapes_passes_rgb_image_to_model(
     *,
     canvas: Canvas,

--- a/tests/unit/widgets/zoom_widget/value_test.py
+++ b/tests/unit/widgets/zoom_widget/value_test.py
@@ -32,3 +32,8 @@ def test_zoom_widget_clamps_to_range(*, widget: ZoomWidget) -> None:
     assert widget.value() == ZoomWidget.PERCENT_MAX
     widget.setValue(0)
     assert widget.value() == 1.0
+
+
+def test_zoom_widget_scale_is_percent_as_factor(*, widget: ZoomWidget) -> None:
+    widget.setValue(150)
+    assert widget.scale == pytest.approx(1.5)


### PR DESCRIPTION
Percent-to-factor conversion for the zoom now lives in one place, and the canvas owns its own resize-and-repaint when its scale changes, so the main window just assigns one to the other.

Three non-obvious bits:

1. `resizeEvent` now calls `super()` first and early-returns. `QMainWindow` does not override `resizeEvent` and `QWidget`'s is empty, and the central widget already has its new geometry on entry, so the fit calculation reads the same viewport size either way; safe. The dropped canvas-truthiness conjunct was always true (a `QWidget` has no `__bool__`).

2. The `Canvas.scale` setter fires unconditionally, on purpose. The file-load path assigns an unchanged zoom to force a geometry refresh for a differently sized image, and a unit test pins that so an equality short-circuit cannot sneak in later.

3. The middle-drag e2e helper drops its manual `adjustSize()`/`update()` after writing `canvas.scale`; the setter does that now.

While verifying the resize guard I found a pre-existing crash on resize after Close File in fit mode; it is unchanged by this PR and tracked in #2598.

No changelog fragment: no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Tk3PrFziUKbanji3ok7zG
