### PR TITLE
refactor: use Qt cursor selection for label navigation

### DIFF
--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -217,15 +217,25 @@ class LabelDialog(QtWidgets.QDialog):
         )
 
     def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent, /) -> bool:
-        if event.type() == QtCore.QEvent.Type.KeyPress and watched is self.edit:
-            assert isinstance(event, QtGui.QKeyEvent)
-            if QtCore.Qt.Key(event.key()) in (
-                QtCore.Qt.Key.Key_Up,
-                QtCore.Qt.Key.Key_Down,
-            ):
-                self.label_list.keyPressEvent(event)
-                return True
-        return super().eventFilter(watched, event)
+        if watched is not self.edit or event.type() != QtCore.QEvent.Type.KeyPress:
+            return super().eventFilter(watched, event)
+        assert isinstance(event, QtGui.QKeyEvent)
+        actions = {
+            QtCore.Qt.Key.Key_Up: QtWidgets.QAbstractItemView.CursorAction.MoveUp,
+            QtCore.Qt.Key.Key_Down: QtWidgets.QAbstractItemView.CursorAction.MoveDown,
+        }
+        action = actions.get(QtCore.Qt.Key(event.key()))
+        if action is None:
+            return super().eventFilter(watched, event)
+
+        index = self.label_list.moveCursor(action, event.modifiers())
+        # At a boundary, even an unselected suggestion must leave typed text alone.
+        if index.isValid() and index != self.label_list.currentIndex():
+            self.label_list.selectionModel().setCurrentIndex(
+                index, self.label_list.selectionCommand(index, event)
+            )
+            self.label_list.scrollTo(index)
+        return True
 
     def _select_current_label(self) -> None:
         # Tabbing into the list sets a current row without selecting a label.

--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -234,7 +234,6 @@ class LabelDialog(QtWidgets.QDialog):
             self.label_list.selectionModel().setCurrentIndex(
                 index, self.label_list.selectionCommand(index, event)
             )
-            self.label_list.scrollTo(index)
         return True
 
     def _select_current_label(self) -> None:

--- a/tests/e2e/label_dialog_validation_test.py
+++ b/tests/e2e/label_dialog_validation_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from functools import partial
 from pathlib import Path
 from typing import Final
@@ -261,3 +262,43 @@ def test_trailing_whitespace_label_is_stripped(
     assert canvas.shapes[-1].label == "cat"
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("key", [Qt.Key.Key_Return, Qt.Key.Key_Enter])
+def test_editor_arrow_then_immediate_return_survives_save_and_reopen(
+    *,
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    data_path: Path,
+    tmp_path: Path,
+    key: Qt.Key,
+) -> None:
+    win = main_win(
+        file_or_dir=data_path / _RAW_FILE,
+        config_overrides={"labels": ["cat", "dog", "person"], "auto_save": True},
+        output_dir=tmp_path,
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    dialog = win._label_dialog
+
+    def choose() -> None:
+        dialog.edit.selectAll()
+        qtbot.keyClicks(dialog.edit, "unmatched")
+        qtbot.keyClick(dialog.edit, Qt.Key.Key_Down)
+        qtbot.keyClick(dialog.edit, Qt.Key.Key_Down)
+        assert dialog.edit.text() == "dog"
+        assert dialog.focusWidget() is dialog.edit
+        qtbot.keyClick(dialog.edit, key)
+
+    _draw_triangle(qtbot=qtbot, win=win)
+    schedule_on_dialog(label_dialog=dialog, action=choose)
+    click_canvas_fraction(
+        qtbot=qtbot, canvas=win._canvas_widgets.canvas, xy=_CLOSE_POLYGON_CLICK
+    )
+    saved = tmp_path / "2011_000003.json"
+    qtbot.waitUntil(saved.exists)
+    assert json.loads(saved.read_text())["shapes"][0]["label"] == "dog"
+    assert win._load_file(image_or_label_path=str(saved))
+    assert [shape.label for shape in win._canvas_widgets.canvas.shapes] == ["dog"]
+    win.close()

--- a/tests/unit/widgets/label_dialog/keyboard_test.py
+++ b/tests/unit/widgets/label_dialog/keyboard_test.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+from PySide6 import QtCore
+from PySide6 import QtGui
+from PySide6 import QtWidgets
+from pytestqt.qtbot import QtBot
+
+from labelme._widgets.label_dialog import LabelDialog
+
+
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        QtCore.Qt.KeyboardModifier.NoModifier,
+        QtCore.Qt.KeyboardModifier.ShiftModifier,
+        QtCore.Qt.KeyboardModifier.ControlModifier,
+        QtCore.Qt.KeyboardModifier.AltModifier,
+        QtCore.Qt.KeyboardModifier.MetaModifier,
+    ],
+)
+def test_editor_arrows_match_native_single_selection(
+    *, qtbot: QtBot, modifier: QtCore.Qt.KeyboardModifier
+) -> None:
+    dialog = LabelDialog(labels=["cat", "dog", "person"])
+    qtbot.addWidget(dialog)
+    reference = QtWidgets.QListWidget()
+    qtbot.addWidget(reference)
+    reference.addItems(["cat", "dog", "person"])
+    with qtbot.waitActive(dialog):
+        dialog.show()
+        dialog.activateWindow()
+    reference.setCurrentRow(1)
+    dialog.label_list.setCurrentRow(1)
+    dialog.edit.setFocus()
+    expected_text = ["dog"]
+
+    def remember_selection() -> None:
+        item = reference.currentItem()
+        if item is not None and item.isSelected():
+            expected_text.append(item.text())
+
+    reference.itemSelectionChanged.connect(remember_selection)
+
+    for key in [QtCore.Qt.Key.Key_Down, QtCore.Qt.Key.Key_Down, QtCore.Qt.Key.Key_Up]:
+        qtbot.keyClick(reference, key, modifier)
+        qtbot.keyClick(dialog.edit, key, modifier)
+        assert dialog.label_list.currentRow() == reference.currentRow()
+        assert [i.text() for i in dialog.label_list.selectedItems()] == [
+            i.text() for i in reference.selectedItems()
+        ]
+        assert dialog.edit.text() == expected_text[-1]
+        assert dialog.focusWidget() is dialog.edit
+
+
+@pytest.mark.parametrize(
+    ("labels", "row", "selected", "key", "expected_row", "expected_text"),
+    [
+        ([], -1, False, QtCore.Qt.Key.Key_Up, -1, "cat"),
+        ([], -1, False, QtCore.Qt.Key.Key_Down, -1, "cat"),
+        (["Cat"], -1, False, QtCore.Qt.Key.Key_Up, 0, "Cat"),
+        (["Cat"], 0, True, QtCore.Qt.Key.Key_Down, 0, "cat"),
+        (["Cat"], 0, False, QtCore.Qt.Key.Key_Up, 0, "cat"),
+        (["Cat", "dog"], 0, False, QtCore.Qt.Key.Key_Down, 1, "dog"),
+    ],
+)
+def test_arrows_preserve_text_without_a_new_selection(
+    *,
+    qtbot: QtBot,
+    labels: list[str],
+    row: int,
+    selected: bool,
+    key: QtCore.Qt.Key,
+    expected_row: int,
+    expected_text: str,
+) -> None:
+    dialog = LabelDialog(labels=labels)
+    qtbot.addWidget(dialog)
+    dialog.show()
+    dialog.label_list.setCurrentRow(row)
+    if not selected:
+        dialog.label_list.clearSelection()
+    dialog.edit.setText("cat")
+    qtbot.keyClick(dialog.edit, key)
+    assert dialog.label_list.currentRow() == expected_row
+    assert dialog.edit.text() == expected_text
+    if row == expected_row:
+        assert bool(dialog.label_list.selectedItems()) == selected
+
+
+def test_repeated_arrows_follow_reordered_rows(*, qtbot: QtBot) -> None:
+    dialog = LabelDialog(labels=["cat", "dog", "person"], sort_labels=False)
+    qtbot.addWidget(dialog)
+    dialog.label_list.insertItem(0, dialog.label_list.takeItem(2))
+    dialog.label_list.setCurrentRow(0)
+    for expected in ["cat", "dog", "dog"]:
+        event = QtGui.QKeyEvent(
+            QtCore.QEvent.Type.KeyPress,
+            QtCore.Qt.Key.Key_Down,
+            QtCore.Qt.KeyboardModifier.NoModifier,
+            autorep=True,
+        )
+        QtWidgets.QApplication.sendEvent(dialog.edit, event)
+        assert dialog.edit.text() == expected
+
+
+@pytest.mark.parametrize("completion", ["startswith", "contains"])
+def test_completion_arrows_then_return_in_real_popup(
+    *, qtbot: QtBot, completion: str
+) -> None:
+    dialog = LabelDialog(labels=["cat", "cattle", "dog"], completion=completion)
+    qtbot.addWidget(dialog)
+
+    def choose() -> None:
+        dialog.edit.clear()
+        qtbot.keyClicks(dialog.edit, "ca")
+        completer = dialog.edit.completer()
+        assert completer is not None
+        popup = completer.popup()
+        target = popup if completion == "contains" else dialog.edit
+        assert target is not None
+        if completion == "contains":
+            assert target.isVisible()
+        qtbot.keyClick(target, QtCore.Qt.Key.Key_Down)
+        assert dialog.edit.text() == "cat"
+        assert dialog.label_list.currentRow() == (-1 if completion == "contains" else 0)
+        qtbot.keyClick(target, QtCore.Qt.Key.Key_Return)
+        if completion == "contains":
+            assert dialog.isVisible()
+            qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Return)
+
+    timer = QtCore.QTimer(dialog)
+    timer.setSingleShot(True)
+    timer.timeout.connect(dialog.reject)
+    timer.start(3000)
+    QtCore.QTimer.singleShot(0, choose)
+    entry = dialog.popup(text="unknown", move=False)
+    timer.stop()
+    assert entry is not None
+    assert entry.label == "cat"


### PR DESCRIPTION
Handle editor-focused label navigation through Qt's cursor and selection APIs. Reaching a list boundary leaves typed spelling intact, and a visible completion popup retains its own keyboard handling.

Validation: 116 focused dialog/application tests pass; 22 keyboard and application cases pass on native macOS Qt 6.11.1 against both main and this change. Desktop checks confirmed typing → arrows → immediate Return → save/reopen, completion Return, and cancellation. `make lint` and `make check_translate` pass. A 40-row, 90-arrow comparison also preserves row, text, and scrollbar values after removing redundant explicit scrolling. Windows and Linux desktop QA was not run.

No media attached: appearance is unchanged, and the modal/event-loop tests capture the keyboard state transitions more precisely than screenshots.
