### PR TITLE
refactor(app): drop stale comment on drawing-state action gating

### DIFF
--- a/labelme/_app.py
+++ b/labelme/_app.py
@@ -1426,7 +1426,6 @@ class MainWindow(QtWidgets.QMainWindow):
         webbrowser.open(url)
 
     def _on_drawing_polygon_changed(self, drawing: bool, /) -> None:  # noqa: FBT001 -- Canvas.drawing_polygon slot
-        # In the middle of drawing, toggling between modes should be disabled.
         self._actions.edit_mode.setEnabled(not drawing)
         self._actions.undo_last_point.setEnabled(drawing)
         self._actions.undo.setEnabled(


### PR DESCRIPTION
## Summary

The comment above the drawing-state slot in the main window said only that mode toggling is disabled mid-draw, but the slot also gates delete and both undo actions, and the four calls below it already state that policy in full. Remove the comment rather than expand it.

Comment-only change.

## Test plan

- `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)