### PR TITLE
fix: validate configuration values before constructing widgets

### DIFF
--- a/changelog.d/2621.fixed.md
+++ b/changelog.d/2621.fixed.md
@@ -1,0 +1,1 @@
+Reject malformed configuration values before they reach desktop controls, and accept integer values for numeric settings such as `epsilon`.

--- a/labelme/_config/__init__.py
+++ b/labelme/_config/__init__.py
@@ -18,22 +18,69 @@ __all__ = ["get_user_config_file", "load_config", "set_overrides"]
 here = Path(__file__).resolve().parent
 
 
+def _validate_leaf_type(
+    *, key_path: tuple[str, ...], value: object, default: object
+) -> None:
+    if key_path == ("canvas", "double_click"):
+        valid = value is None or isinstance(value, str)
+        expected = "str or null"
+    elif key_path[0] == "shortcuts":
+        valid = (
+            value is None
+            or isinstance(value, str)
+            or (isinstance(value, list) and all(isinstance(key, str) for key in value))
+        )
+        expected = "a string, a list of strings, or null"
+    elif default is None:
+        nullable_types: dict[tuple[str, ...], type] = {
+            ("file_search",): str,
+            ("language",): str,
+            ("flags",): list,
+            ("label_flags",): dict,
+            ("labels",): list,
+            ("shape_color", "by_label", "colors"): dict,
+            ("validate_label",): str,
+        }
+        allowed = nullable_types.get(key_path)
+        valid = value is None or (allowed is not None and isinstance(value, allowed))
+        expected = "null" if allowed is None else f"{allowed.__name__} or null"
+    else:
+        expected_type = type(default)
+        valid = type(value) is expected_type
+        expected = expected_type.__name__
+    if not valid:
+        name = ".".join(key_path)
+        raise ValueError(
+            f"Config key {name!r} must be {expected}, "
+            f"but got {type(value).__name__}: {value!r}"
+        )
+
+
 def _update_dict(
     *,
     target_dict: dict[str, object],
+    defaults: dict[str, object],
     new_dict: dict[str, object],
     key_path: tuple[str, ...],
 ) -> None:
     for key, value in new_dict.items():
         item_path = (*key_path, key)
-        _validate_config_item(key_path=item_path, value=value)
-        if key not in target_dict:
+        if key not in defaults:
             raise ValueError(f"Unexpected key in config: {key}")
-        if not isinstance(target_dict[key], dict):
+        default = defaults[key]
+        if not isinstance(default, dict):
+            if (
+                isinstance(default, float)
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+            ):
+                value = float(value)
+            _validate_leaf_type(key_path=item_path, value=value, default=default)
+            _validate_config_item(key_path=item_path, value=value)
             target_dict[key] = value
             continue
 
-        # target_dict[key] is a section, so the override must be a mapping.
+        # Nested default mappings define sections; nullable mappings are values.
         if value is None:
             # An empty section (e.g. a bare `shortcuts:`) keeps its defaults
             # instead of wiping the whole section.
@@ -48,6 +95,7 @@ def _update_dict(
             )
         _update_dict(
             target_dict=cast(dict[str, object], target_dict[key]),
+            defaults=cast(dict[str, object], default),
             new_dict=cast(dict[str, object], value),
             key_path=item_path,
         )
@@ -55,8 +103,49 @@ def _update_dict(
 
 def _validate_config_item(*, key_path: tuple[str, ...], value: object) -> None:
     MASK_POLYGONIZATION_DETAIL_MAX: Final = 100
+    RGBA_CHANNEL_COUNT: Final = 4
+    RGBA_CHANNEL_MAX: Final = 255
+    enum_values: dict[tuple[str, ...], set[object]] = {
+        ("canvas", "double_click"): {None, "close"},
+        ("color_theme",): {"system", "light", "dark"},
+        ("label_completion",): {"startswith", "contains"},
+        ("validate_label",): {None, "exact"},
+    }
 
     key = key_path[-1]
+    if key_path in enum_values and value not in enum_values[key_path]:
+        choices = sorted(map(repr, enum_values[key_path]))
+        raise ValueError(
+            f"Unexpected value for config key {'.'.join(key_path)!r}: {value!r}; "
+            f"expected one of {', '.join(choices)}"
+        )
+    if key_path == ("canvas", "num_backups") and (
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+    ):
+        raise ValueError("canvas.num_backups must be a positive integer")
+    if key_path == ("label_flags",) and value is not None:
+        assert isinstance(value, dict)
+        if any(
+            not isinstance(pattern, str)
+            or not isinstance(flags, list)
+            or any(not isinstance(flag, str) for flag in flags)
+            for pattern, flags in value.items()
+        ):
+            raise ValueError("label_flags must map string patterns to lists of strings")
+    if key_path[0] == "shape" and key.endswith("_color"):
+        if not (
+            isinstance(value, list)
+            and len(value) == RGBA_CHANNEL_COUNT
+            and all(
+                isinstance(channel, int)
+                and not isinstance(channel, bool)
+                and 0 <= channel <= RGBA_CHANNEL_MAX
+                for channel in value
+            )
+        ):
+            raise ValueError(
+                f"{'.'.join(key_path)} must be a list of four integers from 0 to 255"
+            )
     if key_path == ("mask_polygonization", "detail") and (
         isinstance(value, bool)
         or not isinstance(value, int)
@@ -66,17 +155,17 @@ def _validate_config_item(*, key_path: tuple[str, ...], value: object) -> None:
             "mask_polygonization.detail must be an integer between 0 and 100, "
             f"but got {value!r}"
         )
-    if key == "validate_label" and value not in [None, "exact"]:
-        raise ValueError(f"Unexpected value for config key 'validate_label': {value}")
-    if key != "labels" or value is None:
+    if key not in {"flags", "labels"} or value is None:
         return
     if not isinstance(value, list):
         raise ValueError(
-            f"Config key 'labels' must be a list, "
+            f"Config key {key!r} must be a list, "
             f"but got {type(value).__name__}: {value!r}"
         )
+    if any(not isinstance(entry, str) for entry in value):
+        raise ValueError(f"Each {key[:-1]} must be a string: {value}")
     if len(value) != len(set(value)):
-        raise ValueError(f"Duplicates are detected for config key 'labels': {value}")
+        raise ValueError(f"Duplicates are detected for config key {key!r}: {value}")
 
 
 def _migrate_config_from_file(*, config_from_yaml: dict) -> None:
@@ -187,7 +276,8 @@ def get_user_config_file(*, create_if_missing: bool = True) -> str:
 def load_config(*, config_file: Path | None, config_overrides: dict) -> dict:
     config: dict
     with open(here / "default_config.yaml", encoding="utf-8") as f:
-        config = _yaml.safe_load(f)
+        defaults = _yaml.safe_load(f)
+    config = copy.deepcopy(defaults)
 
     if config_file is not None:
         with open(config_file, encoding="utf-8") as f:
@@ -196,13 +286,21 @@ def load_config(*, config_file: Path | None, config_overrides: dict) -> dict:
             _migrate_config_from_file(config_from_yaml=config_from_yaml)
             if "shape_color" in config_from_yaml:
                 validate_shape_color(config=config_from_yaml["shape_color"])
-            _update_dict(target_dict=config, new_dict=config_from_yaml, key_path=())
+            _update_dict(
+                target_dict=config,
+                defaults=defaults,
+                new_dict=config_from_yaml,
+                key_path=(),
+            )
 
     config_overrides = copy.deepcopy(config_overrides)
+    _migrate_config_from_file(config_from_yaml=config_overrides)
     migrate_shape_color(config=config_overrides)
     if "shape_color" in config_overrides:
         validate_shape_color(config=config_overrides["shape_color"])
-    _update_dict(target_dict=config, new_dict=config_overrides, key_path=())
+    _update_dict(
+        target_dict=config, defaults=defaults, new_dict=config_overrides, key_path=()
+    )
 
     if not config["labels"] and config["validate_label"]:
         raise ValueError("labels must be specified when validate_label is enabled")

--- a/tests/e2e/config_test.py
+++ b/tests/e2e/config_test.py
@@ -51,18 +51,22 @@ def test_MainWindow_config(
 
 
 @pytest.mark.gui
+@pytest.mark.parametrize(
+    "config_text",
+    ["auto_save: [unclosed\n", "ai:\n  default: true\n"],
+    ids=["malformed-yaml", "invalid-leaf-type"],
+)
 def test_MainWindow_config_load_error_falls_back(
     *,
     main_win: MainWinFactory,
     qtbot: QtBot,
     tmp_path: Path,
     pause: bool,
+    config_text: str,
 ) -> None:
-    # Malformed YAML makes load_config raise a non-ValueError (a yaml
-    # ParserError); the backstop must catch any such error and fall back to
-    # defaults instead of crashing the app before the window opens.
+    # Any invalid config must fall back before downstream widgets consume it.
     config_file = tmp_path / "labelmerc.yaml"
-    config_file.write_text("auto_save: [unclosed\n")
+    config_file.write_text(config_text)
 
     win = main_win(config_file=config_file)
 

--- a/tests/unit/_config/api_test.py
+++ b/tests/unit/_config/api_test.py
@@ -61,6 +61,27 @@ def test_migrate_removes_logger_level(*, tmp_path: Path) -> None:
     assert "logger_level" not in config
 
 
+@pytest.mark.parametrize("language", [None, "en_US", "ja_JP", "xx_ZZ"])
+@pytest.mark.parametrize("source", ["file", "override"])
+def test_load_config_preserves_language(
+    *, tmp_path: Path, language: str | None, source: str
+) -> None:
+    config_file = None
+    overrides = {"language": language}
+    if source == "file":
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(json.dumps(overrides))
+        overrides = {}
+    config = _config.load_config(config_file=config_file, config_overrides=overrides)
+    assert config["language"] == language
+
+
+@pytest.mark.parametrize("language", [True, 1, [], {}])
+def test_load_config_rejects_non_string_language(*, language: object) -> None:
+    with pytest.raises(ValueError, match="Config key 'language' must be str or null"):
+        _config.load_config(config_file=None, config_overrides={"language": language})
+
+
 @pytest.mark.parametrize(
     "input_name, expected_name",
     [
@@ -84,15 +105,24 @@ def test_migrate_tolerates_non_string_ai_default(*, model_name: object) -> None:
     assert config["ai"]["default"] == model_name
 
 
-def test_load_config_keeps_other_keys_when_ai_default_is_not_a_string(
+def test_load_config_rejects_ai_default_that_is_not_a_string(
     *,
     tmp_path: Path,
 ) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text("labels:\n  - cat\n  - dog\nai:\n  default: true\n")
+    with pytest.raises(ValueError, match="Config key 'ai.default' must be str"):
+        _config.load_config(config_file=config_file, config_overrides={})
+
+
+def test_load_config_keeps_settings_with_unknown_ai_default(*, tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("auto_save: false\nai:\n  default: Unknown Model\n")
+
     config = _config.load_config(config_file=config_file, config_overrides={})
-    assert config["ai"]["default"] is True
-    assert config["labels"] == ["cat", "dog"]
+
+    assert config["auto_save"] is False
+    assert config["ai"]["default"] == "Unknown Model"
 
 
 @pytest.mark.parametrize("value", [-1, 101, True, "80"])
@@ -103,9 +133,86 @@ def test_load_config_rejects_invalid_polygon_detail(
     config_file.write_text(f"mask_polygonization:\n  detail: {json.dumps(value)}\n")
 
     with pytest.raises(
-        ValueError, match=r"mask_polygonization\.detail must be an integer"
+        ValueError, match=r"mask_polygonization\.detail.*(?:int|integer)"
     ):
         _config.load_config(config_file=config_file, config_overrides={})
+
+
+@pytest.mark.parametrize(
+    ("config_text", "key_name", "expected_type"),
+    [
+        ('auto_save: "false"\n', "auto_save", "bool"),
+        ('epsilon: "10.0"\n', "epsilon", "float"),
+        ("epsilon: true\n", "epsilon", "float"),
+        ('canvas:\n  num_backups: "10"\n', "canvas.num_backups", "int"),
+        ("file_search: true\n", "file_search", "str or null"),
+    ],
+)
+def test_load_config_rejects_wrong_scalar_type(
+    *, tmp_path: Path, config_text: str, key_name: str, expected_type: str
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(config_text)
+
+    with pytest.raises(
+        ValueError, match=f"Config key {key_name!r} must be {expected_type}"
+    ):
+        _config.load_config(config_file=config_file, config_overrides={})
+
+
+@pytest.mark.parametrize("source", ["file", "override"])
+def test_load_config_normalizes_integer_epsilon(*, tmp_path: Path, source: str) -> None:
+    config_file = None
+    config_overrides = {}
+    if source == "file":
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("epsilon: 10\n")
+    else:
+        config_overrides = {"epsilon": 10}
+
+    config = _config.load_config(
+        config_file=config_file,
+        config_overrides=config_overrides,
+    )
+
+    assert config["epsilon"] == 10.0
+    assert isinstance(config["epsilon"], float)
+
+
+@pytest.mark.parametrize(
+    ("config_text", "key_name"),
+    [
+        ("label_completion: anywhere\n", "label_completion"),
+        ("color_theme: sepia\n", "color_theme"),
+        ("canvas:\n  double_click: save\n", "canvas.double_click"),
+    ],
+)
+def test_load_config_rejects_invalid_enum(
+    *, tmp_path: Path, config_text: str, key_name: str
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(config_text)
+
+    with pytest.raises(
+        ValueError, match=f"Unexpected value for config key {key_name!r}"
+    ):
+        _config.load_config(config_file=config_file, config_overrides={})
+
+
+@pytest.mark.parametrize("num_backups", [-1, 0])
+def test_load_config_rejects_invalid_canvas_backup_count(*, num_backups: int) -> None:
+    with pytest.raises(ValueError, match="canvas.num_backups must be"):
+        _config.load_config(
+            config_file=None,
+            config_overrides={"canvas": {"num_backups": num_backups}},
+        )
+
+
+def test_load_config_accepts_disabled_canvas_double_click() -> None:
+    config = _config.load_config(
+        config_file=None, config_overrides={"canvas": {"double_click": None}}
+    )
+    assert config["canvas"]["double_click"] is None
 
 
 _POLYGON_TO_SHAPE_RENAMES: Final = {
@@ -310,7 +417,7 @@ def test_migrate_keep_prev_brightness_contrast(
         ),
         ({"shape_color": "random"}, "Unexpected value for config key 'shape_color'"),
         ({"labels": ["cat", "cat"]}, "Duplicates are detected for config key 'labels'"),
-        ({"labels": "cat"}, "Config key 'labels' must be a list, but got str"),
+        ({"labels": "cat"}, "Config key 'labels' must be list or null"),
         ({"not_a_real_key": True}, "Unexpected key in config: not_a_real_key"),
         (
             {"shortcuts": {"not_a_real_shortcut": "Ctrl+Z"}},
@@ -329,6 +436,72 @@ def test_migrate_keep_prev_brightness_contrast(
 def test_load_config_rejects_invalid_override(*, overrides: dict, message: str) -> None:
     with pytest.raises(ValueError, match=message):
         _config.load_config(config_file=None, config_overrides=overrides)
+
+
+@pytest.mark.parametrize("label", [None, False, 1, 1.0, [], {}])
+def test_load_config_rejects_non_string_label(*, label: object) -> None:
+    with pytest.raises(ValueError, match="Each label must be a string"):
+        _config.load_config(
+            config_file=None,
+            config_overrides={"labels": ["cat", label]},
+        )
+
+
+@pytest.mark.parametrize("flag", [None, False, 1, 1.0, [], {}])
+def test_load_config_rejects_non_string_flag(*, flag: object) -> None:
+    with pytest.raises(ValueError, match="Each flag must be a string"):
+        _config.load_config(
+            config_file=None,
+            config_overrides={"flags": ["occluded", flag]},
+        )
+
+
+@pytest.mark.parametrize(
+    "label_flags",
+    [
+        {1: ["occluded"]},
+        {"cat": "occluded"},
+        {"cat": ["occluded", 1]},
+    ],
+)
+def test_load_config_rejects_malformed_label_flags(*, label_flags: dict) -> None:
+    with pytest.raises(ValueError, match="label_flags must map"):
+        _config.load_config(
+            config_file=None,
+            config_overrides={"label_flags": label_flags},
+        )
+
+
+@pytest.mark.parametrize(
+    "color",
+    [[0, 0, 0], [0, 0, 0, 256], [0, 0, 0, True], "black"],
+)
+def test_load_config_rejects_invalid_shape_rgba(*, color: object) -> None:
+    with pytest.raises(ValueError, match="shape.line_color.*list"):
+        _config.load_config(
+            config_file=None,
+            config_overrides={"shape": {"line_color": color}},
+        )
+
+
+@pytest.mark.parametrize(
+    ("config_text", "labels"),
+    [
+        ("labels: null\n", None),
+        ("labels: []\n", []),
+        ('labels: [""]\n', [""]),
+    ],
+)
+def test_load_config_accepts_compatible_labels(
+    *, tmp_path: Path, config_text: str, labels: list[str] | None
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(config_text)
+    config = _config.load_config(
+        config_file=config_file,
+        config_overrides={},
+    )
+    assert config["labels"] == labels
 
 
 def test_load_config_requires_labels_when_validate_label_enabled() -> None:
@@ -542,3 +715,26 @@ def test_load_config_rejects_invalid_shape_color(
             config_file=None,
             config_overrides={"shape_color": shape_color},
         )
+
+
+@pytest.mark.parametrize(
+    ("key", "saved", "override"),
+    [
+        ("language", "ja_JP", None),
+        ("flags", ["occluded"], None),
+        ("label_flags", {"cat": ["occluded"]}, None),
+        ("label_flags", {"cat": ["occluded"]}, {"dog": ["hidden"]}),
+    ],
+)
+def test_load_config_overrides_nullable_values_using_default_types(
+    *, tmp_path: Path, key: str, saved: object, override: object
+) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(json.dumps({key: saved, "canvas": {"num_backups": 12}}))
+    config = _config.load_config(
+        config_file=config_file,
+        config_overrides={key: override, "canvas": {"double_click": None}},
+    )
+    assert config[key] == override
+    assert config["canvas"]["num_backups"] == 12
+    assert config["canvas"]["double_click"] is None

--- a/tests/unit/widgets/settings_dialog_test.py
+++ b/tests/unit/widgets/settings_dialog_test.py
@@ -429,7 +429,8 @@ def test_navigation_elides_long_localized_names_without_squeezing_content(
             qtbot=qtbot, applied=applied, overrides={}, succeed=True, previewed=None
         )
         navigation = dialog._page._navigation
-        long_title = "Продолжение работы между изображениями"
+        long_title = translator.translate("SettingsDialog", "Continue between images")
+        assert long_title and long_title != "Continue between images"
 
         assert navigation.item(3).text() == long_title
         assert navigation.item(3).toolTip() == long_title


### PR DESCRIPTION
Reject invalid configuration values before constructing widgets. Validate overrides against the default schema so a saved language can be reset to the system default and nullable settings can be cleared after loading a file.

After restacking, the combined stack passed 1,549 tests (7 skipped), full lint, 36 exporter tests, and all example CI commands.

Stacked on #2620; review that PR first. Next: #2622. Stack starts at #2627.
