### PR TITLE
refactor: inline end_move helpers and simplify shape-copy application

### DIFF
--- a/labelme/_widgets/canvas.py
+++ b/labelme/_widgets/canvas.py
@@ -1362,26 +1362,18 @@ class Canvas(QtWidgets.QWidget):
         self._is_moving_shape = False
 
     def end_move(self, *, copy: bool) -> bool:
-        assert self.selected_shapes and self._selected_shapes_copy
-        assert len(self._selected_shapes_copy) == len(self.selected_shapes)
+        assert len(self.selected_shapes) == len(self._selected_shapes_copy) > 0
         if copy:
-            self._apply_copy_move()
+            self.shapes.extend(self._selected_shapes_copy)
+            self.selected_shapes[:] = self._selected_shapes_copy
         else:
-            self._apply_in_place_move()
+            for shape, preview in zip(self.selected_shapes, self._selected_shapes_copy):
+                shape.points = preview.points.copy()
         self._selected_shapes_copy.clear()
         self._drag_anchor = None
-        self.update()
         self.backup_shapes()
+        self.update()
         return True
-
-    def _apply_copy_move(self) -> None:
-        for i, clone in enumerate(self._selected_shapes_copy):
-            self.shapes.append(clone)
-            self.selected_shapes[i] = clone
-
-    def _apply_in_place_move(self) -> None:
-        for original, clone in zip(self.selected_shapes, self._selected_shapes_copy):
-            original.points = clone.points.copy()
 
     def _can_close_shape(self) -> bool:
         if self.mode != _CanvasMode.CREATE:


### PR DESCRIPTION
Canvas.end_move delegated to two tiny private helpers, _apply_copy_move and _apply_in_place_move, that existed only to hold one loop each; folding them back into end_move removes a layer of indirection without losing readability, and the copy branch now reads as an extend-then-reassign instead of a manual enumerate loop, which is closer to what it is actually doing.

The two leading asserts collapsed into one since a non-empty selection with matching list lengths already guarantees the preview list is non-empty, and the trailing backup_shapes/update calls were reordered to match the bookkeeping-before-repaint order used elsewhere in this file.

Validated with `uv run pytest tests -x -q` (QT_QPA_PLATFORM=offscreen) and `make lint`, both passing unchanged.