### PR TITLE
refactor: express drawing closure as per-mode point thresholds

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1364,10 +1364,6 @@ class Canvas(QtWidgets.QWidget):
             return False
         if self._current is None:
             return False
-        if self.create_mode == "ai_points_to_shape":
-            return True
-        if self.create_mode == "linestrip":
-            return len(self._current.points) >= MIN_LINESTRIP_POINT_COUNT
         if self.create_mode == "oriented_rectangle":
             # Points 2 and 3 are seeded as duplicates of points 1 and 0 after
             # the first edge is locked; mouse movement reprojects them. Treat
@@ -1376,7 +1372,11 @@ class Canvas(QtWidgets.QWidget):
                 len(self._current.points) == ORIENTED_RECTANGLE_POINT_COUNT
                 and self._current.points[2] != self._current.points[1]
             )
-        return len(self._current.points) >= MIN_POLYGON_POINT_COUNT
+        minimum_points = {
+            "ai_points_to_shape": 0,
+            "linestrip": MIN_LINESTRIP_POINT_COUNT,
+        }.get(self.create_mode, MIN_POLYGON_POINT_COUNT)
+        return len(self._current.points) >= minimum_points
 
     def mouseDoubleClickEvent(self, _a0: QtGui.QMouseEvent, /) -> None:
         if self._double_click != "close":

--- a/tests/unit/widgets/_canvas_interaction/canvas_test.py
+++ b/tests/unit/widgets/_canvas_interaction/canvas_test.py
@@ -478,6 +478,31 @@ def test_right_menu_failure_restores_origin_and_preserves_preview(
     assert canvas._selected_shapes_copy == [preview]
 
 
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("create_mode", "points", "expected"),
+    [
+        ("ai_points_to_shape", (), True),
+        ("linestrip", (QPointF(),), False),
+        ("linestrip", (QPointF(), QPointF(1, 1)), True),
+        ("polygon", (QPointF(), QPointF(1, 0)), False),
+        ("polygon", (QPointF(), QPointF(1, 0), QPointF(1, 1)), True),
+    ],
+)
+def test_can_close_shape_uses_mode_point_requirement(
+    *,
+    canvas: Canvas,
+    create_mode: str,
+    points: tuple[QPointF, ...],
+    expected: bool,
+) -> None:
+    canvas.set_editing(value=False)
+    canvas.create_mode = create_mode
+    canvas._current = _DraftShape(points=points)
+
+    assert canvas._can_close_shape() is expected
+
+
 # ---------------------------------------------------------------------------
 # Vertex hover-highlight + snapping parity across zoom (scale) levels
 #


### PR DESCRIPTION
Keep close-eligibility consistent across Enter/Space, double-click, and status guidance by expressing mode-specific point requirements with one threshold comparison. The existing edit-mode, empty-draft, and oriented-rectangle rules are preserved.

Validation on `18fde87a`: full offscreen suite, 1,440 passed and 7 skipped; `make lint` passed. The five added regression cases pass on both main (`eadc5668`) and this head. A separate comparison across 144 states covering all drawing modes found identical predicate results.

Next in the stack: #2619.
