### PR TITLE
refactor: make widget data access explicit

### DIFF
--- a/changelog.d/2635.changed.md
+++ b/changelog.d/2635.changed.md
@@ -1,0 +1,1 @@
+Expose widget state through explicit properties, retaining supported canvas image, shape, and selection assignments.

--- a/changelog.d/2635.changed.md
+++ b/changelog.d/2635.changed.md
@@ -1,1 +1,1 @@
-Expose widget state through explicit properties, retaining supported canvas image, shape, and selection assignments.
+Expose widget-owned state through read-only properties, retaining directly annotated public canvas image, shape, and selection fields.

--- a/labelme/_widgets/brightness_contrast_dialog.py
+++ b/labelme/_widgets/brightness_contrast_dialog.py
@@ -14,6 +14,14 @@ _NEUTRAL: Final = 50
 
 
 class BrightnessContrastDialog(QtWidgets.QDialog):
+    @property
+    def slider_brightness(self) -> QtWidgets.QSlider:
+        return self._slider_brightness
+
+    @property
+    def slider_contrast(self) -> QtWidgets.QSlider:
+        return self._slider_contrast
+
     def __init__(
         self,
         *,
@@ -28,8 +36,8 @@ class BrightnessContrastDialog(QtWidgets.QDialog):
         # Alpha rides along as an untouched band; every other mode collapses
         # to RGB so one lookup table covers all color channels.
         self._img = img.convert("RGBA" if "A" in img.getbands() else "RGB")
-        self.slider_brightness = QtWidgets.QSlider(Qt.Orientation.Horizontal)
-        self.slider_contrast = QtWidgets.QSlider(Qt.Orientation.Horizontal)
+        self._slider_brightness = QtWidgets.QSlider(Qt.Orientation.Horizontal)
+        self._slider_contrast = QtWidgets.QSlider(Qt.Orientation.Horizontal)
 
         grid = QtWidgets.QGridLayout(self)
         grid.setColumnStretch(1, 1)

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -143,16 +143,16 @@ class _CanvasMode(enum.Enum):
 
 
 class Canvas(QtWidgets.QWidget):
-    pixmap: QtGui.QPixmap
+    _pixmap: QtGui.QPixmap
     _pixmap_hash: int | None
     _cursor: CursorRole
-    shapes: list[Shape]
-    shape_backups: collections.deque[list[Shape]]
+    _shapes: list[Shape]
+    _shape_backups: collections.deque[list[Shape]]
     _is_moving_shape: bool
-    selected_shapes: list[Shape]
+    _selected_shapes: list[Shape]
     _selected_shapes_copy: list[Shape]
     _current: _DraftShape | None
-    hovered_shape: Shape | None
+    _hovered_shape: Shape | None
     _last_hovered_shape: Shape | None
     _hovered_vertex: int | None
     _last_hovered_vertex: int | None
@@ -176,7 +176,7 @@ class Canvas(QtWidgets.QWidget):
     mouse_moved = QtCore.Signal(QPointF)
     status_updated = QtCore.Signal(str)
 
-    mode: _CanvasMode = _CanvasMode.EDIT
+    _mode: _CanvasMode = _CanvasMode.EDIT
 
     _create_mode: _CreateMode = "polygon"
 
@@ -206,6 +206,50 @@ class Canvas(QtWidgets.QWidget):
     _ai_existing_shape_highlights: list[Shape]
     _ai_points_preview: list[Shape]
     _ai_points_preview_key: tuple[object, ...] | None
+
+    @property
+    def pixmap(self) -> QtGui.QPixmap:
+        return self._pixmap
+
+    @pixmap.setter
+    def pixmap(self, value: QtGui.QPixmap, /) -> None:
+        self._pixmap = value
+
+    @property
+    def shapes(self) -> list[Shape]:
+        return self._shapes
+
+    @shapes.setter
+    def shapes(self, value: list[Shape], /) -> None:
+        self._shapes = value
+
+    @property
+    def shape_backups(self) -> collections.deque[list[Shape]]:
+        return self._shape_backups
+
+    @property
+    def selected_shapes(self) -> list[Shape]:
+        return self._selected_shapes
+
+    @selected_shapes.setter
+    def selected_shapes(self, value: list[Shape], /) -> None:
+        self._selected_shapes = value
+
+    @property
+    def hovered_shape(self) -> Shape | None:
+        return self._hovered_shape
+
+    @property
+    def mode(self) -> _CanvasMode:
+        return self._mode
+
+    @property
+    def context_menus(self) -> _canvas_interaction.ContextMenuPair:
+        return self._context_menus
+
+    @property
+    def context_menu_origin(self) -> QtCore.QPoint | None:
+        return self._context_menu_origin
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self._epsilon: float = kwargs.pop("epsilon", 10.0)
@@ -266,11 +310,11 @@ class Canvas(QtWidgets.QWidget):
         self._point_type: Literal["square", "round"] = "round"
         self._draft_palette = _DEFAULT_PALETTE
         self._palette_cache = {}
-        self.context_menus = _canvas_interaction.ContextMenuPair(
+        self._context_menus = _canvas_interaction.ContextMenuPair(
             without_selection=QtWidgets.QMenu(),
             with_selection=QtWidgets.QMenu(),
         )
-        self.context_menu_origin: QtCore.QPoint | None = None
+        self._context_menu_origin: QtCore.QPoint | None = None
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.FocusPolicy.WheelFocus)
 
@@ -539,7 +583,7 @@ class Canvas(QtWidgets.QWidget):
 
         # Peeking would leave this entry on the stack, and the reload that
         # follows would record it a second time, making the next undo a no-op.
-        self.shapes = self.shape_backups.pop()
+        self._shapes = self.shape_backups.pop()
         self.selected_shapes.clear()
         self.update()
 
@@ -570,7 +614,7 @@ class Canvas(QtWidgets.QWidget):
         new_mode = _CanvasMode.EDIT if value else _CanvasMode.CREATE
         if new_mode is not self.mode:
             self._clear_ai_existing_shape_highlights()
-        self.mode = new_mode
+        self._mode = new_mode
         if self.mode == _CanvasMode.EDIT:
             # CREATE -> EDIT
             self.update()  # clear crosshair
@@ -610,7 +654,7 @@ class Canvas(QtWidgets.QWidget):
         self._last_hovered_edge = (
             self._hovered_edge if hovered_edge is None else hovered_edge
         )
-        self.hovered_shape = hovered_shape
+        self._hovered_shape = hovered_shape
         self._hovered_vertex = hovered_vertex
         self._hovered_edge = hovered_edge
         self._hovered_rotation = hovered_rotation
@@ -1015,7 +1059,7 @@ class Canvas(QtWidgets.QWidget):
             return
         shape.insert_point(i=index, point=(point.x(), point.y()))
         self._highlight_vertex(index=index, mode="move")
-        self.hovered_shape = shape
+        self._hovered_shape = shape
         self._hovered_vertex = index
         self._hovered_edge = None
         self._is_moving_shape = True
@@ -1032,7 +1076,7 @@ class Canvas(QtWidgets.QWidget):
         # Drop the hovered vertex and selection so the press that deleted the
         # point cannot also drag the adjacent vertex (#968) or the whole shape.
         self.deselect_shape()
-        self.hovered_shape = shape
+        self._hovered_shape = shape
         self._hovered_vertex = None
         self._last_hovered_vertex = None
         self._is_moving_shape = True  # commit the removal on release
@@ -1267,11 +1311,11 @@ class Canvas(QtWidgets.QWidget):
             has_selection=len(self._selected_shapes_copy) > 0
         )
         self._release_cursor()
-        self.context_menu_origin = self.mapToGlobal(event.position().toPoint())
+        self._context_menu_origin = self.mapToGlobal(event.position().toPoint())
         try:
             triggered = menu.exec(self.context_menu_origin)  # type: ignore
         finally:
-            self.context_menu_origin = None
+            self._context_menu_origin = None
         if triggered:
             return
         if not self._selected_shapes_copy:
@@ -1537,7 +1581,7 @@ class Canvas(QtWidgets.QWidget):
         if not self.selected_shapes:
             return []
         removed = list(self.selected_shapes)
-        self.shapes = [s for s in self.shapes if s not in self.selected_shapes]
+        self._shapes = [s for s in self.shapes if s not in self.selected_shapes]
         self.backup_shapes()
         self.selected_shapes.clear()
         self._set_ai_existing_shape_highlights(shapes=[])
@@ -1547,7 +1591,7 @@ class Canvas(QtWidgets.QWidget):
     def delete_shape(self, *, shape: Shape) -> None:
         if shape in self.selected_shapes:
             self.selected_shapes.remove(shape)
-        self.shapes = [s for s in self.shapes if s is not shape]
+        self._shapes = [s for s in self.shapes if s is not shape]
         self.backup_shapes()
         self._set_ai_existing_shape_highlights(shapes=[])
         self.update()
@@ -2067,7 +2111,7 @@ class Canvas(QtWidgets.QWidget):
 
     def _reset_interaction_state(self) -> None:
         self._current = None
-        self.hovered_shape = None
+        self._hovered_shape = None
         self._hovered_vertex = None
         self._hovered_edge = None
         self._hovered_rotation = None
@@ -2076,18 +2120,18 @@ class Canvas(QtWidgets.QWidget):
 
     def load_pixmap(self, *, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
         pixmap_arr = _utils.img_qt_to_arr(pixmap.toImage())
-        self.pixmap = pixmap
+        self._pixmap = pixmap
         self._pixmap_hash = hash(pixmap_arr.tobytes())
         # A new image is a fresh inference context that should surface its own
         # first failure rather than staying muted by the prior image's latch.
         self._ai_inference_failed = False
         self._set_ai_existing_shape_highlights(shapes=[])
         if clear_shapes:
-            self.shapes = []
+            self._shapes = []
         self.update()
 
     def load_shapes(self, *, shapes: list[Shape], replace: bool = True) -> None:
-        self.shapes = list(shapes) if replace else self.shapes + list(shapes)
+        self._shapes = list(shapes) if replace else self.shapes + list(shapes)
         self.backup_shapes()
         self._reset_interaction_state()
         self.update()
@@ -2120,19 +2164,19 @@ class Canvas(QtWidgets.QWidget):
         self._ai_points_preview = []
         self._ai_points_preview_key = None
         self._release_cursor()
-        self.pixmap = QtGui.QPixmap()
+        self._pixmap = QtGui.QPixmap()
         self._pixmap_hash = None
-        self.shapes = []
-        self.shape_backups = collections.deque(maxlen=self._num_backups)
+        self._shapes = []
+        self._shape_backups = collections.deque(maxlen=self._num_backups)
         self._is_moving_shape = False
-        self.selected_shapes = []
+        self._selected_shapes = []
         self._selected_shapes_copy = []
         self._current = None
         self._view_offset = QPointF()
         self._highlight = None
         self._rotation_highlight = None
         self._set_ai_existing_shape_highlights(shapes=[])
-        self.hovered_shape = None
+        self._hovered_shape = None
         self._last_hovered_shape = None
         self._hovered_vertex = None
         self._last_hovered_vertex = None

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -143,13 +143,13 @@ class _CanvasMode(enum.Enum):
 
 
 class Canvas(QtWidgets.QWidget):
-    _pixmap: QtGui.QPixmap
+    pixmap: QtGui.QPixmap
     _pixmap_hash: int | None
     _cursor: CursorRole
-    _shapes: list[Shape]
+    shapes: list[Shape]
     _shape_backups: collections.deque[list[Shape]]
     _is_moving_shape: bool
-    _selected_shapes: list[Shape]
+    selected_shapes: list[Shape]
     _selected_shapes_copy: list[Shape]
     _current: _DraftShape | None
     _hovered_shape: Shape | None
@@ -208,32 +208,8 @@ class Canvas(QtWidgets.QWidget):
     _ai_points_preview_key: tuple[object, ...] | None
 
     @property
-    def pixmap(self) -> QtGui.QPixmap:
-        return self._pixmap
-
-    @pixmap.setter
-    def pixmap(self, value: QtGui.QPixmap, /) -> None:
-        self._pixmap = value
-
-    @property
-    def shapes(self) -> list[Shape]:
-        return self._shapes
-
-    @shapes.setter
-    def shapes(self, value: list[Shape], /) -> None:
-        self._shapes = value
-
-    @property
     def shape_backups(self) -> collections.deque[list[Shape]]:
         return self._shape_backups
-
-    @property
-    def selected_shapes(self) -> list[Shape]:
-        return self._selected_shapes
-
-    @selected_shapes.setter
-    def selected_shapes(self, value: list[Shape], /) -> None:
-        self._selected_shapes = value
 
     @property
     def hovered_shape(self) -> Shape | None:
@@ -583,7 +559,7 @@ class Canvas(QtWidgets.QWidget):
 
         # Peeking would leave this entry on the stack, and the reload that
         # follows would record it a second time, making the next undo a no-op.
-        self._shapes = self.shape_backups.pop()
+        self.shapes = self.shape_backups.pop()
         self.selected_shapes.clear()
         self.update()
 
@@ -1581,7 +1557,7 @@ class Canvas(QtWidgets.QWidget):
         if not self.selected_shapes:
             return []
         removed = list(self.selected_shapes)
-        self._shapes = [s for s in self.shapes if s not in self.selected_shapes]
+        self.shapes = [s for s in self.shapes if s not in self.selected_shapes]
         self.backup_shapes()
         self.selected_shapes.clear()
         self._set_ai_existing_shape_highlights(shapes=[])
@@ -1591,7 +1567,7 @@ class Canvas(QtWidgets.QWidget):
     def delete_shape(self, *, shape: Shape) -> None:
         if shape in self.selected_shapes:
             self.selected_shapes.remove(shape)
-        self._shapes = [s for s in self.shapes if s is not shape]
+        self.shapes = [s for s in self.shapes if s is not shape]
         self.backup_shapes()
         self._set_ai_existing_shape_highlights(shapes=[])
         self.update()
@@ -2120,18 +2096,18 @@ class Canvas(QtWidgets.QWidget):
 
     def load_pixmap(self, *, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
         pixmap_arr = _utils.img_qt_to_arr(pixmap.toImage())
-        self._pixmap = pixmap
+        self.pixmap = pixmap
         self._pixmap_hash = hash(pixmap_arr.tobytes())
         # A new image is a fresh inference context that should surface its own
         # first failure rather than staying muted by the prior image's latch.
         self._ai_inference_failed = False
         self._set_ai_existing_shape_highlights(shapes=[])
         if clear_shapes:
-            self._shapes = []
+            self.shapes = []
         self.update()
 
     def load_shapes(self, *, shapes: list[Shape], replace: bool = True) -> None:
-        self._shapes = list(shapes) if replace else self.shapes + list(shapes)
+        self.shapes = list(shapes) if replace else self.shapes + list(shapes)
         self.backup_shapes()
         self._reset_interaction_state()
         self.update()
@@ -2164,12 +2140,12 @@ class Canvas(QtWidgets.QWidget):
         self._ai_points_preview = []
         self._ai_points_preview_key = None
         self._release_cursor()
-        self._pixmap = QtGui.QPixmap()
+        self.pixmap = QtGui.QPixmap()
         self._pixmap_hash = None
-        self._shapes = []
+        self.shapes = []
         self._shape_backups = collections.deque(maxlen=self._num_backups)
         self._is_moving_shape = False
-        self._selected_shapes = []
+        self.selected_shapes = []
         self._selected_shapes_copy = []
         self._current = None
         self._view_offset = QPointF()

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -28,6 +28,22 @@ _PLACEHOLDER_TEXT: Final[str] = "Enter object label"
 class LabelDialog(QtWidgets.QDialog):
     """Dialog for entering label, group id, description, and flags."""
 
+    @property
+    def edit(self) -> QtWidgets.QLineEdit:
+        return self._edit
+
+    @property
+    def edit_group_id(self) -> QtWidgets.QLineEdit:
+        return self._edit_group_id
+
+    @property
+    def edit_description(self) -> QtWidgets.QTextEdit:
+        return self._edit_description
+
+    @property
+    def label_list(self) -> QtWidgets.QListWidget:
+        return self._label_list
+
     def __init__(
         self,
         *,
@@ -70,12 +86,12 @@ class LabelDialog(QtWidgets.QDialog):
         self._fit_to_content = fit_to_content
 
         # Build widgets
-        self.edit = QtWidgets.QLineEdit()
+        self._edit = QtWidgets.QLineEdit()
         self.edit.setPlaceholderText(text)
         self.edit.setAccessibleName(self.tr("Label"))
 
         group_id_name = self.tr("Group ID")
-        self.edit_group_id = QtWidgets.QLineEdit()
+        self._edit_group_id = QtWidgets.QLineEdit()
         self.edit_group_id.setPlaceholderText(group_id_name)
         self.edit_group_id.setAccessibleName(group_id_name)
         self.edit_group_id.setValidator(
@@ -83,12 +99,12 @@ class LabelDialog(QtWidgets.QDialog):
         )
 
         description_name = self.tr("Description")
-        self.edit_description = QtWidgets.QTextEdit()
+        self._edit_description = QtWidgets.QTextEdit()
         self.edit_description.setPlaceholderText(description_name)
         self.edit_description.setAccessibleName(description_name)
         self.edit_description.setFixedHeight(50)
 
-        self.label_list = QtWidgets.QListWidget()
+        self._label_list = QtWidgets.QListWidget()
         self.label_list.setFixedHeight(LABEL_LIST_HEIGHT)
 
         # Configure label list


### PR DESCRIPTION
Make widget ownership explicit as part of [Gruff #85](https://github.com/wkentaro/gruff/issues/85). Callers retain property reads and mutation of returned widgets/collections. The migrated read-only properties prevent reassignment. Canvas pixmap, shapes, and selected_shapes retain their original directly annotated public fields; they need no pass-through descriptors under the revised GR012 policy.

The final diff introduces read-only properties and redirects their owner stores to private backing fields. An AST comparison against the original base confirms no other existing statements changed. Shapes remain dataclasses and widgets remain Qt classes.

Validation: `make lint` and the full offscreen suite passed on the final source: 1,428 tests passed, seven skipped. With the updated GR012, findings decrease from the preceding iteration’s 18 to seven, all in test doubles; the original trial had 44. Existing class-body declarations now cover the eight Shape-field writes and three AI-assist writes without modifying those classes.

The change concerns ownership and reassignment contracts. Evidence is the existing deterministic Qt tests and source-shape comparison; no manual desktop inspection was performed. See Gruff #85 for pinned revisions and full dogfood results.
