### PR TITLE
refactor: capture label dialog entries on acceptance

### DIFF
--- a/labelme/_widgets/label_dialog.py
+++ b/labelme/_widgets/label_dialog.py
@@ -61,6 +61,8 @@ class LabelDialog(QtWidgets.QDialog):
         self._locked: frozenset[LabelDialogField] = frozenset()
         # A popup opened without a label starts from the last one accepted.
         self._last_label = ""
+        self._entry: LabelDialogEntry | None = None
+        self.accepted.connect(self._capture_entry)
         # The flags currently on show, keyed by flag name, so a flag named by
         # two matching label_flags patterns gets exactly one checkbox.
         self._flag_checkboxes: dict[str, QtWidgets.QCheckBox] = {}
@@ -318,6 +320,7 @@ class LabelDialog(QtWidgets.QDialog):
         move: bool = True,
         position: QtCore.QPoint | None = None,
     ) -> LabelDialogEntry | None:
+        self._entry = None
         self._locked = frozenset(locked)
         # Drop the previous popup's checkboxes and their remembered states so a
         # fresh popup starts unchecked. This has to precede setText() below,
@@ -371,14 +374,15 @@ class LabelDialog(QtWidgets.QDialog):
             # visible dialog, while the clamp is a no-op unless it overflows.
             QtCore.QTimer.singleShot(0, lambda: self._clamp_within_screen(target))
 
-        if self.exec() != QtWidgets.QDialog.DialogCode.Accepted:
-            return None
+        self.exec()
+        return self._entry
 
+    def _capture_entry(self) -> None:
         # The flag checkboxes follow the text, so normalize it before they are
         # collected: "cat " must yield the flags of "cat", not none.
         self.edit.setText(self.edit.text().strip())
         group_id_text = self.edit_group_id.text()
-        entry = LabelDialogEntry(
+        self._entry = LabelDialogEntry(
             label=self.edit.text(),
             flags=self._collect_flags(),
             group_id=int(group_id_text) if group_id_text else None,
@@ -386,8 +390,7 @@ class LabelDialog(QtWidgets.QDialog):
         )
         # A locked label is accepted as blank, and the next new-shape popup
         # starts blank too, exactly as a cancelled locked edit leaves it.
-        self.remember_label(label=entry.label)
-        return entry
+        self.remember_label(label=self._entry.label)
 
     def _get_field_widgets(
         self,

--- a/tests/unit/widgets/label_dialog/interaction_test.py
+++ b/tests/unit/widgets/label_dialog/interaction_test.py
@@ -35,22 +35,19 @@ def _run_popup(
     description: str | None,
     locked: Collection[LabelDialogField],
 ) -> LabelDialogEntry | None:
-    code = (
-        QtWidgets.QDialog.DialogCode.Accepted
-        if accept
-        else QtWidgets.QDialog.DialogCode.Rejected
-    )
+    def finish_popup() -> None:
+        try:
+            if at_show is not None:
+                at_show(dialog)
+        finally:
+            if accept:
+                dialog.accept()
+            else:
+                dialog.reject()
 
-    def fake_exec() -> int:
-        if at_show is not None:
-            at_show(dialog)
-        return code
-
-    dialog.exec = fake_exec  # ty: ignore[invalid-assignment]
+    QtCore.QTimer.singleShot(0, finish_popup)
     return dialog.popup(
         text=text,
-        # Keeping the dialog put makes the popup deterministic under a stubbed
-        # exec(), which never shows it.
         move=False,
         flags=flags,
         group_id=group_id,
@@ -557,7 +554,7 @@ def test_flag_named_by_two_matching_patterns_keeps_its_checked_state(
 
 
 # ---------------------------------------------------------------------------
-# popup() round-trips (exec stubbed)
+# Modal popup round-trips
 # ---------------------------------------------------------------------------
 
 
@@ -1060,3 +1057,75 @@ def test_popup_preserves_label_case(*, qtbot: QtBot) -> None:
     assert seen["current"] == "Cat"
     assert entry is not None
     assert entry.label == "cat"
+
+
+@pytest.mark.parametrize("cancel_locked", [False, True])
+def test_repeated_modal_popups_restore_focus_and_isolate_results(
+    *, qtbot: QtBot, cancel_locked: bool
+) -> None:
+    dialog = _add_dialog(
+        qtbot, dialog=LabelDialog(labels=["Cat"], flags={"^cat$": ["indoor"]})
+    )
+
+    watchdog = QtCore.QTimer(dialog)
+    watchdog.timeout.connect(dialog.reject)
+    watchdog.start(5000)
+
+    def accept_with_space() -> None:
+        assert dialog.focusWidget() is dialog.edit
+        assert dialog.edit.selectedText() == "cat"
+        assert dialog.label_list.currentItem().text() == "Cat"
+        _checkbox(dialog=dialog, name="indoor").setChecked(True)
+        dialog.edit.setText("cat ")
+        qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Return)
+
+    QtCore.QTimer.singleShot(0, accept_with_space)
+    entry = dialog.popup(text=" cat", group_id=0, description="<b>pet</b>", move=False)
+    assert entry == LabelDialogEntry(
+        label="cat", flags={"indoor": True}, group_id=0, description="<b>pet</b>"
+    )
+
+    def finish_locked() -> None:
+        assert not dialog.edit.isEnabled()
+        assert not dialog.edit_group_id.isEnabled()
+        assert not dialog.edit_description.isEnabled()
+        assert not _checkboxes(dialog)
+        qtbot.keyClick(
+            dialog,
+            QtCore.Qt.Key.Key_Escape if cancel_locked else QtCore.Qt.Key.Key_Return,
+        )
+
+    QtCore.QTimer.singleShot(0, finish_locked)
+    locked_entry = dialog.popup(
+        text="mixed",
+        flags={"indoor": True},
+        group_id=7,
+        description="mixed",
+        locked=("label", "flags", "group_id", "description"),
+        move=False,
+    )
+    assert locked_entry == (
+        None
+        if cancel_locked
+        else LabelDialogEntry(label="", flags={}, group_id=None, description="")
+    )
+
+    def cancel_unlocked() -> None:
+        assert dialog.focusWidget() is dialog.edit
+        assert dialog.edit.isEnabled()
+        assert dialog.edit_group_id.isEnabled()
+        assert dialog.edit_description.isEnabled()
+        assert dialog.edit.text() == ("cat" if cancel_locked else "")
+        assert dialog.edit.selectedText() == dialog.edit.text()
+        assert dialog.edit_group_id.text() == ""
+        assert dialog.edit_description.toPlainText() == ""
+        if cancel_locked:
+            assert not _checkbox(dialog=dialog, name="indoor").isChecked()
+        dialog.edit.setText("discarded")
+        qtbot.keyClick(dialog.edit, QtCore.Qt.Key.Key_Escape)
+
+    QtCore.QTimer.singleShot(0, cancel_unlocked)
+    assert dialog.popup(move=False) is None
+    assert _get_shown_text(dialog=dialog, accept=False, text=None) == (
+        "cat" if cancel_locked else ""
+    )


### PR DESCRIPTION
Capture each label entry at Qt's acceptance boundary so the modal caller receives a completed result. The accepted signal covers OK, Return and double-click acceptance; cancellation leaves the per-popup result empty. Initial field setup and screen placement retain their ordering.

Validation: 140 focused tests pass on both the unchanged base and candidate, `make lint` passes, and all 21 CI checks pass. Existing popup round-trip assertions now use a real modal event loop. Native macOS 26.6.2 / Qt 6.11.1 checks: 27 popup/flag tests and 57 keyboard, accessibility, screen-fit and application tests pass; desktop inspection confirms select-all, casing, flags, immediate Return/Escape and locked-to-unlocked reuse.

Two pre-existing native limitations were observed: the existing four-Tab test lands on Description on this Mac, and a reused popup anchored at the bottom-right extends 32 pixels below the available screen. The latter reproduces with identical visible-frame geometry on base and candidate. Neither is changed here. Windows/Linux desktop behavior remains unverified. Visual attachments are omitted because appearance is unchanged and modal checks provide the useful evidence.


