### PR TITLE
refactor: centralize canvas highlight repaint scheduling

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -550,13 +550,12 @@ class Canvas(QtWidgets.QWidget):
         self._update_status(extra_messages=None)
 
     def leaveEvent(self, _a0: QtCore.QEvent, /) -> None:
-        if self._set_highlight(
+        self._set_highlight(
             hovered_shape=None,
             hovered_edge=None,
             hovered_vertex=None,
             hovered_rotation=None,
-        ):
-            self.update()
+        )
         self._release_cursor()
         self._update_status(extra_messages=None)
 
@@ -578,15 +577,13 @@ class Canvas(QtWidgets.QWidget):
             self.update()  # clear crosshair
         else:
             # EDIT -> CREATE
-            need_update: bool = self._set_highlight(
+            self._set_highlight(
                 hovered_shape=None,
                 hovered_edge=None,
                 hovered_vertex=None,
                 hovered_rotation=None,
             )
-            need_update |= self.deselect_shape()
-            if need_update:
-                self.update()
+            self.deselect_shape()
         self._update_status(extra_messages=None)
 
     def _set_highlight(
@@ -596,12 +593,10 @@ class Canvas(QtWidgets.QWidget):
         hovered_edge: int | None,
         hovered_vertex: int | None,
         hovered_rotation: int | None,
-    ) -> bool:
+    ) -> None:
         previous_shape: Shape | None = self.hovered_shape
-        need_update: bool = hovered_shape is not None
         if previous_shape is not None:
             self._clear_highlight_state()
-            need_update = True
         # NOTE: Store last highlighted for adding/removing points.
         self._last_hovered_shape = (
             previous_shape if hovered_shape is None else hovered_shape
@@ -616,7 +611,8 @@ class Canvas(QtWidgets.QWidget):
         self._hovered_vertex = hovered_vertex
         self._hovered_edge = hovered_edge
         self._hovered_rotation = hovered_rotation
-        return need_update
+        if previous_shape is not None or hovered_shape is not None:
+            self.update()
 
     def _is_vertex_selected(self) -> bool:
         return self._hovered_vertex is not None
@@ -938,13 +934,12 @@ class Canvas(QtWidgets.QWidget):
 
         if target is None:
             self._release_cursor()
-            if self._set_highlight(
+            self._set_highlight(
                 hovered_shape=None,
                 hovered_edge=None,
                 hovered_vertex=None,
                 hovered_rotation=None,
-            ):
-                self.update()
+            )
             return
 
         if target.kind is HitKind.VERTEX:
@@ -960,7 +955,6 @@ class Canvas(QtWidgets.QWidget):
             status_messages.append(self.tr("Click & drag to move point"))
             if target.shape.can_remove_point():
                 status_messages.append(self.tr("ALT + SHIFT + Click to delete point"))
-            self.update()
             return
 
         if target.kind is HitKind.ROTATION_HANDLE:
@@ -974,7 +968,6 @@ class Canvas(QtWidgets.QWidget):
             self._highlight_rotation_point(index=target.index, mode="move")
             self._apply_cursor(CursorRole.HANDLE)
             status_messages.append(self.tr("Click & drag to rotate the shape"))
-            self.update()
             return
 
         if target.kind is HitKind.EDGE:
@@ -987,7 +980,6 @@ class Canvas(QtWidgets.QWidget):
             )
             self._apply_cursor(CursorRole.HANDLE)
             status_messages.append(self.tr("ALT + Click to create point on shape"))
-            self.update()
             return
 
         if target.kind is HitKind.BODY:
@@ -1004,7 +996,6 @@ class Canvas(QtWidgets.QWidget):
                 ]
             )
             self._apply_cursor(CursorRole.GRAB)
-            self.update()
             return
 
         typing.assert_never(target.kind)

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -2524,3 +2524,81 @@ def test_square_drawing_commits_ai_box_prompt(
         pos=QtCore.QPoint(70, 30),
     )
     assert prompts == [[QPointF(10, 10), QPointF(30, 30)]]
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("clear_action", ["empty", "leave", "create"])
+def test_hover_transitions_repaint(
+    *, canvas: Canvas, qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, clear_action: str
+) -> None:
+    polygon = _make_polygon()
+    rotated = _make_oriented_rectangle(
+        corners=[(60, 10), (100, 10), (100, 40), (60, 40)]
+    )
+    canvas.pixmap = QtGui.QPixmap(140, 60)
+    canvas.pixmap.fill(Qt.GlobalColor.white)
+    canvas.load_shapes(shapes=[polygon, rotated])
+    # Keep the desktop pointer from overwriting the scripted hover targets.
+    canvas.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+    canvas.show()
+    qtbot.waitExposed(canvas)
+    qtbot.wait(20)
+    painted = []
+    paint_event = canvas.paintEvent
+
+    def record_paint(event: QtGui.QPaintEvent, /) -> None:
+        paint_event(event)
+        painted.append(
+            tuple(
+                canvas._render_context(
+                    shape=shape, highlighted=shape is canvas.hovered_shape
+                )
+                for shape in (polygon, rotated)
+            )
+        )
+
+    monkeypatch.setattr(canvas, "paintEvent", record_paint)
+    for point, shape_index, vertex, rotation in [
+        (QPointF(10, 10), 0, 0, None),
+        (QPointF(25, 10), 0, None, None),
+        (QPointF(25, 25), 0, None, None),
+        (QPointF(80, 10), 1, None, 1),
+        (QPointF(100, 40), 1, 2, None),
+    ]:
+        painted.clear()
+        canvas._refresh_hover_state(pos=point)
+        qtbot.waitUntil(lambda: bool(painted))
+        active = painted[-1][shape_index]
+        inactive = painted[-1][1 - shape_index]
+        assert active.fill
+        assert (active.highlight.index if active.highlight else None) == vertex
+        assert (
+            active.rotation_highlight.index if active.rotation_highlight else None
+        ) == rotation
+        assert not inactive.fill
+        assert inactive.highlight is None
+        assert inactive.rotation_highlight is None
+
+    painted.clear()
+    if clear_action == "empty":
+        canvas._refresh_hover_state(pos=QPointF(130, 50))
+    elif clear_action == "leave":
+        canvas.leaveEvent(QtCore.QEvent(QtCore.QEvent.Type.Leave))
+    else:
+        canvas.set_editing(value=False)
+    qtbot.waitUntil(lambda: bool(painted))
+    assert all(
+        not context.fill
+        and context.highlight is None
+        and context.rotation_highlight is None
+        for context in painted[-1]
+    )
+    if clear_action == "empty":
+        painted.clear()
+        canvas._refresh_hover_state(pos=QPointF(125, 50))
+        qtbot.wait(20)
+        assert not painted
+    if clear_action == "create":
+        painted.clear()
+        canvas.set_editing(value=True)
+        qtbot.waitUntil(lambda: bool(painted))


### PR DESCRIPTION
Centralize hover repaint scheduling while preserving the existing repaint condition: repaint when either the previous or incoming hover has a shape. Moving through empty space stays paint-free. Qt schedules the paint after the current event handler completes its vertex/rotation styling and deselection work.

Validation: 288 focused canvas, hit-testing and application interaction tests and `make lint` pass. The retained paint-event test covers vertex, edge, body and rotation hover, target changes, leave/empty/create clearing, and return to edit. Its empty-to-empty assertion failed with the unconditional repaint and passes with the guard. All three cases also pass with native macOS Qt.

Native visual inspection used a temporary canvas harness on macOS 26.6.2 / Qt 6.11.1 (Cocoa), covering visible hover styles, changing shapes, and empty/create clearing. Leave and the absence of redundant paints are tested through the event loop. Windows/Linux native repaint behavior remains unverified; the referenced GUI QA skill was unavailable. Media and a changelog fragment are omitted because this refactor preserves the visible behavior.
