### PR TITLE
fix: keep annotation actions consistent with current state

### DIFF
--- a/changelog.d/2660.fixed.md
+++ b/changelog.d/2660.fixed.md
@@ -1,0 +1,1 @@
+Keep Save As available for images with no shapes, and update Hide, Show, and Toggle Shapes availability after loading, deleting, undoing, or closing annotations.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -169,7 +169,6 @@ class _Actions(NamedTuple):
     draw: list[tuple[str, QtGui.QAction]]
     zoom: tuple[ZoomWidget | QtGui.QAction, ...]
     on_load_active: tuple[QtGui.QAction, ...]
-    on_shapes_present: tuple[QtGui.QAction, ...]
     context_menu: tuple[QtGui.QAction, ...]
     edit_menu: tuple[QtGui.QAction, ...]
 
@@ -693,7 +692,6 @@ class MainWindow(QtWidgets.QMainWindow):
             shortcut=shortcuts["hide_all_shapes"],
             icon="phosphor/eye.svg",
             tip=self.tr("Hide all shapes"),
-            enabled=False,
         )
         show_all = action(
             text=self.tr("&Show\nShapes"),
@@ -701,7 +699,6 @@ class MainWindow(QtWidgets.QMainWindow):
             shortcut=shortcuts["show_all_shapes"],
             icon="phosphor/eye.svg",
             tip=self.tr("Show all shapes"),
-            enabled=False,
         )
         toggle_all = action(
             text=self.tr("&Toggle\nShapes"),
@@ -709,8 +706,22 @@ class MainWindow(QtWidgets.QMainWindow):
             shortcut=shortcuts["toggle_all_shapes"],
             icon="phosphor/eye.svg",
             tip=self.tr("Toggle all shapes"),
-            enabled=False,
         )
+
+        visibility_actions = QtGui.QActionGroup(self)
+        visibility_actions.setExclusive(False)
+        visibility_actions.addAction(hide_all)
+        visibility_actions.addAction(show_all)
+        visibility_actions.addAction(toggle_all)
+
+        def update_visibility_actions() -> None:
+            visibility_actions.setEnabled(not self.has_no_shapes())
+
+        label_model = self._docks.label_list.model()
+        label_model.rowsInserted.connect(update_visibility_actions)
+        label_model.rowsRemoved.connect(update_visibility_actions)
+        label_model.modelReset.connect(update_visibility_actions)
+        update_visibility_actions()
 
         zoom_widget_action = QtWidgets.QWidgetAction(self)
         zoom_box_layout = QtWidgets.QVBoxLayout()
@@ -753,6 +764,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         on_load_active = (
             close,
+            save_as,
             create_mode,
             create_rectangle_mode,
             create_oriented_rectangle_mode,
@@ -764,7 +776,6 @@ class MainWindow(QtWidgets.QMainWindow):
             create_ai_box_to_shape_mode,
             brightness_contrast,
         )
-        on_shapes_present = (save_as, hide_all, show_all, toggle_all)
         # Both menus follow the platform Edit-menu convention: history first,
         # then the clipboard group, then the actions that alter a shape.
         history = (undo, undo_last_point)
@@ -844,7 +855,6 @@ class MainWindow(QtWidgets.QMainWindow):
             draw=draw,
             zoom=zoom,
             on_load_active=on_load_active,
-            on_shapes_present=on_shapes_present,
             context_menu=context_menu,
             edit_menu=edit_menu,
         )
@@ -1652,8 +1662,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 ),
             )
         self._label_dialog.add_label_history(label=shape.label)
-        for action in self._actions.on_shapes_present:
-            action.setEnabled(True)
 
         fill_rgb = self._get_rgb_by_label(
             label=shape.label,
@@ -2454,7 +2462,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self._canvas_widgets.canvas.setEnabled(False)
         self._canvas_widgets.surface.setCurrentWidget(self._canvas_widgets.empty_state)
         self._docks.file_list.setFocus()
-        self._actions.save_as.setEnabled(False)
 
     def current_label_file_path(self) -> str:
         assert self._image_path is not None
@@ -2843,9 +2850,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 shape=self._canvas_widgets.canvas.hovered_shape
             )
             self.remove_labels(shapes=[self._canvas_widgets.canvas.hovered_shape])
-            if self.has_no_shapes():
-                for action in self._actions.on_shapes_present:
-                    action.setEnabled(False)
         self.mark_dirty()
 
     def delete_selected_shapes(self) -> None:
@@ -2856,9 +2860,6 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self.remove_labels(shapes=self._canvas_widgets.canvas.delete_selected())
         self.mark_dirty()
-        if self.has_no_shapes():
-            for action in self._actions.on_shapes_present:
-                action.setEnabled(False)
 
     def copy_shape(self) -> None:
         canvas = self._canvas_widgets.canvas

--- a/tests/e2e/action_availability_test.py
+++ b/tests/e2e/action_availability_test.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QFileDialog
+
+from labelme._shape import Shape
+
+from .conftest import MainWinFactory
+
+
+@pytest.mark.gui
+def test_actions_follow_image_and_shapes(
+    *, main_win: MainWinFactory, data_path: Path
+) -> None:
+    win = main_win(config_overrides={"auto_save": False})
+    visibility_actions = (
+        win._actions.hide_all,
+        win._actions.show_all,
+        win._actions.toggle_all,
+    )
+    assert not win._actions.save_as.isEnabled()
+    assert all(not action.isEnabled() for action in visibility_actions)
+
+    assert win._load_file(
+        image_or_label_path=str(data_path / "annotated/2011_000003.jpg")
+    )
+    assert win._actions.save_as.isEnabled()
+    assert all(action.isEnabled() for action in visibility_actions)
+
+    assert win._load_file(image_or_label_path=str(data_path / "raw/2011_000003.jpg"))
+    assert win._actions.save_as.isEnabled()
+    assert all(not action.isEnabled() for action in visibility_actions)
+
+    win.close_file()
+    assert not win._actions.save_as.isEnabled()
+    assert all(not action.isEnabled() for action in visibility_actions)
+
+
+@pytest.mark.gui
+def test_save_as_writes_empty_annotation(
+    *,
+    main_win: MainWinFactory,
+    data_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    win = main_win(file_or_dir=data_path / "raw/2011_000003.jpg")
+    destination = tmp_path / "empty.json"
+    monkeypatch.setattr(
+        QFileDialog,
+        "getSaveFileName",
+        lambda **_kwargs: (str(destination), ""),
+    )
+    assert win._actions.save_as.isEnabled()
+    win._actions.save_as.trigger()
+    assert json.loads(destination.read_text())["shapes"] == []
+    assert win._load_file(image_or_label_path=str(destination))
+    assert len(win._docks.label_list) == 0
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("clear_by", ["undo", "delete"])
+def test_visibility_actions_follow_last_shape_and_restore(
+    *,
+    main_win: MainWinFactory,
+    data_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clear_by: str,
+) -> None:
+    win = main_win(
+        file_or_dir=data_path / "raw/2011_000003.jpg",
+        config_overrides={"auto_save": False},
+    )
+    visibility_actions = (
+        win._actions.hide_all,
+        win._actions.show_all,
+        win._actions.toggle_all,
+    )
+    shape = Shape(label="point", shape_type="point", points=np.array([[20.0, 20.0]]))
+    win._insert_shapes([shape])
+    win.mark_clean()
+    assert all(action.isEnabled() for action in visibility_actions)
+
+    if clear_by == "undo":
+        win._actions.undo.trigger()
+    else:
+        monkeypatch.setattr(win, "_confirm_deletion", lambda **_kwargs: True)
+        win.delete_selected_shapes()
+    win.mark_clean()
+    assert len(win._docks.label_list) == 0
+    assert all(not action.isEnabled() for action in visibility_actions)
+    assert win._actions.save_as.isEnabled()
+
+    if clear_by == "delete":
+        win._actions.undo.trigger()
+    else:
+        win._insert_shapes([shape])
+    win.mark_clean()
+    assert len(win._docks.label_list) == 1
+    assert all(action.isEnabled() for action in visibility_actions)
+    win._actions.hide_all.trigger()
+    assert not win._canvas_widgets.canvas.shapes[0].visible
+    win._actions.show_all.trigger()
+    assert win._canvas_widgets.canvas.shapes[0].visible
+    win._actions.toggle_all.trigger()
+    assert not win._canvas_widgets.canvas.shapes[0].visible
+    win.mark_clean()


### PR DESCRIPTION
Opening an unannotated image after an annotated one could leave shape visibility actions enabled; Undo could leave the same stale state. Save As also depended on whether shapes had previously existed. Save As now accepts any open image, including empty annotations, while Hide/Show/Toggle follow whether shapes currently exist.

Rebased onto `e697dd8` without conflicts; application code and tests are unchanged by the rebase. Validation: 94 focused tests passed before rebasing; the four new regression cases and `make lint` passed again on `6c8e8d1`. All 21 CI checks passed on that head. All four new cases also fail against the previous application code.

macOS computer-use verification used the rebased source with isolated settings and temporary image copies. Native menus and dialogs were operated through accessibility controls, and canvas points were created and selected with pointer input. Observed results:

| Scenario | Result |
| --- | --- |
| Annotated image → empty image | Hide/Show/Toggle disabled; Save As enabled. |
| Save As with zero shapes | Native Save dialog wrote valid empty JSON; reopening it displayed the image with an empty Shape List. |
| Undo creation of the only point | Shape List emptied and Hide/Show/Toggle disabled. |
| Delete the only point, then Undo | Visibility actions disabled after deletion and re-enabled when the point returned; Save As remained enabled after deletion. |
| Hide, Show, and Toggle | Canvas overlays and Shape List checkboxes changed accordingly. |
| Close image | Save As and all three visibility actions disabled. |

The QA launcher required a distinct macOS application identity and normal macOS launching for reliable computer-use targeting. Native Windows/Linux interaction was not exercised; CI covers automated checks on all three platforms.
