### PR TITLE
refactor: remove obsolete application comments

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1620,7 +1620,6 @@ class MainWindow(QtWidgets.QMainWindow):
         ):
             self._restore_file_list_state(item=previous_item)
 
-    # React to canvas signals.
     def _on_shape_selection_changed(self, selected_shapes: list[Shape], /) -> None:
         self._docks.label_list.item_selection_changed.disconnect(
             self._label_selection_changed
@@ -2133,7 +2132,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 message=self.tr("No such file: <b>%s</b>") % image_or_label_path,
             )
             return False
-        # assumes same name, but json extension
         self.show_status_message(
             self.tr("Loading %s...") % Path(image_or_label_path).name
         )


### PR DESCRIPTION
The JSON-extension comment is detached from path resolution, and the callback name already explains the section comment.

Validation: `make lint` and `git diff --check` pass; AST and non-comment token comparisons against the base are identical. Visual evidence and a changelog fragment are unnecessary for these two comment deletions.
