### PR TITLE
refactor: use point arithmetic for canvas coordinate conversion

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1784,9 +1784,7 @@ class Canvas(QtWidgets.QWidget):
 
     def transform_widget_point_to_image(self, point: QPointF, /) -> QPointF:
         origin = self._compute_image_origin_offset(area=None)
-        image_x = point.x() / self.scale - origin.x()
-        image_y = point.y() / self.scale - origin.y()
-        return QPointF(image_x, image_y)
+        return point / self.scale - origin
 
     def transform_image_point_to_widget(
         self, point: QPointF, /, *, area: QtCore.QSize | None = None

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -64,6 +64,35 @@ def test_setting_unchanged_scale_still_resizes_canvas(*, canvas: Canvas) -> None
 
 
 @pytest.mark.gui
+@pytest.mark.parametrize(
+    ("scale", "area", "pan", "widget_point", "image_point"),
+    [
+        (2.0, QSize(500, 300), QPointF(17, -11), QPointF(207, 149), QPointF(20, 30)),
+        (2.0, QSize(80, 40), QPointF(-7, 3), QPointF(33, 63), QPointF(20, 30)),
+        (1.25, QSize(160, 70), QPointF(5.5, -2.25), QPointF(48, 39), QPointF(20, 30)),
+        (0.5, QSize(100, 50), QPointF(), QPointF(-20, -30), QPointF(-90, -85)),
+    ],
+)
+def test_transform_widget_point_to_image(
+    *,
+    canvas: Canvas,
+    scale: float,
+    area: QSize,
+    pan: QPointF,
+    widget_point: QPointF,
+    image_point: QPointF,
+) -> None:
+    canvas.scale = scale
+    canvas.resize(area)
+    canvas._view_offset = pan
+
+    actual = canvas.transform_widget_point_to_image(widget_point)
+
+    assert actual.x() == pytest.approx(image_point.x())
+    assert actual.y() == pytest.approx(image_point.y())
+
+
+@pytest.mark.gui
 def test_propose_ai_shapes_passes_rgb_image_to_model(
     *,
     canvas: Canvas,


### PR DESCRIPTION
Use QPointF division and subtraction for widget-to-image coordinates, replacing duplicate x/y calculations while retaining the existing image-space origin calculation.

Add four explicit coordinate cases covering centering, a viewport smaller than the image, fractional zoom and pan, and points outside the image.

Validation: all four new cases pass on both the base and the refactor; the full suite passes (1,444 passed, 7 skipped), and `make lint` passes. Independent standards and behavior reviews checked the committed change.

Next dependent PR: #2620.
