### PR TITLE
refactor(render): paint every outline from the shared image-space path

### DIFF
--- a/labelme/_widgets/_shape_render.py
+++ b/labelme/_widgets/_shape_render.py
@@ -13,6 +13,7 @@ from PySide6 import QtGui
 
 from .. import _utils
 from .._shape import CIRCLE_POINT_COUNT
+from .._shape import LINE_POINT_COUNT
 from .._shape import ORIENTED_RECTANGLE_POINT_COUNT
 from .._shape import RECTANGLE_POINT_COUNT
 from .._shape import Shape
@@ -307,71 +308,49 @@ def _build_shape_points_paths(
     paths = _ShapePaths()
     scale = context.scale
     points = shape.points
-    if shape.shape_type in ["rectangle", "mask"]:
+    if shape.shape_type in ("rectangle", "mask", "circle"):
         assert len(points) in [1, 2]
-        paths.line.addPath(_build_two_point_outline(shape=shape, scale=scale))
-        if shape.shape_type == "rectangle":
-            for i in range(len(points)):
-                _build_shape_point_path(
-                    path=paths.vertices, shape=shape, context=context, vertex_index=i
-                )
     elif shape.shape_type == "oriented_rectangle":
         assert len(points) in [1, 2, 4]
-        if len(points) == ORIENTED_RECTANGLE_POINT_COUNT:
-            paths.line.moveTo(QtCore.QPointF(*(points[0] * scale)))
-            for i in range(len(points)):
-                paths.line.lineTo(QtCore.QPointF(*(points[i] * scale)))
-                _build_shape_point_path(
-                    path=paths.vertices, shape=shape, context=context, vertex_index=i
-                )
-            paths.line.lineTo(QtCore.QPointF(*(points[0] * scale)))
-            for i in range(len(points)):
-                _build_shape_rotation_point_path(
-                    path=paths.rotation_vertices,
-                    shape=shape,
-                    context=context,
-                    vertex_index=i,
-                )
-            _build_shape_oriented_rectangle_arrow_path(
-                path=paths.orientation_arrow, shape=shape, scale=scale
-            )
-        elif len(points) == CIRCLE_POINT_COUNT:
-            paths.line.moveTo(QtCore.QPointF(*(points[0] * scale)))
-            paths.line.lineTo(QtCore.QPointF(*(points[1] * scale)))
-            for i in range(2):
-                _build_shape_point_path(
-                    path=paths.vertices, shape=shape, context=context, vertex_index=i
-                )
-    elif shape.shape_type == "circle":
-        assert len(points) in [1, 2]
-        paths.line.addPath(_build_two_point_outline(shape=shape, scale=scale))
-        for i in range(len(points)):
-            _build_shape_point_path(
-                path=paths.vertices, shape=shape, context=context, vertex_index=i
-            )
-    elif shape.shape_type == "linestrip":
-        paths.line.moveTo(QtCore.QPointF(*(points[0] * scale)))
-        for i in range(len(points)):
-            paths.line.lineTo(QtCore.QPointF(*(points[i] * scale)))
-            _build_shape_point_path(
-                path=paths.vertices, shape=shape, context=context, vertex_index=i
-            )
     elif shape.shape_type == "points":
         assert len(points) == len(shape.point_labels)
+
+    if shape.shape_type == "points":
+        # Prompt points are standalone markers; their outline only bounds them.
         for i, point_label in enumerate(shape.point_labels):
             path = paths.vertices if point_label == 1 else paths.negative_vertices
             _build_shape_point_path(
                 path=path, shape=shape, context=context, vertex_index=i
             )
-    else:
-        paths.line.moveTo(QtCore.QPointF(*(points[0] * scale)))
+        return paths
+
+    paths.line.addPath(
+        QtGui.QTransform.fromScale(scale, scale).map(_build_outline_path(shape=shape))
+    )
+    # A mask's corners are not draggable, and an oriented rectangle's first
+    # corner is drawn by the drag preview until its first edge is locked.
+    if shape.shape_type == "mask" or (
+        shape.shape_type == "oriented_rectangle" and len(points) == 1
+    ):
+        return paths
+    for i in range(len(points)):
+        _build_shape_point_path(
+            path=paths.vertices, shape=shape, context=context, vertex_index=i
+        )
+    if (
+        shape.shape_type == "oriented_rectangle"
+        and len(points) == ORIENTED_RECTANGLE_POINT_COUNT
+    ):
         for i in range(len(points)):
-            paths.line.lineTo(QtCore.QPointF(*(points[i] * scale)))
-            _build_shape_point_path(
-                path=paths.vertices, shape=shape, context=context, vertex_index=i
+            _build_shape_rotation_point_path(
+                path=paths.rotation_vertices,
+                shape=shape,
+                context=context,
+                vertex_index=i,
             )
-        if shape.closed:
-            paths.line.lineTo(QtCore.QPointF(*(points[0] * scale)))
+        _build_shape_oriented_rectangle_arrow_path(
+            path=paths.orientation_arrow, shape=shape, scale=scale
+        )
     return paths
 
 
@@ -404,20 +383,34 @@ def bounds(*, shape: Shape) -> QtCore.QRectF:
 
 
 def _build_outline_path(*, shape: Shape) -> QtGui.QPainterPath:
+    # The single image-space outline behind painting, hit-testing and bounds,
+    # so a shape is picked exactly where it is drawn.
     points = shape.points
     path = QtGui.QPainterPath()
     if shape.shape_type in ("rectangle", "mask", "circle"):
         path.addPath(_build_two_point_outline(shape=shape, scale=1.0))
-    elif shape.shape_type == "oriented_rectangle":
-        if len(points) == ORIENTED_RECTANGLE_POINT_COUNT:
-            path.moveTo(QtCore.QPointF(*points[0]))
-            for point in points[1:]:
-                path.lineTo(QtCore.QPointF(*point))
-            path.lineTo(QtCore.QPointF(*points[0]))
+    elif shape.shape_type == "oriented_rectangle" and len(points) not in (
+        LINE_POINT_COUNT,
+        ORIENTED_RECTANGLE_POINT_COUNT,
+    ):
+        # Neither the first edge being dragged nor a finished loop yet.
+        pass
     elif len(points) > 0:
+        # lineTo, unlike addPolygon, drops a repeated point instead of adding a
+        # zero-length segment the stroker would cap with a dot.
         path.moveTo(QtCore.QPointF(*points[0]))
         for point in points[1:]:
             path.lineTo(QtCore.QPointF(*point))
+        # An oriented rectangle is a loop exactly when finished, whatever its
+        # flag says (a preview inherits the flag from the previous mode). A
+        # linestrip is flagged closed on commit like every shape, yet stays
+        # open by definition.
+        if shape.shape_type == "oriented_rectangle":
+            is_loop = len(points) == ORIENTED_RECTANGLE_POINT_COUNT
+        else:
+            is_loop = shape.closed and shape.shape_type != "linestrip"
+        if is_loop:
+            path.lineTo(QtCore.QPointF(*points[0]))
     return path
 
 

--- a/tests/unit/widgets/_shape_render_test.py
+++ b/tests/unit/widgets/_shape_render_test.py
@@ -250,15 +250,24 @@ def test_point_shape_label_is_drawn() -> None:
         ("mask", [[20, 30], [70, 60]], (90, 60)),
         # radius = ||(15, 20)|| = 25
         ("circle", [[50, 50], [65, 70]], (100, 50)),
+        ("line", [[20, 30], [70, 30]], (90, 60)),
+        ("linestrip", [[20, 30], [70, 30], [70, 60]], (90, 60)),
+        ("polygon", [[20, 30], [70, 30], [70, 60], [20, 60]], (90, 60)),
+        # The first edge of an oriented rectangle while it is being dragged. The
+        # finished loop is left out: its orientation arrow has a fixed
+        # image-space size, so pre-scaling the corners does not pre-scale it.
+        ("oriented_rectangle", [[20, 30], [70, 30]], (90, 60)),
     ],
 )
-def test_two_point_shape_scales_like_its_points(
+def test_outline_scales_like_its_points(
     *, shape_type: ShapeType, points: list[list[float]], outline_probe: tuple[int, int]
 ) -> None:
     # Vertex markers are sized in screen pixels, so they match in both renders
     # and the equality isolates the outline.
     shape = _shape(shape_type=shape_type, points=points)
+    shape.closed = shape_type == "polygon"
     prescaled = _shape(shape_type=shape_type, points=(np.array(points) * 2).tolist())
+    prescaled.closed = shape.closed
     rendered = _render(
         shape=shape,
         show_label=False,
@@ -274,6 +283,33 @@ def test_two_point_shape_scales_like_its_points(
         highlight=None,
         rotation_highlight=None,
     )
+
+
+@pytest.mark.gui
+@pytest.mark.usefixtures("qapp")
+@pytest.mark.parametrize(
+    # A pixel halfway along the segment that must not exist: a linestrip is
+    # open even once committed (which flags it closed like every finished
+    # shape), and prompt points are markers with nothing joining them.
+    ("shape_type", "points", "gap_probe"),
+    [
+        ("linestrip", [[20, 20], [120, 20], [120, 120]], (70, 70)),
+        ("points", [[20, 20], [120, 20]], (70, 20)),
+    ],
+)
+def test_no_outline_where_points_are_not_joined(
+    *, shape_type: ShapeType, points: list[list[float]], gap_probe: tuple[int, int]
+) -> None:
+    shape = _shape(shape_type=shape_type, points=points)
+    shape.closed = True
+    image = _render(
+        shape=shape,
+        show_label=False,
+        scale=1.0,
+        highlight=None,
+        rotation_highlight=None,
+    )
+    assert image.pixelColor(*gap_probe) == QtGui.QColor(255, 255, 255)
 
 
 def _mask_shape() -> Shape:


### PR DESCRIPTION
Painting and hit-testing built the same polyline twice: paint scaled each point as it appended it, while `is_hit_by_point` and `bounds` used a separate image-space outline. The image-space outline now feeds all three, and paint maps it once with the transform masks and two-point shapes already use. What is drawn and what can be picked can no longer drift apart.

Three non-obvious bits:

1. Closure is decided per type inside the shared outline, not from the `closed` flag alone. Every committed shape is flagged closed, including linestrips, which must stay open; and a two-corner oriented-rectangle preview inherits whatever flag the previous draw mode left, while its loop exists only at four corners. Both keep the old paint output exactly.

2. The outline keeps the explicit `lineTo` loop rather than `addPolygon`: `lineTo` drops a repeated point, `addPolygon` keeps a zero-length segment the stroker caps with a dot. Draft shapes carry repeated points (a locked oriented-rectangle first edge, a line before the cursor moves), so this keeps them pixel-identical.

3. `bounds` changes for one state nothing measures: a two-corner oriented-rectangle preview now bounds to its edge instead of the null rect. The only callers are the drag anchor and drag clamp, which run on committed selected shapes; a loaded `points` shape keeps its previous bounds.

<!-- before-and-after:start -->
Preview: the head renderer was compared pixel-for-pixel against the base renderer (both modules imported side by side) over every shape type, each in draft and committed (`closed`) state, six zoom levels from 0.25 to 3.7, selected/fill/highlight/point-type combinations, plus `is_hit_by_point` on a 34×34 image-space grid at three zoom levels and `bounds`.

```
renders compared: 10944 hit probes: 124848 mismatches: 2
('orect-2', False, 'bounds', (0.0, 0.0, 0.0, 0.0), (20.0, 30.0, 50.0, 0.0))
('orect-2', True, 'bounds', (0.0, 0.0, 0.0, 0.0), (20.0, 30.0, 50.0, 0.0))
```

The two mismatches are the `bounds` case described above. Verified on macOS 26.6.2 arm64 with PySide6/Qt 6.11.1; the Linux pixel snapshot tests were skipped locally and run in CI.
<!-- before-and-after:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1ZZAxKyfXP3grycDYxWHy
