### PR TITLE
docs: remove obsolete canvas sizing comment

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1917,8 +1917,6 @@ class Canvas(QtWidgets.QWidget):
             self._set_ai_existing_shape_highlights(shapes=[])
         self.update()
 
-    # Required by QScrollArea: it queries these to compute the
-    # scrollable viewport whenever adjustSize() is called.
     def _compute_canvas_size(self) -> QtCore.QSize:
         if self.pixmap.isNull():
             return super().minimumSizeHint()


### PR DESCRIPTION
Remove the outdated method-group note above the shared sizing helper. Comparing the Python AST before and after confirms identical executable syntax; Ruff lint and formatting checks pass.
