### PR TITLE
fix: refit images after canvas layout changes

### DIFF
--- a/changelog.d/2634.fixed.md
+++ b/changelog.d/2634.fixed.md
@@ -1,1 +1,0 @@
-Keep Fit to Window and Fit to Width aligned with the available canvas when opening images, resizing the layout, and navigating between images.

--- a/changelog.d/2634.fixed.md
+++ b/changelog.d/2634.fixed.md
@@ -1,0 +1,1 @@
+Recalculate Fit to Window and Fit to Width after resizing docks or navigating between images, while preserving saved pan and scroll positions during navigation.

--- a/changelog.d/2634.fixed.md
+++ b/changelog.d/2634.fixed.md
@@ -1,0 +1,1 @@
+Keep Fit to Window and Fit to Width aligned with the available canvas when opening images, resizing the layout, and navigating between images.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -2234,7 +2234,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # The zoom value can be unchanged across images, so update geometry
         # explicitly before restoring positions against the new scroll range.
         self._apply_zoom_to_canvas()
-        if target_viewport is not None and self._zoom_mode == _ZoomMode.MANUAL_ZOOM:
+        if target_viewport is not None:
             for orientation, value in target_viewport.scroll_values.items():
                 self.set_scroll_value(orientation=orientation, value=value)
             self._canvas_widgets.canvas.reset_view_offset()

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -298,6 +298,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.zoom_widget.valueChanged.connect(
             self._apply_zoom_to_canvas
         )
+        self._canvas_widgets.scroll_area.installEventFilter(self)
 
         self.populate_mode_actions()
 
@@ -2223,14 +2224,17 @@ class MainWindow(QtWidgets.QMainWindow):
         is_initial_load = not self._viewport_states
         if target_viewport is not None:
             self._zoom_mode = target_viewport.zoom_mode
-            self._set_zoom(value=target_viewport.zoom_value, pos=None)
+            if self._zoom_mode == _ZoomMode.MANUAL_ZOOM:
+                self._set_zoom(value=target_viewport.zoom_value, pos=None)
+            else:
+                self._adjust_scale()
         elif is_initial_load or not self._config["keep_prev_scale"]:
             self._zoom_mode = _ZoomMode.FIT_WINDOW
             self._adjust_scale()
         # The zoom value can be unchanged across images, so update geometry
         # explicitly before restoring positions against the new scroll range.
         self._apply_zoom_to_canvas()
-        if target_viewport is not None:
+        if target_viewport is not None and self._zoom_mode == _ZoomMode.MANUAL_ZOOM:
             for orientation, value in target_viewport.scroll_values.items():
                 self.set_scroll_value(orientation=orientation, value=value)
             self._canvas_widgets.canvas.reset_view_offset()
@@ -2254,11 +2258,17 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         return True
 
-    def resizeEvent(self, a0: QtGui.QResizeEvent, /) -> None:
-        super().resizeEvent(a0)
-        if self._image.isNull() or self._zoom_mode == _ZoomMode.MANUAL_ZOOM:
-            return
-        self._adjust_scale()
+    def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent, /) -> bool:
+        if (
+            watched is self._canvas_widgets.scroll_area
+            and event.type() == QtCore.QEvent.Type.Resize
+            and not self._image.isNull()
+            and self._zoom_mode != _ZoomMode.MANUAL_ZOOM
+        ):
+            # The outer window resizes before its nested layout settles. Observe
+            # the scroll area, whose size is also independent of scrollbar changes.
+            self._adjust_scale()
+        return super().eventFilter(watched, event)
 
     def _apply_zoom_to_canvas(self) -> None:
         if self._image.isNull():

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -451,7 +451,6 @@ def test_navigation_restores_view_offset_with_retained_brightness(
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
 
     canvas = win._canvas_widgets.canvas
-    win._set_zoom_to_original()
     canvas.pan_view(step=QPointF(17, 23))
     expected_view_offset = canvas.get_view_offset()
     first_image_path = win._image_path
@@ -464,6 +463,46 @@ def test_navigation_restores_view_offset_with_retained_brightness(
     assert canvas.get_view_offset() == expected_view_offset
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("mode", [_ZoomMode.FIT_WINDOW, _ZoomMode.FIT_WIDTH])
+@pytest.mark.parametrize("keep_prev_scale", [True, False])
+def test_navigation_restores_fitted_view_position(
+    *,
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    tmp_path: Path,
+    mode: _ZoomMode,
+    keep_prev_scale: bool,
+) -> None:
+    image = QtGui.QImage(400, 800, QtGui.QImage.Format.Format_RGB32)
+    image.fill(0)
+    for name in ["a.png", "b.png"]:
+        assert image.save(str(tmp_path / name))
+    win = main_win(
+        file_or_dir=str(tmp_path),
+        config_overrides={"keep_prev_scale": keep_prev_scale},
+    )
+    qtbot.waitExposed(win)
+    win._switch_zoom_mode(mode)
+    canvas = win._canvas_widgets.canvas
+    vertical_bar = win._canvas_widgets.scroll_bars[Qt.Orientation.Vertical]
+    if mode == _ZoomMode.FIT_WIDTH:
+        qtbot.waitUntil(lambda: vertical_bar.maximum() > 240)
+        vertical_bar.setValue(240)
+    canvas.pan_view(step=QPointF(17, 23))
+    expected_scroll = vertical_bar.value()
+    expected_offset = canvas.get_view_offset()
+
+    win._open_next_image()
+    if keep_prev_scale:
+        assert vertical_bar.value() == expected_scroll
+        assert canvas.get_view_offset() == expected_offset
+    win._open_prev_image()
+    assert win._zoom_mode == mode
+    assert vertical_bar.value() == expected_scroll
+    assert canvas.get_view_offset() == expected_offset
 
 
 @pytest.mark.gui

--- a/tests/e2e/zoom_test.py
+++ b/tests/e2e/zoom_test.py
@@ -39,6 +39,105 @@ def _win(
     return win
 
 
+def _wait_for_fitted_image(*, qtbot: QtBot, win: MainWindow) -> None:
+    def check() -> None:
+        canvas = win._canvas_widgets.canvas
+        viewport = win._canvas_widgets.scroll_area.viewport().size()
+        width = canvas.pixmap.width() * canvas.scale
+        height = canvas.pixmap.height() * canvas.scale
+        assert width <= viewport.width() + 1
+        if win._zoom_mode == _ZoomMode.FIT_WIDTH:
+            assert abs(width - viewport.width()) < 2
+        else:
+            assert height <= viewport.height() + 1
+            assert (
+                min(abs(width - viewport.width()), abs(height - viewport.height())) < 2
+            )
+
+    qtbot.waitUntil(check)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("open_at_startup", [True, False])
+def test_open_image_fits_settled_viewport(
+    *, main_win: MainWinFactory, qtbot: QtBot, data_path: Path, open_at_startup: bool
+) -> None:
+    path = str(data_path / "raw/2011_000003.jpg")
+    win = main_win(file_or_dir=path if open_at_startup else None, size=None)
+    qtbot.waitExposed(win)
+    if not open_at_startup:
+        win._load_from_file_or_dir(file_or_dir=path)
+    assert win._zoom_mode == _ZoomMode.FIT_WINDOW
+    _wait_for_fitted_image(qtbot=qtbot, win=win)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("mode", list(_ZoomMode))
+def test_resize_preserves_zoom_mode(
+    *, main_win: MainWinFactory, qtbot: QtBot, data_path: Path, mode: _ZoomMode
+) -> None:
+    win = main_win(file_or_dir=str(data_path / "raw/2011_000003.jpg"))
+    qtbot.waitExposed(win)
+    win._switch_zoom_mode(mode)
+    canvas = win._canvas_widgets.canvas
+    if mode == _ZoomMode.MANUAL_ZOOM:
+        win._set_zoom(value=300, pos=None)
+        canvas.pan_view(step=QPointF(17, 23))
+    offset = canvas.get_view_offset()
+    scroll_area = win._canvas_widgets.scroll_area
+    old_size = scroll_area.size()
+    win.resize(win.width() + 150, win.height() + 100)
+    qtbot.waitUntil(lambda: scroll_area.size() != old_size)
+    if mode == _ZoomMode.MANUAL_ZOOM:
+        assert canvas.scale == 3
+        assert canvas.get_view_offset() == offset
+    else:
+        _wait_for_fitted_image(qtbot=qtbot, win=win)
+
+    old_size = scroll_area.size()
+    win.resizeDocks([win._docks.file_dock], [350], Qt.Orientation.Horizontal)
+    qtbot.waitUntil(lambda: scroll_area.size() != old_size)
+    assert win._zoom_mode == mode
+    if mode == _ZoomMode.MANUAL_ZOOM:
+        assert canvas.scale == 3
+        assert canvas.get_view_offset() == offset
+    else:
+        _wait_for_fitted_image(qtbot=qtbot, win=win)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("mode", [_ZoomMode.FIT_WINDOW, _ZoomMode.FIT_WIDTH])
+@pytest.mark.parametrize("keep_prev_scale", [True, False])
+def test_navigation_recalculates_fit_mode(
+    *,
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    tmp_path: Path,
+    mode: _ZoomMode,
+    keep_prev_scale: bool,
+) -> None:
+    for name, width, height in [("landscape", 800, 400), ("portrait", 400, 800)]:
+        image = QtGui.QImage(width, height, QtGui.QImage.Format.Format_RGB32)
+        image.fill(0)
+        assert image.save(str(tmp_path / f"{name}.png"))
+    win = main_win(
+        file_or_dir=str(tmp_path),
+        config_overrides={"keep_prev_scale": keep_prev_scale},
+    )
+    qtbot.waitExposed(win)
+    win._switch_zoom_mode(mode)
+    win._open_next_image()
+    if keep_prev_scale:
+        assert win._zoom_mode == mode
+        _wait_for_fitted_image(qtbot=qtbot, win=win)
+    win._switch_zoom_mode(mode)
+    win.resize(win.width() + 150, win.height() + 100)
+    _wait_for_fitted_image(qtbot=qtbot, win=win)
+    win._open_prev_image()
+    assert win._zoom_mode == mode
+    _wait_for_fitted_image(qtbot=qtbot, win=win)
+
+
 @pytest.mark.gui
 def test_zoom_fit_window(
     *,
@@ -238,6 +337,7 @@ def _make_scrolled_win(
         config_overrides={"keep_prev_scale": True},
     )
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    win._set_zoom_to_original()
     win._set_zoom(value=_VIEWPORT_ZOOM, pos=None)
     scroll_values = _set_scroll_bars_to_fraction(
         qtbot=qtbot,
@@ -301,7 +401,7 @@ def test_navigation_chooses_viewport_by_keep_previous_scale(
             assert bar.value() == bar.minimum()
         assert canvas.get_view_offset().isNull()
 
-    win.set_fit_window_mode(True)
+    win._set_zoom_to_original()
     win._set_zoom(value=350, pos=None)
     second_scroll_values = _set_scroll_bars_to_fraction(
         qtbot=qtbot,
@@ -317,9 +417,6 @@ def test_navigation_chooses_viewport_by_keep_previous_scale(
     win._open_prev_image()
     qtbot.waitUntil(lambda: win._image_path == first_image_path)
     expected_zoom = 350 if keep_prev_scale else _VIEWPORT_ZOOM
-    expected_zoom_mode = (
-        _ZoomMode.FIT_WINDOW if keep_prev_scale else _ZoomMode.MANUAL_ZOOM
-    )
     expected_scroll_values = (
         second_scroll_values if keep_prev_scale else first_scroll_values
     )
@@ -330,7 +427,7 @@ def test_navigation_chooses_viewport_by_keep_previous_scale(
         scroll_values=expected_scroll_values,
         zoom_value=expected_zoom,
     )
-    assert win._zoom_mode == expected_zoom_mode
+    assert win._zoom_mode == _ZoomMode.MANUAL_ZOOM
     assert canvas.get_view_offset() == expected_view_offset
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
@@ -354,6 +451,7 @@ def test_navigation_restores_view_offset_with_retained_brightness(
     show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
 
     canvas = win._canvas_widgets.canvas
+    win._set_zoom_to_original()
     canvas.pan_view(step=QPointF(17, 23))
     expected_view_offset = canvas.get_view_offset()
     first_image_path = win._image_path


### PR DESCRIPTION
Fixes the Fit to Window regression introduced by #2524 (`659c2e68`): the urban-plaza image opened at 40.2% with fit selected, despite requiring 95.4% to fill the available canvas. The same reproduction passes on v7.4.1 and the introducing commit's parent.

<!-- before-and-after:start -->
| Before | After |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/5d8460df-1555-47d0-a9f9-453a20b8985f) | ![After](https://github.com/user-attachments/assets/23fe5cea-d658-47c3-a85b-8076dae2f955) |

<!-- before-and-after:end -->

Fit modes now follow layout changes and recompute when navigating between images. Saved pan and scroll positions are restored in every zoom mode after the fitted scale is recalculated.

Validation: 46 targeted tests passed across zoom, empty-state, window-geometry persistence, and middle-drag scrolling; Ruff, gruff, and type checks passed. Desktop verification covered startup, window resizing, navigation, retained manual zoom, and Fit Width scroll restoration (240 → 240). Dock resizing is covered by automated Qt tests; native pointer automation could not drive the dock divider.


The changelog entry covers dock resizing and navigation behavior reproduced on released v7.4.1; the startup regression itself was unreleased.
