### PR TITLE
refactor: populate image flags directly from their sources

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1182,11 +1182,7 @@ class MainWindow(QtWidgets.QMainWindow):
         flag_list = QtWidgets.QListWidget()
         flag = QtWidgets.QDockWidget(self.tr("Flags"), self)
         flag.setObjectName("Flags")
-        if self._config["flags"]:
-            self._load_flags(
-                flags={k: False for k in self._config["flags"]},
-                widget=flag_list,
-            )
+        self._load_flags(flags={}, widget=flag_list)
         flag.setWidget(flag_list)
         flag_list.itemChanged.connect(self.mark_dirty)
 
@@ -1717,13 +1713,13 @@ class MainWindow(QtWidgets.QMainWindow):
         widget: QtWidgets.QListWidget,
     ) -> None:
         widget.clear()
-        key: str
-        flag: bool
-        for key, flag in flags.items():
+        for key in dict.fromkeys([*(self._config["flags"] or []), *flags]):
             item: QtWidgets.QListWidgetItem = QtWidgets.QListWidgetItem(key)
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
             item.setCheckState(
-                Qt.CheckState.Checked if flag else Qt.CheckState.Unchecked
+                Qt.CheckState.Checked
+                if flags.get(key, False)
+                else Qt.CheckState.Unchecked
             )
             widget.addItem(item)
 
@@ -2203,13 +2199,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.load_pixmap(pixmap=QtGui.QPixmap.fromImage(image))
         self._canvas_widgets.surface.setCurrentWidget(self._canvas_widgets.scroll_area)
         logger.debug("Loaded pixmap in {:.0f}ms", (time.time() - t0) * 1000)
-        flags = {k: False for k in self._config["flags"] or []}
         # Record one baseline state. Loading carried-forward shapes separately
         # would create a false Undo step that discards them before any edit.
         carry_prev_shapes = bool(prev_shapes) and not shapes
         self._load_shapes(prev_shapes if carry_prev_shapes else shapes, replace=True)
-        flags.update(annotation.flags)
-        self._load_flags(flags=flags, widget=self._docks.flag_list)
+        self._load_flags(flags=annotation.flags, widget=self._docks.flag_list)
         if carry_prev_shapes:
             self.mark_dirty()
         else:
@@ -2703,10 +2697,9 @@ class MainWindow(QtWidgets.QMainWindow):
             # keep every flag already in the dock with its checked state. Like the
             # label docks, a flag removed from the config lingers until the next
             # image load, so the edit never drops a flag the current image carries.
-            current = self._read_flag_dock_states()
-            flags = {key: False for key in self._config["flags"] or []}
-            flags.update(current)
-            self._load_flags(flags=flags, widget=self._docks.flag_list)
+            self._load_flags(
+                flags=self._read_flag_dock_states(), widget=self._docks.flag_list
+            )
         elif key_path in (
             ("sort_labels",),
             ("show_label_text_field",),

--- a/tests/e2e/file_loading_test.py
+++ b/tests/e2e/file_loading_test.py
@@ -663,3 +663,52 @@ def test_open_dir_with_failing_first_image_keeps_other_images_reachable(
     qtbot.waitUntil(lambda: win._image_path == str(valid_image))
 
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("configured", [None, [], ["new", "shared", "new"]])
+def test_image_flags_survive_save_and_navigation(
+    *,
+    main_win: MainWinFactory,
+    qtbot: QtBot,
+    create_annotated_session_image: Path,
+    configured: list[str] | None,
+) -> None:
+    image_path = create_annotated_session_image
+    label_path = image_path.with_suffix(".json")
+    data = json.loads(label_path.read_text())
+    data["flags"] = {"file_only": True, "shared": True, "unchecked": False}
+    label_path.write_text(json.dumps(data))
+    next_image = image_path.with_name("02-next.jpg")
+    shutil.copyfile(src=image_path, dst=next_image)
+    win = main_win(
+        file_or_dir=image_path.parent,
+        config_overrides={"flags": configured, "auto_save": False},
+    )
+    show_window_and_wait_for_imagedata(qtbot=qtbot, win=win)
+    expected = (
+        [("new", False), ("shared", True), ("file_only", True), ("unchecked", False)]
+        if configured
+        else [("file_only", True), ("shared", True), ("unchecked", False)]
+    )
+    assert list(win._read_flag_dock_states().items()) == expected
+    assert not win._is_changed
+
+    item = win._docks.flag_list.item(0)
+    assert item is not None
+    item.setCheckState(Qt.CheckState.Checked if configured else Qt.CheckState.Unchecked)
+    expected[0] = (expected[0][0], bool(configured))
+    assert win._is_changed
+    win._save_label_file(save_as=False)
+    assert list(json.loads(label_path.read_text())["flags"].items()) == expected
+    assert not win._is_changed
+
+    win._open_next_image()
+    assert win._image_path == str(next_image)
+    assert list(win._read_flag_dock_states().items()) == (
+        [("new", False), ("shared", False)] if configured else []
+    )
+    assert not win._is_changed
+    win._open_prev_image()
+    assert list(win._read_flag_dock_states().items()) == expected
+    assert not win._is_changed

--- a/tests/e2e/settings_test.py
+++ b/tests/e2e/settings_test.py
@@ -325,6 +325,24 @@ def test_flags_setting_refreshes_flag_dock_live(
     # The new "blurry" flag appears unchecked while "occluded" stays checked.
     assert states == {"occluded": True, "truncated": False, "blurry": False}
 
+    flags_editor.setPlainText("blurry\ntruncated")
+    flags_editor.commit()
+    assert list(win._read_flag_dock_states().items()) == [
+        ("blurry", False),
+        ("truncated", False),
+        ("occluded", True),
+    ]
+    assert not win._is_changed
+
+    flags_editor.setPlainText("")
+    flags_editor.commit()
+    assert list(win._read_flag_dock_states().items()) == [
+        ("blurry", False),
+        ("truncated", False),
+        ("occluded", True),
+    ]
+    assert not win._is_changed
+
     close_or_pause(qtbot=qtbot, widget=win, pause=pause)
 
 


### PR DESCRIPTION
Keep image-flag initialization consistent across startup, image loading, and live settings edits by populating dock rows directly from configured names and supplied states.

Configured names retain their order and default to unchecked; file and current-dock values take precedence. Removing a configured name still leaves its existing dock entry until reload.

Validation: all 57 settings/file-loading tests pass on both the base and candidate; `make lint` passes. Native macOS checks covered initial flags, settings addition/removal, check-state retention, dirty state, save, navigation, and reopen. Visual media is omitted because this refactor preserves the existing presentation and interaction.
