### PR TITLE
refactor(label_dialog): own arrow-key list navigation in the dialog

### DIFF
--- a/changelog.d/2606.fixed.md
+++ b/changelog.d/2606.fixed.md
@@ -1,0 +1,1 @@
+Clear the label dialog's stale list highlight when the current label is not in the list.

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -25,25 +25,6 @@ class LabelDialogEntry:
 _PLACEHOLDER_TEXT: Final[str] = "Enter object label"
 
 
-class LabelQLineEdit(QtWidgets.QLineEdit):
-    """QLineEdit that forwards Up/Down key events to a paired list widget."""
-
-    def __init__(self, *, parent: QtWidgets.QWidget | None = None) -> None:
-        super().__init__(parent)
-        self.list_widget: QtWidgets.QListWidget | None = None
-
-    def set_list_widget(self, *, list_widget: QtWidgets.QListWidget) -> None:
-        self.list_widget = list_widget
-
-    def keyPressEvent(self, event: QtGui.QKeyEvent, /) -> None:
-        key = event.key()
-        if key in (QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down):
-            if self.list_widget is not None:
-                QtWidgets.QApplication.sendEvent(self.list_widget, event)
-            return
-        super().keyPressEvent(event)
-
-
 class LabelDialog(QtWidgets.QDialog):
     """Dialog for entering label, group id, description, and flags."""
 
@@ -88,7 +69,7 @@ class LabelDialog(QtWidgets.QDialog):
         self._fit_to_content = fit_to_content
 
         # Build widgets
-        self.edit = LabelQLineEdit()
+        self.edit = QtWidgets.QLineEdit()
         self.edit.setPlaceholderText(text)
 
         self.edit_group_id = QtWidgets.QLineEdit()
@@ -126,7 +107,9 @@ class LabelDialog(QtWidgets.QDialog):
         # Set up completer bound to label_list's model
         completer = self._make_completer(completion=completion)
         self.edit.setCompleter(completer)
-        self.edit.set_list_widget(list_widget=self.label_list)
+        # Up/Down are taken before the line edit sees them so the arrow keys walk
+        # the label list while every other key keeps editing the text.
+        self.edit.installEventFilter(self)
 
         button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
@@ -221,6 +204,20 @@ class LabelDialog(QtWidgets.QDialog):
             "label" in self._locked or bool(self.edit.text().strip())
         )
 
+    def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent, /) -> bool:
+        if watched is self.edit and event.type() == QtCore.QEvent.Type.KeyPress:
+            assert isinstance(event, QtGui.QKeyEvent)
+            step = {QtCore.Qt.Key.Key_Up: -1, QtCore.Qt.Key.Key_Down: 1}.get(
+                QtCore.Qt.Key(event.key())
+            )
+            if step is not None:
+                row = self.label_list.currentRow() + step
+                self.label_list.setCurrentRow(
+                    min(max(row, 0), self.label_list.count() - 1)
+                )
+                return True
+        return super().eventFilter(watched, event)
+
     def _on_label_selected(
         self,
         current: QtWidgets.QListWidgetItem | None,
@@ -280,6 +277,18 @@ class LabelDialog(QtWidgets.QDialog):
     def remember_label(self, *, label: str) -> None:
         self._last_label = label
 
+    def _find_label_row(self, text: str, /) -> int:
+        # Match through the model so the highlight folds case the way Qt's own
+        # text matching does; Python's folding differs on the sharp s, say.
+        model = self.label_list.model()
+        hits = model.match(
+            model.index(0, 0),
+            QtCore.Qt.ItemDataRole.DisplayRole,
+            text,
+            flags=QtCore.Qt.MatchFlag.MatchFixedString,
+        )
+        return hits[0].row() if hits else -1
+
     def popup(
         self,
         *,
@@ -328,9 +337,9 @@ class LabelDialog(QtWidgets.QDialog):
         else:
             self._set_flag_checkboxes(flags=flags)
 
-        matches = self.label_list.findItems(text, QtCore.Qt.MatchFlag.MatchFixedString)
-        if matches:
-            self.label_list.setCurrentItem(matches[0])
+        row = self._find_label_row(text)
+        if row >= 0:
+            self.label_list.setCurrentRow(row)
 
         self._fit_label_list_to_content()
         self._refresh_ok_button()

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -315,7 +315,6 @@ class LabelDialog(QtWidgets.QDialog):
                 widget.setEnabled(name not in self._locked)
         if "label" in self._locked:
             text = ""
-            self.label_list.setCurrentRow(-1)
         elif text is None:
             text = self._last_label
         if "group_id" in self._locked:
@@ -337,9 +336,7 @@ class LabelDialog(QtWidgets.QDialog):
         else:
             self._set_flag_checkboxes(flags=flags)
 
-        row = self._find_label_row(text)
-        if row >= 0:
-            self.label_list.setCurrentRow(row)
+        self.label_list.setCurrentRow(self._find_label_row(text))
 
         self._fit_label_list_to_content()
         self._refresh_ok_button()

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -130,7 +130,7 @@ def test_arrow_keys_in_label_edit_navigate_label_list(
 
     def _press_down_capture_then_cancel() -> None:
         # Sorted labels: cat, dog, person. Pin selection to row 0 so Down
-        # forwarded from the line edit advances to row 1.
+        # pressed in the line edit advances the list to row 1.
         label_dialog.label_list.setCurrentRow(0)
         qtbot.keyClick(label_dialog.edit, Qt.Key.Key_Down)
         qtbot.wait(50)
@@ -207,9 +207,9 @@ def test_label_completer_autocompletes_typed_prefix(
     completion: list[str] = []
 
     def _type_p_capture_completion_then_cancel() -> None:
-        # LabelQLineEdit.keyPressEvent forwards Up/Down to the list widget
-        # and routes everything else to QLineEdit, so typing 'p' must drive
-        # the QCompleter to suggest the only "p"-prefixed label.
+        # Only Up/Down are diverted to the label list; every other key reaches
+        # the line edit, so typing 'p' must drive the QCompleter to suggest the
+        # only "p"-prefixed label.
         label_dialog.edit.clear()
         qtbot.keyClick(label_dialog.edit, Qt.Key.Key_P)
         qtbot.wait(50)

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -11,7 +11,6 @@ from pytestqt.qtbot import QtBot
 from labelme._widgets.label_dialog import LabelDialog
 from labelme._widgets.label_dialog import LabelDialogEntry
 from labelme._widgets.label_dialog import LabelDialogField
-from labelme._widgets.label_dialog import LabelQLineEdit
 
 # Black-box characterization of LabelDialog: behavior is exercised only through
 # the public surface (popup(), public methods, public widgets edit/
@@ -79,57 +78,51 @@ def _ok_button(dialog: LabelDialog, /) -> QtWidgets.QPushButton:
 
 
 # ---------------------------------------------------------------------------
-# LabelQLineEdit
+# Arrow keys in the label field
 # ---------------------------------------------------------------------------
 
 
-def test_set_list_widget_stores_reference(*, qtbot: QtBot) -> None:
-    edit = LabelQLineEdit()
-    qtbot.addWidget(edit)
-    list_widget = QtWidgets.QListWidget()
-    qtbot.addWidget(list_widget)
-    edit.set_list_widget(list_widget=list_widget)
-    assert edit.list_widget is list_widget
+def _show_dialog_with_labels(qtbot: QtBot, /, *, labels: list[str]) -> LabelDialog:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=labels, sort_labels=False))
+    dialog.show()
+    return dialog
 
 
-def test_key_down_forwarded_to_list_widget(*, qtbot: QtBot) -> None:
-    edit = LabelQLineEdit()
-    qtbot.addWidget(edit)
-    list_widget = QtWidgets.QListWidget()
-    qtbot.addWidget(list_widget)
-    list_widget.addItems(["a", "b", "c"])
-    list_widget.setCurrentRow(0)
-    edit.set_list_widget(list_widget=list_widget)
-    edit.show()
-    qtbot.keyClick(edit, QtCore.Qt.Key.Key_Down)
-    assert list_widget.currentRow() == 1
+def test_key_down_in_edit_moves_list_selection(*, qtbot: QtBot) -> None:
+    dialog = _show_dialog_with_labels(qtbot, labels=["a", "b", "c"])
+    dialog.label_list.setCurrentRow(0)
+    qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Down)
+    assert dialog.label_list.currentRow() == 1
+    assert dialog.edit.text() == "b"
 
 
-def test_key_up_forwarded_to_list_widget(*, qtbot: QtBot) -> None:
-    edit = LabelQLineEdit()
-    qtbot.addWidget(edit)
-    list_widget = QtWidgets.QListWidget()
-    qtbot.addWidget(list_widget)
-    list_widget.addItems(["a", "b", "c"])
-    list_widget.setCurrentRow(2)
-    edit.set_list_widget(list_widget=list_widget)
-    edit.show()
-    qtbot.keyClick(edit, QtCore.Qt.Key.Key_Up)
-    assert list_widget.currentRow() == 1
+def test_key_up_in_edit_moves_list_selection(*, qtbot: QtBot) -> None:
+    dialog = _show_dialog_with_labels(qtbot, labels=["a", "b", "c"])
+    dialog.label_list.setCurrentRow(2)
+    qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Up)
+    assert dialog.label_list.currentRow() == 1
+    assert dialog.edit.text() == "b"
 
 
-def test_other_keys_edit_text_not_forwarded(*, qtbot: QtBot) -> None:
-    edit = LabelQLineEdit()
-    qtbot.addWidget(edit)
-    list_widget = QtWidgets.QListWidget()
-    qtbot.addWidget(list_widget)
-    list_widget.addItems(["a", "b", "c"])
-    list_widget.setCurrentRow(0)
-    edit.set_list_widget(list_widget=list_widget)
-    edit.show()
-    qtbot.keyClicks(edit, "x")
-    assert edit.text() == "x"
-    assert list_widget.currentRow() == 0
+def test_arrow_keys_stop_at_list_ends(*, qtbot: QtBot) -> None:
+    dialog = _show_dialog_with_labels(qtbot, labels=["a", "b"])
+    dialog.label_list.setCurrentRow(-1)
+    qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Down)
+    assert dialog.label_list.currentRow() == 0
+    qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Up)
+    assert dialog.label_list.currentRow() == 0
+    qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Down)
+    qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Down)
+    assert dialog.label_list.currentRow() == 1
+
+
+def test_other_keys_edit_text_not_list(*, qtbot: QtBot) -> None:
+    dialog = _show_dialog_with_labels(qtbot, labels=["a", "b", "c"])
+    dialog.label_list.setCurrentRow(0)
+    dialog.edit.clear()
+    qtbot.keyClicks(dialog.edit, "x")
+    assert dialog.edit.text() == "x"
+    assert dialog.label_list.currentRow() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +132,6 @@ def test_other_keys_edit_text_not_forwarded(*, qtbot: QtBot) -> None:
 
 def test_default_widgets_exist(*, qtbot: QtBot) -> None:
     dialog = _add_dialog(qtbot, dialog=LabelDialog())
-    assert isinstance(dialog.edit, LabelQLineEdit)
     assert isinstance(dialog.edit_group_id, QtWidgets.QLineEdit)
     assert isinstance(dialog.edit_description, QtWidgets.QTextEdit)
     assert isinstance(dialog.label_list, QtWidgets.QListWidget)

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -833,6 +833,25 @@ def test_popup_highlights_matching_label_case_insensitively(*, qtbot: QtBot) -> 
     assert seen["cur"] == "Cat"
 
 
+def test_popup_clears_stale_highlight_when_nothing_matches(*, qtbot: QtBot) -> None:
+    seen: dict[str, object] = {}
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog"]))
+    dialog.label_list.setCurrentRow(0)
+    _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="bird",
+        at_show=lambda d: seen.update(
+            row=d.label_list.currentRow(), text=d.edit.text()
+        ),
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=(),
+    )
+    assert seen == {"row": -1, "text": "bird"}
+
+
 def test_popup_sets_description_at_show(*, qtbot: QtBot) -> None:
     seen: dict[str, str] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog())


### PR DESCRIPTION
The label dialog now handles Up/Down itself instead of through a line-edit subclass whose only job was to re-send the key event to the list, and it selects the highlighted entry by row. Second commit is the one behavior change: a popup for a label that is not in the list no longer keeps the previous popup's row highlighted next to the new text.

Three things the diff does not spell out:

1. The dialog's event filter is installed after the completer's, so Qt runs it first. That does not affect popup completion: while the completion popup is open, Qt delivers keys to the popup window and the line edit never sees them. Checked in both `startswith` and `contains` modes, old and new behave the same.

2. Stepping the row by hand reproduces what forwarding to the list did, including Qt's rule that Up or Down from no selection lands on the first row; both ends are pinned by tests.

3. The row lookup goes through `QAbstractItemModel.match` with `MatchFixedString`, which is what `findItems` calls internally, so the case folding is unchanged (the sharp s and micro sign behave as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pn6a8wABPxAiM6E45bSVW5
