### PR TITLE
chore: suggest next release version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,31 @@ coverage:  # Run tests with coverage
 
 release:  # Prepare a release: make release VERSION=X.Y.Z
 	@test -n "$(VERSION)" || { \
-		echo "usage: make release VERSION=X.Y.Z" >&2; \
+		fragments=$$(find changelog.d -maxdepth 1 -type f \( \
+			-name "*.added.md" -o -name "*.changed.md" -o \
+			-name "*.deprecated.md" -o -name "*.removed.md" -o \
+			-name "*.fixed.md" -o -name "*.security.md" \)); \
+		latest=$$(git tag --sort=-v:refname | \
+			grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -1); \
+		if test -n "$$fragments" && test -n "$$latest"; then \
+			version=$${latest#v}; \
+			major=$${version%%.*}; \
+			remainder=$${version#*.}; \
+			minor=$${remainder%%.*}; \
+			patch=$${remainder#*.}; \
+			if grep -q '\*\*Breaking:\*\*' $$fragments; then \
+				next=$$((major + 1)).0.0; \
+			elif find changelog.d -maxdepth 1 -type f \( \
+				-name "*.added.md" -o -name "*.changed.md" -o \
+				-name "*.deprecated.md" -o -name "*.removed.md" \) | grep -q .; then \
+				next=$$major.$$((minor + 1)).0; \
+			else \
+				next=$$major.$$minor.$$((patch + 1)); \
+			fi; \
+			echo "suggested: make release VERSION=$$next" >&2; \
+		else \
+			echo "usage: make release VERSION=X.Y.Z" >&2; \
+		fi; \
 		echo "recent releases:" >&2; \
 		git tag --sort=-v:refname | head -5 | sed "s/^/  /" >&2; \
 		exit 1; \


### PR DESCRIPTION
Removes the manual version-number guess from release preparation.

The suggestion follows the repository's fragment policy: breaking entries bump major, improvement types bump minor, and fix/security-only sets bump patch. If fragments or a stable tag are unavailable, the existing generic usage hint remains.
