### PR TITLE
fix(app): prevent resize crash after Close File

### DIFF
--- a/changelog.d/2603.fixed.md
+++ b/changelog.d/2603.fixed.md
@@ -1,0 +1,1 @@
+Prevent a crash when resizing the window after closing an image in Fit to Window or Fit to Width mode.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1480,6 +1480,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def reset_state(self) -> None:
         self._docks.label_list.clear()
         self._annotation = None
+        self._image = QtGui.QImage()
         self._image_path = None
         self._file_list_image_path = None
         self._label_file_path = None

--- a/tests/e2e/file_operations_test.py
+++ b/tests/e2e/file_operations_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -15,16 +16,23 @@ from .conftest import show_window_and_wait_for_imagedata
 
 
 @pytest.mark.gui
+@pytest.mark.parametrize(
+    "set_fit_mode",
+    [MainWindow.set_fit_window_mode, MainWindow.set_fit_width_mode],
+)
 def test_close_file(
     *,
     annotated_win: MainWindow,
     qtbot: QtBot,
     pause: bool,
+    set_fit_mode: Callable[[MainWindow], None],
 ) -> None:
     assert annotated_win._annotation is not None
     assert annotated_win._canvas_widgets.canvas.isEnabled()
 
+    set_fit_mode(annotated_win)
     annotated_win.close_file()
+    annotated_win.resize(annotated_win.width() + 50, annotated_win.height() + 50)
     qtbot.wait(50)
 
     assert not annotated_win._canvas_widgets.canvas.isEnabled()


### PR DESCRIPTION
Closes #2598.

Close File cleared the canvas pixmap but left the main window's Image live, so a fit-mode resize treated an empty canvas as loaded and divided by zero. The shared reset now restores that invariant.

Verified in both Fit Window and Fit Width with 29 focused E2E tests, Ruff, Ty, and a real GUI close-and-resize flow.
