### PR TITLE
Keep Previous Scale: the previous image's zoom wins over the zoom stored for this image

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2260,13 +2260,15 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.setEnabled(True)
         # Zoom changes the live scroll positions, so resolve the intended
         # viewport first.
-        target_viewport = self._viewport_states.get(self._image_path)
-        if (
-            target_viewport is None
-            and self._config["keep_prev_scale"]
-            and self._prev_image_path is not None
-        ):
+        # "Keep Previous Scale" means the zoom follows the viewer, not the
+        # image: the previous image's viewport wins over one stored for this
+        # image, otherwise every image visited once snaps back to its own
+        # remembered zoom on Prev/Next and the setting has no effect.
+        target_viewport = None
+        if self._config["keep_prev_scale"] and self._prev_image_path is not None:
             target_viewport = self._viewport_states.get(self._prev_image_path)
+        if target_viewport is None:
+            target_viewport = self._viewport_states.get(self._image_path)
         # set zoom values
         is_initial_load = not self._viewport_states
         if target_viewport is not None:


### PR DESCRIPTION
Fixes #2601.

With `keep_prev_scale` on, `load_file` looked up the viewport stored for the image being opened first and used the previous image's only when none was stored. Once every image in a folder had been visited, Prev/Next always landed on each image's own remembered zoom and the setting had no effect.

This swaps the priority: when the setting is on, the previous image's viewport is preferred; the stored one is used when the setting is off or there is no previous image. Behaviour with the setting off is unchanged.

Eight lines in `labelme/_app.py`, no new state. We are running this patch locally while labelling a folder of camera frames.