### PR TITLE
refactor(render): build two-point shapes from one rect helper

### DIFF
--- a/labelme/_shape.py
+++ b/labelme/_shape.py
@@ -123,51 +123,46 @@ def nearest_vertex_index(
     *,
     shape: Shape,
     point: npt.NDArray[np.float64],
-    scale: float,
-    epsilon: float,
+    image_epsilon: float,
 ) -> int | None:
     if shape.shape_type in ("mask", "point") or len(shape.points) == 0:
         return None
-    distances = np.linalg.norm((shape.points - point) * scale, axis=1)
-    return _nearest_index_within_epsilon(distances=distances, epsilon=epsilon)
+    distances = np.linalg.norm(shape.points - point, axis=1)
+    return _nearest_index_within_epsilon(distances=distances, epsilon=image_epsilon)
 
 
 def nearest_edge_index(
     *,
     shape: Shape,
     point: npt.NDArray[np.float64],
-    scale: float,
-    epsilon: float,
+    image_epsilon: float,
 ) -> int | None:
     if len(shape.points) == 0:
         return None
-    scaled_point = point * scale
-    scaled_points = shape.points * scale
-    starts = np.roll(scaled_points, 1, axis=0)
-    segments = scaled_points - starts
+    starts = np.roll(shape.points, 1, axis=0)
+    segments = shape.points - starts
     length_squared = (segments * segments).sum(axis=1)
     t = np.clip(
-        ((scaled_point - starts) * segments).sum(axis=1)
+        ((point - starts) * segments).sum(axis=1)
         / np.where(length_squared == 0, 1.0, length_squared),
         0.0,
         1.0,
     )
     projections = starts + t[:, None] * segments
-    distances = np.linalg.norm(scaled_point - projections, axis=1)
+    distances = np.linalg.norm(point - projections, axis=1)
     if shape.shape_type == "linestrip":
         # A linestrip is an open polyline: the wrap-around segment np.roll builds
         # at index 0 (last point back to the first) is never rendered, so it must
         # not be a hit target.
         distances[0] = np.inf
-    return _nearest_index_within_epsilon(distances=distances, epsilon=epsilon)
+    return _nearest_index_within_epsilon(distances=distances, epsilon=image_epsilon)
 
 
 def nearest_rotation_point_index(
     *,
     shape: Shape,
     point: npt.NDArray[np.float64],
-    scale: float,
-    epsilon: float,
+    image_epsilon: float,
 ) -> int | None:
     if (
         shape.shape_type != "oriented_rectangle"
@@ -175,8 +170,8 @@ def nearest_rotation_point_index(
     ):
         return None
     handles = (shape.points + np.roll(shape.points, 1, axis=0)) / 2
-    distances = np.linalg.norm((handles - point) * scale, axis=1)
-    return _nearest_index_within_epsilon(distances=distances, epsilon=epsilon)
+    distances = np.linalg.norm(handles - point, axis=1)
+    return _nearest_index_within_epsilon(distances=distances, epsilon=image_epsilon)
 
 
 def get_rotation_handle(*, shape: Shape, index: int) -> npt.NDArray[np.float64]:

--- a/labelme/_widgets/_canvas_interaction.py
+++ b/labelme/_widgets/_canvas_interaction.py
@@ -44,10 +44,14 @@ def find_hover_target(
         priority_shape=priority_shape,
     )
 
+    # Proximity is measured in image space, so the screen-pixel threshold is
+    # converted here rather than scaling every shape's points.
+    image_epsilon = epsilon / scale
+
     # Pass 1: vertex proximity
     for shape in candidates:
         idx = nearest_vertex_index(
-            shape=shape, point=point, scale=scale, epsilon=epsilon
+            shape=shape, point=point, image_epsilon=image_epsilon
         )
         if idx is not None:
             return HitTarget(kind=HitKind.VERTEX, shape=shape, index=idx)
@@ -55,7 +59,7 @@ def find_hover_target(
     # Pass 2: rotation handle proximity
     for shape in candidates:
         idx = nearest_rotation_point_index(
-            shape=shape, point=point, scale=scale, epsilon=epsilon
+            shape=shape, point=point, image_epsilon=image_epsilon
         )
         if idx is not None:
             return HitTarget(kind=HitKind.ROTATION_HANDLE, shape=shape, index=idx)
@@ -64,7 +68,7 @@ def find_hover_target(
     for shape in candidates:
         if not shape.can_add_point():
             continue
-        idx = nearest_edge_index(shape=shape, point=point, scale=scale, epsilon=epsilon)
+        idx = nearest_edge_index(shape=shape, point=point, image_epsilon=image_epsilon)
         if idx is not None:
             return HitTarget(kind=HitKind.EDGE, shape=shape, index=idx)
 

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import typing
+from typing import ClassVar
 from typing import Final
 from typing import Literal
 
@@ -19,8 +20,6 @@ from .._shape import Shape
 from .._shape import get_rotation_handle
 from .._shape import nearest_edge_index
 from .._shape import oriented_rectangle_arrow_points
-
-PEN_WIDTH: Final[int] = 2
 
 
 @dataclasses.dataclass(frozen=True)
@@ -80,6 +79,9 @@ class ShapeRenderContext:
     rotation_highlight: VertexHighlight | None
     show_label: bool = False
     line_style: QtCore.Qt.PenStyle = QtCore.Qt.PenStyle.SolidLine
+    # Outline stroke width in screen pixels, shared by every pen this module
+    # draws with so the label offset clears the stroke.
+    pen_width: ClassVar[int] = 2
 
 
 def render_shape(
@@ -91,7 +93,7 @@ def render_shape(
     palette = context.palette
     color = palette.select_line if context.selected else palette.line
     pen = QtGui.QPen(color)
-    pen.setWidth(PEN_WIDTH)
+    pen.setWidth(context.pen_width)
     pen.setStyle(context.line_style)
     painter.setPen(pen)
 
@@ -121,7 +123,7 @@ def _paint_shape_label(
         text += f" ({shape.group_id})"
     painter.setPen(QtGui.QPen(context.palette.line))
     painter.drawText(
-        QtCore.QPointF(float(top_left[0]), float(top_left[1]) - PEN_WIDTH),
+        QtCore.QPointF(float(top_left[0]), float(top_left[1]) - context.pen_width),
         text,
     )
 
@@ -202,14 +204,14 @@ def _paint_shape_points(
         painter.fillPath(paths.line, fill)
     if paths.orientation_arrow.length() > 0:
         arrow_pen = QtGui.QPen(palette.vertex_fill)
-        arrow_pen.setWidth(PEN_WIDTH)
+        arrow_pen.setWidth(context.pen_width)
         painter.setPen(arrow_pen)
         painter.drawPath(paths.orientation_arrow)
 
     if paths.negative_vertices.length() > 0:
         neg_color = QtGui.QColor(255, 0, 0, 255)
         neg_pen = QtGui.QPen(neg_color)
-        neg_pen.setWidth(PEN_WIDTH)
+        neg_pen.setWidth(context.pen_width)
         painter.setPen(neg_pen)
         painter.drawPath(paths.negative_vertices)
         painter.fillPath(paths.negative_vertices, neg_color)

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -316,13 +316,7 @@ def _build_shape_points_paths(
     points = shape.points
     if shape.shape_type in ["rectangle", "mask"]:
         assert len(points) in [1, 2]
-        if len(points) == RECTANGLE_POINT_COUNT:
-            paths.line.addRect(
-                QtCore.QRectF(
-                    QtCore.QPointF(*(points[0] * scale)),
-                    QtCore.QPointF(*(points[1] * scale)),
-                )
-            )
+        paths.line.addPath(_build_two_point_shape_path(shape=shape, scale=scale))
         if shape.shape_type == "rectangle":
             for i in range(len(points)):
                 _build_shape_point_path(
@@ -357,9 +351,7 @@ def _build_shape_points_paths(
                 )
     elif shape.shape_type == "circle":
         assert len(points) in [1, 2]
-        if len(points) == CIRCLE_POINT_COUNT:
-            radius = float(np.linalg.norm((points[0] - points[1]) * scale))
-            paths.line.addEllipse(QtCore.QPointF(*(points[0] * scale)), radius, radius)
+        paths.line.addPath(_build_two_point_shape_path(shape=shape, scale=scale))
         for i in range(len(points)):
             _build_shape_point_path(
                 path=paths.vertices, shape=shape, context=context, vertex_index=i
@@ -430,15 +422,8 @@ def bounds(*, shape: Shape) -> QtCore.QRectF:
 def _build_image_path(*, shape: Shape) -> QtGui.QPainterPath:
     points = shape.points
     out = QtGui.QPainterPath()
-    if shape.shape_type in ("rectangle", "mask"):
-        if len(points) == RECTANGLE_POINT_COUNT:
-            out.addRect(
-                QtCore.QRectF(QtCore.QPointF(*points[0]), QtCore.QPointF(*points[1]))
-            )
-    elif shape.shape_type == "circle":
-        if len(points) == CIRCLE_POINT_COUNT:
-            radius = float(np.linalg.norm(points[0] - points[1]))
-            out.addEllipse(QtCore.QPointF(*points[0]), radius, radius)
+    if shape.shape_type in ("rectangle", "mask", "circle"):
+        out.addPath(_build_two_point_shape_path(shape=shape, scale=1.0))
     elif shape.shape_type == "oriented_rectangle":
         if len(points) == ORIENTED_RECTANGLE_POINT_COUNT:
             out.moveTo(QtCore.QPointF(*points[0]))
@@ -451,3 +436,30 @@ def _build_image_path(*, shape: Shape) -> QtGui.QPainterPath:
             for p in points[1:]:
                 out.lineTo(QtCore.QPointF(*p))
     return out
+
+
+def _build_rect_between(
+    *, corner: npt.NDArray[np.float64], opposite: npt.NDArray[np.float64]
+) -> QtCore.QRectF:
+    x0, y0 = corner
+    x1, y1 = opposite
+    return QtCore.QRectF(x0, y0, x1 - x0, y1 - y0)
+
+
+def _build_two_point_shape_path(*, shape: Shape, scale: float) -> QtGui.QPainterPath:
+    # A rectangle, a Mask Shape's bounding box, and a circle are each fully
+    # described by two points, so one image-space rect covers all three.
+    path = QtGui.QPainterPath()
+    if shape.shape_type == "circle" and len(shape.points) == CIRCLE_POINT_COUNT:
+        center, rim = shape.points
+        radius = float(np.linalg.norm(rim - center))
+        path.addEllipse(
+            _build_rect_between(corner=center - radius, opposite=center + radius)
+        )
+    elif (
+        shape.shape_type in ("rectangle", "mask")
+        and len(shape.points) == RECTANGLE_POINT_COUNT
+    ):
+        corner, opposite = shape.points
+        path.addRect(_build_rect_between(corner=corner, opposite=opposite))
+    return QtGui.QTransform.fromScale(scale, scale).map(path)

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -400,7 +400,7 @@ def is_hit_by_point(
 ) -> bool:
     if shape.shape_type in ("line", "linestrip"):
         return (
-            nearest_edge_index(shape=shape, point=point, scale=scale, epsilon=epsilon)
+            nearest_edge_index(shape=shape, point=point, image_epsilon=epsilon / scale)
             is not None
         )
     if shape.shape_type == "points":
@@ -408,7 +408,7 @@ def is_hit_by_point(
     if shape.shape_type == "point":
         if len(shape.points) == 0:
             return False
-        return bool(np.linalg.norm((point - shape.points[0]) * scale) <= point_size / 2)
+        return bool(np.linalg.norm(point - shape.points[0]) <= point_size / 2 / scale)
     if shape.mask is not None:
         raw_y = int(round(float(point[1]) - float(shape.points[0][1])))
         raw_x = int(round(float(point[0]) - float(shape.points[0][0])))

--- a/tests/unit/_shape_test.py
+++ b/tests/unit/_shape_test.py
@@ -143,9 +143,7 @@ def test_nearest_vertex_index_returns_none_for_mask() -> None:
 
     for corner in shape.points:
         assert (
-            _shape.nearest_vertex_index(
-                shape=shape, point=corner, scale=1.0, epsilon=10.0
-            )
+            _shape.nearest_vertex_index(shape=shape, point=corner, image_epsilon=10.0)
             is None
         )
 
@@ -161,7 +159,7 @@ def test_nearest_vertex_index_returns_none_for_point() -> None:
 
     assert (
         _shape.nearest_vertex_index(
-            shape=shape, point=shape.points[0], scale=1.0, epsilon=10.0
+            shape=shape, point=shape.points[0], image_epsilon=10.0
         )
         is None
     )
@@ -403,7 +401,7 @@ def test_nearest_edge_index_matches_edge_under_point(
     shape = _make_square_polygon()
 
     index = _shape.nearest_edge_index(
-        shape=shape, point=np.array(point), scale=1.0, epsilon=1.0
+        shape=shape, point=np.array(point), image_epsilon=1.0
     )
 
     assert index == expected_edge
@@ -421,7 +419,7 @@ def test_nearest_edge_index_handles_zero_length_segment() -> None:
     )
 
     index = _shape.nearest_edge_index(
-        shape=shape, point=np.array([5.0, 0.0]), scale=1.0, epsilon=1.0
+        shape=shape, point=np.array([5.0, 0.0]), image_epsilon=1.0
     )
 
     assert index == 2
@@ -431,7 +429,7 @@ def test_nearest_edge_index_returns_none_when_far() -> None:
     shape = _make_square_polygon()
 
     index = _shape.nearest_edge_index(
-        shape=shape, point=np.array([5.0, 100.0]), scale=1.0, epsilon=1.0
+        shape=shape, point=np.array([5.0, 100.0]), image_epsilon=1.0
     )
 
     assert index is None
@@ -441,7 +439,7 @@ def test_nearest_edge_index_returns_none_for_empty_shape() -> None:
     shape = Shape(shape_type="polygon")
 
     index = _shape.nearest_edge_index(
-        shape=shape, point=np.array([0.0, 0.0]), scale=1.0, epsilon=10.0
+        shape=shape, point=np.array([0.0, 0.0]), image_epsilon=10.0
     )
 
     assert index is None
@@ -454,7 +452,7 @@ def test_nearest_edge_index_ignores_phantom_closing_edge_for_linestrip() -> None
     shape = _make_open_linestrip()
 
     index = _shape.nearest_edge_index(
-        shape=shape, point=np.array([5.0, 5.0]), scale=1.0, epsilon=2.0
+        shape=shape, point=np.array([5.0, 5.0]), image_epsilon=2.0
     )
 
     assert index is None
@@ -464,7 +462,7 @@ def test_nearest_edge_index_matches_drawn_edge_for_linestrip() -> None:
     shape = _make_open_linestrip()
 
     index = _shape.nearest_edge_index(
-        shape=shape, point=np.array([5.0, 0.0]), scale=1.0, epsilon=1.0
+        shape=shape, point=np.array([5.0, 0.0]), image_epsilon=1.0
     )
 
     assert index == 1
@@ -472,12 +470,12 @@ def test_nearest_edge_index_matches_drawn_edge_for_linestrip() -> None:
 
 def test_nearest_vertex_index_returns_nearest_within_epsilon() -> None:
     shape = _make_square_polygon()
-    # vertex 1 is at (10.0, 0.0); probe 0.4 units away, within epsilon=1.0
+    # vertex 1 is at (10.0, 0.0); probe 0.4 units away, inside the 1.0 threshold
     vertex_1 = shape.points[1]
     point_within_epsilon = vertex_1 + np.array([0.4, 0.0])
 
     index = _shape.nearest_vertex_index(
-        shape=shape, point=point_within_epsilon, scale=1.0, epsilon=1.0
+        shape=shape, point=point_within_epsilon, image_epsilon=1.0
     )
 
     assert index == 1
@@ -487,7 +485,7 @@ def test_nearest_vertex_index_returns_none_when_far() -> None:
     shape = _make_square_polygon()
 
     index = _shape.nearest_vertex_index(
-        shape=shape, point=np.array([5.0, 5.0]), scale=1.0, epsilon=1.0
+        shape=shape, point=np.array([5.0, 5.0]), image_epsilon=1.0
     )
 
     assert index is None
@@ -497,7 +495,7 @@ def test_nearest_vertex_index_returns_none_for_empty_shape() -> None:
     shape = Shape(shape_type="polygon")
 
     index = _shape.nearest_vertex_index(
-        shape=shape, point=np.array([0.0, 0.0]), scale=1.0, epsilon=10.0
+        shape=shape, point=np.array([0.0, 0.0]), image_epsilon=10.0
     )
 
     assert index is None
@@ -540,7 +538,7 @@ def test_nearest_rotation_point_index_returns_handle_within_epsilon() -> None:
     point = np.array([10.3, 2.0])
 
     index = _shape.nearest_rotation_point_index(
-        shape=shape, point=point, scale=1.0, epsilon=1.0
+        shape=shape, point=point, image_epsilon=1.0
     )
 
     assert index == 2
@@ -550,7 +548,7 @@ def test_nearest_rotation_point_index_returns_none_when_far() -> None:
     shape = _make_axis_aligned_oriented_rectangle()
 
     index = _shape.nearest_rotation_point_index(
-        shape=shape, point=np.array([20.0, 20.0]), scale=1.0, epsilon=1.0
+        shape=shape, point=np.array([20.0, 20.0]), image_epsilon=1.0
     )
 
     assert index is None
@@ -560,7 +558,7 @@ def test_nearest_rotation_point_index_returns_none_for_non_oriented_rectangle() 
     shape = _make_square_polygon()
 
     index = _shape.nearest_rotation_point_index(
-        shape=shape, point=np.array([5.0, 0.0]), scale=1.0, epsilon=10.0
+        shape=shape, point=np.array([5.0, 0.0]), image_epsilon=10.0
     )
 
     assert index is None
@@ -570,7 +568,7 @@ def test_nearest_rotation_point_index_returns_none_for_empty_shape() -> None:
     shape = Shape(shape_type="oriented_rectangle")
 
     index = _shape.nearest_rotation_point_index(
-        shape=shape, point=np.array([0.0, 0.0]), scale=1.0, epsilon=10.0
+        shape=shape, point=np.array([0.0, 0.0]), image_epsilon=10.0
     )
 
     assert index is None

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -405,11 +405,9 @@ def test_right_release_with_selection_copy_executes_menus_1(
 # ---------------------------------------------------------------------------
 # Vertex hover-highlight + snapping parity across zoom (scale) levels
 #
-# Proximity formula (from _shape.nearest_vertex_index):
-#   screen_distance = euclidean_distance(image_point, vertex) * scale
-#   hit iff screen_distance <= epsilon          (epsilon default = 10.0)
-#
-# Equivalently: image_distance <= epsilon / scale
+# The vertex hit radius is a fixed number of screen pixels (default 10) at
+# every zoom, so an offset of N screen pixels is N divided by the zoom factor
+# in image pixels.
 #
 # The polygon below has a vertex at image-center (100, 50) and the other
 # vertices at the image periphery.  Test points are displaced along X only

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -250,23 +250,26 @@ def test_label_anchor_tracks_scale() -> None:
     )
 
 
-def _hit(*, shape: Shape, point: tuple[float, float]) -> bool:
+def _hit(*, shape: Shape, point: tuple[float, float], scale: float) -> bool:
     return is_hit_by_point(
         shape=shape,
         point=np.array(point, dtype=np.float64),
-        scale=1.0,
+        scale=scale,
         point_size=8,
         epsilon=5.0,
     )
 
 
-def test_line_is_hit_near_its_segment() -> None:
+@pytest.mark.parametrize("scale", [0.5, 1.0, 2.0])
+def test_line_is_hit_near_its_segment(*, scale: float) -> None:
     shape = Shape(
         shape_type="line",
         points=np.array([[0, 0], [100, 0]], dtype=np.float64),
     )
-    assert _hit(shape=shape, point=(50, 2)) is True
-    assert _hit(shape=shape, point=(50, 20)) is False
+    # The pick radius is 5 screen pixels, so probes at 4 and 6 screen pixels
+    # straddle it; they are converted to image space for the zoom under test.
+    assert _hit(shape=shape, point=(50, 4 / scale), scale=scale) is True
+    assert _hit(shape=shape, point=(50, 6 / scale), scale=scale) is False
 
 
 def test_linestrip_hit_ignores_phantom_closing_edge() -> None:
@@ -275,10 +278,30 @@ def test_linestrip_hit_ignores_phantom_closing_edge() -> None:
         points=np.array([[0, 0], [100, 0], [100, 100]], dtype=np.float64),
     )
     # Near a real segment (the bottom edge) is a hit.
-    assert _hit(shape=shape, point=(50, 2)) is True
+    assert _hit(shape=shape, point=(50, 2), scale=1.0) is True
     # The diagonal from the last point back to the first is never drawn, so a
     # click on it must not register as a hit.
-    assert _hit(shape=shape, point=(50, 50)) is False
+    assert _hit(shape=shape, point=(50, 50), scale=1.0) is False
+
+
+def test_rectangle_body_hit_reaches_its_corners() -> None:
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array([[0, 0], [100, 100]], dtype=np.float64),
+    )
+    # (5, 5) is inside the rectangle but outside its inscribed ellipse.
+    assert _hit(shape=shape, point=(5, 5), scale=1.0) is True
+
+
+def test_circle_body_hit_is_round_not_its_bounding_box() -> None:
+    shape = Shape(
+        shape_type="circle",
+        points=np.array([[50, 50], [65, 70]], dtype=np.float64),
+    )
+    assert _hit(shape=shape, point=(50, 50), scale=1.0) is True
+    # (28, 28) is inside the bounding box but 31 units from the center, past
+    # the radius of 25.
+    assert _hit(shape=shape, point=(28, 28), scale=1.0) is False
 
 
 def test_points_shape_is_never_body_hit() -> None:
@@ -286,22 +309,24 @@ def test_points_shape_is_never_body_hit() -> None:
         shape_type="points",
         points=np.array([[10, 10], [20, 20]], dtype=np.float64),
     )
-    assert _hit(shape=shape, point=(10, 10)) is False
+    assert _hit(shape=shape, point=(10, 10), scale=1.0) is False
 
 
-def test_point_shape_hit_within_radius() -> None:
+@pytest.mark.parametrize("scale", [0.5, 1.0, 2.0])
+def test_point_shape_hit_within_radius(*, scale: float) -> None:
     shape = Shape(
         shape_type="point",
         points=np.array([[10, 10]], dtype=np.float64),
     )
-    # point_size / 2 == 4, so a point 2px away hits and one 10px away misses.
-    assert _hit(shape=shape, point=(10, 12)) is True
-    assert _hit(shape=shape, point=(10, 20)) is False
+    # The point marker's hit radius is 4 screen pixels, so probes at 3 and 5
+    # screen pixels straddle it at every zoom.
+    assert _hit(shape=shape, point=(10, 10 + 3 / scale), scale=scale) is True
+    assert _hit(shape=shape, point=(10, 10 + 5 / scale), scale=scale) is False
 
 
 def test_empty_point_shape_is_not_hit() -> None:
     shape = Shape(shape_type="point")
-    assert _hit(shape=shape, point=(0, 0)) is False
+    assert _hit(shape=shape, point=(0, 0), scale=1.0) is False
 
 
 def test_mask_shape_hit_reads_the_translated_pixel() -> None:
@@ -313,15 +338,15 @@ def test_mask_shape_hit_reads_the_translated_pixel() -> None:
         mask=mask,
     )
     # The mask origin is the bbox top-left (10, 10), so mask[2, 3] is at (13, 12).
-    assert _hit(shape=shape, point=(13, 12)) is True
+    assert _hit(shape=shape, point=(13, 12), scale=1.0) is True
     # Inside the bbox but where the mask is False.
-    assert _hit(shape=shape, point=(11, 11)) is False
+    assert _hit(shape=shape, point=(11, 11), scale=1.0) is False
     # Outside the mask array bounds is guarded to a miss.
-    assert _hit(shape=shape, point=(5, 5)) is False
-    assert _hit(shape=shape, point=(100, 100)) is False
+    assert _hit(shape=shape, point=(5, 5), scale=1.0) is False
+    assert _hit(shape=shape, point=(100, 100), scale=1.0) is False
 
 
 def test_polygon_hit_uses_path_containment() -> None:
     shape = _unit_square_polygon()
-    assert _hit(shape=shape, point=(5, 5)) is True
-    assert _hit(shape=shape, point=(50, 50)) is False
+    assert _hit(shape=shape, point=(5, 5), scale=1.0) is True
+    assert _hit(shape=shape, point=(50, 50), scale=1.0) is False

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -78,6 +78,8 @@ def _shape(*, shape_type: ShapeType, points: list[list[float]]) -> Shape:
     ("shape_type", "points", "expected"),
     [
         ("rectangle", [[10, 10], [50, 30]], (10.0, 10.0, 40.0, 20.0)),
+        # Corners in either order describe the same rectangle.
+        ("rectangle", [[50, 30], [10, 10]], (10.0, 10.0, 40.0, 20.0)),
         ("mask", [[10, 10], [50, 30]], (10.0, 10.0, 40.0, 20.0)),
         # radius = ||(3, 4)|| = 5, so the box is the point (0, 0) inflated by 5.
         ("circle", [[0, 0], [3, 4]], (-5.0, -5.0, 10.0, 10.0)),
@@ -181,6 +183,31 @@ def test_point_shape_label_is_drawn() -> None:
         )
         > 0
     )
+
+
+@pytest.mark.gui
+@pytest.mark.usefixtures("qapp")
+@pytest.mark.parametrize(
+    # The probe is a screen pixel on the zoomed outline, away from any vertex
+    # marker, so the test also fails when the outline is not drawn at all.
+    ("shape_type", "points", "outline_probe"),
+    [
+        ("rectangle", [[20, 30], [70, 60]], (90, 60)),
+        ("mask", [[20, 30], [70, 60]], (90, 60)),
+        # radius = ||(15, 20)|| = 25
+        ("circle", [[50, 50], [65, 70]], (100, 50)),
+    ],
+)
+def test_two_point_shape_scales_like_its_points(
+    *, shape_type: ShapeType, points: list[list[float]], outline_probe: tuple[int, int]
+) -> None:
+    # Vertex markers are sized in screen pixels, so they match in both renders
+    # and the equality isolates the outline.
+    shape = _shape(shape_type=shape_type, points=points)
+    prescaled = _shape(shape_type=shape_type, points=(np.array(points) * 2).tolist())
+    rendered = _render(shape=shape, show_label=False, scale=2.0)
+    assert rendered.pixelColor(*outline_probe) != QtGui.QColor(255, 255, 255)
+    assert rendered == _render(shape=prescaled, show_label=False, scale=1.0)
 
 
 def _mask_shape() -> Shape:


### PR DESCRIPTION
Consolidates the two-point shape geometry and the zoom handling around it, so rectangles, mask bounding boxes, and circles come from one image-space rect and the pick threshold is converted from screen pixels once instead of scaling every shape's points.

Three things the diff does not spell out:

1. The nearest-vertex, nearest-edge, and rotation-handle helpers now take an image-space `image_epsilon` and no `scale`. The canvas-facing functions keep their signatures and do the `epsilon / scale` conversion at the boundary, which is the convention the polygon-snap check already used; hit results are unchanged.

2. Draw sites no longer guard on point count before adding the two-point path. Adding an empty path is a no-op in Qt, so a rectangle or circle mid-draw with one point still draws nothing, exactly as before.

3. `pen_width` is a class attribute on the render context holding the old value, so stroke widths and the label offset render identically.

Old and new path construction agree to floating-point noise across zoom levels; the new zoom-parametrized hit tests and the scaled-render equality test pin the conversions. No changelog fragment since nothing is user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TgMo6BGXrRANsrLUN973J
