### PR TITLE
fix: reduce coordinate rounding drift while dragging shapes

### DIFF
--- a/changelog.d/2657.fixed.md
+++ b/changelog.d/2657.fixed.md
@@ -1,0 +1,1 @@
+Reduce coordinate rounding drift while dragging shapes.

--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -48,6 +48,37 @@ _DEFAULT_SHAPE_RGB: Final[tuple[int, int, int]] = (0, 255, 0)
 _DEFAULT_PALETTE: Final[Palette] = Palette.from_rgb(_DEFAULT_SHAPE_RGB)
 
 
+@dataclasses.dataclass
+class _DragAnchor:
+    rel_tl: QPointF
+    bounds: QRectF
+    origin: QPointF
+    last_cursor: QPointF
+    sources: dict[Shape, np.ndarray]
+    limits: tuple[QtCore.QSize, bool]
+    requested_cursor: tuple[float, float] | None = None
+
+    def is_current(self, *, shapes: list[Shape], cursor: QPointF) -> bool:
+        if self.sources.keys() != set(shapes):
+            return False
+        if (cursor.x(), cursor.y()) != (self.last_cursor.x(), self.last_cursor.y()):
+            return False
+        offset = self.last_cursor - self.origin
+        # Bounds alone miss interior vertex edits and replacement geometry.
+        return all(
+            np.array_equal(shape.points, source + (offset.x(), offset.y()))
+            for shape, source in self.sources.items()
+        )
+
+    def place(self, *, cursor: QPointF) -> None:
+        offset = cursor - self.origin
+        for shape, source in self.sources.items():
+            points = source + (offset.x(), offset.y())
+            if not np.array_equal(shape.points, points):
+                shape.points = points
+        self.last_cursor = QPointF(cursor)
+
+
 @dataclasses.dataclass(frozen=True)
 class _DraftShape:
     """In-progress shape held in QPointF while drawing, before it is committed
@@ -188,7 +219,7 @@ class Canvas(QtWidgets.QWidget):
 
     _prev_point: QPointF
     _prev_move_point: QPointF
-    _drag_anchor: tuple[QPointF, QRectF]
+    _drag_anchor: _DragAnchor | None
     _rotation_center: np.ndarray
     _rotation_initial_angle: float
     _rotation_original_points: np.ndarray
@@ -250,7 +281,6 @@ class Canvas(QtWidgets.QWidget):
         self._line = _DraftShape()
         self._prev_point = QPointF()
         self._prev_move_point = QPointF()
-        self._drag_anchor = (QPointF(), QRectF())
         self._rotation_center = np.zeros(2)
         self._rotation_initial_angle = 0.0
         self._rotation_original_points = np.empty((0, 2))
@@ -543,6 +573,7 @@ class Canvas(QtWidgets.QWidget):
         # follows would record it a second time, making the next undo a no-op.
         self.shapes = self.shape_backups.pop()
         self.selected_shapes.clear()
+        self._drag_anchor = None
         self.update()
 
     def enterEvent(self, _a0: QtCore.QEvent, /) -> None:
@@ -560,6 +591,7 @@ class Canvas(QtWidgets.QWidget):
         self._update_status(extra_messages=None)
 
     def focusOutEvent(self, _a0: QtGui.QFocusEvent, /) -> None:
+        self._drag_anchor = None
         self._release_cursor()
         self._update_status(extra_messages=None)
 
@@ -1242,6 +1274,7 @@ class Canvas(QtWidgets.QWidget):
     def mouseReleaseEvent(self, a0: QtGui.QMouseEvent, /) -> None:
         self._dispatch_pointer_release(event=a0)
         self._commit_pending_shape_move()
+        self._drag_anchor = None
         self._update_status(extra_messages=None)
 
     def _dispatch_pointer_release(self, *, event: QtGui.QMouseEvent) -> None:
@@ -1339,6 +1372,7 @@ class Canvas(QtWidgets.QWidget):
         else:
             self._apply_in_place_move()
         self._selected_shapes_copy.clear()
+        self._drag_anchor = None
         self.update()
         self.backup_shapes()
         return True
@@ -1426,10 +1460,20 @@ class Canvas(QtWidgets.QWidget):
 
     def _record_drag_anchor(self, *, shapes: list[Shape], click: QPointF) -> None:
         if not shapes:
-            self._drag_anchor = (QPointF(), QRectF())
+            self._drag_anchor = None
             return
         bounds = _compute_shapes_bounds(shapes=shapes)
-        self._drag_anchor = (bounds.topLeft() - click, bounds)
+        sources = {shape: shape.points.copy() for shape in shapes}
+        for source in sources.values():
+            source.setflags(write=False)
+        self._drag_anchor = _DragAnchor(
+            rel_tl=bounds.topLeft() - click,
+            bounds=bounds,
+            origin=QPointF(click),
+            last_cursor=QPointF(click),
+            sources=sources,
+            limits=(self.pixmap.size(), self._allow_out_of_bounds_points),
+        )
 
     def _bounded_move_vertex(
         self,
@@ -1489,14 +1533,19 @@ class Canvas(QtWidgets.QWidget):
             return
 
         current_bounds = _compute_shapes_bounds(shapes=shapes)
-        rel_tl, bounds = self._drag_anchor
-        expected_top_left = self._prev_point + rel_tl
         if (
-            bounds.size() != current_bounds.size()
-            or expected_top_left != current_bounds.topLeft()
+            self._drag_anchor is None
+            or self._drag_anchor.limits
+            != (self.pixmap.size(), self._allow_out_of_bounds_points)
+            or not self._drag_anchor.is_current(shapes=shapes, cursor=self._prev_point)
         ):
             self._record_drag_anchor(shapes=shapes, click=self._prev_point)
-            rel_tl, bounds = self._drag_anchor
+        anchor = self._drag_anchor
+        assert anchor is not None
+        # Re-clamping an identical request can introduce a rounding-only move.
+        if anchor.requested_cursor == (cursor.x(), cursor.y()):
+            return
+        rel_tl, bounds = anchor.rel_tl, anchor.bounds
 
         target = cursor + rel_tl
         if not self._allow_out_of_bounds_points:
@@ -1509,14 +1558,9 @@ class Canvas(QtWidgets.QWidget):
             target.setX(min(max(target.x(), min_x), max_x))
             target.setY(min(max(target.y(), min_y), max_y))
 
-        new_cursor = target - rel_tl
-        delta = new_cursor - self._prev_point
-        if delta.isNull():
-            return
-
-        for shape in shapes:
-            shape.translate(offset=(delta.x(), delta.y()))
-        self._prev_point = new_cursor
+        self._prev_point = target - rel_tl
+        anchor.place(cursor=self._prev_point)
+        anchor.requested_cursor = (cursor.x(), cursor.y())
 
     def deselect_shape(self) -> bool:
         if not self.selected_shapes:
@@ -1983,6 +2027,7 @@ class Canvas(QtWidgets.QWidget):
                     self.shape_moved.emit()
 
                 self._is_moving_shape = False
+                self._drag_anchor = None
 
     def set_last_label(self, *, text: str, flags: dict[str, bool]) -> list[Shape]:
         if not text:
@@ -2056,6 +2101,7 @@ class Canvas(QtWidgets.QWidget):
             self._cancel_current_shape()
 
     def _reset_interaction_state(self) -> None:
+        self._drag_anchor = None
         self._current = None
         self.hovered_shape = None
         self._hovered_vertex = None
@@ -2067,6 +2113,7 @@ class Canvas(QtWidgets.QWidget):
     def load_pixmap(self, *, pixmap: QtGui.QPixmap, clear_shapes: bool = True) -> None:
         pixmap_arr = _utils.img_qt_to_arr(pixmap.toImage())
         self.pixmap = pixmap
+        self._drag_anchor = None
         self._pixmap_hash = hash(pixmap_arr.tobytes())
         # A new image is a fresh inference context that should surface its own
         # first failure rather than staying muted by the prior image's latch.
@@ -2112,6 +2159,7 @@ class Canvas(QtWidgets.QWidget):
         self._release_cursor()
         self.pixmap = QtGui.QPixmap()
         self._pixmap_hash = None
+        self._drag_anchor = None
         self.shapes = []
         self.shape_backups = collections.deque(maxlen=self._num_backups)
         self._is_moving_shape = False

--- a/tests/unit/widgets/canvas_test.py
+++ b/tests/unit/widgets/canvas_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
+import weakref
 from collections.abc import Callable
 from typing import Final
 from unittest.mock import Mock
@@ -307,7 +308,7 @@ def test_drag_shapes_blocked_off_image_by_default(*, canvas: Canvas) -> None:
         closed=True,
     )
     canvas._prev_point = QPointF(50, 25)
-    canvas._drag_anchor = (QPointF(0, 0), QtCore.QRectF(40, 20, 20, 10))
+    canvas._record_drag_anchor(shapes=[shape], click=canvas._prev_point)
 
     canvas._drag_shapes(shapes=[shape], cursor=QPointF(150, 80), constrain_cursor=True)
 
@@ -325,13 +326,121 @@ def test_drag_shapes_keeps_out_of_bounds_when_enabled(*, canvas: Canvas) -> None
         closed=True,
     )
     canvas._prev_point = QPointF(50, 25)
-    canvas._drag_anchor = (QPointF(0, 0), QtCore.QRectF(40, 20, 20, 10))
+    canvas._record_drag_anchor(shapes=[shape], click=canvas._prev_point)
 
     canvas._drag_shapes(shapes=[shape], cursor=QPointF(150, 80), constrain_cursor=True)
 
     assert canvas._prev_point == QPointF(150, 80)
     assert (shape.points[0][0], shape.points[0][1]) == pytest.approx((140, 75))
     assert (shape.points[1][0], shape.points[1][1]) == pytest.approx((160, 85))
+
+
+@pytest.mark.gui
+def test_drag_shapes_preserves_fractional_noop_and_round_trip(
+    *, canvas: Canvas
+) -> None:
+    shape = Shape(
+        shape_type="rectangle",
+        points=np.array(
+            [
+                (8.44414798007001, 2.8813233909973786),
+                (12.795045643540696, 7.5153405275769956),
+            ]
+        ),
+    )
+    original = shape.points.copy()
+    click = QPointF(10.619596811805353, 5.198331959287187)
+    canvas._prev_point = QPointF(click)
+    canvas._record_drag_anchor(shapes=[shape], click=click)
+    cursor = QPointF(48.87823985103782, 6.985739658056511)
+
+    canvas._drag_shapes(shapes=[shape], cursor=cursor, constrain_cursor=True)
+    placed = shape.points
+    previous_cursor = QPointF(canvas._prev_point)
+    canvas._drag_shapes(shapes=[shape], cursor=cursor, constrain_cursor=True)
+
+    assert shape.points is placed
+    assert canvas._prev_point == previous_cursor
+    canvas._drag_shapes(shapes=[shape], cursor=click, constrain_cursor=True)
+    np.testing.assert_array_equal(shape.points, original)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("change", ["policy", "image_size"])
+def test_drag_shapes_retries_clamped_request_after_limits_change(
+    *, canvas: Canvas, change: str
+) -> None:
+    shape = Shape(shape_type="rectangle", points=np.array([(20, 20), (40, 40)]))
+    canvas._prev_point = QPointF(30, 30)
+    canvas._record_drag_anchor(shapes=[shape], click=canvas._prev_point)
+    canvas._drag_shapes(shapes=[shape], cursor=QPointF(200, 30), constrain_cursor=False)
+    np.testing.assert_array_equal(shape.points, [(80, 20), (100, 40)])
+
+    if change == "policy":
+        canvas.set_allow_out_of_bounds_points(value=True)
+    else:
+        canvas.pixmap = QtGui.QPixmap(300, 50)
+    canvas._drag_shapes(shapes=[shape], cursor=QPointF(200, 30), constrain_cursor=False)
+
+    np.testing.assert_array_equal(shape.points, [(190, 20), (210, 40)])
+
+
+@pytest.mark.gui
+def test_drag_shapes_rebases_after_edit_preview_and_cursor_reset(
+    *, canvas: Canvas
+) -> None:
+    shape = Shape(points=np.array([(20, 20), (40, 20), (30, 30), (20, 40)]))
+    canvas._prev_point = QPointF(30, 30)
+    canvas._record_drag_anchor(shapes=[shape], click=canvas._prev_point)
+    canvas._drag_shapes(shapes=[shape], cursor=QPointF(40, 30), constrain_cursor=True)
+
+    shape.move_vertex(i=2, pos=(46, 36))
+    edited = shape.points
+    canvas._drag_shapes(shapes=[shape], cursor=QPointF(40, 30), constrain_cursor=True)
+    assert shape.points is edited
+    preview = shape.copy()
+    canvas._drag_shapes(shapes=[preview], cursor=QPointF(45, 30), constrain_cursor=True)
+    np.testing.assert_array_equal(
+        shape.points, [(30, 20), (50, 20), (46, 36), (30, 40)]
+    )
+    np.testing.assert_array_equal(
+        preview.points, [(35, 20), (55, 20), (51, 36), (35, 40)]
+    )
+    canvas.selected_shapes = [preview]
+    canvas._prev_point = QPointF(60, 60)
+
+    canvas._move_by_keyboard(offset=QPointF(0, 5))
+
+    np.testing.assert_array_equal(
+        preview.points, [(35, 25), (55, 25), (51, 41), (35, 45)]
+    )
+    assert canvas._prev_point == QPointF(60, 65)
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    "reset", ["image", "shapes", "empty_capture", "canvas", "focus"]
+)
+def test_drag_anchor_releases_captured_shapes_on_reset(
+    *, canvas: Canvas, reset: str
+) -> None:
+    shape = Shape(shape_type="rectangle", points=np.array([(20, 20), (40, 40)]))
+    reference = weakref.ref(shape)
+    canvas._record_drag_anchor(shapes=[shape], click=QPointF(30, 30))
+    del shape
+
+    if reset == "image":
+        canvas.load_pixmap(pixmap=QtGui.QPixmap(100, 50), clear_shapes=False)
+    elif reset == "shapes":
+        canvas.load_shapes(shapes=[])
+    elif reset == "empty_capture":
+        canvas._record_drag_anchor(shapes=[], click=QPointF())
+    elif reset == "focus":
+        canvas.focusOutEvent(QtGui.QFocusEvent(QtCore.QEvent.Type.FocusOut))
+    else:
+        canvas.reset_state()
+
+    assert reference() is None
 
 
 @pytest.mark.gui


### PR DESCRIPTION
Place dragged shapes from their press geometry to avoid accumulating coordinate rounding across mouse events. Saved low-order coordinate bits can differ: a 15,000-move sample observed a maximum difference of 1.3e-13 pixels and no point-array replacements on baseline no-op steps. This is a sampled comparison, not a global error bound.

Validation: all 21 CI checks passed at `9d828d2`; 290 relevant tests; 30 movement/lifetime cases on native Cocoa; `make lint`; and `make check_translate` for 20 languages. Native macOS acceptance covered grouped drag/clamping, no-op dirty/backup behavior, Duplicate Shapes, keyboard movement, Copy here, Move here, Escape cancellation, save, Undo, and reopen. Desktop keys exercised the native menus and keyboard path; the final focus-release change was rechecked with native Qt event automation. An existing accessibility-inspection crash reproduced on the base; acceptance used fresh windows without reloading after attaching inspection. Windows/Linux UI and post-Undo accessibility were not checked locally.

Placement-only timings on macOS arm64 (five-round medians, including bounds calculation): 100 rectangles took 0.37 ms before and 0.57 ms after; a 10,000-point polygon took 4.64 ms before and 4.70 ms after. Snapshots copy 16 bytes per point, excluding object state and temporary arrays.
