### PR TITLE
fix: preserve labels until a suggestion is selected

### DIFF
--- a/changelog.d/2640.fixed.md
+++ b/changelog.d/2640.fixed.md
@@ -1,0 +1,1 @@
+Preserve typed shape labels when tabbing into suggestions or opening a label with a case-insensitive match, while applying explicit mouse and keyboard choices before acceptance.

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -166,8 +166,9 @@ class LabelDialog(QtWidgets.QDialog):
 
         # Connect signals
         self.edit.textChanged.connect(self._on_text_changed)
-        self.label_list.currentItemChanged.connect(self._on_label_selected)
-        self.label_list.itemDoubleClicked.connect(self._submit_item)
+        self.label_list.itemSelectionChanged.connect(self._select_current_label)
+        self.label_list.itemClicked.connect(self._on_label_selected)
+        self.label_list.itemDoubleClicked.connect(self._accept_clicked_label)
 
         # Populate initial labels
         for label in dict.fromkeys([*(labels or []), *self._label_history]):
@@ -216,31 +217,28 @@ class LabelDialog(QtWidgets.QDialog):
         )
 
     def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent, /) -> bool:
-        if watched is self.edit and event.type() == QtCore.QEvent.Type.KeyPress:
+        if event.type() == QtCore.QEvent.Type.KeyPress and watched is self.edit:
             assert isinstance(event, QtGui.QKeyEvent)
-            step = {QtCore.Qt.Key.Key_Up: -1, QtCore.Qt.Key.Key_Down: 1}.get(
-                QtCore.Qt.Key(event.key())
-            )
-            if step is not None:
-                row = self.label_list.currentRow() + step
-                self.label_list.setCurrentRow(
-                    min(max(row, 0), self.label_list.count() - 1)
-                )
+            if QtCore.Qt.Key(event.key()) in (
+                QtCore.Qt.Key.Key_Up,
+                QtCore.Qt.Key.Key_Down,
+            ):
+                self.label_list.keyPressEvent(event)
                 return True
         return super().eventFilter(watched, event)
 
-    def _on_label_selected(
-        self,
-        current: QtWidgets.QListWidgetItem | None,
-        _previous: QtWidgets.QListWidgetItem | None,
-        /,
-    ) -> None:
-        if current is None:
-            return
-        self.edit.setText(current.text())
+    def _select_current_label(self) -> None:
+        # Tabbing into the list sets a current row without selecting a label.
+        # Only an explicit selection should replace the typed text.
+        item = self.label_list.currentItem()
+        if item is not None and item.isSelected():
+            self._on_label_selected(item)
 
-    def _submit_item(self, item: QtWidgets.QListWidgetItem, /) -> None:
-        self.label_list.setCurrentItem(item)
+    def _on_label_selected(self, item: QtWidgets.QListWidgetItem, /) -> None:
+        self.edit.setText(item.text())
+
+    def _accept_clicked_label(self, item: QtWidgets.QListWidgetItem, /) -> None:
+        self._on_label_selected(item)
         self._ok_button.click()
 
     def _clear_flag_checkboxes(self) -> None:
@@ -347,7 +345,9 @@ class LabelDialog(QtWidgets.QDialog):
         else:
             self._set_flag_checkboxes(flags=flags)
 
-        self.label_list.setCurrentRow(self._find_label_row(text))
+        # Highlight the suggestion without applying its spelling to the label.
+        with QtCore.QSignalBlocker(self.label_list):
+            self.label_list.setCurrentRow(self._find_label_row(text))
 
         self._fit_label_list_to_content()
         self._refresh_ok_button()

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -813,26 +813,6 @@ def test_popup_highlights_matching_label_at_show(*, qtbot: QtBot) -> None:
     assert seen["cur"] == "dog"
 
 
-def test_popup_highlights_matching_label_case_insensitively(*, qtbot: QtBot) -> None:
-    seen: dict[str, object] = {}
-    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["Cat", "Dog"]))
-    _run_popup(
-        dialog=dialog,
-        accept=True,
-        text="cat",
-        at_show=lambda d: seen.update(
-            cur=d.label_list.currentItem().text()
-            if d.label_list.currentItem()
-            else None
-        ),
-        flags=None,
-        group_id=None,
-        description=None,
-        locked=(),
-    )
-    assert seen["cur"] == "Cat"
-
-
 def test_popup_clears_stale_highlight_when_nothing_matches(*, qtbot: QtBot) -> None:
     seen: dict[str, object] = {}
     dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog"]))
@@ -1020,3 +1000,63 @@ def test_locked_flags_stay_hidden_after_label_edit(*, qtbot: QtBot) -> None:
         description=None,
     )
     assert seen["count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [(QtCore.Qt.Key.Key_P, "person"), (QtCore.Qt.Key.Key_Down, "dog")],
+)
+def test_list_keyboard_choice_is_accepted_immediately(
+    *, qtbot: QtBot, key: QtCore.Qt.Key, expected: str
+) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat", "dog", "person"]))
+
+    def choose_label() -> None:
+        dialog.label_list.setFocus(QtCore.Qt.FocusReason.TabFocusReason)
+        dialog.label_list.setCurrentRow(0)
+        dialog.edit.setText("custom")
+        qtbot.keyClick(dialog.label_list, key)
+        qtbot.keyClick(dialog.label_list, QtCore.Qt.Key.Key_Return)
+
+    QtCore.QTimer.singleShot(0, choose_label)
+    QtCore.QTimer.singleShot(1000, dialog.reject)
+    entry = dialog.popup(text="custom", move=False)
+    assert entry is not None
+    assert entry.label == expected
+
+
+def test_tabbing_into_choices_does_not_replace_custom_text(*, qtbot: QtBot) -> None:
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["cat"]))
+    dialog.edit.setText("custom")
+    with qtbot.waitExposed(dialog):
+        dialog.show()
+    dialog.edit.setFocus()
+    for _ in range(4):
+        qtbot.keyClick(dialog.focusWidget(), QtCore.Qt.Key.Key_Tab)
+    assert dialog.focusWidget() is dialog.label_list
+    assert dialog.label_list.currentRow() == 0
+    assert dialog.edit.text() == "custom"
+
+
+def test_popup_preserves_label_case(*, qtbot: QtBot) -> None:
+    seen: dict[str, object] = {}
+    dialog = _add_dialog(qtbot, dialog=LabelDialog(labels=["Cat"]))
+
+    entry = _run_popup(
+        dialog=dialog,
+        accept=True,
+        text="cat",
+        at_show=lambda d: seen.update(
+            current=d.label_list.currentItem().text()
+            if d.label_list.currentItem()
+            else None
+        ),
+        flags=None,
+        group_id=None,
+        description=None,
+        locked=(),
+    )
+
+    assert seen["current"] == "Cat"
+    assert entry is not None
+    assert entry.label == "cat"


### PR DESCRIPTION
Opening a shape whose label differs only in case from a listed suggestion replaced it with the list's spelling (`cat` became `Cat`), and tabbing from the text field into the suggestion list overwrote custom text with the first row. Both came from applying the list's current item to the text field, which changes on open and on focus-in without the user choosing anything.

The dialog now applies a suggestion only on an explicit selection, click, or arrow key. The stored label is still highlighted and scrolled into view on open, with the list's signals blocked so the highlight cannot rewrite the label. Double-click still applies the item and accepts.

<!-- before-and-after:start -->
Before, on main at `55a360e6`, with this PR's regression tests:

```text
FAILED test_tabbing_into_choices_does_not_replace_custom_text
FAILED test_popup_preserves_label_case  (assert 'Cat' == 'cat')
```

After:

```text
uv run pytest -q tests/unit/widgets/label_dialog tests/e2e/label_dialog_validation_test.py
100 passed
make lint
All checks passed
```
<!-- before-and-after:end -->

An offscreen 500-label popup check at main and at this head highlighted `Label499` and kept it visible in both runs; accepting `label499` returned `Label499` on main and `label499` here. Native desktop verification was not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sFqszUNzkhKTDCbnDeyRg
