### PR TITLE
refactor: clarify --label-flags CLI help

### DIFF
--- a/changelog.d/2652.changed.md
+++ b/changelog.d/2652.changed.md
@@ -1,0 +1,1 @@
+Clarify the `--label-flags` CLI help: the value is a YAML mapping from a label regex to its flag names, given inline or as a path to a YAML/JSON file.

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -281,8 +281,8 @@ def main() -> None:
         "--labelflags",  # deprecated
         dest="label_flags",
         action=_DeprecatedAlias,
-        help=r"yaml string of label specific flags OR file containing json "
-        r"string of label specific flags (ex. {person-\d+: [male, tall], "
+        help=r"YAML mapping from a label regex to its flag names, given inline "
+        r"or as a path to a YAML/JSON file (ex. {person-\d+: [male, tall], "
         r"dog-\d+: [black, brown, white], .*: [occluded]})",  # NOQA
         default=argparse.SUPPRESS,
     )


### PR DESCRIPTION
Reword the `--label-flags` / `--labelflags` help text so it describes what the parser accepts: a YAML mapping from a label regex to its flag names, given inline or as a path to a YAML/JSON file. Both branches go through the same YAML safe loader, so the old wording ("yaml string … OR file containing json string") understated the file path and was hard to read.

Option names, the deprecated-alias warning, the regex example, defaults and parsing are unchanged; the diff is the help string only.

## Validation

- `labelme --help` renders the new text wrapped cleanly with the `\d+` examples intact.
- Python AST diff against `main` shows only the one string constant changed.
- Parsed a JSON file and an inline YAML mapping through the same loader the CLI uses; both produce the expected regex-to-flags dict.
- `make lint`, `make check_translate` (argparse help is not in the Qt catalogs) and `tests/unit/__main___test.py` + `tests/unit/_label_flags_test.py` (47 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MDxmjaSTBNfMMN3NHHK56