### PR TITLE
refactor: isolate mask painting and shape outlines

### DIFF
--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -309,7 +309,7 @@ def _build_shape_points_paths(
     points = shape.points
     if shape.shape_type in ["rectangle", "mask"]:
         assert len(points) in [1, 2]
-        paths.line.addPath(_build_two_point_shape_path(shape=shape, scale=scale))
+        paths.line.addPath(_build_two_point_outline(shape=shape, scale=scale))
         if shape.shape_type == "rectangle":
             for i in range(len(points)):
                 _build_shape_point_path(
@@ -344,7 +344,7 @@ def _build_shape_points_paths(
                 )
     elif shape.shape_type == "circle":
         assert len(points) in [1, 2]
-        paths.line.addPath(_build_two_point_shape_path(shape=shape, scale=scale))
+        paths.line.addPath(_build_two_point_outline(shape=shape, scale=scale))
         for i in range(len(points)):
             _build_shape_point_path(
                 path=paths.vertices, shape=shape, context=context, vertex_index=i
@@ -395,40 +395,30 @@ def is_hit_by_point(
             return False
         return bool(np.linalg.norm(point - shape.points[0]) <= point_size / 2 / scale)
     if shape.mask is not None:
-        raw_y = int(round(float(point[1]) - float(shape.points[0][1])))
-        raw_x = int(round(float(point[0]) - float(shape.points[0][0])))
-        if (
-            raw_y < 0
-            or raw_y >= shape.mask.shape[0]
-            or raw_x < 0
-            or raw_x >= shape.mask.shape[1]
-        ):
-            return False
-        return bool(shape.mask[raw_y, raw_x])
-    return _build_image_path(shape=shape).contains(QtCore.QPointF(*point))
+        return _hits_mask_pixel(shape=shape, point=point)
+    return _build_outline_path(shape=shape).contains(QtCore.QPointF(*point))
 
 
 def bounds(*, shape: Shape) -> QtCore.QRectF:
-    return _build_image_path(shape=shape).boundingRect()
+    return _build_outline_path(shape=shape).boundingRect()
 
 
-def _build_image_path(*, shape: Shape) -> QtGui.QPainterPath:
+def _build_outline_path(*, shape: Shape) -> QtGui.QPainterPath:
     points = shape.points
-    out = QtGui.QPainterPath()
+    path = QtGui.QPainterPath()
     if shape.shape_type in ("rectangle", "mask", "circle"):
-        out.addPath(_build_two_point_shape_path(shape=shape, scale=1.0))
+        path.addPath(_build_two_point_outline(shape=shape, scale=1.0))
     elif shape.shape_type == "oriented_rectangle":
         if len(points) == ORIENTED_RECTANGLE_POINT_COUNT:
-            out.moveTo(QtCore.QPointF(*points[0]))
-            for p in points[1:]:
-                out.lineTo(QtCore.QPointF(*p))
-            out.lineTo(QtCore.QPointF(*points[0]))
-    else:
-        if len(points) > 0:
-            out.moveTo(QtCore.QPointF(*points[0]))
-            for p in points[1:]:
-                out.lineTo(QtCore.QPointF(*p))
-    return out
+            path.moveTo(QtCore.QPointF(*points[0]))
+            for point in points[1:]:
+                path.lineTo(QtCore.QPointF(*point))
+            path.lineTo(QtCore.QPointF(*points[0]))
+    elif len(points) > 0:
+        path.moveTo(QtCore.QPointF(*points[0]))
+        for point in points[1:]:
+            path.lineTo(QtCore.QPointF(*point))
+    return path
 
 
 def _build_rect_between(
@@ -439,9 +429,9 @@ def _build_rect_between(
     return QtCore.QRectF(x0, y0, x1 - x0, y1 - y0)
 
 
-def _build_two_point_shape_path(*, shape: Shape, scale: float) -> QtGui.QPainterPath:
-    # A rectangle, a Mask Shape's bounding box, and a circle are each fully
-    # described by two points, so one image-space rect covers all three.
+def _build_two_point_outline(*, shape: Shape, scale: float) -> QtGui.QPainterPath:
+    # A rectangle, a mask shape's bounding box, and a circle are each fully
+    # described by two points, so one image-space path shape covers all three.
     path = QtGui.QPainterPath()
     if shape.shape_type == "circle" and len(shape.points) == CIRCLE_POINT_COUNT:
         center, rim = shape.points
@@ -456,3 +446,12 @@ def _build_two_point_shape_path(*, shape: Shape, scale: float) -> QtGui.QPainter
         corner, opposite = shape.points
         path.addRect(_build_rect_between(corner=corner, opposite=opposite))
     return QtGui.QTransform.fromScale(scale, scale).map(path)
+
+
+def _hits_mask_pixel(*, shape: Shape, point: npt.NDArray[np.float64]) -> bool:
+    assert shape.mask is not None
+    row = int(round(float(point[1]) - float(shape.points[0][1])))
+    col = int(round(float(point[0]) - float(shape.points[0][0])))
+    if row < 0 or row >= shape.mask.shape[0] or col < 0 or col >= shape.mask.shape[1]:
+        return False
+    return bool(shape.mask[row, col])

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -96,7 +96,7 @@ def render_shape(
     painter.setPen(QtGui.QPen(color, _OUTLINE_WIDTH, context.line_style))
 
     if shape.shape_type == "mask" and shape.mask is not None:
-        _paint_shape_mask(painter=painter, shape=shape, context=context)
+        _paint_mask(painter=painter, shape=shape, context=context)
 
     if len(shape.points) > 0:
         _paint_shape_points(painter=painter, shape=shape, context=context)
@@ -122,40 +122,41 @@ def _paint_label(
     )
 
 
-def _paint_shape_mask(
-    *,
-    painter: QtGui.QPainter,
-    shape: Shape,
-    context: ShapeRenderContext,
+def _paint_mask(
+    *, painter: QtGui.QPainter, shape: Shape, context: ShapeRenderContext
 ) -> None:
     assert shape.mask is not None
-    fill = context.palette.select_fill if context.selected else context.palette.fill
-    image_to_draw = np.zeros(shape.mask.shape + (4,), dtype=np.uint8)
-    image_to_draw[shape.mask] = fill.getRgb()
-    qimage = QtGui.QImage.fromData(_utils.img_arr_to_data(image_to_draw))
     origin = shape.points[0]
-    target_top_left = origin * context.scale
-    target_rect = QtCore.QRectF(
-        target_top_left[0],
-        target_top_left[1],
-        qimage.width() * context.scale,
-        qimage.height() * context.scale,
+    fill_color = (
+        context.palette.select_fill if context.selected else context.palette.fill
     )
-    painter.drawImage(target_rect, qimage)
 
-    # Pad so a region touching the mask border still has a background ring to
-    # close its contour against; the resulting offset is removed below.
+    rgba = np.zeros(shape.mask.shape + (4,), dtype=np.uint8)
+    rgba[shape.mask] = fill_color.getRgb()
+    bitmap = QtGui.QImage.fromData(_utils.img_arr_to_data(rgba))
+    top_left = origin * context.scale
+    painter.drawImage(
+        QtCore.QRectF(
+            top_left[0],
+            top_left[1],
+            bitmap.width() * context.scale,
+            bitmap.height() * context.scale,
+        ),
+        bitmap,
+    )
+
+    # Pad the mask so a True region touching its border still has a false
+    # ring to close a contour against; the pad offset is subtracted back out.
     PAD: Final[int] = 1
-    outline = QtGui.QPainterPath()
+    contour_path = QtGui.QPainterPath()
     for contour in skimage.measure.find_contours(np.pad(shape.mask, pad_width=PAD)):
-        # Contours come as (row, col) and stay in image space here so the whole
-        # outline can be scaled in one step below.
-        points_xy = contour[:, ::-1] - PAD + origin
-        outline.addPolygon(
-            QtGui.QPolygonF([QtCore.QPointF(x, y) for x, y in points_xy])
-        )
-    to_widget = QtGui.QTransform.fromScale(context.scale, context.scale)
-    painter.drawPath(to_widget.map(outline))
+        # skimage yields (row, col); flip to (x, y) and drop the pad, staying
+        # in image space so the whole contour can be scaled together below.
+        xy = contour[:, ::-1] - PAD + origin
+        contour_path.addPolygon(QtGui.QPolygonF([QtCore.QPointF(x, y) for x, y in xy]))
+    painter.drawPath(
+        QtGui.QTransform.fromScale(context.scale, context.scale).map(contour_path)
+    )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -102,27 +102,23 @@ def render_shape(
         _paint_shape_points(painter=painter, shape=shape, context=context)
 
     if context.show_label:
-        _paint_shape_label(painter=painter, shape=shape, context=context)
+        _paint_label(painter=painter, shape=shape, context=context)
 
 
-def _paint_shape_label(
-    *,
-    painter: QtGui.QPainter,
-    shape: Shape,
-    context: ShapeRenderContext,
+def _paint_label(
+    *, painter: QtGui.QPainter, shape: Shape, context: ShapeRenderContext
 ) -> None:
     if not shape.label or len(shape.points) == 0:
         return
-    # Anchor at the points' top-left so the text stays close to the shape and
-    # tracks zoom/pan; lift it by the outline width to clear the stroke.
-    top_left = shape.points.min(axis=0) * context.scale
-    text = shape.label
-    if shape.group_id is not None:
-        text += f" ({shape.group_id})"
+    text = (
+        shape.label if shape.group_id is None else f"{shape.label} ({shape.group_id})"
+    )
+    # Anchor at the points' top-left corner so the label stays close to the
+    # shape and tracks pan/zoom; lift it above the outline stroke.
+    anchor = shape.points.min(axis=0) * context.scale
     painter.setPen(QtGui.QPen(context.palette.line))
     painter.drawText(
-        QtCore.QPointF(float(top_left[0]), float(top_left[1]) - _OUTLINE_WIDTH),
-        text,
+        QtCore.QPointF(float(anchor[0]), float(anchor[1]) - _OUTLINE_WIDTH), text
     )
 
 


### PR DESCRIPTION
Keep mask pixel picking, contour painting, label anchors, and outline bounds in focused rendering helpers.

Review 3 of 7. After #2628. Next: #2630.

Validation: full test suite — 1,428 passed, 7 skipped; Ruff and type checks passed.

Focused test: `uv run pytest -q tests/unit/widgets/_shape_render_test.py`.

Manual check: Open a mask annotation, toggle labels, and zoom; the contour, filled mask, and label anchor should stay aligned.

