### PR TITLE
fix(ai): keep the app open when text Shape generation fails

### DIFF
--- a/changelog.d/2611.fixed.md
+++ b/changelog.d/2611.fixed.md
@@ -1,0 +1,1 @@
+AI Text Prompt reports errors during Shape generation instead of closing the app.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import enum
 import functools
-import json
 import math
 import os
 import platform
@@ -1380,85 +1379,15 @@ class MainWindow(QtWidgets.QMainWindow):
             self._text_osam_session = _automation.OsamSession(model_name=model_name)
 
         try:
-            boxes, scores, labels, masks = _automation.get_bboxes_from_texts(
+            shapes = _automation.propose_shapes_from_texts(
                 session=self._text_osam_session,
                 image=_utils.img_qt_to_rgb_arr(self._image),
                 image_id=str(hash(self._image_path)),
                 texts=texts,
-            )
-            if (
-                masks is None
-                and len(boxes) > 0
-                and shape_type in _automation.MASK_REQUIRED_SHAPE_TYPES
-            ):
-                QtWidgets.QMessageBox.warning(
-                    self,
-                    self.tr("Mask Output Unavailable"),
-                    self.tr(
-                        "%s only detects bounding boxes and cannot create "
-                        "'%s' annotations.\n\n"
-                        "Switch the AI Text-to-Annotation model to 'SAM3 (smart)', "
-                        "or set the output format to 'Rectangle'."
-                    )
-                    % (self._ai_text.get_model_display_name(), shape_type),
-                )
-                return
-
-            SCORE_FOR_EXISTING_SHAPE: Final[float] = 1.01
-            for shape in self._canvas_widgets.canvas.shapes:
-                if shape.shape_type != shape_type or shape.label not in texts:
-                    continue
-                shape_bbox = _automation.shape_to_xyxy_bbox(shape=shape)
-                if shape_bbox is None:
-                    continue
-                boxes = np.r_[boxes, [shape_bbox]]
-                scores = np.r_[scores, [SCORE_FOR_EXISTING_SHAPE]]
-                labels = np.r_[labels, [texts.index(shape.label)]]
-
-            boxes, scores, labels, indices = _automation.nms_bboxes(
-                boxes=boxes,
-                scores=scores,
-                labels=labels,
+                shape_type=shape_type,
+                existing_shapes=self._canvas_widgets.canvas.shapes,
                 iou_threshold=self._ai_text.get_iou_threshold(),
                 score_threshold=self._ai_text.get_score_threshold(),
-                max_num_detections=100,
-            )
-
-            is_new = scores != SCORE_FOR_EXISTING_SHAPE
-            boxes = boxes[is_new]
-            scores = scores[is_new]
-            labels = labels[is_new]
-            indices = indices[is_new]
-
-            if masks is None:
-                masks = [None] * len(boxes)
-            else:
-                masks = [masks[i] for i in indices]
-            del indices
-
-            detections: list[_automation.Detection] = []
-            for box, score, label, mask in zip(boxes, scores, labels, masks):
-                text: str = texts[label]
-                detections.append(
-                    _automation.Detection(
-                        bbox=(
-                            float(box[0]),
-                            float(box[1]),
-                            float(box[2]),
-                            float(box[3]),
-                        ),
-                        mask=mask,
-                        label=text,
-                        description=json.dumps(dict(score=score.item(), text=text)),
-                    )
-                )
-            detections = _automation.suppress_detections_greedy(
-                detections=detections,
-                iou_threshold=self._ai_text.get_iou_threshold(),
-            )
-            shapes: list[Shape] = _automation.shapes_from_detections(
-                detections=detections,
-                shape_type=shape_type,
                 image_size=(
                     None
                     if self._config["canvas"]["allow_out_of_bounds_points"]
@@ -1466,10 +1395,19 @@ class MainWindow(QtWidgets.QMainWindow):
                 ),
                 polygon_detail=self._config["mask_polygonization"]["detail"],
             )
-            _automation.assign_available_group_ids(
-                shapes=shapes,
-                existing_shapes=self._canvas_widgets.canvas.shapes,
+        except _automation.MaskOutputUnavailableError:
+            QtWidgets.QMessageBox.warning(
+                self,
+                self.tr("Mask Output Unavailable"),
+                self.tr(
+                    "%s only detects bounding boxes and cannot create "
+                    "'%s' annotations.\n\n"
+                    "Switch the AI Text-to-Annotation model to 'SAM3 (smart)', "
+                    "or set the output format to 'Rectangle'."
+                )
+                % (self._ai_text.get_model_display_name(), shape_type),
             )
+            return
         except Exception as e:
             logger.opt(exception=e).error("AI text inference failed")
             self._on_inference_failed(f"{type(e).__name__}: {e}")

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1386,95 +1386,94 @@ class MainWindow(QtWidgets.QMainWindow):
                 image_id=str(hash(self._image_path)),
                 texts=texts,
             )
+            if (
+                masks is None
+                and len(boxes) > 0
+                and shape_type in _automation.MASK_REQUIRED_SHAPE_TYPES
+            ):
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    self.tr("Mask Output Unavailable"),
+                    self.tr(
+                        "%s only detects bounding boxes and cannot create "
+                        "'%s' annotations.\n\n"
+                        "Switch the AI Text-to-Annotation model to 'SAM3 (smart)', "
+                        "or set the output format to 'Rectangle'."
+                    )
+                    % (self._ai_text.get_model_display_name(), shape_type),
+                )
+                return
+
+            SCORE_FOR_EXISTING_SHAPE: Final[float] = 1.01
+            for shape in self._canvas_widgets.canvas.shapes:
+                if shape.shape_type != shape_type or shape.label not in texts:
+                    continue
+                shape_bbox = _automation.shape_to_xyxy_bbox(shape=shape)
+                if shape_bbox is None:
+                    continue
+                boxes = np.r_[boxes, [shape_bbox]]
+                scores = np.r_[scores, [SCORE_FOR_EXISTING_SHAPE]]
+                labels = np.r_[labels, [texts.index(shape.label)]]
+
+            boxes, scores, labels, indices = _automation.nms_bboxes(
+                boxes=boxes,
+                scores=scores,
+                labels=labels,
+                iou_threshold=self._ai_text.get_iou_threshold(),
+                score_threshold=self._ai_text.get_score_threshold(),
+                max_num_detections=100,
+            )
+
+            is_new = scores != SCORE_FOR_EXISTING_SHAPE
+            boxes = boxes[is_new]
+            scores = scores[is_new]
+            labels = labels[is_new]
+            indices = indices[is_new]
+
+            if masks is None:
+                masks = [None] * len(boxes)
+            else:
+                masks = [masks[i] for i in indices]
+            del indices
+
+            detections: list[_automation.Detection] = []
+            for box, score, label, mask in zip(boxes, scores, labels, masks):
+                text: str = texts[label]
+                detections.append(
+                    _automation.Detection(
+                        bbox=(
+                            float(box[0]),
+                            float(box[1]),
+                            float(box[2]),
+                            float(box[3]),
+                        ),
+                        mask=mask,
+                        label=text,
+                        description=json.dumps(dict(score=score.item(), text=text)),
+                    )
+                )
+            detections = _automation.suppress_detections_greedy(
+                detections=detections,
+                iou_threshold=self._ai_text.get_iou_threshold(),
+            )
+            shapes: list[Shape] = _automation.shapes_from_detections(
+                detections=detections,
+                shape_type=shape_type,
+                image_size=(
+                    None
+                    if self._config["canvas"]["allow_out_of_bounds_points"]
+                    else (self._image.width(), self._image.height())
+                ),
+                polygon_detail=self._config["mask_polygonization"]["detail"],
+            )
+            _automation.assign_available_group_ids(
+                shapes=shapes,
+                existing_shapes=self._canvas_widgets.canvas.shapes,
+            )
         except Exception as e:
             logger.opt(exception=e).error("AI text inference failed")
             self._on_inference_failed(f"{type(e).__name__}: {e}")
             return
-
-        if (
-            masks is None
-            and len(boxes) > 0
-            and shape_type in _automation.MASK_REQUIRED_SHAPE_TYPES
-        ):
-            QtWidgets.QMessageBox.warning(
-                self,
-                self.tr("Mask Output Unavailable"),
-                self.tr(
-                    "%s only detects bounding boxes and cannot create "
-                    "'%s' annotations.\n\n"
-                    "Switch the AI Text-to-Annotation model to 'SAM3 (smart)', "
-                    "or set the output format to 'Rectangle'."
-                )
-                % (self._ai_text.get_model_display_name(), shape_type),
-            )
-            return
-
-        SCORE_FOR_EXISTING_SHAPE: Final[float] = 1.01
-        for shape in self._canvas_widgets.canvas.shapes:
-            if shape.shape_type != shape_type or shape.label not in texts:
-                continue
-            shape_bbox = _automation.shape_to_xyxy_bbox(shape=shape)
-            if shape_bbox is None:
-                continue
-            boxes = np.r_[boxes, [shape_bbox]]
-            scores = np.r_[scores, [SCORE_FOR_EXISTING_SHAPE]]
-            labels = np.r_[labels, [texts.index(shape.label)]]
-
-        boxes, scores, labels, indices = _automation.nms_bboxes(
-            boxes=boxes,
-            scores=scores,
-            labels=labels,
-            iou_threshold=self._ai_text.get_iou_threshold(),
-            score_threshold=self._ai_text.get_score_threshold(),
-            max_num_detections=100,
-        )
-
-        is_new = scores != SCORE_FOR_EXISTING_SHAPE
-        boxes = boxes[is_new]
-        scores = scores[is_new]
-        labels = labels[is_new]
-        indices = indices[is_new]
-
-        if masks is None:
-            masks = [None] * len(boxes)
-        else:
-            masks = [masks[i] for i in indices]
-        del indices
-
-        detections: list[_automation.Detection] = []
-        for box, score, label, mask in zip(boxes, scores, labels, masks):
-            text: str = texts[label]
-            detections.append(
-                _automation.Detection(
-                    bbox=(
-                        float(box[0]),
-                        float(box[1]),
-                        float(box[2]),
-                        float(box[3]),
-                    ),
-                    mask=mask,
-                    label=text,
-                    description=json.dumps(dict(score=score.item(), text=text)),
-                )
-            )
-        detections = _automation.suppress_detections_greedy(
-            detections=detections,
-            iou_threshold=self._ai_text.get_iou_threshold(),
-        )
-        shapes: list[Shape] = _automation.shapes_from_detections(
-            detections=detections,
-            shape_type=shape_type,
-            image_size=(
-                None
-                if self._config["canvas"]["allow_out_of_bounds_points"]
-                else (self._image.width(), self._image.height())
-            ),
-            polygon_detail=self._config["mask_polygonization"]["detail"],
-        )
-        _automation.assign_available_group_ids(
-            shapes=shapes,
-            existing_shapes=self._canvas_widgets.canvas.shapes,
-        )
 
         self._load_shapes(shapes, replace=False)
         self.mark_dirty()

--- a/labelme/_automation/__init__.py
+++ b/labelme/_automation/__init__.py
@@ -7,8 +7,8 @@ from ._shape_builders import Detection
 from ._shape_builders import assign_available_group_ids
 from ._shape_builders import shapes_from_detections
 from ._suppression import suppress_detections_greedy
-from ._text_detection import get_bboxes_from_texts
-from ._text_detection import nms_bboxes
+from ._text_detection import MaskOutputUnavailableError
+from ._text_detection import propose_shapes_from_texts
 from ._types import AiOutputFormat
 from ._types import AiPromptKind
 
@@ -19,10 +19,10 @@ __all__ = [
     "AiOutputFormat",
     "AiPromptKind",
     "Detection",
+    "MaskOutputUnavailableError",
     "OsamSession",
     "assign_available_group_ids",
-    "get_bboxes_from_texts",
-    "nms_bboxes",
+    "propose_shapes_from_texts",
     "shape_to_xyxy_bbox",
     "shapes_from_detections",
     "suppress_detections_greedy",

--- a/labelme/_automation/_text_detection.py
+++ b/labelme/_automation/_text_detection.py
@@ -1,11 +1,113 @@
+from __future__ import annotations
+
+import json
 import time
+from typing import Final
 
 import numpy as np
 import osam
 from loguru import logger
 from numpy.typing import NDArray
 
+from .._shape import Shape
+from ._geometry import shape_to_xyxy_bbox
 from ._osam_session import OsamSession
+from ._shape_builders import MASK_REQUIRED_SHAPE_TYPES
+from ._shape_builders import Detection
+from ._shape_builders import assign_available_group_ids
+from ._shape_builders import shapes_from_detections
+from ._suppression import suppress_detections_greedy
+from ._types import AiOutputFormat
+
+
+class MaskOutputUnavailableError(ValueError):
+    pass
+
+
+def propose_shapes_from_texts(
+    *,
+    session: OsamSession,
+    image: np.ndarray,
+    image_id: str,
+    texts: list[str],
+    shape_type: AiOutputFormat,
+    existing_shapes: list[Shape],
+    iou_threshold: float,
+    score_threshold: float,
+    image_size: tuple[int, int] | None,
+    polygon_detail: int,
+) -> list[Shape]:
+    boxes, scores, labels, masks = get_bboxes_from_texts(
+        session=session, image=image, image_id=image_id, texts=texts
+    )
+    if masks is None and len(boxes) > 0 and shape_type in MASK_REQUIRED_SHAPE_TYPES:
+        raise MaskOutputUnavailableError(f"{shape_type!r} requires model masks")
+
+    # Existing Shapes outrank model scores so overlapping predictions disappear
+    # without returning the existing Shapes as new proposals.
+    SCORE_FOR_EXISTING_SHAPE: Final[float] = 1.01
+    for shape in existing_shapes:
+        if shape.shape_type != shape_type or shape.label not in texts:
+            continue
+        shape_bbox = shape_to_xyxy_bbox(shape=shape)
+        if shape_bbox is None:
+            continue
+        boxes = np.r_[boxes, [shape_bbox]]
+        scores = np.r_[scores, [SCORE_FOR_EXISTING_SHAPE]]
+        labels = np.r_[labels, [texts.index(shape.label)]]
+
+    boxes, scores, labels, indices = nms_bboxes(
+        boxes=boxes,
+        scores=scores,
+        labels=labels,
+        iou_threshold=iou_threshold,
+        score_threshold=score_threshold,
+        max_num_detections=100,
+    )
+
+    is_new = scores != SCORE_FOR_EXISTING_SHAPE
+    boxes = boxes[is_new]
+    scores = scores[is_new]
+    labels = labels[is_new]
+    indices = indices[is_new]
+
+    if masks is None:
+        masks = [None] * len(boxes)
+    else:
+        masks = [masks[i] for i in indices]
+    del indices
+
+    detections: list[Detection] = []
+    for box, score, label, mask in zip(boxes, scores, labels, masks):
+        text = texts[label]
+        detections.append(
+            Detection(
+                bbox=(
+                    float(box[0]),
+                    float(box[1]),
+                    float(box[2]),
+                    float(box[3]),
+                ),
+                mask=mask,
+                label=text,
+                description=json.dumps(dict(score=score.item(), text=text)),
+            )
+        )
+    detections = suppress_detections_greedy(
+        detections=detections,
+        iou_threshold=iou_threshold,
+    )
+    shapes = shapes_from_detections(
+        detections=detections,
+        shape_type=shape_type,
+        image_size=image_size,
+        polygon_detail=polygon_detail,
+    )
+    assign_available_group_ids(
+        shapes=shapes,
+        existing_shapes=existing_shapes,
+    )
+    return shapes
 
 
 def get_bboxes_from_texts(

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -361,7 +361,7 @@ def test_text_prompt_error_preserves_annotation(
         ),
     )
     if failure_stage == "postprocessing":
-        monkeypatch.setattr("labelme._automation.nms_bboxes", _raise)
+        monkeypatch.setattr("labelme._automation._text_detection.nms_bboxes", _raise)
     _run_text_prompt(
         win=win,
         qtbot=qtbot,

--- a/tests/e2e/ai_text_to_annotation_test.py
+++ b/tests/e2e/ai_text_to_annotation_test.py
@@ -332,24 +332,36 @@ def test_score_threshold_filters_detections(
 
 
 @pytest.mark.gui
-def test_text_prompt_inference_error_surfaces_without_crashing(
+@pytest.mark.parametrize("failure_stage", ["inference", "postprocessing"])
+def test_text_prompt_error_preserves_annotation(
     *,
     main_win: MainWinFactory,
     monkeypatch: pytest.MonkeyPatch,
     qtbot: QtBot,
     data_path: Path,
     pause: bool,
+    failure_stage: str,
 ) -> None:
-    # A model error during text-to-annotation inference must not crash the app:
-    # it surfaces as a non-fatal status message and the window stays alive.
-    win = main_win(file_or_dir=str(data_path / "raw/2011_000003.jpg"))
+    win = main_win(file_or_dir=str(data_path / "annotated/2011_000003.jpg"))
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
     canvas = win._canvas_widgets.canvas
+    previous_shapes = canvas.shapes[:]
+    assert previous_shapes
 
     def _raise(**_: object) -> osam.types.GenerateResponse:
         raise RuntimeError("boom")
 
-    _install_mock_session(win=win, monkeypatch=monkeypatch, response_fn=_raise)
+    _install_mock_session(
+        win=win,
+        monkeypatch=monkeypatch,
+        response_fn=(
+            _raise
+            if failure_stage == "inference"
+            else functools.partial(_make_person_response, with_masks=False)
+        ),
+    )
+    if failure_stage == "postprocessing":
+        monkeypatch.setattr("labelme._automation.nms_bboxes", _raise)
     _run_text_prompt(
         win=win,
         qtbot=qtbot,
@@ -359,7 +371,7 @@ def test_text_prompt_inference_error_surfaces_without_crashing(
     )
 
     assert win.isVisible()
-    assert canvas.shapes == []
+    assert canvas.shapes == previous_shapes
     assert "AI inference failed" in win.statusBar().currentMessage()
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)

--- a/tests/unit/_automation/_text_detection_test.py
+++ b/tests/unit/_automation/_text_detection_test.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import osam
 import pytest
 from numpy.typing import NDArray
 
+from labelme._automation._text_detection import MaskOutputUnavailableError
 from labelme._automation._text_detection import get_bboxes_from_texts
 from labelme._automation._text_detection import nms_bboxes
+from labelme._automation._text_detection import propose_shapes_from_texts
+from labelme._shape import Shape
 
 
 class _FakeOsamSession:
@@ -172,3 +177,71 @@ def test_nms_bboxes_scatters_scores_into_one_hot_class_matrix(
     )
     np.testing.assert_array_equal(indices, np.array([0], dtype=np.int64))
     assert len(out_boxes) == 1
+
+
+def test_text_proposal_keeps_mask_and_score_alignment_after_suppression() -> None:
+    masks = [np.ones((4, 4), dtype=bool) for _ in range(3)]
+    masks[1][0, 0] = False
+    response = osam.types.GenerateResponse(
+        model="stub",
+        annotations=[
+            osam.types.Annotation(
+                text="cat",
+                score=score,
+                bounding_box=osam.types.BoundingBox(xmin=x, ymin=0, xmax=x + 3, ymax=3),
+                mask=mask,
+            )
+            for x, score, mask in zip([0, 10, 20], [0.2, 0.9, 0.8], masks)
+        ],
+    )
+    existing = Shape(
+        label="cat",
+        shape_type="mask",
+        points=np.array([[20, 0], [23, 3]]),
+        mask=masks[2],
+        group_id=7,
+    )
+
+    shapes = propose_shapes_from_texts(
+        session=_FakeOsamSession(response=response),  # ty: ignore[invalid-argument-type]
+        image=np.zeros((30, 30, 3), dtype=np.uint8),
+        image_id="img",
+        texts=["cat"],
+        shape_type="mask",
+        existing_shapes=[existing],
+        iou_threshold=0.5,
+        score_threshold=0.5,
+        image_size=(30, 30),
+        polygon_detail=80,
+    )
+
+    (shape,) = shapes
+    assert shape.label == "cat"
+    assert shape.shape_type == "mask"
+    np.testing.assert_array_equal(shape.points, [[10, 0], [13, 3]])
+    np.testing.assert_array_equal(shape.mask, masks[1])
+    assert shape.description is not None
+    assert json.loads(shape.description)["score"] == pytest.approx(0.9)
+    assert existing.group_id == 7
+    np.testing.assert_array_equal(existing.points, [[20, 0], [23, 3]])
+
+
+def test_text_proposal_rejects_maskless_detections_for_mask_output() -> None:
+    session = _FakeOsamSession(
+        response=osam.types.GenerateResponse(
+            model="stub", annotations=[_make_annotation(with_mask=False)]
+        )
+    )
+    with pytest.raises(MaskOutputUnavailableError, match="requires model masks"):
+        propose_shapes_from_texts(
+            session=session,  # ty: ignore[invalid-argument-type]
+            image=np.zeros((4, 4, 3), dtype=np.uint8),
+            image_id="img",
+            texts=["cat"],
+            shape_type="mask",
+            existing_shapes=[],
+            iou_threshold=0.5,
+            score_threshold=0.5,
+            image_size=(4, 4),
+            polygon_detail=80,
+        )


### PR DESCRIPTION
Only the model call in the AI Text Prompt handler was guarded. Any error raised afterwards, in suppression, mask indexing, Shape construction, or Group allocation, escaped the slot and the global excepthook closed the app with a critical dialog.

MainWindow owned that numeric protocol: synthetic scores for existing Shapes, aligned box/mask indices, and conversion into new Shapes. Moving it behind one Qt-free proposal call puts the whole pipeline under the existing failure handler and gives it a direct test surface.

Text suppression intentionally keeps its existing semantics, which differ from AI Assist point matching. Missing-mask output retains its specific user warning; other inference and postprocessing failures use the existing failure status message.

Validation: 138 automation and text-workflow tests passed before the additional regressions; the final text-focused run passed 20 tests, including real NMS with mask/index alignment and preservation of existing Shapes on failures. `make lint` passed, and a fresh-process import confirmed the proposal module loads without Qt. The desktop text-model check was not completed because computer-use model selection returned an accessibility error; no desktop parity claim is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3geU2ZzSYoc5sjxpXXTDJ
