### PR TITLE
refactor: simplify standalone dataset exporters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         if: matrix.os != 'windows-latest'
         run: |
-          uv pip install cython && uv pip install pycocotools
+          uv pip install cython pycocotools
       # Pixel snapshots skip themselves off Linux (tests/e2e/conftest.py), so
       # one plain invocation runs the right set everywhere.
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           packages: xvfb libegl1 libxkbcommon0 libxcb-cursor0 libgl1
           version: 1.0
+      # The COCO exporter tests skip themselves without pycocotools, so it has
+      # to be present before pytest runs. The pip install survives the inexact
+      # sync that uv run performs.
+      - name: Install optional example dependencies
+        shell: bash
+        if: matrix.os != 'windows-latest'
+        run: |
+          uv pip install cython && uv pip install pycocotools
       # Pixel snapshots skip themselves off Linux (tests/e2e/conftest.py), so
       # one plain invocation runs the right set everywhere.
       - name: Test
@@ -64,7 +72,6 @@ jobs:
           (cd examples/video_annotation && rm -rf data_dataset_voc && ./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt && git checkout -- .)
           uv pip install lxml  # for bbox_detection/labelme2voc.py
           (cd examples/bbox_detection && rm -rf data_dataset_voc && ./labelme2voc.py data_annotated data_dataset_voc --labels labels.txt && git checkout -- .)
-          uv pip install cython && uv pip install pycocotools  # for instance_segmentation/labelme2coco.py
           (cd examples/instance_segmentation && rm -rf data_dataset_coco && ./labelme2coco.py data_annotated data_dataset_coco --labels labels.txt && git checkout -- .)
   artifact-install-smoke:
     runs-on: ${{ matrix.os }}

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -14,14 +14,21 @@ from typing import Final
 import imgviz
 import numpy as np
 
+try:
+    import pycocotools.mask  # type: ignore
+except ImportError:
+    print("Please install pycocotools:\n\n    pip install pycocotools\n")
+    sys.exit(1)
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
 
 
-def _polygon_vertex_count_for_circle(radius: float, /) -> int:
+def _count_polygon_vertices_for_circle(radius: float, /) -> int:
     CIRCLE_APPROXIMATION_TOLERANCE_PX: Final = 1.0
     CIRCLE_MIN_VERTEX_COUNT: Final = 12
 
+    # Doubling reduces the chord-to-arc deviation until it is within one pixel.
     vertex_count = CIRCLE_MIN_VERTEX_COUNT
     while radius * (1.0 - math.cos(math.pi / vertex_count)) > (
         CIRCLE_APPROXIMATION_TOLERANCE_PX
@@ -38,7 +45,7 @@ def _circle_to_polygon_segmentation(
     if radius == 0.0:
         raise ValueError("Degenerate circle: center and edge are the same point.")
 
-    vertex_count = _polygon_vertex_count_for_circle(radius)
+    vertex_count = _count_polygon_vertices_for_circle(radius)
     angles = np.linspace(0.0, 2.0 * math.pi, num=vertex_count, endpoint=False)
     vertices = np.column_stack(
         (cx + radius * np.cos(angles), cy + radius * np.sin(angles))
@@ -47,14 +54,6 @@ def _circle_to_polygon_segmentation(
 
 
 def main() -> None:
-    # Imported lazily so importing this module for its polygon geometry (as
-    # the unit tests do) never requires the optional pycocotools dependency.
-    try:
-        import pycocotools.mask  # type: ignore  # noqa: PLC0415
-    except ImportError:
-        print("Please install pycocotools:\n\n    pip install pycocotools\n")
-        sys.exit(1)
-
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -14,46 +14,47 @@ from typing import Final
 import imgviz
 import numpy as np
 
-try:
-    import pycocotools.mask  # type: ignore
-except ImportError:
-    print("Please install pycocotools:\n\n    pip install pycocotools\n")
-    sys.exit(1)
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
+
+
+def _polygon_vertex_count_for_circle(radius: float, /) -> int:
+    CIRCLE_APPROXIMATION_TOLERANCE_PX: Final = 1.0
+    CIRCLE_MIN_VERTEX_COUNT: Final = 12
+
+    vertex_count = CIRCLE_MIN_VERTEX_COUNT
+    while radius * (1.0 - math.cos(math.pi / vertex_count)) > (
+        CIRCLE_APPROXIMATION_TOLERANCE_PX
+    ):
+        vertex_count *= 2
+    return vertex_count
 
 
 def _circle_to_polygon_segmentation(
     *, center: tuple[float, float], edge: tuple[float, float]
 ) -> list[float]:
-    CHORD_TOLERANCE_PX: Final = 1.0
-    MIN_VERTICES: Final = 12
-
     cx, cy = center
-    ex, ey = edge
-    radius = math.hypot(ex - cx, ey - cy)
+    radius = math.dist(center, edge)
     if radius == 0.0:
         raise ValueError("Degenerate circle: center and edge are the same point.")
 
-    # Pick a vertex count so the chord-to-arc deviation stays within 1 pixel:
-    # solving r * (1 - cos(pi / n)) <= tol for n yields n >= pi / acos(1 - tol/r).
-    # When r <= tol the formula domain breaks, so clamp to the minimum.
-    if radius <= CHORD_TOLERANCE_PX:
-        n_vertices = MIN_VERTICES
-    else:
-        n_vertices = max(
-            MIN_VERTICES,
-            int(math.pi / math.acos(1.0 - CHORD_TOLERANCE_PX / radius)),
-        )
-    angles = (2.0 * math.pi / n_vertices) * np.arange(n_vertices)
-    coords = np.empty((n_vertices, 2), dtype=float)
-    coords[:, 0] = cx + radius * np.cos(angles)
-    coords[:, 1] = cy + radius * np.sin(angles)
-    return coords.flatten().tolist()
+    vertex_count = _polygon_vertex_count_for_circle(radius)
+    angles = np.linspace(0.0, 2.0 * math.pi, num=vertex_count, endpoint=False)
+    vertices = np.column_stack(
+        (cx + radius * np.cos(angles), cy + radius * np.sin(angles))
+    )
+    return vertices.ravel().tolist()
 
 
 def main() -> None:
+    # Imported lazily so importing this module for its polygon geometry (as
+    # the unit tests do) never requires the optional pycocotools dependency.
+    try:
+        import pycocotools.mask  # type: ignore  # noqa: PLC0415
+    except ImportError:
+        print("Please install pycocotools:\n\n    pip install pycocotools\n")
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )

--- a/examples/instance_segmentation/labelme2voc.py
+++ b/examples/instance_segmentation/labelme2voc.py
@@ -7,9 +7,77 @@ from pathlib import Path
 
 import imgviz
 import numpy as np
+from numpy.typing import NDArray
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import utils  # noqa: E402  # examples/utils.py, vendored alongside this script
+
+
+def _create_output_directories(
+    output_dir: Path,
+    /,
+    *,
+    include_npy: bool,
+    include_visualizations: bool,
+    include_objects: bool,
+) -> None:
+    output_dir.mkdir(parents=True)
+    (output_dir / "JPEGImages").mkdir()
+    (output_dir / "SegmentationClass").mkdir()
+    if include_npy:
+        (output_dir / "SegmentationClassNpy").mkdir()
+    if include_visualizations:
+        (output_dir / "SegmentationClassVisualization").mkdir()
+    if not include_objects:
+        return
+    (output_dir / "SegmentationObject").mkdir()
+    if include_npy:
+        (output_dir / "SegmentationObjectNpy").mkdir()
+    if include_visualizations:
+        (output_dir / "SegmentationObjectVisualization").mkdir()
+
+
+def _save_label_layer(
+    *,
+    output_dir: Path,
+    layer: str,
+    base: str,
+    label: NDArray[np.int32],
+    gray_img: NDArray[np.uint8],
+    label_names: list[str],
+    include_npy: bool,
+    include_visualization: bool,
+) -> None:
+    imgviz.io.lblsave(output_dir / layer / f"{base}.png", label.astype(np.uint8))
+    if include_npy:
+        np.save(output_dir / f"{layer}Npy" / f"{base}.npy", label)
+    if include_visualization:
+        viz = imgviz.label2rgb(
+            label, gray_img, label_names=label_names, font_size=15, loc="rb"
+        )
+        imgviz.io.imsave(output_dir / f"{layer}Visualization" / f"{base}.jpg", viz)
+
+
+def _load_class_names(labels_arg: str, /) -> tuple[list[str], dict[str, int]]:
+    if Path(labels_arg).exists():
+        with open(labels_arg) as f:
+            labels = [label.strip() for label in f if label]
+    else:
+        labels = [label.strip() for label in labels_arg.split(",")]
+
+    class_names: list[str] = []
+    class_name_to_id: dict[str, int] = {}
+    for i, label in enumerate(labels):
+        class_id = i - 1  # starts with -1
+        class_name = label.strip()
+        class_name_to_id[class_name] = class_id
+        if class_id == -1:
+            assert class_name == "__ignore__"
+            continue
+        elif class_id == 0:
+            assert class_name == "_background_"
+        class_names.append(class_name)
+    return class_names, class_name_to_id
 
 
 def main() -> None:
@@ -36,39 +104,18 @@ def main() -> None:
     if output_dir.exists():
         print("Output directory already exists:", output_dir)
         sys.exit(1)
-    output_dir.mkdir(parents=True)
-    (output_dir / "JPEGImages").mkdir(parents=True)
-    (output_dir / "SegmentationClass").mkdir(parents=True)
-    if not args.nonpy:
-        (output_dir / "SegmentationClassNpy").mkdir(parents=True)
-    if not args.noviz:
-        (output_dir / "SegmentationClassVisualization").mkdir(parents=True)
-    if not args.noobject:
-        (output_dir / "SegmentationObject").mkdir(parents=True)
-        if not args.nonpy:
-            (output_dir / "SegmentationObjectNpy").mkdir(parents=True)
-        if not args.noviz:
-            (output_dir / "SegmentationObjectVisualization").mkdir(parents=True)
+    include_npy = not args.nonpy
+    include_visualizations = not args.noviz
+    include_objects = not args.noobject
+    _create_output_directories(
+        output_dir,
+        include_npy=include_npy,
+        include_visualizations=include_visualizations,
+        include_objects=include_objects,
+    )
     print("Creating dataset:", output_dir)
 
-    if Path(args.labels).exists():
-        with open(args.labels) as f:
-            labels = [label.strip() for label in f if label]
-    else:
-        labels = [label.strip() for label in args.labels.split(",")]
-
-    class_names: list[str] = []
-    class_name_to_id = {}
-    for i, label in enumerate(labels):
-        class_id = i - 1  # starts with -1
-        class_name = label.strip()
-        class_name_to_id[class_name] = class_id
-        if class_id == -1:
-            assert class_name == "__ignore__"
-            continue
-        elif class_id == 0:
-            assert class_name == "_background_"
-        class_names.append(class_name)
+    class_names, class_name_to_id = _load_class_names(args.labels)
     print("class_names:", class_names)
     out_class_names_file = output_dir / "class_names.txt"
     with open(out_class_names_file, "w") as f:
@@ -79,27 +126,10 @@ def main() -> None:
         print("Generating dataset from:", path)
 
         label_file = utils.load_label_file(str(path))
-
         base = path.stem
-        out_img_file = output_dir / "JPEGImages" / f"{base}.jpg"
-        out_clsp_file = output_dir / "SegmentationClass" / f"{base}.png"
-        if not args.nonpy:
-            out_cls_file = output_dir / "SegmentationClassNpy" / f"{base}.npy"
-        if not args.noviz:
-            out_clsv_file = (
-                output_dir / "SegmentationClassVisualization" / f"{base}.jpg"
-            )
-        if not args.noobject:
-            out_insp_file = output_dir / "SegmentationObject" / f"{base}.png"
-            if not args.nonpy:
-                out_ins_file = output_dir / "SegmentationObjectNpy" / f"{base}.npy"
-            if not args.noviz:
-                out_insv_file = (
-                    output_dir / "SegmentationObjectVisualization" / f"{base}.jpg"
-                )
 
         img = utils.decode_img_data_as_rgb(label_file.image_data)
-        imgviz.io.imsave(out_img_file, img)
+        imgviz.io.imsave(output_dir / "JPEGImages" / f"{base}.jpg", img)
 
         cls, ins = utils.shapes_to_label(
             img_shape=img.shape,
@@ -107,41 +137,34 @@ def main() -> None:
             label_name_to_value=class_name_to_id,
         )
         ins[cls == -1] = 0  # ignore it.
+        gray_img = imgviz.rgb2gray(img)
 
-        # class label
-        imgviz.io.lblsave(out_clsp_file, cls.astype(np.uint8))
-        if not args.nonpy:
-            np.save(out_cls_file, cls)
-        if not args.noviz:
-            clsv = imgviz.label2rgb(
-                cls,
-                imgviz.rgb2gray(img),
-                label_names=class_names,
-                font_size=15,
-                loc="rb",
-            )
-            imgviz.io.imsave(out_clsv_file, clsv)
+        _save_label_layer(
+            output_dir=output_dir,
+            layer="SegmentationClass",
+            base=base,
+            label=cls,
+            gray_img=gray_img,
+            label_names=class_names,
+            include_npy=include_npy,
+            include_visualization=include_visualizations,
+        )
 
-        if args.noobject:
-            continue
-
-        # instance label
-        imgviz.io.lblsave(out_insp_file, ins.astype(np.uint8))
-        if not args.nonpy:
-            np.save(out_ins_file, ins)
-        if args.noviz:
+        if not include_objects:
             continue
 
         instance_ids = np.unique(ins)
         instance_names = [str(i) for i in range(max(instance_ids) + 1)]
-        insv = imgviz.label2rgb(
-            ins,
-            imgviz.rgb2gray(img),
+        _save_label_layer(
+            output_dir=output_dir,
+            layer="SegmentationObject",
+            base=base,
+            label=ins,
+            gray_img=gray_img,
             label_names=instance_names,
-            font_size=15,
-            loc="rb",
+            include_npy=include_npy,
+            include_visualization=include_visualizations,
         )
-        imgviz.io.imsave(out_insv_file, insv)
 
 
 if __name__ == "__main__":

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python
-"""Keep these helpers independent so example users can copy and adapt them on
-their own schedule, separate from the application maintainers. Dependencies
-stay limited to the standard library, NumPy, and Pillow to avoid requiring
-the application or its GUI stack.
+"""Self-contained helpers for reading the labelme JSON annotation format.
+
+labelme is an application, not a Python library: the supported way to consume
+its output is to read the JSON format yourself, the way a PyTorch ``Dataset``
+reads whatever format its data lives in. This module is the worked reference for
+doing that. It depends only on the standard library, numpy, and PIL, never on
+``labelme``, so it keeps working regardless of how labelme's internals evolve.
+
+It deliberately re-implements the rasterization helpers rather than importing
+them: this copy and labelme's internal copy have different owners and
+lifecycles. Copy this file next to your own scripts and adapt it.
 """
 
 from __future__ import annotations
@@ -30,35 +37,32 @@ class LabeledImage:
     shapes: list[dict[str, Any]]
 
 
-def _read_image_bytes(record: dict[str, Any], /, *, json_dir: Path) -> bytes:
-    embedded = record.get("imageData")
-    if embedded is not None:
-        return base64.b64decode(embedded)
-    # imagePath may carry Windows-style separators even when read on a
-    # different OS than the one that produced the annotation.
-    relative_path = PureWindowsPath(record["imagePath"]).as_posix()
-    return (json_dir / relative_path).read_bytes()
-
-
-def _build_shape(shape: dict[str, Any], /) -> dict[str, Any]:
-    raw_mask = shape.get("mask")
-    return {
-        "label": shape["label"],
-        "points": shape["points"],
-        "shape_type": shape.get("shape_type") or "polygon",
-        "group_id": shape.get("group_id"),
-        "flags": shape.get("flags") or {},
-        "mask": None if raw_mask is None else img_b64_to_arr(raw_mask).astype(bool),
-    }
-
-
 def load_label_file(filename: str, /) -> LabeledImage:
     json_path = Path(filename)
-    record = json.loads(json_path.read_text(encoding="utf-8"))
-    return LabeledImage(
-        image_data=_read_image_bytes(record, json_dir=json_path.parent),
-        shapes=[_build_shape(shape) for shape in record["shapes"]],
-    )
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+
+    if data.get("imageData") is None:
+        # imagePath may carry Windows-style separators even when read on a
+        # different OS than the one that produced the annotation.
+        image_path = PureWindowsPath(data["imagePath"]).as_posix()
+        image_data = (json_path.parent / image_path).read_bytes()
+    else:
+        image_data = base64.b64decode(data["imageData"])
+
+    shapes = [
+        {
+            "label": shape["label"],
+            "points": shape["points"],
+            "shape_type": shape.get("shape_type") or "polygon",
+            "group_id": shape.get("group_id"),
+            "flags": shape.get("flags") or {},
+            "mask": None
+            if shape.get("mask") is None
+            else img_b64_to_arr(shape["mask"]).astype(bool),
+        }
+        for shape in data["shapes"]
+    ]
+    return LabeledImage(image_data=image_data, shapes=shapes)
 
 
 def img_data_to_arr(img_data: bytes, /) -> NDArray[np.uint8]:

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,18 +1,4 @@
 #!/usr/bin/env python
-"""Self-contained helpers for reading the labelme JSON annotation format.
-
-labelme is an application, not a Python library: the supported way to consume
-its output is to read the JSON format yourself, the way a PyTorch ``Dataset``
-reads whatever format its data lives in. This module is the worked reference for
-doing that. It depends only on the standard library, numpy, and PIL, never on
-``labelme``, so it keeps working regardless of how labelme's internals evolve.
-
-It deliberately re-implements the rasterization helpers (``shape_to_mask``,
-``shapes_to_label``, ``img_data_to_arr``) rather than importing them: this copy
-and labelme's internal copy have different owners and lifecycles. Copy this file
-next to your own scripts and adapt it.
-"""
-
 from __future__ import annotations
 
 import base64
@@ -38,30 +24,35 @@ class LabeledImage:
     shapes: list[dict[str, Any]]
 
 
+def _image_bytes_from_record(record: dict[str, Any], /, *, json_dir: Path) -> bytes:
+    embedded = record.get("imageData")
+    if embedded is not None:
+        return base64.b64decode(embedded)
+    # imagePath may carry Windows-style separators even when read on a
+    # different OS than the one that produced the annotation.
+    relative_path = PureWindowsPath(record["imagePath"]).as_posix()
+    return (json_dir / relative_path).read_bytes()
+
+
+def _shape_from_record(shape: dict[str, Any], /) -> dict[str, Any]:
+    raw_mask = shape.get("mask")
+    return {
+        "label": shape["label"],
+        "points": shape["points"],
+        "shape_type": shape.get("shape_type") or "polygon",
+        "group_id": shape.get("group_id"),
+        "flags": shape.get("flags") or {},
+        "mask": None if raw_mask is None else img_b64_to_arr(raw_mask).astype(bool),
+    }
+
+
 def load_label_file(filename: str, /) -> LabeledImage:
-    with open(filename, encoding="utf-8") as f:
-        data = json.load(f)
-
-    if data.get("imageData") is None:
-        image_path = PureWindowsPath(data["imagePath"]).as_posix()
-        image_data = (Path(filename).parent / image_path).read_bytes()
-    else:
-        image_data = base64.b64decode(data["imageData"])
-
-    shapes = [
-        {
-            "label": shape["label"],
-            "points": shape["points"],
-            "shape_type": shape.get("shape_type") or "polygon",
-            "group_id": shape.get("group_id"),
-            "flags": shape.get("flags") or {},
-            "mask": None
-            if shape.get("mask") is None
-            else img_b64_to_arr(shape["mask"]).astype(bool),
-        }
-        for shape in data["shapes"]
-    ]
-    return LabeledImage(image_data=image_data, shapes=shapes)
+    json_path = Path(filename)
+    record = json.loads(json_path.read_text(encoding="utf-8"))
+    return LabeledImage(
+        image_data=_image_bytes_from_record(record, json_dir=json_path.parent),
+        shapes=[_shape_from_record(shape) for shape in record["shapes"]],
+    )
 
 
 def img_data_to_arr(img_data: bytes, /) -> NDArray[np.uint8]:

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+"""Keep these helpers independent so example users can copy and adapt them on
+their own schedule, separate from the application maintainers. Dependencies
+stay limited to the standard library, NumPy, and Pillow to avoid requiring
+the application or its GUI stack.
+"""
+
 from __future__ import annotations
 
 import base64
@@ -24,7 +30,7 @@ class LabeledImage:
     shapes: list[dict[str, Any]]
 
 
-def _image_bytes_from_record(record: dict[str, Any], /, *, json_dir: Path) -> bytes:
+def _read_image_bytes(record: dict[str, Any], /, *, json_dir: Path) -> bytes:
     embedded = record.get("imageData")
     if embedded is not None:
         return base64.b64decode(embedded)
@@ -34,7 +40,7 @@ def _image_bytes_from_record(record: dict[str, Any], /, *, json_dir: Path) -> by
     return (json_dir / relative_path).read_bytes()
 
 
-def _shape_from_record(shape: dict[str, Any], /) -> dict[str, Any]:
+def _build_shape(shape: dict[str, Any], /) -> dict[str, Any]:
     raw_mask = shape.get("mask")
     return {
         "label": shape["label"],
@@ -50,8 +56,8 @@ def load_label_file(filename: str, /) -> LabeledImage:
     json_path = Path(filename)
     record = json.loads(json_path.read_text(encoding="utf-8"))
     return LabeledImage(
-        image_data=_image_bytes_from_record(record, json_dir=json_path.parent),
-        shapes=[_shape_from_record(shape) for shape in record["shapes"]],
+        image_data=_read_image_bytes(record, json_dir=json_path.parent),
+        shapes=[_build_shape(shape) for shape in record["shapes"]],
     )
 
 

--- a/tests/unit/examples/labelme2coco_test.py
+++ b/tests/unit/examples/labelme2coco_test.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import math
+from typing import Final
+
+import numpy as np
+import pytest
+
+# Importing the module must not require pycocotools: that dependency is only
+# pulled in inside main(), specifically so geometry helpers like this one
+# stay testable without it installed.
+from examples.instance_segmentation import labelme2coco
+
+_CIRCLE_MIN_VERTEX_COUNT: Final = 12
+
+
+def test_circle_to_polygon_segmentation_rejects_zero_radius() -> None:
+    with pytest.raises(ValueError, match="Degenerate circle"):
+        labelme2coco._circle_to_polygon_segmentation(center=(5.0, 5.0), edge=(5.0, 5.0))
+
+
+def test_circle_to_polygon_segmentation_returns_flattened_xy_pairs() -> None:
+    coords = labelme2coco._circle_to_polygon_segmentation(
+        center=(0.0, 0.0), edge=(10.0, 0.0)
+    )
+    assert len(coords) % 2 == 0
+    points = np.array(coords).reshape(-1, 2)
+    distances = np.hypot(points[:, 0], points[:, 1])
+    np.testing.assert_allclose(distances, 10.0)
+
+
+@pytest.mark.parametrize("radius", [0.1, 1.0])
+def test_circle_to_polygon_segmentation_never_drops_below_min_vertices(
+    *, radius: float
+) -> None:
+    coords = labelme2coco._circle_to_polygon_segmentation(
+        center=(0.0, 0.0), edge=(radius, 0.0)
+    )
+    n_vertices = len(coords) // 2
+    assert n_vertices >= _CIRCLE_MIN_VERTEX_COUNT
+
+
+def test_circle_to_polygon_segmentation_radius_100_stays_within_one_pixel() -> None:
+    radius = 100.0
+    coords = labelme2coco._circle_to_polygon_segmentation(
+        center=(0.0, 0.0), edge=(radius, 0.0)
+    )
+    n_vertices = len(coords) // 2
+    # Sagitta of a chord spanning 2*pi/n radians of a circle with this
+    # radius: the maximum distance the chord deviates from the true arc.
+    max_deviation = radius * (1.0 - math.cos(math.pi / n_vertices))
+    assert max_deviation <= 1.0
+
+
+def test_circle_to_polygon_segmentation_refines_large_circles() -> None:
+    radius = 1_000.0
+    coords = labelme2coco._circle_to_polygon_segmentation(
+        center=(0.0, 0.0), edge=(radius, 0.0)
+    )
+    n_vertices = len(coords) // 2
+    assert n_vertices > _CIRCLE_MIN_VERTEX_COUNT
+    refinements = n_vertices // _CIRCLE_MIN_VERTEX_COUNT
+    assert refinements & (refinements - 1) == 0

--- a/tests/unit/examples/labelme2coco_test.py
+++ b/tests/unit/examples/labelme2coco_test.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import importlib
 import math
 from typing import Final
 
 import numpy as np
 import pytest
 
-# Importing the module must not require pycocotools: that dependency is only
-# pulled in inside main(), specifically so geometry helpers like this one
-# stay testable without it installed.
-from examples.instance_segmentation import labelme2coco
+pytest.importorskip("pycocotools.mask")
+labelme2coco = importlib.import_module("examples.instance_segmentation.labelme2coco")
 
 _CIRCLE_MIN_VERTEX_COUNT: Final = 12
 

--- a/tests/unit/examples/labelme2coco_test.py
+++ b/tests/unit/examples/labelme2coco_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import math
-from typing import Final
 
 import numpy as np
 import pytest
@@ -10,53 +9,23 @@ import pytest
 pytest.importorskip("pycocotools.mask")
 labelme2coco = importlib.import_module("examples.instance_segmentation.labelme2coco")
 
-_CIRCLE_MIN_VERTEX_COUNT: Final = 12
-
 
 def test_circle_to_polygon_segmentation_rejects_zero_radius() -> None:
     with pytest.raises(ValueError, match="Degenerate circle"):
         labelme2coco._circle_to_polygon_segmentation(center=(5.0, 5.0), edge=(5.0, 5.0))
 
 
-def test_circle_to_polygon_segmentation_returns_flattened_xy_pairs() -> None:
-    coords = labelme2coco._circle_to_polygon_segmentation(
-        center=(0.0, 0.0), edge=(10.0, 0.0)
-    )
-    assert len(coords) % 2 == 0
-    points = np.array(coords).reshape(-1, 2)
-    distances = np.hypot(points[:, 0], points[:, 1])
-    np.testing.assert_allclose(distances, 10.0)
-
-
-@pytest.mark.parametrize("radius", [0.1, 1.0])
-def test_circle_to_polygon_segmentation_never_drops_below_min_vertices(
+@pytest.mark.parametrize("radius", [0.1, 1.0, 50.0, 100.0, 1_000.0])
+def test_circle_to_polygon_segmentation_stays_within_one_pixel(
     *, radius: float
 ) -> None:
     coords = labelme2coco._circle_to_polygon_segmentation(
-        center=(0.0, 0.0), edge=(radius, 0.0)
+        center=(3.0, -2.0), edge=(3.0 + radius, -2.0)
     )
-    n_vertices = len(coords) // 2
-    assert n_vertices >= _CIRCLE_MIN_VERTEX_COUNT
-
-
-def test_circle_to_polygon_segmentation_radius_100_stays_within_one_pixel() -> None:
-    radius = 100.0
-    coords = labelme2coco._circle_to_polygon_segmentation(
-        center=(0.0, 0.0), edge=(radius, 0.0)
-    )
-    n_vertices = len(coords) // 2
-    # Sagitta of a chord spanning 2*pi/n radians of a circle with this
-    # radius: the maximum distance the chord deviates from the true arc.
-    max_deviation = radius * (1.0 - math.cos(math.pi / n_vertices))
-    assert max_deviation <= 1.0
-
-
-def test_circle_to_polygon_segmentation_refines_large_circles() -> None:
-    radius = 1_000.0
-    coords = labelme2coco._circle_to_polygon_segmentation(
-        center=(0.0, 0.0), edge=(radius, 0.0)
-    )
-    n_vertices = len(coords) // 2
-    assert n_vertices > _CIRCLE_MIN_VERTEX_COUNT
-    refinements = n_vertices // _CIRCLE_MIN_VERTEX_COUNT
-    assert refinements & (refinements - 1) == 0
+    points = np.array(coords).reshape(-1, 2)
+    np.testing.assert_allclose(np.hypot(points[:, 0] - 3.0, points[:, 1] + 2.0), radius)
+    n_vertices = len(points)
+    assert n_vertices >= 12
+    # Sagitta of a chord spanning 2*pi/n radians: the maximum distance the
+    # polygon edge deviates from the true arc.
+    assert radius * (1.0 - math.cos(math.pi / n_vertices)) <= 1.0

--- a/tests/unit/examples/labelme2coco_test.py
+++ b/tests/unit/examples/labelme2coco_test.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import importlib
+import json
 import math
+import subprocess
+import sys
+from pathlib import Path
 
 import numpy as np
+import PIL.Image
 import pytest
 
 pytest.importorskip("pycocotools.mask")
@@ -16,16 +21,49 @@ def test_circle_to_polygon_segmentation_rejects_zero_radius() -> None:
 
 
 @pytest.mark.parametrize("radius", [0.1, 1.0, 50.0, 100.0, 1_000.0])
-def test_circle_to_polygon_segmentation_stays_within_one_pixel(
-    *, radius: float
+def test_labelme2coco_exports_circle_within_one_pixel(
+    *, radius: float, tmp_path: Path
 ) -> None:
-    coords = labelme2coco._circle_to_polygon_segmentation(
-        center=(3.0, -2.0), edge=(3.0 + radius, -2.0)
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    center = (radius + 3.0, radius + 2.0)
+    size = math.ceil(2 * radius + 6)
+    PIL.Image.new("RGB", (size, size)).save(input_dir / "circle.png")
+    (input_dir / "circle.json").write_text(
+        json.dumps(
+            {
+                "imagePath": "circle.png",
+                "shapes": [
+                    {
+                        "label": "circle",
+                        "shape_type": "circle",
+                        "points": [center, (center[0] + radius, center[1])],
+                    }
+                ],
+            }
+        )
     )
+    labels_file = tmp_path / "labels.txt"
+    labels_file.write_text("__ignore__\ncircle\n")
+    output_dir = tmp_path / "output"
+    subprocess.run(
+        [
+            sys.executable,
+            str(Path(labelme2coco.__file__)),
+            str(input_dir),
+            str(output_dir),
+            "--labels",
+            str(labels_file),
+            "--noviz",
+        ],
+        check=True,
+    )
+    exported = json.loads((output_dir / "annotations.json").read_text())
+    (annotation,) = exported["annotations"]
+    (coords,) = annotation["segmentation"]
     points = np.array(coords).reshape(-1, 2)
-    np.testing.assert_allclose(np.hypot(points[:, 0] - 3.0, points[:, 1] + 2.0), radius)
-    n_vertices = len(points)
-    assert n_vertices >= 12
-    # Sagitta of a chord spanning 2*pi/n radians: the maximum distance the
-    # polygon edge deviates from the true arc.
-    assert radius * (1.0 - math.cos(math.pi / n_vertices)) <= 1.0
+    np.testing.assert_allclose(np.linalg.norm(points - center, axis=1), radius)
+    assert len(points) >= 12
+    # A chord is farthest from the circle at its midpoint; include the closing edge.
+    midpoints = (points + np.roll(points, shift=-1, axis=0)) / 2
+    assert np.all(radius - np.linalg.norm(midpoints - center, axis=1) <= 1.0)

--- a/tests/unit/examples/labelme2voc_test.py
+++ b/tests/unit/examples/labelme2voc_test.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Final
 
+import numpy as np
 import PIL.Image
 import pytest
 
@@ -41,7 +42,7 @@ def _write_annotation(directory: Path, /) -> None:
 def _run(
     *extra_args: str, input_dir: Path, output_dir: Path, labels_file: Path
 ) -> None:
-    script = _REPO_ROOT / "examples" / "semantic_segmentation" / "labelme2voc.py"
+    script = _REPO_ROOT / "examples" / "instance_segmentation" / "labelme2voc.py"
     subprocess.run(
         [
             sys.executable,
@@ -72,22 +73,66 @@ def _labels_file(*, tmp_path: Path) -> Path:
     return path
 
 
-def test_labelme2voc_default_writes_visualization_outputs(
-    *, annotated_dir: Path, labels_file: Path, tmp_path: Path
+@pytest.mark.parametrize("noobject", [False, True])
+@pytest.mark.parametrize("nonpy", [False, True])
+@pytest.mark.parametrize("noviz", [False, True])
+def test_labelme2voc_writes_only_requested_outputs(
+    *,
+    annotated_dir: Path,
+    labels_file: Path,
+    tmp_path: Path,
+    noobject: bool,
+    nonpy: bool,
+    noviz: bool,
 ) -> None:
     output_dir = tmp_path / "dataset"
-    _run(input_dir=annotated_dir, output_dir=output_dir, labels_file=labels_file)
+    flags = []
+    if noobject:
+        flags.append("--noobject")
+    if nonpy:
+        flags.append("--nonpy")
+    if noviz:
+        flags.append("--noviz")
+    _run(
+        *flags, input_dir=annotated_dir, output_dir=output_dir, labels_file=labels_file
+    )
 
-    assert (output_dir / "SegmentationClass" / "0001.png").is_file()
-    assert (output_dir / "SegmentationClassNpy" / "0001.npy").is_file()
-    assert (output_dir / "SegmentationClassVisualization" / "0001.jpg").is_file()
-    assert (output_dir / "SegmentationObject" / "0001.png").is_file()
-    assert (output_dir / "SegmentationObjectVisualization" / "0001.jpg").is_file()
+    expected = {"class_names.txt", "JPEGImages/0001.jpg", "SegmentationClass/0001.png"}
+    if not nonpy:
+        expected.add("SegmentationClassNpy/0001.npy")
+    if not noviz:
+        expected.add("SegmentationClassVisualization/0001.jpg")
+    if not noobject:
+        expected.add("SegmentationObject/0001.png")
+        if not nonpy:
+            expected.add("SegmentationObjectNpy/0001.npy")
+        if not noviz:
+            expected.add("SegmentationObjectVisualization/0001.jpg")
+    assert {
+        path.relative_to(output_dir).as_posix()
+        for path in output_dir.rglob("*")
+        if path.is_file()
+    } == expected
+    assert {path.name for path in output_dir.iterdir() if path.is_dir()} == {
+        path.split("/")[0] for path in expected if "/" in path
+    }
 
 
-def test_labelme2voc_noviz_omits_visualization_outputs_only(
+def test_labelme2voc_merges_grouped_shapes_and_keeps_ungrouped_shapes_separate(
     *, annotated_dir: Path, labels_file: Path, tmp_path: Path
 ) -> None:
+    annotation = annotated_dir / "0001.json"
+    record = json.loads(annotation.read_text())
+    record["shapes"] = [
+        dict(label="cat", points=points, group_id=group_id, shape_type="rectangle")
+        for points, group_id in [
+            ([[1, 1], [2, 2]], 7),
+            ([[5, 5], [6, 6]], 7),
+            ([[5, 1], [6, 2]], None),
+            ([[1, 5], [2, 6]], None),
+        ]
+    ]
+    annotation.write_text(json.dumps(record))
     output_dir = tmp_path / "dataset"
     _run(
         "--noviz",
@@ -96,9 +141,16 @@ def test_labelme2voc_noviz_omits_visualization_outputs_only(
         labels_file=labels_file,
     )
 
-    assert not (output_dir / "SegmentationClassVisualization").exists()
-    assert not (output_dir / "SegmentationObjectVisualization").exists()
-    # The visualization flag must not affect the other output groups.
-    assert (output_dir / "SegmentationClass" / "0001.png").is_file()
-    assert (output_dir / "SegmentationClassNpy" / "0001.npy").is_file()
-    assert (output_dir / "SegmentationObject" / "0001.png").is_file()
+    expected = np.zeros((8, 8), dtype=np.uint8)
+    expected[1:3, 1:3] = 1
+    expected[5:7, 5:7] = 1
+    expected[1:3, 5:7] = 2
+    expected[5:7, 1:3] = 3
+    np.testing.assert_array_equal(
+        np.load(output_dir / "SegmentationObjectNpy/0001.npy"), expected
+    )
+    with PIL.Image.open(output_dir / "SegmentationObject/0001.png") as image:
+        np.testing.assert_array_equal(np.asarray(image), expected)
+    np.testing.assert_array_equal(
+        np.load(output_dir / "SegmentationClassNpy/0001.npy"), expected > 0
+    )

--- a/tests/unit/examples/labelme2voc_test.py
+++ b/tests/unit/examples/labelme2voc_test.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+import PIL.Image
+import pytest
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[3]
+
+
+def _write_annotation(directory: Path, /) -> None:
+    img = PIL.Image.new("RGB", (8, 8), color=(0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    record = {
+        "version": "5.0.0",
+        "flags": {},
+        "shapes": [
+            {
+                "label": "cat",
+                "points": [[1, 1], [6, 6]],
+                "group_id": None,
+                "shape_type": "rectangle",
+                "flags": {},
+            }
+        ],
+        "imagePath": "0001.png",
+        "imageData": base64.b64encode(buf.getvalue()).decode("ascii"),
+        "imageHeight": 8,
+        "imageWidth": 8,
+    }
+    (directory / "0001.json").write_text(json.dumps(record))
+
+
+def _run(
+    *extra_args: str, input_dir: Path, output_dir: Path, labels_file: Path
+) -> None:
+    script = _REPO_ROOT / "examples" / "semantic_segmentation" / "labelme2voc.py"
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(input_dir),
+            str(output_dir),
+            "--labels",
+            str(labels_file),
+            *extra_args,
+        ],
+        check=True,
+        cwd=_REPO_ROOT,
+    )
+
+
+@pytest.fixture(name="annotated_dir")
+def _annotated_dir(*, tmp_path: Path) -> Path:
+    directory = tmp_path / "data_annotated"
+    directory.mkdir()
+    _write_annotation(directory)
+    return directory
+
+
+@pytest.fixture(name="labels_file")
+def _labels_file(*, tmp_path: Path) -> Path:
+    path = tmp_path / "labels.txt"
+    path.write_text("__ignore__\n_background_\ncat\n")
+    return path
+
+
+def test_labelme2voc_default_writes_visualization_outputs(
+    *, annotated_dir: Path, labels_file: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "dataset"
+    _run(input_dir=annotated_dir, output_dir=output_dir, labels_file=labels_file)
+
+    assert (output_dir / "SegmentationClass" / "0001.png").is_file()
+    assert (output_dir / "SegmentationClassNpy" / "0001.npy").is_file()
+    assert (output_dir / "SegmentationClassVisualization" / "0001.jpg").is_file()
+    assert (output_dir / "SegmentationObject" / "0001.png").is_file()
+    assert (output_dir / "SegmentationObjectVisualization" / "0001.jpg").is_file()
+
+
+def test_labelme2voc_noviz_omits_visualization_outputs_only(
+    *, annotated_dir: Path, labels_file: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "dataset"
+    _run(
+        "--noviz",
+        input_dir=annotated_dir,
+        output_dir=output_dir,
+        labels_file=labels_file,
+    )
+
+    assert not (output_dir / "SegmentationClassVisualization").exists()
+    assert not (output_dir / "SegmentationObjectVisualization").exists()
+    # The visualization flag must not affect the other output groups.
+    assert (output_dir / "SegmentationClass" / "0001.png").is_file()
+    assert (output_dir / "SegmentationClassNpy" / "0001.npy").is_file()
+    assert (output_dir / "SegmentationObject" / "0001.png").is_file()

--- a/tests/unit/examples/utils_test.py
+++ b/tests/unit/examples/utils_test.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import base64
 import io
+import json
+from pathlib import Path
 from typing import Any
 from typing import Final
 
@@ -163,3 +166,54 @@ def test_decode_img_data_as_rgb_discards_alpha_without_compositing(
     rgba.putalpha(PIL.Image.new("L", rgba.size, 0))
     arr = utils.decode_img_data_as_rgb(_encode_png(rgba))
     np.testing.assert_array_equal(arr, np.asarray(source_rgb))
+
+
+def _write_annotation(directory: Path, /, *, record: dict[str, Any]) -> Path:
+    record.setdefault("shapes", [])
+    path = directory / "ann.json"
+    path.write_text(json.dumps(record))
+    return path
+
+
+def test_load_label_file_embedded_image_data_wins_over_missing_path(
+    *, tmp_path: Path
+) -> None:
+    png_bytes = _encode_png(PIL.Image.new("RGB", (2, 2)))
+    ann_path = _write_annotation(
+        tmp_path,
+        record={
+            "imageData": base64.b64encode(png_bytes).decode("ascii"),
+            # Points at a file that was never created: reading it would
+            # raise, so the embedded bytes must be used instead of falling
+            # through to this.
+            "imagePath": "does-not-exist.png",
+        },
+    )
+    label_file = utils.load_label_file(str(ann_path))
+    assert label_file.image_data == png_bytes
+
+
+def test_load_label_file_resolves_referenced_image_relative_to_json_dir(
+    *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    annotated_dir = tmp_path / "annotated"
+    (annotated_dir / "images").mkdir(parents=True)
+    png_bytes = _encode_png(PIL.Image.new("RGB", (2, 2)))
+    (annotated_dir / "images" / "0001.png").write_bytes(png_bytes)
+    ann_path = _write_annotation(
+        annotated_dir,
+        record={
+            "imageData": None,
+            # Windows-style separator, as labelme itself writes on Windows.
+            "imagePath": "images\\0001.png",
+        },
+    )
+
+    # A cwd unrelated to the annotation proves resolution follows the JSON
+    # file's own directory rather than the process's working directory.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    label_file = utils.load_label_file(str(ann_path))
+    assert label_file.image_data == png_bytes


### PR DESCRIPTION
Keep the standalone VOC and COCO converters easy to adapt while preserving optional output controls and grouped-instance behavior.

Circle export now picks its vertex count by doubling from 12 until the chord-to-arc deviation is within one pixel. The previous closed-form count floored the result and slightly exceeded the tolerance (about 1.01 to 1.09 px for radii of 50 px and up), so circles of that size gain vertices. For example, radius 2,000 changes from 99 to 192 vertices (+94%), and radius 10,000 changes from 222 to 384 (+73%).

Validation: VOC output on `tests/data/annotated` is byte-identical to `main`, and COCO output differs only in the creation timestamp. 36 exporter tests pass with pycocotools installed; CI now installs it before pytest on the non-Windows legs so the COCO tests execute there instead of skipping. The circle accuracy test reads the real CLI’s exported JSON and checks every edge, including the closing edge; it rejects both a semicircle mutation and the old floor-rounding defect. `make lint` passes with an existing unused-type-ignore warning on the optional pycocotools import.

Stack 2/8. Prerequisite #2616 is merged. Next: #2618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EEs8Vh1FEmZiiwJL36AfR