### PR TITLE
perf(canvas): reuse AI previews across repaints

### DIFF
--- a/changelog.d/2610.changed.md
+++ b/changelog.d/2610.changed.md
@@ -1,0 +1,1 @@
+AI Assist point previews reuse predictions across repaints and keep the previous preview visible while updating.

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -204,6 +204,8 @@ class Canvas(QtWidgets.QWidget):
     _ai_assist_session: _automation.AiAssistSession
     _ai_suppress_existing_shape_matches: bool
     _ai_existing_shape_highlights: list[Shape]
+    _ai_points_preview: list[Shape]
+    _ai_points_preview_key: tuple[object, ...] | None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self._epsilon: float = kwargs.pop("epsilon", 10.0)
@@ -232,6 +234,9 @@ class Canvas(QtWidgets.QWidget):
         )
         super().__init__(*args, **kwargs)
 
+        self._ai_preview_timer = QtCore.QTimer(self)
+        self._ai_preview_timer.setSingleShot(True)
+        self._ai_preview_timer.timeout.connect(self._refresh_ai_points_preview)
         self._cursor = CursorRole.DEFAULT
         self.reset_state()
 
@@ -277,6 +282,7 @@ class Canvas(QtWidgets.QWidget):
 
     def set_allow_out_of_bounds_points(self, *, value: bool) -> None:
         self._allow_out_of_bounds_points = value
+        self.update()
 
     def pan_view(self, *, step: QPointF, constrain_to_center: bool = True) -> None:
         viewport = self._scroll_viewport()
@@ -1707,12 +1713,15 @@ class Canvas(QtWidgets.QWidget):
         render_shape(painter=painter, shape=shape, context=context)
 
     def _build_preview_shapes(self) -> list[Shape]:
+        if self.create_mode == "ai_points_to_shape":
+            # Defer inference until painting ends; unchanged inputs stop the loop.
+            self._ai_preview_timer.start(0)
         if self._current is None:
             return []
         if self.create_mode == "polygon":
             return [self._build_polygon_preview(current=self._current)]
         if self.create_mode == "ai_points_to_shape":
-            return self._build_ai_points_preview(current=self._current)
+            return self._ai_points_preview
         return []
 
     def _build_polygon_preview(self, *, current: _DraftShape) -> Shape:
@@ -1724,9 +1733,31 @@ class Canvas(QtWidgets.QWidget):
             preview = preview.add_point(self._line.points[1], autoclose=True)
         return _draft_to_shape(preview)
 
-    def _build_ai_points_preview(self, *, current: _DraftShape) -> list[Shape]:
+    def _refresh_ai_points_preview(self) -> None:
+        current = self._current
+        if current is None or self.create_mode != "ai_points_to_shape":
+            self._ai_points_preview = []
+            self._ai_points_preview_key = None
+            return
+        key = (
+            current,
+            self._line,
+            self._ai_assist_session.model_name,
+            self._ai_assist_session.output_format,
+            self._ai_assist_session.polygon_detail,
+            self._ai_suppress_existing_shape_matches,
+            self._allow_out_of_bounds_points,
+            self._pixmap_hash,
+            tuple(self.shapes),
+        )
+        if key == self._ai_points_preview_key:
+            return
+        self._ai_points_preview_key = key
         if not _ai_models.supports_point_prompts(model_name=self.get_ai_model_name()):
-            return []
+            self._ai_points_preview = []
+            self._set_ai_existing_shape_highlights(shapes=[])
+            self.update()
+            return
         preview = current.add_point(
             self._line.points[1],
             label=self._line.point_labels[1],
@@ -1738,16 +1769,18 @@ class Canvas(QtWidgets.QWidget):
                 point_labels=preview.point_labels,
             )
         except Exception as e:
-            # This runs inside paintEvent on every repaint, so a persistently
-            # failing model would report on every frame. Report once; a later
-            # success re-arms the report.
+            self._ai_points_preview = []
+            self._set_ai_existing_shape_highlights(shapes=[])
+            # Repeated failed prompts report once; a success re-arms the report.
             if not self._ai_inference_failed:
                 self._report_inference_failure(error=e)
-            self._set_ai_existing_shape_highlights(shapes=[])
-            return []
-        self._ai_inference_failed = False
-        self._set_ai_existing_shape_highlights(shapes=proposal.matching_existing_shapes)
-        return proposal.new_shapes
+        else:
+            self._ai_inference_failed = False
+            self._ai_points_preview = proposal.new_shapes
+            self._set_ai_existing_shape_highlights(
+                shapes=proposal.matching_existing_shapes
+            )
+        self.update()
 
     def transform_widget_point_to_image(self, point: QPointF, /) -> QPointF:
         origin = self._compute_image_origin_offset(area=None)
@@ -2083,6 +2116,9 @@ class Canvas(QtWidgets.QWidget):
         QtWidgets.QApplication.restoreOverrideCursor()
 
     def reset_state(self) -> None:
+        self._ai_preview_timer.stop()
+        self._ai_points_preview = []
+        self._ai_points_preview_key = None
         self._release_cursor()
         self.pixmap = QtGui.QPixmap()
         self._pixmap_hash = None

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -1124,9 +1124,7 @@ def test_points_preview_hides_failed_and_empty_predictions(
     canvas: Canvas,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The points preview re-runs inference on every repaint, so a persistently
-    # failing model must report once, not once per frame. A later success
-    # re-arms the report so a fresh failure surfaces again.
+    # Repeated failed prompts report once; a successful prompt re-arms errors.
     behavior = {"fail": True}
 
     def _maybe_raise(**_: object) -> AiAssistProposal:
@@ -1141,7 +1139,7 @@ def test_points_preview_hides_failed_and_empty_predictions(
         points=(QPointF(0, 0), QPointF(5, 5)),
         point_labels=(1, 1),
     )
-    current = _DraftShape(
+    canvas._current = _DraftShape(
         shape_type="rectangle",
         points=(QPointF(0, 0),),
         point_labels=(1,),
@@ -1149,14 +1147,27 @@ def test_points_preview_hides_failed_and_empty_predictions(
     failed: list[str] = []
     canvas.inference_failed.connect(failed.append)
 
-    assert canvas._build_ai_points_preview(current=current) == []
-    assert canvas._build_ai_points_preview(current=current) == []
+    canvas._refresh_ai_points_preview()
+    assert canvas._build_preview_shapes() == []
+    canvas._line = dataclasses.replace(
+        canvas._line, points=(QPointF(0, 0), QPointF(5, 6))
+    )
+    canvas._refresh_ai_points_preview()
+    assert canvas._build_preview_shapes() == []
     assert failed == ["RuntimeError: boom"]
 
     behavior["fail"] = False
-    assert canvas._build_ai_points_preview(current=current) == []
+    canvas._line = dataclasses.replace(
+        canvas._line, points=(QPointF(0, 0), QPointF(6, 6))
+    )
+    canvas._refresh_ai_points_preview()
+    assert canvas._build_preview_shapes() == []
     behavior["fail"] = True
-    assert canvas._build_ai_points_preview(current=current) == []
+    canvas._line = dataclasses.replace(
+        canvas._line, points=(QPointF(0, 0), QPointF(7, 7))
+    )
+    canvas._refresh_ai_points_preview()
+    assert canvas._build_preview_shapes() == []
     assert failed == ["RuntimeError: boom", "RuntimeError: boom"]
 
 
@@ -1196,6 +1207,7 @@ def test_ai_points_preview_renders_every_proposed_shape(
         points=(QPointF(5, 5), QPointF(6, 6)),
         point_labels=(1, 1),
     )
+    canvas._refresh_ai_points_preview()
     image = QtGui.QImage(_WIDTH, _HEIGHT, QtGui.QImage.Format.Format_ARGB32)
     image.fill(Qt.GlobalColor.black)
     painter = QtGui.QPainter(image)
@@ -2233,3 +2245,172 @@ def test_end_move_in_place_copies_points(*, canvas: Canvas) -> None:
 
     assert np.array_equal(shape.points, clone.points)
     assert not np.shares_memory(shape.points, clone.points)
+
+
+@pytest.mark.gui
+def test_ai_preview_follows_input_without_inference_during_paint(
+    *, canvas: Canvas, qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prompts: list[list[list[float]]] = []
+    pending_previews: list[list[Shape]] = []
+    proposal = AiAssistProposal(
+        new_shapes=[
+            Shape(
+                shape_type="polygon",
+                points=np.array([[10, 10], [30, 10], [30, 30]]),
+                closed=True,
+            )
+        ],
+        matching_existing_shapes=[],
+    )
+
+    def propose_shapes(*, points: np.ndarray, **_: object) -> AiAssistProposal:
+        assert not canvas._painter.isActive()
+        pending_previews.append(canvas._build_preview_shapes())
+        prompts.append(points.tolist())
+        return proposal
+
+    monkeypatch.setattr(canvas._ai_assist_session, "propose_shapes", propose_shapes)
+    monkeypatch.setattr("labelme._widgets.canvas.download_ai_model", lambda **_: True)
+    canvas.set_editing(value=False, create_mode="ai_points_to_shape")
+    canvas.show()
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(10, 10))
+    qtbot.waitUntil(lambda: len(prompts) == 1)
+    assert prompts[-1] == [[10, 10], [10, 10]]
+    assert canvas._build_preview_shapes() == proposal.new_shapes
+
+    for _ in range(3):
+        canvas.grab()
+        canvas.update()
+        QtCore.QCoreApplication.processEvents()
+    canvas.scale = 2
+    canvas.grab()
+    QtCore.QCoreApplication.processEvents()
+    assert len(prompts) == 1
+
+    qtbot.mouseMove(canvas, QtCore.QPoint(40, 40))
+    qtbot.waitUntil(lambda: len(prompts) == 2)
+    assert prompts[-1] == [[10, 10], [20, 20]]
+    assert pending_previews[-1] == proposal.new_shapes
+
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(40, 40))
+    qtbot.waitUntil(lambda: len(prompts) == 3)
+    assert prompts[-1] == [[10, 10], [20, 20], [20, 20]]
+    canvas.undo_last_point()
+    qtbot.waitUntil(lambda: len(prompts) == 4)
+    assert prompts[-1] == [[10, 10], [20, 20]]
+
+    # Cancel before queued work runs: no proposal may revive the discarded draft.
+    canvas.set_ai_polygon_detail(detail=50)
+    qtbot.keyClick(canvas, Qt.Key.Key_Escape)
+    QtCore.QCoreApplication.processEvents()
+    canvas.grab()
+    assert len(prompts) == 4
+    assert canvas._build_preview_shapes() == []
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    "change",
+    [
+        "model",
+        "format",
+        "detail",
+        "suppression",
+        "bounds",
+        "brightness",
+        "hidden",
+        "shapes",
+    ],
+)
+def test_ai_preview_refreshes_when_proposal_inputs_change(
+    *,
+    canvas: Canvas,
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    change: str,
+) -> None:
+    requests: list[dict[str, object]] = []
+
+    def propose_shapes(**kwargs: object) -> AiAssistProposal:
+        requests.append(kwargs)
+        return AiAssistProposal(new_shapes=[], matching_existing_shapes=[])
+
+    monkeypatch.setattr(canvas._ai_assist_session, "propose_shapes", propose_shapes)
+    monkeypatch.setattr("labelme._widgets.canvas.download_ai_model", lambda **_: True)
+    canvas.set_editing(value=False, create_mode="ai_points_to_shape")
+    canvas.show()
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(10, 10))
+    qtbot.waitUntil(lambda: len(requests) == 1)
+
+    if change == "model":
+        canvas.set_ai_model_name(model_name="sam:vit_b")
+    elif change == "format":
+        canvas.set_ai_output_format("mask")
+    elif change == "detail":
+        canvas.set_ai_polygon_detail(detail=50)
+    elif change == "suppression":
+        canvas.set_ai_existing_shape_suppression(enabled=True)
+    elif change == "bounds":
+        canvas.set_allow_out_of_bounds_points(value=True)
+    elif change == "shapes":
+        canvas.shapes.append(
+            Shape(shape_type="rectangle", points=np.array([[0, 0], [10, 10]]))
+        )
+        canvas.update()
+    elif change == "hidden":
+        canvas.hide()
+        canvas.set_ai_polygon_detail(detail=50)
+        canvas.show()
+    else:
+        pixmap = QtGui.QPixmap(_WIDTH, _HEIGHT)
+        pixmap.fill(Qt.GlobalColor.white)
+        canvas.load_pixmap(pixmap=pixmap, clear_shapes=False)
+    qtbot.waitUntil(lambda: len(requests) == 2)
+    if change == "bounds":
+        assert requests[-1]["image_size"] is None
+    canvas.grab()
+    assert len(requests) == 2
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("outcome", ["empty", "error", "cancel", "reset"])
+def test_ai_preview_clears_when_replacement_is_unavailable(
+    *, canvas: Canvas, qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, outcome: str
+) -> None:
+    proposal = AiAssistProposal(
+        new_shapes=[
+            Shape(
+                shape_type="polygon",
+                points=np.array([[10, 10], [30, 10], [30, 30]]),
+                closed=True,
+            )
+        ],
+        matching_existing_shapes=[],
+    )
+    fail = False
+
+    def propose_shapes(**_: object) -> AiAssistProposal:
+        if fail:
+            raise RuntimeError("inference failed")
+        return proposal
+
+    monkeypatch.setattr(canvas._ai_assist_session, "propose_shapes", propose_shapes)
+    monkeypatch.setattr("labelme._widgets.canvas.download_ai_model", lambda **_: True)
+    canvas.set_editing(value=False, create_mode="ai_points_to_shape")
+    canvas.show()
+    qtbot.mouseClick(canvas, Qt.MouseButton.LeftButton, pos=QtCore.QPoint(10, 10))
+    qtbot.waitUntil(lambda: bool(canvas._build_preview_shapes()))
+
+    canvas._update_drawing_line(pos=QPointF(20, 20), is_shift_pressed=False)
+    assert canvas._build_preview_shapes() == proposal.new_shapes
+    if outcome == "cancel":
+        qtbot.keyClick(canvas, Qt.Key.Key_Escape)
+    elif outcome == "reset":
+        canvas.reset_state()
+    else:
+        fail = outcome == "error"
+        proposal = AiAssistProposal(new_shapes=[], matching_existing_shapes=[])
+        canvas.update()
+        qtbot.waitUntil(lambda: not canvas._build_preview_shapes())
+    assert canvas._build_preview_shapes() == []


### PR DESCRIPTION
Repainting an unchanged AI point preview repeatedly runs inference while the painter is active. Painting now queues a deferred refresh, which memoizes the proposal inputs so an unchanged repaint performs no inference. The previous preview stays visible until its replacement arrives, avoiding blank frames during pointer motion.

Inference still runs synchronously on the GUI thread. Paint-driven refresh also handles showing a hidden canvas without caller-side scheduling hooks. Match highlights use one store; finalization computes a fresh proposal from committed prompt points. This addresses the repaint-related portion of #2151.

Validation: 187 canvas tests and 1,158 unit tests passed (one unit test skipped and one deselected); make lint passed. The retained click/move/repaint regression checks inference runs outside the active painter and the preview remains available during refresh. Additional coverage checks hidden Settings changes, Shape-list changes, brightness updates, and observable empty/error/cancel/reset outcomes. Desktop QA with cached SAM2 verified preview generation, brightness adjustment during an active draft, and Escape cancellation. All 21 GitHub checks pass on `a8a5d24d`.
