### PR TITLE
fix: refresh Delete File after loading and saving

### DIFF
--- a/changelog.d/2662.fixed.md
+++ b/changelog.d/2662.fixed.md
@@ -1,0 +1,1 @@
+Update Delete File availability when carrying annotations to another image and after automatic saving.

--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1718,6 +1718,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if items:
                 items[0].setCheckState(Qt.CheckState.Checked)
             self._last_failed_auto_save_path = None
+            self._actions.delete_file.setEnabled(True)
             return True
         except (LabelFileError, OSError, ValueError) as e:
             if show_error:
@@ -2165,7 +2166,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.mark_dirty()
         else:
             self.mark_clean()
-            self._actions.delete_file.setEnabled(self.has_label_file())
+        self._actions.delete_file.setEnabled(self.has_label_file())
         self._canvas_widgets.canvas.setEnabled(True)
         # Zoom changes the live scroll positions, so resolve the intended
         # viewport first.
@@ -2387,7 +2388,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if self.save_labels(label_path=label_path):
             self.mark_clean()
-            self._actions.delete_file.setEnabled(self.has_label_file())
 
     def prompt_save_file_path(self) -> str:
         assert self._image_path is not None

--- a/tests/e2e/action_availability_test.py
+++ b/tests/e2e/action_availability_test.py
@@ -173,3 +173,36 @@ def test_drawing_tool_survives_file_transitions(
     assert not win._actions.edit_mode.isEnabled()
     assert all(action.isEnabled() for _, action in win._actions.draw)
     win.mark_clean()
+
+
+@pytest.mark.gui
+@pytest.mark.parametrize("auto_save", [False, True])
+def test_delete_file_follows_carried_annotation_save_state(
+    *, main_win: MainWinFactory, data_path: Path, auto_save: bool
+) -> None:
+    win = main_win(
+        file_or_dir=data_path / "annotated/2011_000003.jpg",
+        config_overrides={"keep_prev": True, "auto_save": auto_save},
+    )
+    assert win._actions.delete_file.isEnabled()
+    labels = [shape.label for shape in win._canvas_widgets.canvas.shapes]
+    image_path = data_path / "raw/2011_000003.jpg"
+    assert win._load_file(image_or_label_path=str(image_path))
+    win.mark_clean()
+    assert [shape.label for shape in win._canvas_widgets.canvas.shapes] == labels
+    assert image_path.with_suffix(".json").exists() == auto_save
+    assert win._actions.delete_file.isEnabled() == auto_save
+
+
+@pytest.mark.gui
+def test_delete_file_enables_after_first_auto_save(
+    *, main_win: MainWinFactory, data_path: Path
+) -> None:
+    image_path = data_path / "raw/2011_000003.jpg"
+    win = main_win(file_or_dir=image_path, config_overrides={"auto_save": True})
+    assert not win._actions.delete_file.isEnabled()
+    win._insert_shapes(
+        [Shape(label="point", shape_type="point", points=np.array([[20.0, 20.0]]))]
+    )
+    assert image_path.with_suffix(".json").exists()
+    assert win._actions.delete_file.isEnabled()


### PR DESCRIPTION
Delete File could stay enabled after Keep Previous Annotation carried shapes to an image without a label file, or stay disabled after the first automatic save created one. Refresh it after every successful load and in the shared save path. This fixes the pre-existing issue noted during #2661 review.

<!-- before-and-after:start -->
```text
python -m pytest tests/e2e/action_availability_test.py -k 'carried or first_auto_save' -q
Before (7041da51): 2 failed, 1 passed
After:             3 passed
```
<!-- before-and-after:end -->

Validation: 50 integration tests passed across action availability, automatic saving, save errors, file loading and deletion confirmation; `make lint` and all 21 CI checks passed at `bbb8f64a`. Native macOS computer-use confirmed Delete File disables after carrying five shapes to an unsaved image, enables after native Save, and enables after the first point is automatically saved on another raw image. The saved JSON files were verified. Native Windows/Linux interaction and the packaged binary were not tested; screenshots were inspected locally, with attachments omitted because the enabled-state observations and regression results capture this change.
